### PR TITLE
perf: eliminate double-vs-float allocation overhead + fused double LSTM training (#478)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -210,9 +210,26 @@ public partial class CpuEngine
                 return (Tensor<T>)(object)trainOut;
             }
 
+            if (typeof(T) == typeof(double))
+            {
+                var trainOut = LstmSequenceForwardDoubleTrain(
+                    (Tensor<double>)(object)input,
+                    (Tensor<double>?)(object?)h0,
+                    (Tensor<double>?)(object?)c0,
+                    (Tensor<double>)(object)wIh,
+                    (Tensor<double>)(object)wHh,
+                    (Tensor<double>?)(object?)bIh,
+                    (Tensor<double>?)(object?)bHh,
+                    batch, seqLen, inFeatures, hidden, gateRows, returnSequences, wantState,
+                    out var hnD, out var cnD);
+                finalHidden = (Tensor<T>)(object)hnD;
+                finalCell = (Tensor<T>)(object)cnD;
+                return (Tensor<T>)(object)trainOut;
+            }
+
             throw new InvalidOperationException(
-                "LstmSequenceForward supports GradientTape for float only in this revision. " +
-                "Route non-float training through the decomposed LSTMLayer.Forward path.");
+                "LstmSequenceForward supports GradientTape for float and double in this revision. " +
+                "Route other element types through the decomposed LSTMLayer.Forward path.");
         }
 
         // Graph-compilation mode (distinct from the eager tape) is not yet supported.

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -612,21 +612,37 @@ public partial class CpuEngine
         out Tensor<T> finalHidden,
         out Tensor<T> finalCell)
     {
-        // Pre-compute Wx = input @ wIh^T + bIh for ALL timesteps as one big GEMM.
-        var inputFlat = input.Reshape(new[] { batch * seqLen, inFeatures });
-        var wxFlat = TensorMatMulTransposed(inputFlat, wIh); // [B*seq, 4H]
+        // #478: pool the one-time input projection Wx = input @ wIh^T + bIh too (the dominant residual
+        // after the per-step buffers below). The old TensorMatMulTransposed(inputFlat, wIh) allocated a
+        // fresh [B*seq, 4*hidden] output; pre-transpose wIh once and MultiplyBlocked into a rented wxBuf
+        // (returned in the finally with the per-step buffers). Mirrors the float fast path's wxBuf.
+        var lstmPool = ArrayPool<T>.Shared;
+        int wxRows = batch * seqLen;
+        var wIhT = lstmPool.Rent(inFeatures * gateRows);
+        var wxBuf = lstmPool.Rent(wxRows * gateRows);
+        {
+            var wIhSrc = wIh.AsSpan();
+            for (int g = 0; g < gateRows; g++)
+                for (int fcol = 0; fcol < inFeatures; fcol++)
+                    wIhT[fcol * gateRows + g] = wIhSrc[g * inFeatures + fcol];
+        }
+        var wxMem = new Memory<T>(wxBuf, 0, wxRows * gateRows);
+        wxMem.Span.Clear();
+        MatrixMultiplyHelper.MultiplyBlocked(MathHelper.GetNumericOperations<T>(),
+            new ReadOnlyMemory<T>(input.GetFlattenedData(), 0, wxRows * inFeatures),
+            new ReadOnlyMemory<T>(wIhT, 0, inFeatures * gateRows),
+            wxMem, wxRows, inFeatures, gateRows, inFeatures, gateRows, gateRows, allowParallel: true);
+        lstmPool.Return(wIhT);
 
         if (bIh is not null)
         {
             var ops = MathHelper.GetNumericOperations<T>();
-            var wxSpan = wxFlat.AsWritableSpan();
             var bIhSpan = bIh.AsSpan();
-            int rows = batch * seqLen;
-            for (int r = 0; r < rows; r++)
+            for (int r = 0; r < wxRows; r++)
             {
                 int off = r * gateRows;
                 for (int g = 0; g < gateRows; g++)
-                    wxSpan[off + g] = ops.Add(wxSpan[off + g], bIhSpan[g]);
+                    wxBuf[off + g] = ops.Add(wxBuf[off + g], bIhSpan[g]);
             }
         }
 
@@ -649,14 +665,13 @@ public partial class CpuEngine
             : AutoTensorCache.RentOrAllocate<T>(hShape);
 
         var opsT = MathHelper.GetNumericOperations<T>();
-        var wxSpanRO = wxFlat.AsSpan();
+        var wxSpanRO = new ReadOnlySpan<T>(wxBuf, 0, wxRows * gateRows);
 
         // #478: pool the per-timestep hidden GEMM. The old TensorMatMulTransposed(hPrev, wHh) allocated
         // a fresh [batch, 4*hidden] output (plus the GEMM's packing scratch) EVERY step. Pre-transpose
         // wHh once into a rented buffer and MultiplyBlocked into ONE reused hh buffer, mirroring the
         // float fast path's wHhT + hhBuf — so the recurrence loop allocates nothing per step. This is
         // the dominant remaining allocation after the ping-pong state buffers above.
-        var lstmPool = ArrayPool<T>.Shared;
         var wHhT = lstmPool.Rent(hidden * gateRows);
         var hhBuf = lstmPool.Rent(batch * gateRows);
         {
@@ -750,6 +765,7 @@ public partial class CpuEngine
         {
             lstmPool.Return(wHhT);
             lstmPool.Return(hhBuf);
+            lstmPool.Return(wxBuf);
         }
 
         if (!returnSequences)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -631,8 +631,18 @@ public partial class CpuEngine
         }
 
         var hShape = new[] { batch, hidden };
-        var hPrev = h0 is null ? Tensor<T>.CreateZeros(hShape) : h0.Clone();
-        var cPrev = c0 is null ? Tensor<T>.CreateZeros(hShape) : c0.Clone();
+        // #478: ping-pong TWO pooled hidden + TWO pooled cell buffers across timesteps instead of a
+        // fresh Tensor<T>.CreateZeros for hCurr AND cCurr EVERY step (2*seqLen allocations that bypass
+        // the arena). That fresh-per-step allocation measured ~25-28x the float fast path's per-call
+        // allocation on a 64-step LSTM; reusing two buffers brings the generic (double/decimal/...)
+        // path's per-call allocation down to a small constant. The inner loop fully overwrites every
+        // element of the destination buffers each step, so no clear is needed between reuses.
+        int stateLen = batch * hidden;
+        var hbufs = new[] { AutoTensorCache.RentOrAllocate<T>(hShape), AutoTensorCache.RentOrAllocate<T>(hShape) };
+        var cbufs = new[] { AutoTensorCache.RentOrAllocate<T>(hShape), AutoTensorCache.RentOrAllocate<T>(hShape) };
+        SeedLstmState(hbufs[0], h0, stateLen);
+        SeedLstmState(cbufs[0], c0, stateLen);
+        int cur = 0;
 
         Tensor<T> output = returnSequences
             ? AutoTensorCache.RentOrAllocate<T>(new[] { batch, seqLen, hidden })
@@ -641,15 +651,40 @@ public partial class CpuEngine
         var opsT = MathHelper.GetNumericOperations<T>();
         var wxSpanRO = wxFlat.AsSpan();
 
+        // #478: pool the per-timestep hidden GEMM. The old TensorMatMulTransposed(hPrev, wHh) allocated
+        // a fresh [batch, 4*hidden] output (plus the GEMM's packing scratch) EVERY step. Pre-transpose
+        // wHh once into a rented buffer and MultiplyBlocked into ONE reused hh buffer, mirroring the
+        // float fast path's wHhT + hhBuf — so the recurrence loop allocates nothing per step. This is
+        // the dominant remaining allocation after the ping-pong state buffers above.
+        var lstmPool = ArrayPool<T>.Shared;
+        var wHhT = lstmPool.Rent(hidden * gateRows);
+        var hhBuf = lstmPool.Rent(batch * gateRows);
+        {
+            var wHhSrc = wHh.AsSpan();
+            for (int g = 0; g < gateRows; g++)
+                for (int hcol = 0; hcol < hidden; hcol++)
+                    wHhT[hcol * gateRows + g] = wHhSrc[g * hidden + hcol];
+        }
+        try
+        {
         for (int t = 0; t < seqLen; t++)
         {
-            var hh = TensorMatMulTransposed(hPrev, wHh);
-            var hhSpan = hh.AsSpan();
-            var hCurr = Tensor<T>.CreateZeros(hShape);
-            var cCurr = Tensor<T>.CreateZeros(hShape);
+            int nxt = 1 - cur;
+            // hh[batch, gateRows] = hbufs[cur][batch, hidden] @ wHhT[hidden, gateRows].
+            // MultiplyBlocked accumulates into C, so clear the reused buffer first.
+            var hhMem = new Memory<T>(hhBuf, 0, batch * gateRows);
+            hhMem.Span.Clear();
+            MatrixMultiplyHelper.MultiplyBlocked(opsT,
+                new ReadOnlyMemory<T>(hbufs[cur].GetDataArray(), 0, stateLen),
+                new ReadOnlyMemory<T>(wHhT, 0, hidden * gateRows),
+                hhMem,
+                batch, hidden, gateRows, hidden, gateRows, gateRows, allowParallel: true);
+            var hhSpan = hhBuf.AsSpan();
+            var hCurr = hbufs[nxt];
+            var cCurr = cbufs[nxt];
             var hCurrSpan = hCurr.AsWritableSpan();
             var cCurrSpan = cCurr.AsWritableSpan();
-            var cPrevSpan = cPrev.AsSpan();
+            var cPrevSpan = cbufs[cur].AsSpan();
             bool hasBhh = bHh is not null;
             ReadOnlySpan<T> bHhSpan = hasBhh ? bHh!.AsSpan() : default;
 
@@ -696,8 +731,7 @@ public partial class CpuEngine
                 }
             }
 
-            hPrev = hCurr;
-            cPrev = cCurr;
+            cur = nxt;
 
             if (returnSequences)
             {
@@ -711,11 +745,17 @@ public partial class CpuEngine
                 }
             }
         }
+        }
+        finally
+        {
+            lstmPool.Return(wHhT);
+            lstmPool.Return(hhBuf);
+        }
 
         if (!returnSequences)
         {
             var outSpan = output.AsWritableSpan();
-            var hLastSpan = hPrev.AsSpan();
+            var hLastSpan = hbufs[cur].AsSpan();
             for (int i = 0; i < batch * hidden; i++)
                 outSpan[i] = hLastSpan[i];
         }
@@ -725,8 +765,8 @@ public partial class CpuEngine
             // Final states (h_n, c_n) for streaming/chunked inference. hPrev / cPrev
             // hold the last timestep's hidden / cell state; Clone so they are owned
             // tensors independent of the loop's intermediate buffers.
-            finalHidden = hPrev.Clone();
-            finalCell = cPrev.Clone();
+            finalHidden = hbufs[cur].Clone();
+            finalCell = cbufs[cur].Clone();
         }
         else
         {
@@ -736,6 +776,17 @@ public partial class CpuEngine
         }
 
         return output;
+    }
+
+    // Seed a ping-pong state buffer (#478): copy the initial state in, or zero it when none is given.
+    // default(T) is the additive identity for the numeric structs this path serves, so Clear() zeroes.
+    private static void SeedLstmState<T>(Tensor<T> buffer, Tensor<T>? source, int n)
+    {
+        var dst = buffer.AsWritableSpan();
+        if (source is null)
+            dst.Slice(0, n).Clear();
+        else
+            source.AsSpan().Slice(0, n).CopyTo(dst.Slice(0, n));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -521,4 +521,384 @@ public partial class CpuEngine
         pool.Return(dhPrev);
         pool.Return(hPrevAll);
     }
+
+    // ── Double fused BPTT (#478 follow-up): same one-tape-node + pooled-scratch structure as the
+    //    float fast path above, so a <double> LSTM under a gradient tape trains FUSED (one backward
+    //    node, not ~5·seqLen decomposed tape ops) instead of throwing. Native double arithmetic +
+    //    scalar Math.Exp activations; the big GEMMs (Wx / dInput / dWih / dWhh) go through the generic
+    //    parallel BlasManaged.Gemm<double>, the tiny per-step recurrent GEMMs stay sequential. ──────
+
+    private static void GemmBigD(System.ReadOnlySpan<double> a, int lda, bool transA,
+                                 System.ReadOnlySpan<double> b, int ldb, bool transB,
+                                 System.Span<double> c, int m, int k, int n)
+    {
+        BlasManaged.BlasManaged.Gemm<double>(a, lda, transA, b, ldb, transB, c, n, m, n, k,
+            new BlasManaged.BlasOptions<double> { PackingMode = BlasManaged.PackingMode.DisableAutotune });
+    }
+
+    private static void SigmoidExactInPlaceD(double[] buf, int off, int len)
+    {
+        for (int i = off; i < off + len; i++) buf[i] = 1.0 / (1.0 + Math.Exp(-buf[i]));
+    }
+
+    private static void TanhExactInPlaceD(double[] buf, int off, int len)
+    {
+        // tanh(x) = 2/(1+exp(-2x)) - 1 (overflow-safe; large |x| → ±1, never NaN).
+        for (int i = off; i < off + len; i++) buf[i] = 2.0 / (1.0 + Math.Exp(-2.0 * buf[i])) - 1.0;
+    }
+
+    private Tensor<double> LstmSequenceForwardDoubleTrain(
+        Tensor<double> input, Tensor<double>? h0, Tensor<double>? c0,
+        Tensor<double> wIh, Tensor<double> wHh, Tensor<double>? bIh, Tensor<double>? bHh,
+        int batch, int seqLen, int inFeatures, int hidden, int gateRows,
+        bool returnSequences, bool wantState,
+        out Tensor<double> finalHidden, out Tensor<double> finalCell)
+    {
+        if (wantState && DifferentiableOps.ThreadTapeActive())
+        {
+            throw new ArgumentException(
+                "LstmSequenceForwardDoubleTrain: wantState=true is not supported under an active gradient tape. " +
+                "The fused BPTT node records gradients only for the sequence output; the returned finalHidden / " +
+                "finalCell carry no backward edge. Set wantState=false, or slice the final state out of the output.",
+                nameof(wantState));
+        }
+
+        int G = gateRows;
+        int totalRows = batch * seqLen;
+
+        var inSpan = input.AsSpan();
+        var wIhSpan = wIh.AsSpan();
+        var wHhSpan = wHh.AsSpan();
+        double[]? bIhArr = bIh?.ToArray();
+        double[]? bHhArr = bHh?.ToArray();
+        double[]? h0Arr = h0?.ToArray();
+        double[]? c0Arr = c0?.ToArray();
+
+        // Saved state (captured by the backward closure). Layout matches the float path.
+        var gates = new double[totalRows * G];
+        var cells = new double[batch * (seqLen + 1) * hidden];
+        var hiddens = new double[batch * (seqLen + 1) * hidden];
+
+        for (int b = 0; b < batch; b++)
+        {
+            int baseTc = b * (seqLen + 1) * hidden;
+            for (int h = 0; h < hidden; h++)
+            {
+                cells[baseTc + h] = c0Arr is null ? 0.0 : c0Arr[b * hidden + h];
+                hiddens[baseTc + h] = h0Arr is null ? 0.0 : h0Arr[b * hidden + h];
+            }
+        }
+
+        // Wx[b,t,:] = wIh @ x[b,t] (+ bIh): one big GEMM x[totalRows, inF] @ wIh^T[inF, G].
+        var wx = new double[totalRows * G];
+        GemmBigD(inSpan, inFeatures, false, wIhSpan, inFeatures, true,
+                 wx.AsSpan(0, totalRows * G), totalRows, inFeatures, G);
+        if (bIhArr is not null)
+            for (int r = 0; r < totalRows; r++)
+            {
+                int off = r * G;
+                for (int g = 0; g < G; g++) wx[off + g] += bIhArr[g];
+            }
+
+        // Pre-transpose wHh [G, hidden] → wHhT [hidden, G] for the per-step recurrent GEMM.
+        var wHhT = new double[hidden * G];
+        for (int g = 0; g < G; g++)
+            for (int h = 0; h < hidden; h++)
+                wHhT[h * G + g] = wHhSpan[g * hidden + h];
+
+        var output = returnSequences
+            ? new Tensor<double>(new[] { batch, seqLen, hidden })
+            : new Tensor<double>(new[] { batch, hidden });
+        var outSpan = output.AsWritableSpan();
+
+        if (seqLen == 0)
+        {
+            if (!returnSequences)
+                for (int b = 0; b < batch; b++)
+                    for (int h = 0; h < hidden; h++)
+                        outSpan[b * hidden + h] = h0Arr is null ? 0.0 : h0Arr[b * hidden + h];
+            if (wantState)
+            {
+                finalHidden = new Tensor<double>(new[] { batch, hidden });
+                finalCell = new Tensor<double>(new[] { batch, hidden });
+                var fh0 = finalHidden.AsWritableSpan(); var fc0 = finalCell.AsWritableSpan();
+                for (int b = 0; b < batch; b++)
+                    for (int h = 0; h < hidden; h++)
+                    {
+                        fh0[b * hidden + h] = h0Arr is null ? 0.0 : h0Arr[b * hidden + h];
+                        fc0[b * hidden + h] = c0Arr is null ? 0.0 : c0Arr[b * hidden + h];
+                    }
+            }
+            else { finalHidden = new Tensor<double>(new[] { 0 }); finalCell = new Tensor<double>(new[] { 0 }); }
+            return output;
+        }
+
+        var hPrev = new double[batch * hidden];
+        var hh = new double[batch * G];
+        for (int b = 0; b < batch; b++)
+            Array.Copy(hiddens, b * (seqLen + 1) * hidden, hPrev, b * hidden, hidden);
+
+        int bh = batch * hidden;
+        var act = new double[4 * bh];
+        var cbuf = new double[bh];
+
+        for (int t = 0; t < seqLen; t++)
+        {
+            // hh = h_prev @ wHhT → [batch, G]. BlasManaged double microkernel — the generic
+            // MatrixMultiplyHelper.MultiplyBlocked is ~128x slower at this tiny per-step shape
+            // (measured 320ms vs 2.5ms for the 32-step loop), which was the whole double-vs-float gap.
+            GemmBigD(hPrev.AsSpan(0, batch * hidden), hidden, false,
+                     wHhT.AsSpan(0, hidden * G), G, false,
+                     hh.AsSpan(0, batch * G), batch, hidden, G);
+
+            for (int b = 0; b < batch; b++)
+            {
+                int wxBase = (b * seqLen + t) * G;
+                int hhBase = b * G;
+                for (int g = 0; g < 4; g++)
+                {
+                    int wxg = wxBase + g * hidden, hhg = hhBase + g * hidden, dst = g * bh + b * hidden;
+                    if (bHhArr is not null)
+                    {
+                        int bOff = g * hidden;
+                        for (int h = 0; h < hidden; h++) act[dst + h] = wx[wxg + h] + hh[hhg + h] + bHhArr[bOff + h];
+                    }
+                    else
+                        for (int h = 0; h < hidden; h++) act[dst + h] = wx[wxg + h] + hh[hhg + h];
+                }
+            }
+
+            SigmoidExactInPlaceD(act, 0 * bh, bh);
+            SigmoidExactInPlaceD(act, 1 * bh, bh);
+            TanhExactInPlaceD(act, 2 * bh, bh);
+            SigmoidExactInPlaceD(act, 3 * bh, bh);
+
+            for (int b = 0; b < batch; b++)
+            {
+                int cPrevRow = (b * (seqLen + 1) + t) * hidden;
+                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
+                int gb = b * hidden;
+                for (int h = 0; h < hidden; h++)
+                {
+                    double c = act[1 * bh + gb + h] * cells[cPrevRow + h] + act[0 * bh + gb + h] * act[2 * bh + gb + h];
+                    cells[cCurRow + h] = c;
+                    cbuf[gb + h] = c;
+                }
+            }
+            TanhExactInPlaceD(cbuf, 0, bh);
+
+            for (int b = 0; b < batch; b++)
+            {
+                int gateRow = (b * seqLen + t) * G;
+                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
+                int outRow = returnSequences ? (b * seqLen + t) * hidden : b * hidden;
+                int gb = b * hidden;
+                bool writeOut = returnSequences || t == seqLen - 1;
+                for (int h = 0; h < hidden; h++)
+                {
+                    double hOut = act[3 * bh + gb + h] * cbuf[gb + h];
+                    gates[gateRow + 0 * hidden + h] = act[0 * bh + gb + h];
+                    gates[gateRow + 1 * hidden + h] = act[1 * bh + gb + h];
+                    gates[gateRow + 2 * hidden + h] = act[2 * bh + gb + h];
+                    gates[gateRow + 3 * hidden + h] = act[3 * bh + gb + h];
+                    hiddens[cCurRow + h] = hOut;
+                    if (writeOut) outSpan[outRow + h] = hOut;
+                }
+            }
+
+            for (int b = 0; b < batch; b++)
+                Array.Copy(hiddens, (b * (seqLen + 1) + t + 1) * hidden, hPrev, b * hidden, hidden);
+        }
+
+        if (wantState)
+        {
+            finalHidden = new Tensor<double>(new[] { batch, hidden });
+            finalCell = new Tensor<double>(new[] { batch, hidden });
+            var fh = finalHidden.AsWritableSpan(); var fc = finalCell.AsWritableSpan();
+            for (int b = 0; b < batch; b++)
+                for (int h = 0; h < hidden; h++)
+                {
+                    fh[b * hidden + h] = hiddens[(b * (seqLen + 1) + seqLen) * hidden + h];
+                    fc[b * hidden + h] = cells[(b * (seqLen + 1) + seqLen) * hidden + h];
+                }
+        }
+        else { finalHidden = new Tensor<double>(new[] { 0 }); finalCell = new Tensor<double>(new[] { 0 }); }
+
+        int nInputs = 3 + (bIh is not null ? 1 : 0) + (bHh is not null ? 1 : 0)
+                        + (h0 is not null ? 1 : 0) + (c0 is not null ? 1 : 0);
+        var inputsArr = new Tensor<double>[nInputs];
+        int idx = 0;
+        inputsArr[idx++] = input;
+        inputsArr[idx++] = wIh;
+        inputsArr[idx++] = wHh;
+        int idxBIh = bIh is not null ? idx : -1; if (bIh is not null) inputsArr[idx++] = bIh;
+        int idxBHh = bHh is not null ? idx : -1; if (bHh is not null) inputsArr[idx++] = bHh;
+        int idxH0 = h0 is not null ? idx : -1; if (h0 is not null) inputsArr[idx++] = h0;
+        int idxC0 = c0 is not null ? idx : -1; if (c0 is not null) inputsArr[idx++] = c0;
+
+        var meta = new int[] { batch, seqLen, inFeatures, hidden, returnSequences ? 1 : 0,
+                               idxBIh, idxBHh, idxH0, idxC0 };
+        var savedState = new object[] { gates, cells, hiddens, meta };
+
+        DifferentiableOps.RecordIfActive<double>(
+            "LstmSequenceForward", output, inputsArr, LstmSequenceBackwardDouble, savedState);
+
+        return output;
+    }
+
+    /// <summary>
+    /// BPTT backward for the fused double LSTM (mirror of <see cref="LstmSequenceBackwardFloat"/>).
+    /// Native double arithmetic; pooled backward scratch; big GEMMs via the generic parallel
+    /// BlasManaged.Gemm&lt;double&gt;, the per-step recurrent GEMM sequential.
+    /// </summary>
+    private static void LstmSequenceBackwardDouble(
+        Tensor<double> gradOutput, Tensor<double>[] inp, Tensor<double> output,
+        object[] savedState, IEngine engine, System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads)
+    {
+        var gates = (double[])savedState[0];
+        var cells = (double[])savedState[1];
+        var hiddens = (double[])savedState[2];
+        var meta = (int[])savedState[3];
+        int batch = meta[0], seqLen = meta[1], inFeatures = meta[2], hidden = meta[3];
+        bool returnSequences = meta[4] != 0;
+        int idxBIh = meta[5], idxBHh = meta[6], idxH0 = meta[7], idxC0 = meta[8];
+        int G = 4 * hidden;
+        int totalRows = batch * seqLen;
+
+        var input = inp[0];
+        var wIh = inp[1];
+        var wHh = inp[2];
+        var gradOutSpan = gradOutput.AsSpan();
+
+        var pool = System.Buffers.ArrayPool<double>.Shared;
+        var dgatesAll = pool.Rent(totalRows * G);
+        var dhNext = pool.Rent(batch * hidden);
+        var dcNext = pool.Rent(batch * hidden);
+        System.Array.Clear(dhNext, 0, batch * hidden);
+        System.Array.Clear(dcNext, 0, batch * hidden);
+        var dgatesT = pool.Rent(batch * G);
+        var dhPrev = pool.Rent(batch * hidden);
+
+        for (int t = seqLen - 1; t >= 0; t--)
+        {
+            for (int b = 0; b < batch; b++)
+            {
+                int gateRow = (b * seqLen + t) * G;
+                int cPrevRow = (b * (seqLen + 1) + t) * hidden;
+                int cCurRow = (b * (seqLen + 1) + t + 1) * hidden;
+                int dgtRow = b * G;
+                int carryRow = b * hidden;
+
+                int goRow = returnSequences ? (b * seqLen + t) * hidden : b * hidden;
+                bool feedThisStep = returnSequences || t == seqLen - 1;
+
+                for (int h = 0; h < hidden; h++)
+                {
+                    double ig = gates[gateRow + 0 * hidden + h];
+                    double fg = gates[gateRow + 1 * hidden + h];
+                    double gg = gates[gateRow + 2 * hidden + h];
+                    double og = gates[gateRow + 3 * hidden + h];
+                    double cCur = cells[cCurRow + h];
+                    double cPrev = cells[cPrevRow + h];
+
+                    double dhTotal = dhNext[carryRow + h] + (feedThisStep ? gradOutSpan[goRow + h] : 0.0);
+                    double tc = Math.Tanh(cCur);
+
+                    double doPre = dhTotal * tc * og * (1.0 - og);                  // sigmoid'
+                    double dcTotal = dcNext[carryRow + h] + dhTotal * og * (1.0 - tc * tc); // tanh'
+
+                    double diPre = dcTotal * gg * ig * (1.0 - ig);
+                    double dgPre = dcTotal * ig * (1.0 - gg * gg);
+                    double dfPre = dcTotal * cPrev * fg * (1.0 - fg);
+                    dcNext[carryRow + h] = dcTotal * fg;
+
+                    dgatesT[dgtRow + 0 * hidden + h] = diPre;
+                    dgatesT[dgtRow + 1 * hidden + h] = dfPre;
+                    dgatesT[dgtRow + 2 * hidden + h] = dgPre;
+                    dgatesT[dgtRow + 3 * hidden + h] = doPre;
+
+                    dgatesAll[gateRow + 0 * hidden + h] = diPre;
+                    dgatesAll[gateRow + 1 * hidden + h] = dfPre;
+                    dgatesAll[gateRow + 2 * hidden + h] = dgPre;
+                    dgatesAll[gateRow + 3 * hidden + h] = doPre;
+                }
+            }
+
+            // dh_prev = dgates_t @ wHh → [batch, hidden]; carried to t-1. BlasManaged double
+            // microkernel (NOT the generic MultiplyBlocked — ~128x slower at this per-step shape).
+            GemmBigD(dgatesT.AsSpan(0, batch * G), G, false,
+                     wHh.AsSpan().Slice(0, G * hidden), hidden, false,
+                     dhPrev.AsSpan(0, batch * hidden), batch, G, hidden);
+            Array.Copy(dhPrev, dhNext, batch * hidden);
+        }
+
+        // gradInput = dgatesAll @ wIh → [totalRows, inFeatures]
+        var gradInput = new Tensor<double>(new[] { batch, seqLen, inFeatures });
+        GemmBigD(dgatesAll.AsSpan(0, totalRows * G), G, false,
+                 wIh.AsSpan().Slice(0, G * inFeatures), inFeatures, false,
+                 gradInput.AsWritableSpan(), totalRows, G, inFeatures);
+        DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
+
+        // gradWIh = dgatesAll^T @ input2d → [G, inFeatures]
+        var gradWIh = new Tensor<double>(new[] { G, inFeatures });
+        GemmBigD(dgatesAll.AsSpan(0, totalRows * G), G, true,
+                 input.AsSpan(), inFeatures, false,
+                 gradWIh.AsWritableSpan(), G, totalRows, inFeatures);
+        DifferentiableOps.AccumulateGrad(grads, wIh, gradWIh, engine);
+
+        // gradWHh = dgatesAll^T @ hPrevAll → [G, hidden]; hPrevAll[b,t] = h_{t-1}.
+        var hPrevAll = pool.Rent(totalRows * hidden);
+        for (int b = 0; b < batch; b++)
+            for (int t = 0; t < seqLen; t++)
+                Array.Copy(hiddens, (b * (seqLen + 1) + t) * hidden,
+                           hPrevAll, (b * seqLen + t) * hidden, hidden);
+        var gradWHh = new Tensor<double>(new[] { G, hidden });
+        GemmBigD(dgatesAll.AsSpan(0, totalRows * G), G, true,
+                 hPrevAll.AsSpan(0, totalRows * hidden), hidden, false,
+                 gradWHh.AsWritableSpan(), G, totalRows, hidden);
+        DifferentiableOps.AccumulateGrad(grads, wHh, gradWHh, engine);
+
+        // gradBIh = gradBHh = column-sum of dgatesAll over (b,t) → [G].
+        if (idxBIh >= 0 || idxBHh >= 0)
+        {
+            var gradB = new double[G];
+            for (int r = 0; r < totalRows; r++)
+            {
+                int off = r * G;
+                for (int g = 0; g < G; g++) gradB[g] += dgatesAll[off + g];
+            }
+            if (idxBIh >= 0)
+            {
+                var gb = new Tensor<double>(new[] { G });
+                gradB.AsSpan().CopyTo(gb.AsWritableSpan());
+                DifferentiableOps.AccumulateGrad(grads, inp[idxBIh], gb, engine);
+            }
+            if (idxBHh >= 0)
+            {
+                var gb = new Tensor<double>(new[] { G });
+                gradB.AsSpan().CopyTo(gb.AsWritableSpan());
+                DifferentiableOps.AccumulateGrad(grads, inp[idxBHh], gb, engine);
+            }
+        }
+
+        if (idxH0 >= 0)
+        {
+            var gh0 = new Tensor<double>(new[] { batch, hidden });
+            dhNext.AsSpan(0, batch * hidden).CopyTo(gh0.AsWritableSpan());
+            DifferentiableOps.AccumulateGrad(grads, inp[idxH0], gh0, engine);
+        }
+        if (idxC0 >= 0)
+        {
+            var gc0 = new Tensor<double>(new[] { batch, hidden });
+            dcNext.AsSpan(0, batch * hidden).CopyTo(gc0.AsWritableSpan());
+            DifferentiableOps.AccumulateGrad(grads, inp[idxC0], gc0, engine);
+        }
+
+        pool.Return(dgatesAll);
+        pool.Return(dhNext);
+        pool.Return(dcNext);
+        pool.Return(dgatesT);
+        pool.Return(dhPrev);
+        pool.Return(hPrevAll);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -238,6 +238,14 @@ public partial class CpuEngine
     }
 
     /// <summary>
+    /// Broadcasts one attention-mask axis index per the IEngine contract (the mask is broadcastable
+    /// to [batch, heads, seq_q, seq_k]): a size-1 axis maps EVERY index to 0 (NumPy-style), so a
+    /// shared mask such as [1, 1, seq, seq] or [batch, 1, seq, seq] is read correctly instead of
+    /// indexing past its bounds. Returns <paramref name="idx"/> unchanged when the axis is full-sized.
+    /// </summary>
+    private static int BroadcastMaskIndex(int idx, int dimSize) => dimSize == 1 ? 0 : idx;
+
+    /// <summary>
     /// Transpose-fused scaled-dot-product attention for the MHA float path
     /// (#476 root-cause-2). Reads Q/K/V for each (batch, head) slice DIRECTLY
     /// from the fused QKV projection buffer — no separate [B,H,seq,dHead]
@@ -267,6 +275,15 @@ public partial class CpuEngine
         int scoff = 3 * seq * dHead;      // dHead*seq == seq*dHead
         int scratchLen = 3 * seq * dHead + seq * seq;
 
+        // Mask broadcasting (IEngine contract: the attention mask is broadcastable to
+        // [batch, heads, seq_q, seq_k] — e.g. [1,1,seq,seq] shared-causal or [batch,1,seq,seq]
+        // per-batch padding). A size-1 dimension maps every index to 0 (NumPy-style); without this
+        // a broadcast mask would index past its bounds (IndexOutOfRangeException / wrong data).
+        int mB = mask is null ? 1 : mask.Shape[0];
+        int mH = mask is null ? 1 : mask.Shape[1];
+        int mSq = mask is null ? 1 : mask.Shape[2];
+        int mSk = mask is null ? 1 : mask.Shape[3];
+
         // Parallelize over batch·heads using the SAME PersistentParallelExecutor as
         // the GEMMs/LayerNorm (NOT Parallel.For/ThreadPool) — a second pool in the
         // forward pass oversubscribed the cores and forced park/wakeup between ops.
@@ -282,6 +299,8 @@ public partial class CpuEngine
                 {
                 int b = bh / heads;
                 int h = bh % heads;
+                int mb = BroadcastMaskIndex(b, mB);   // broadcast batch/head indices into the mask
+                int mh = BroadcastMaskIndex(h, mH);
                 int hQ = qCol + h * dHead;
                 int hK = kCol + h * dHead;
                 int hV = vCol + h * dHead;
@@ -358,7 +377,7 @@ public partial class CpuEngine
                         for (int j = 0; j < seq; j++)
                         {
                             float v = scratch[rowOff + j] * scaleF;
-                            if (mask != null && !mask[b, h, i, j]) v = negInfF;
+                            if (mask != null && !mask[mb, mh, BroadcastMaskIndex(i, mSq), BroadcastMaskIndex(j, mSk)]) v = negInfF;
                             if (v > maxVal) maxVal = v;
                             scratch[rowOff + j] = v;
                         }
@@ -514,6 +533,15 @@ public partial class CpuEngine
         int scoff = 3 * seq * dHead;
         int scratchLen = 3 * seq * dHead + seq * seq;
         var pool = ArrayPool<double>.Shared;
+
+        // Mask broadcasting (IEngine contract: broadcastable to [batch, heads, seq_q, seq_k]). A
+        // size-1 dimension maps every index to 0; without this a broadcast mask (e.g. [1,1,seq,seq])
+        // indexes past its bounds. See BroadcastMaskIndex.
+        int mB = mask is null ? 1 : mask.Shape[0];
+        int mH = mask is null ? 1 : mask.Shape[1];
+        int mSq = mask is null ? 1 : mask.Shape[2];
+        int mSk = mask is null ? 1 : mask.Shape[3];
+
         int chunks = Math.Max(1, Math.Min(bhCount, CpuParallelSettings.MaxDegreeOfParallelism));
 
         PersistentParallelExecutor.Instance.Execute(chunks, chunk =>
@@ -525,6 +553,8 @@ public partial class CpuEngine
                 {
                     int b = bh / heads;
                     int h = bh % heads;
+                    int mb = BroadcastMaskIndex(b, mB);   // broadcast batch/head indices into the mask
+                    int mh = BroadcastMaskIndex(h, mH);
                     int headOff = h * dHead;
 
                     // Gather: Q [seq×dHead], V [seq×dHead] contiguous; K transposed into [dHead×seq].
@@ -558,7 +588,7 @@ public partial class CpuEngine
                         for (int j = 0; j < seq; j++)
                         {
                             double v = scratch[rowOff + j] * scaleValue;
-                            if (mask != null && !mask[b, h, i, j]) v = double.NegativeInfinity;
+                            if (mask != null && !mask[mb, mh, BroadcastMaskIndex(i, mSq), BroadcastMaskIndex(j, mSk)]) v = double.NegativeInfinity;
                             if (v > maxVal) maxVal = v;
                             scratch[rowOff + j] = v;
                         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -121,6 +121,22 @@ public partial class CpuEngine
                 mask,
                 batch, seqLen, dModel, numHeads, dHead);
 
+        // Double fast path (#478 / #1675): the generic-T path below materializes the FULL
+        // [B*heads, seq, seq] attention scores + weights + four strided-transpose tensors per call,
+        // none pooled (scores exceed ArrayPool.Shared's 2^20-element bucket). At paper scale that is
+        // ~50x the float path's allocation per MHA layer (measured 54x), and the resulting GC/heap
+        // churn — not the math — is what makes a <double> transformer forward ~65x slower than
+        // <float> on a memory-bounded host. Route double through the same per-head, single-reused-
+        // scratch structure the float fast path uses (no full-scores matrix, no transpose buffers).
+        if (typeof(T) == typeof(double))
+            return (Tensor<T>)(object)MultiHeadAttentionForwardDouble(
+                (Tensor<double>)(object)input,
+                (Tensor<double>)(object)qWeight,
+                (Tensor<double>)(object)kWeight,
+                (Tensor<double>)(object)vWeight,
+                (Tensor<double>)(object)outWeight,
+                mask, batch, seqLen, dModel, numHeads, dHead);
+
         return MultiHeadAttentionForwardGeneric(
             input, qWeight, kWeight, vWeight, outWeight, mask,
             batch, seqLen, dModel, numHeads, dHead);
@@ -405,6 +421,188 @@ public partial class CpuEngine
         return m;
     }
 #endif
+
+    /// <summary>
+    /// Double fast path (#478 / #1675). Same allocation discipline as the float fast path — fused
+    /// Q/K/V projections into pooled scratch, a per-head fused SDPA that reuses ONE pooled scratch
+    /// buffer across all heads (never materializing the full [B*H, seq, seq] scores or the four
+    /// strided transposes the generic path allocates), and the output projection — but in managed
+    /// (no-intrinsic) code so it runs on both TFMs. The per-head math is identical to
+    /// <see cref="ScaledDotProductAttention{T}"/>'s double path; only the buffering changes.
+    /// </summary>
+    private Tensor<double> MultiHeadAttentionForwardDouble(
+        Tensor<double> input,
+        Tensor<double> qWeight, Tensor<double> kWeight, Tensor<double> vWeight, Tensor<double> outWeight,
+        Tensor<bool>? mask,
+        int batch, int seqLen, int dModel, int numHeads, int dHead)
+    {
+        int totalRows = batch * seqLen;
+        int proj = totalRows * dModel;
+        var ops = MathHelper.GetNumericOperations<double>();
+        var pool = ArrayPool<double>.Shared;
+
+        // Pooled projection scratch (returned at end of call) instead of fresh Tensor intermediates.
+        var qBuf = pool.Rent(proj);
+        var kBuf = pool.Rent(proj);
+        var vBuf = pool.Rent(proj);
+        var concatBuf = pool.Rent(proj);
+        var output = AutoTensorCache.RentOrAllocate<double>(new[] { batch, seqLen, dModel });
+        try
+        {
+            var inArr = input.GetFlattenedData();
+            var qW = qWeight.GetFlattenedData();
+            var kW = kWeight.GetFlattenedData();
+            var vW = vWeight.GetFlattenedData();
+            var oW = outWeight.GetFlattenedData();
+            var inMem = new ReadOnlyMemory<double>(inArr, 0, proj);
+
+            // Q/K/V = input[totalRows, dModel] @ W[dModel, dModel]. MultiplyBlocked accumulates into C,
+            // so the (un-zeroed) pooled destination must be cleared first.
+            void Project(double[] w, double[] dst)
+            {
+                Array.Clear(dst, 0, proj);
+                MatrixMultiplyHelper.MultiplyBlocked(ops, inMem,
+                    new ReadOnlyMemory<double>(w, 0, dModel * dModel),
+                    new Memory<double>(dst, 0, proj),
+                    totalRows, dModel, dModel, dModel, dModel, dModel, allowParallel: true);
+            }
+            Project(qW, qBuf);
+            Project(kW, kBuf);
+            Project(vW, vBuf);
+
+            MultiHeadAttentionFusedSdpaDouble(qBuf, kBuf, vBuf, dModel, mask,
+                1.0 / Math.Sqrt(dHead), batch, numHeads, seqLen, dHead, concatBuf, dModel);
+
+            // Output projection: concat[totalRows, dModel] @ outWeight[dModel, dModel] -> output.
+            var outArr = output.GetDataArray();
+            Array.Clear(outArr, 0, proj);
+            MatrixMultiplyHelper.MultiplyBlocked(ops,
+                new ReadOnlyMemory<double>(concatBuf, 0, proj),
+                new ReadOnlyMemory<double>(oW, 0, dModel * dModel),
+                new Memory<double>(outArr, 0, proj),
+                totalRows, dModel, dModel, dModel, dModel, dModel, allowParallel: true);
+
+            return output;
+        }
+        finally
+        {
+            pool.Return(qBuf);
+            pool.Return(kBuf);
+            pool.Return(vBuf);
+            pool.Return(concatBuf);
+        }
+    }
+
+    /// <summary>
+    /// Per-head fused SDPA for the double MHA fast path. Mirrors the float
+    /// <see cref="MultiHeadAttentionFusedSdpa"/>: each (batch, head) slice gathers Q/V contiguous
+    /// and K already-transposed into ONE pooled scratch (reused across the chunk's slices), runs
+    /// Q·Kᵀ → scaled+masked stable softmax → P·V, and scatters into <paramref name="concat"/> in
+    /// [B, seq, H, dHead] = [B*seq, dModel] layout. No full-scores matrix, no transpose buffers.
+    /// </summary>
+    private void MultiHeadAttentionFusedSdpaDouble(
+        double[] qd, double[] kd, double[] vd, int rowStride,
+        Tensor<bool>? mask, double scaleValue,
+        int batch, int heads, int seq, int dHead,
+        double[] concat, int dModel)
+    {
+        int bhCount = batch * heads;
+        var ops = MathHelper.GetNumericOperations<double>();
+        int qSoff = 0;
+        int vSoff = seq * dHead;
+        int ktoff = 2 * seq * dHead;
+        int scoff = 3 * seq * dHead;
+        int scratchLen = 3 * seq * dHead + seq * seq;
+        var pool = ArrayPool<double>.Shared;
+        int chunks = Math.Max(1, Math.Min(bhCount, CpuParallelSettings.MaxDegreeOfParallelism));
+
+        PersistentParallelExecutor.Instance.Execute(chunks, chunk =>
+        {
+            var scratch = pool.Rent(scratchLen);
+            try
+            {
+                for (int bh = chunk; bh < bhCount; bh += chunks)
+                {
+                    int b = bh / heads;
+                    int h = bh % heads;
+                    int headOff = h * dHead;
+
+                    // Gather: Q [seq×dHead], V [seq×dHead] contiguous; K transposed into [dHead×seq].
+                    for (int s = 0; s < seq; s++)
+                    {
+                        int row = (b * seq + s) * rowStride + headOff;
+                        int qdst = qSoff + s * dHead;
+                        int vdst = vSoff + s * dHead;
+                        for (int d = 0; d < dHead; d++)
+                        {
+                            scratch[qdst + d] = qd[row + d];
+                            scratch[vdst + d] = vd[row + d];
+                            scratch[ktoff + d * seq + s] = kd[row + d];   // Kᵀ
+                        }
+                    }
+
+                    // scores[seq×seq] = Q[seq×dHead] · Kᵀ[dHead×seq]. MultiplyBlocked accumulates → clear.
+                    var scoresMem = new Memory<double>(scratch, scoff, seq * seq);
+                    scoresMem.Span.Clear();
+                    MatrixMultiplyHelper.MultiplyBlocked(ops,
+                        new ReadOnlyMemory<double>(scratch, qSoff, seq * dHead),
+                        new ReadOnlyMemory<double>(scratch, ktoff, dHead * seq),
+                        scoresMem,
+                        seq, dHead, seq, dHead, seq, seq, allowParallel: false);
+
+                    // In-place scale + numerically-stable softmax, row by row.
+                    for (int i = 0; i < seq; i++)
+                    {
+                        int rowOff = scoff + i * seq;
+                        double maxVal = double.NegativeInfinity;
+                        for (int j = 0; j < seq; j++)
+                        {
+                            double v = scratch[rowOff + j] * scaleValue;
+                            if (mask != null && !mask[b, h, i, j]) v = double.NegativeInfinity;
+                            if (v > maxVal) maxVal = v;
+                            scratch[rowOff + j] = v;
+                        }
+                        if (double.IsNegativeInfinity(maxVal))
+                        {
+                            for (int j = 0; j < seq; j++) scratch[rowOff + j] = 0d;
+                            continue;
+                        }
+                        double sumExp = 0d;
+                        for (int j = 0; j < seq; j++)
+                        {
+                            double e = Math.Exp(scratch[rowOff + j] - maxVal);
+                            scratch[rowOff + j] = e;
+                            sumExp += e;
+                        }
+                        double inv = sumExp != 0d ? 1d / sumExp : 0d;
+                        for (int j = 0; j < seq; j++) scratch[rowOff + j] *= inv;
+                    }
+
+                    // out[seq×dHead] = P[seq×seq] · V[seq×dHead], reusing the Q region as output.
+                    var outMem = new Memory<double>(scratch, qSoff, seq * dHead);
+                    outMem.Span.Clear();
+                    MatrixMultiplyHelper.MultiplyBlocked(ops,
+                        new ReadOnlyMemory<double>(scratch, scoff, seq * seq),
+                        new ReadOnlyMemory<double>(scratch, vSoff, seq * dHead),
+                        outMem,
+                        seq, seq, dHead, seq, dHead, dHead, allowParallel: false);
+
+                    // Scatter into concat[B, seq, H, dHead] = [B*seq, dModel].
+                    for (int s = 0; s < seq; s++)
+                    {
+                        int dst = (b * seq + s) * dModel + headOff;
+                        int src = qSoff + s * dHead;
+                        for (int d = 0; d < dHead; d++)
+                            concat[dst + d] = scratch[src + d];
+                    }
+                }
+            }
+            finally
+            {
+                pool.Return(scratch);
+            }
+        });
+    }
 
     /// <summary>
     /// Generic-T path. Composes existing tensor-level primitives. Used for

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -13842,7 +13842,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         finally { poolKt.Return(kT); }
                     }
                 });
-                return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)new Vector<double>(gradInputD1x1));
+                return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)Vector<double>.FromMemory(gradInputD1x1));
             }
 #if !NET471
             // #415 Phase B: direct-kernel fast path for 3×3 stride=1 padding=1
@@ -13962,7 +13962,7 @@ public partial class CpuEngine : ITensorLevelEngine
                                 padH: 1, padW: 1, dilationH: 1, dilationW: 1);
                         }
                     }
-                    return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)new Vector<double>(gradInputDDirect));
+                    return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)Vector<double>.FromMemory(gradInputDDirect));
                     }
                     finally { poolFlip.Return(kernelFlippedBuf); }
                 }
@@ -14053,7 +14053,7 @@ public partial class CpuEngine : ITensorLevelEngine
                             outputHeight, outputWidth);
                     });
 
-                    return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)new Vector<double>(gradInputD));
+                    return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)Vector<double>.FromMemory(gradInputD));
                 }
                 finally
                 {
@@ -14107,7 +14107,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 finally { poolD.Return(colBuf); }
             });
 
-            return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)new Vector<double>(gradInputD));
+            return TensorAllocator.Rent<T>(inputShape, (Vector<T>)(object)Vector<double>.FromMemory(gradInputD));
         }
 
         // Generic fallback for non-float, non-double types
@@ -14908,7 +14908,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         }
                     }
                 }
-                return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)new Vector<double>(gradKernelD));
+                return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)Vector<double>.FromMemory(gradKernelD));
             }
 
 #if !NET471
@@ -14948,7 +14948,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         batch, inChannels, outChannels,
                         height, width, outputHeight, outputWidth,
                         padH: 1, padW: 1);
-                    return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)new Vector<double>(gradKernelD));
+                    return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)Vector<double>.FromMemory(gradKernelD));
                 }
             }
 #endif
@@ -14995,7 +14995,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         im2colAll, 0, batchColW, true,
                         gradKernelD, 0, colH))
                     {
-                        return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)new Vector<double>(gradKernelD));
+                        return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)Vector<double>.FromMemory(gradKernelD));
                     }
                     // BLAS declined (non-deterministic + no native BLAS): clear
                     // the partial destination and fall through to the per-batch
@@ -15092,7 +15092,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 kPoolD.Return(lg);
             }
 
-            return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)new Vector<double>(gradKernelD));
+            return TensorAllocator.Rent<T>(kernelShape, (Vector<T>)(object)Vector<double>.FromMemory(gradKernelD));
         }
 
         // Generic fallback for non-float, non-double types
@@ -21192,9 +21192,12 @@ public partial class CpuEngine : ITensorLevelEngine
             var outDArr = new double[logicalLength];
 #endif
             BatchNorm4DDouble(inD, gamD, betD, epsD, batch, channels, spatialSize, meanDArr, varDArr, outDArr);
-            mean = (Tensor<T>)(object)TensorAllocator.Rent<T>(new[] { channels }, (Vector<T>)(object)new Vector<double>(meanDArr));
-            variance = (Tensor<T>)(object)TensorAllocator.Rent<T>(new[] { channels }, (Vector<T>)(object)new Vector<double>(varDArr));
-            return (Tensor<T>)(object)TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)new Vector<double>(outDArr));
+            // #478: wrap the freshly-allocated result arrays with FromMemory (zero-copy hand-off, like
+            // the float path above) instead of `new Vector<double>(arr)`, which COPIED every array —
+            // doubling the output allocation (measured 4x the float path; now ~2x = just the bytes).
+            mean = (Tensor<T>)(object)TensorAllocator.Rent<T>(new[] { channels }, (Vector<T>)(object)Vector<double>.FromMemory(meanDArr));
+            variance = (Tensor<T>)(object)TensorAllocator.Rent<T>(new[] { channels }, (Vector<T>)(object)Vector<double>.FromMemory(varDArr));
+            return (Tensor<T>)(object)TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)Vector<double>.FromMemory(outDArr));
         }
 
         var meanData = new T[channels];
@@ -21985,9 +21988,9 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             });
 
-            gradGamma = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)new Vector<float>(ggF));
-            gradBeta = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)new Vector<float>(gbF));
-            return TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)new Vector<float>(giF));
+            gradGamma = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)Vector<float>.FromMemory(ggF));
+            gradBeta = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)Vector<float>.FromMemory(gbF));
+            return TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)Vector<float>.FromMemory(giF));
         }
 
         // Double fast path — replaces the per-channel scalar inner loops with
@@ -22009,9 +22012,9 @@ public partial class CpuEngine : ITensorLevelEngine
             BatchNormBackward4DDouble(goD, inD, gaD, meD, vaD, epsD,
                 batch, channels, spatialSize, elemD,
                 ggD, gbD, giD);
-            gradGamma = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)new Vector<double>(ggD));
-            gradBeta = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)new Vector<double>(gbD));
-            return TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)new Vector<double>(giD));
+            gradGamma = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)Vector<double>.FromMemory(ggD));
+            gradBeta = TensorAllocator.Rent<T>([channels], (Vector<T>)(object)Vector<double>.FromMemory(gbD));
+            return TensorAllocator.Rent<T>(input._shape, (Vector<T>)(object)Vector<double>.FromMemory(giD));
         }
 
         var gradGammaData = new T[channels];
@@ -25681,9 +25684,9 @@ public partial class CpuEngine : ITensorLevelEngine
             finally { System.Buffers.ArrayPool<float>.Shared.Return(gradWeights, clearArray: false); }
         });
 
-        gradValue = TensorAllocator.Rent<float>(value._shape, new Vector<float>(gradVData));
-        gradKey = TensorAllocator.Rent<float>(key._shape, new Vector<float>(gradKData));
-        return TensorAllocator.Rent<float>(query._shape, new Vector<float>(gradQData));
+        gradValue = TensorAllocator.Rent<float>(value._shape, Vector<float>.FromMemory(gradVData));
+        gradKey = TensorAllocator.Rent<float>(key._shape, Vector<float>.FromMemory(gradKData));
+        return TensorAllocator.Rent<float>(query._shape, Vector<float>.FromMemory(gradQData));
     }
 
     /// <summary>
@@ -25820,9 +25823,9 @@ public partial class CpuEngine : ITensorLevelEngine
             finally { System.Buffers.ArrayPool<double>.Shared.Return(gradWeights, clearArray: false); }
         });
 
-        gradValue = TensorAllocator.Rent<double>(value._shape, new Vector<double>(gradVData));
-        gradKey = TensorAllocator.Rent<double>(key._shape, new Vector<double>(gradKData));
-        return TensorAllocator.Rent<double>(query._shape, new Vector<double>(gradQData));
+        gradValue = TensorAllocator.Rent<double>(value._shape, Vector<double>.FromMemory(gradVData));
+        gradKey = TensorAllocator.Rent<double>(key._shape, Vector<double>.FromMemory(gradKData));
+        return TensorAllocator.Rent<double>(query._shape, Vector<double>.FromMemory(gradQData));
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardGradientDoubleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardGradientDoubleTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Validates the fused tape-aware <b>double</b> LSTM backward
+/// (CpuEngine.LstmSequenceForwardDoubleTrain + LstmSequenceBackwardDouble, the #478 follow-up that
+/// lets a &lt;double&gt; LSTM train through ONE fused BPTT node instead of throwing) against central
+/// finite differences for every differentiable input. Same structure as the float gradient test
+/// (<see cref="LstmFusedBackwardGradientTests"/>) but with a much tighter tolerance — double FD with
+/// central differences is accurate to ~1e-10, so a gate-coupling or transpose error in the BPTT
+/// would show up far outside the threshold.
+///
+/// The loss is a random-weighted sum of the output (non-trivial upstream gradient), and every loss
+/// evaluation runs under a tape so the FD forward uses the SAME exact-activation fused path as the
+/// analytic gradient.
+/// </summary>
+public class LstmFusedBackwardGradientDoubleTests
+{
+    private static Tensor<double> Rand(int[] shape, Random rng, double scale = 0.4)
+    {
+        var t = new Tensor<double>(shape);
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (rng.NextDouble() * 2 - 1) * scale;
+        return t;
+    }
+
+    private static double Loss(CpuEngine eng, Tensor<double> input, Tensor<double>? h0, Tensor<double>? c0,
+        Tensor<double> wIh, Tensor<double> wHh, Tensor<double>? bIh, Tensor<double>? bHh,
+        Tensor<double> coeff, bool returnSequences)
+    {
+        using var tape = new GradientTape<double>();
+        var outp = eng.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+        var prod = eng.TensorMultiply(outp, coeff);
+        var loss = eng.ReduceSum(prod, null);
+        return loss.AsSpan()[0];
+    }
+
+    private static void CheckFiniteDiff(string name,
+        Tensor<double> analytic, Func<double> lossFn, Tensor<double> paramRef)
+    {
+        const double eps = 1e-5;
+        var pSpan = paramRef.AsWritableSpan();
+        var aSpan = analytic.AsSpan();
+        double maxAbsErr = 0.0, maxRel = 0.0;
+        for (int i = 0; i < pSpan.Length; i++)
+        {
+            double orig = pSpan[i];
+            pSpan[i] = orig + eps; double lp = lossFn();
+            pSpan[i] = orig - eps; double lm = lossFn();
+            pSpan[i] = orig;
+            double num = (lp - lm) / (2 * eps);
+            double ana = aSpan[i];
+            double absErr = Math.Abs(num - ana);
+            double rel = absErr / (1e-9 + Math.Abs(num) + Math.Abs(ana));
+            maxAbsErr = Math.Max(maxAbsErr, absErr);
+            maxRel = Math.Max(maxRel, rel);
+        }
+        // double central-difference FD is clean; require small absolute OR relative error per worst element.
+        Assert.True(maxAbsErr < 1e-6 || maxRel < 1e-6,
+            $"{name}: gradient mismatch vs finite-difference. maxAbsErr={maxAbsErr:E3}, maxRel={maxRel:E3}");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Gradients_MatchFiniteDifference_WithBiasesAndInitialStates(bool returnSequences)
+    {
+        var eng = new CpuEngine();
+        var rng = new Random(20260611);
+        int batch = 2, seq = 3, inF = 4, hidden = 5, G = 4 * hidden;
+
+        var input = Rand(new[] { batch, seq, inF }, rng);
+        var wIh = Rand(new[] { G, inF }, rng);
+        var wHh = Rand(new[] { G, hidden }, rng);
+        var bIh = Rand(new[] { G }, rng);
+        var bHh = Rand(new[] { G }, rng);
+        var h0 = Rand(new[] { batch, hidden }, rng);
+        var c0 = Rand(new[] { batch, hidden }, rng);
+        var coeff = Rand(returnSequences ? new[] { batch, seq, hidden } : new[] { batch, hidden }, rng);
+
+        Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            var outp = eng.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+            var loss = eng.ReduceSum(eng.TensorMultiply(outp, coeff), null);
+            grads = tape.ComputeGradients(loss, new[] { input, wIh, wHh, bIh, bHh, h0, c0 });
+        }
+
+        Func<double> L = () => Loss(eng, input, h0, c0, wIh, wHh, bIh, bHh, coeff, returnSequences);
+        CheckFiniteDiff("input", grads[input], L, input);
+        CheckFiniteDiff("wIh", grads[wIh], L, wIh);
+        CheckFiniteDiff("wHh", grads[wHh], L, wHh);
+        CheckFiniteDiff("bIh", grads[bIh], L, bIh);
+        CheckFiniteDiff("bHh", grads[bHh], L, bHh);
+        CheckFiniteDiff("h0", grads[h0], L, h0);
+        CheckFiniteDiff("c0", grads[c0], L, c0);
+    }
+
+    [Fact]
+    public void Gradients_MatchFiniteDifference_NoBiasesNoInitialStates()
+    {
+        var eng = new CpuEngine();
+        var rng = new Random(7);
+        int batch = 3, seq = 4, inF = 3, hidden = 4, G = 4 * hidden;
+
+        var input = Rand(new[] { batch, seq, inF }, rng);
+        var wIh = Rand(new[] { G, inF }, rng);
+        var wHh = Rand(new[] { G, hidden }, rng);
+        var coeff = Rand(new[] { batch, seq, hidden }, rng);
+
+        Dictionary<Tensor<double>, Tensor<double>> grads;
+        using (var tape = new GradientTape<double>())
+        {
+            var outp = eng.LstmSequenceForward(input, null, null, wIh, wHh, null, null, returnSequences: true);
+            var loss = eng.ReduceSum(eng.TensorMultiply(outp, coeff), null);
+            grads = tape.ComputeGradients(loss, new[] { input, wIh, wHh });
+        }
+
+        Func<double> L = () => Loss(eng, input, null, null, wIh, wHh, null, null, coeff, true);
+        CheckFiniteDiff("input", grads[input], L, input);
+        CheckFiniteDiff("wIh", grads[wIh], L, wIh);
+        CheckFiniteDiff("wHh", grads[wHh], L, wHh);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
@@ -155,5 +155,35 @@ public class MhaLeanSdpaAllocTests
             $"Double LSTM forward allocated {kbPerCall:F0} KB/call; expected < 8192 KB (buffer-reusing " +
             "path). Regressed to the per-timestep CreateZeros + per-step hidden-GEMM allocation (#478)?");
     }
+
+    // #478 regression guard for the systemic zero-copy result hand-off: BatchNorm (and the conv /
+    // SDPA / norm backward paths) must wrap their freshly-allocated result arrays with
+    // Vector<T>.FromMemory, NOT `new Vector<T>(arr)`, which routes through the IEnumerable<T> ctor and
+    // COPIES the whole array — doubling the result allocation (BatchNorm forward measured 4x the float
+    // path; FromMemory brings it to ~2x = just the bytes).
+    [Trait("Category", "Performance")]
+    [Fact]
+    public void BatchNormForward_Double_ZeroCopyHandoff_NotVectorCopy()
+    {
+        var eng = new CpuEngine();
+        const int n = 8, c = 256, h = 16, w = 16;
+        var r = new Random(2026);
+        var input = RandD(r, n, c, h, w);
+        var gamma = RandD(r, c); var beta = RandD(r, c);
+
+        for (int wi = 0; wi < 5; wi++) _ = eng.BatchNorm(input, gamma, beta, 1e-5, out _, out _);
+
+        const int reps = 10;
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < reps; i++) _ = eng.BatchNorm(input, gamma, beta, 1e-5, out _, out _);
+        long a1 = GC.GetAllocatedBytesForCurrentThread();
+        double kbPerCall = (a1 - a0) / 1024.0 / reps;
+
+        // Output [8,256,16,16] double ≈ 4 MB; the fixed path hands it off zero-copy. The reverted
+        // `new Vector<double>(outDArr)` path COPIED it (~8 MB/call). 6 MB threshold catches a revert.
+        Assert.True(kbPerCall < 6144,
+            $"Double BatchNorm allocated {kbPerCall:F0} KB/call; expected < 6144 KB (zero-copy " +
+            "FromMemory hand-off). Regressed to new Vector<double>(arr) which copies the result (#478)?");
+    }
 #endif
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
@@ -78,5 +78,48 @@ public class MhaLeanSdpaAllocTests
             $"MHA forward allocated {kbPerCall:F0} KB/call; expected < 3072 KB (lean ~1024, " +
             "old weight-materializing path ~7200). Regressed to the non-lean SDPA?");
     }
+
+    private static Tensor<double> RandD(Random r, params int[] s)
+    {
+        var t = new Tensor<double>(s);
+        var sp = t.AsWritableSpan();
+        for (int i = 0; i < sp.Length; i++) sp[i] = r.NextDouble() * 2 - 1;
+        return t;
+    }
+
+    // #478 / #1675 regression guard: <double> MHA forward must use the pooled per-head fast path
+    // (MultiHeadAttentionForwardDouble), NOT fall to MultiHeadAttentionForwardGeneric — which
+    // materializes the full [B*H, seq, seq] attention scores + weights + four transpose tensors per
+    // call (unpooled, > 2^20 elems), measured at 54x the float path's allocation per MHA layer and
+    // the direct cause of a <double> transformer forward being ~65x slower than <float> on a
+    // memory-bounded host (GC/heap churn, not math). Measured here at a seq where the generic path's
+    // full-scores allocation is large enough to be unambiguous.
+    [Trait("Category", "Performance")]
+    [Fact]
+    public void MhaForward_Double_UsesPooledFastPath_NotGenericFullScores()
+    {
+        var eng = new CpuEngine();
+        const int batch = 1, seq = 256, dModel = 1280, numHeads = 20;
+        var r = new Random(2026);
+        var input = RandD(r, batch, seq, dModel);
+        var qW = RandD(r, dModel, dModel); var kW = RandD(r, dModel, dModel);
+        var vW = RandD(r, dModel, dModel); var oW = RandD(r, dModel, dModel);
+
+        for (int w = 0; w < 5; w++) _ = eng.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads);
+
+        const int n = 10;
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < n; i++) _ = eng.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads);
+        long a1 = GC.GetAllocatedBytesForCurrentThread();
+        double kbPerCall = (a1 - a0) / 1024.0 / n;
+
+        // Fast path: pooled Q/K/V/concat scratch + one output tensor — a few MB/call. The generic
+        // full-scores path it replaced allocated ~tens of MB/call at this shape (the [1,20,256,256]
+        // scores + weights alone are ~10 MB each in double). 16 MB threshold catches a revert with
+        // a wide margin against measurement noise.
+        Assert.True(kbPerCall < 16384,
+            $"Double MHA forward allocated {kbPerCall:F0} KB/call; expected < 16384 KB (pooled fast " +
+            "path). Regressed to MultiHeadAttentionForwardGeneric's full-scores path (#478/#1675)?");
+    }
 #endif
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MhaLeanSdpaAllocTests.cs
@@ -121,5 +121,39 @@ public class MhaLeanSdpaAllocTests
             $"Double MHA forward allocated {kbPerCall:F0} KB/call; expected < 16384 KB (pooled fast " +
             "path). Regressed to MultiHeadAttentionForwardGeneric's full-scores path (#478/#1675)?");
     }
+
+    // #478 regression guard for the generic (double) LSTM forward: it must reuse ping-pong state
+    // buffers + a pooled hidden-GEMM buffer across timesteps, NOT allocate a fresh hCurr/cCurr +
+    // hidden GEMM output EVERY step (which measured ~25-28x the float fast path's allocation on a
+    // 64-step LSTM and is the same GC-churn class as the MHA #478 fix).
+    [Trait("Category", "Performance")]
+    [Fact]
+    public void LstmForward_Double_ReusesBuffers_NotPerStepAlloc()
+    {
+        var eng = new CpuEngine();
+        const int batch = 4, seq = 128, inF = 256, hidden = 256;
+        var r = new Random(2026);
+        var input = RandD(r, batch, seq, inF);
+        var wIh = RandD(r, 4 * hidden, inF);
+        var wHh = RandD(r, 4 * hidden, hidden);
+        var bIh = RandD(r, 4 * hidden);
+        var bHh = RandD(r, 4 * hidden);
+
+        for (int w = 0; w < 5; w++) _ = eng.LstmSequenceForward(input, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+
+        const int n = 10;
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < n; i++) _ = eng.LstmSequenceForward(input, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+        long a1 = GC.GetAllocatedBytesForCurrentThread();
+        double kbPerCall = (a1 - a0) / 1024.0 / n;
+
+        // After the ping-pong + pooled-GEMM fix this is a small constant per call (state buffers +
+        // one-time input projection + output). The pre-fix per-step path allocated 2*seqLen state
+        // tensors + seqLen GEMM outputs => many MB/call that scales with seq. 8 MB threshold catches
+        // a revert to per-step allocation with a wide margin.
+        Assert.True(kbPerCall < 8192,
+            $"Double LSTM forward allocated {kbPerCall:F0} KB/call; expected < 8192 KB (buffer-reusing " +
+            "path). Regressed to the per-timestep CreateZeros + per-step hidden-GEMM allocation (#478)?");
+    }
 #endif
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/MultiHeadAttentionForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MultiHeadAttentionForwardTests.cs
@@ -162,6 +162,47 @@ public class MultiHeadAttentionForwardTests
     }
 
     [Fact]
+    public void MultiHeadAttentionForward_BroadcastMask_MatchesFullyMaterializedMask()
+    {
+        // #674 (CodeRabbit): the IEngine contract allows masks BROADCASTABLE to [batch, heads, seq, seq]
+        // — e.g. a shared causal mask [1, 1, seq, seq]. Direct mask[b, h, i, j] indexing threw
+        // IndexOutOfRangeException (or read wrong data) for b>0/h>0. A [1, 1, seq, seq] mask must be
+        // applied to EVERY (batch, head) and produce the same result as the fully-materialized mask.
+        // seq=5 (not a multiple of 8) forces the scalar softmax path that consults the mask.
+        const int batch = 3, seq = 5, dModel = 8, numHeads = 2;
+        var rng = new Random(11);
+
+        var input = MakeRandom(rng, batch, seq, dModel);
+        var qW = MakeRandom(rng, dModel, dModel);
+        var kW = MakeRandom(rng, dModel, dModel);
+        var vW = MakeRandom(rng, dModel, dModel);
+        var oW = MakeRandom(rng, dModel, dModel);
+
+        // Shared causal mask broadcast over batch + heads: [1, 1, seq, seq].
+        var shared = new Tensor<bool>(new[] { 1, 1, seq, seq });
+        var sharedSpan = shared.AsWritableSpan();
+        for (int i = 0; i < seq; i++)
+            for (int j = 0; j < seq; j++)
+                sharedSpan[i * seq + j] = j <= i;
+
+        // The same pattern, fully materialized to [batch, heads, seq, seq] — the known-good reference.
+        var full = new Tensor<bool>(new[] { batch, numHeads, seq, seq });
+        var fullSpan = full.AsWritableSpan();
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+                for (int i = 0; i < seq; i++)
+                    for (int j = 0; j < seq; j++)
+                        fullSpan[((b * numHeads + h) * seq + i) * seq + j] = j <= i;
+
+        // (a) must not throw on b>0/h>0, and (b) must equal the fully-materialized mask's result.
+        var broadcastResult = _engine.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads, shared);
+        var fullResult = _engine.MultiHeadAttentionForward(input, qW, kW, vW, oW, numHeads, full);
+
+        Assert.Equal(new[] { batch, seq, dModel }, broadcastResult.Shape.ToArray());
+        AssertClose(broadcastResult, fullResult, atol: 1e-4f);
+    }
+
+    [Fact]
     public void MultiHeadAttentionForward_RejectsBadShapes()
     {
         var input = Tensor<float>.CreateZeros(2, 4, 8);


### PR DESCRIPTION
## #478 — a `<double>` CPU forward is ~65x slower than `<float>`

Root cause (dotnet-trace + per-layer allocation breakdown of a real Whisper forward, CPU-only): **not per-op compute** — every op is 1–5x in double (the 2x bytes + half SIMD width) — but **super-linear allocation / GC churn** wherever double falls out of the pooled fast paths that `<float>` uses. At paper scale this balloons to tens of GB of transient allocation per forward, and on a memory-bounded host the resulting gen2-GC / heap-limit thrashing — not the math — is the 65x.

This PR closes every catastrophic case found by an allocation-probe sweep of the float-typed fast paths, then makes double LSTM **training** fused as well.

### Forward allocation fixes
| op | before | after | fix |
|---|---|---|---|
| MultiHeadAttention | **54x** | 2.0x | double per-head fused SDPA into one pooled scratch — no full `[B*H, seq, seq]` scores / weights / transpose tensors |
| LSTM (generic forward) | 24–28x | ~2.2x | ping-pong pooled state buffers + pooled hidden-GEMM + pooled input projection |
| BatchNorm fwd + conv / SDPA / norm backward | 4.0x (+ symmetric 2x-copy) | 2.0x | 21 sites: `new Vector<T>(arr)` (binds the `IEnumerable<T>` copy ctor) → `Vector<T>.FromMemory(arr)` zero-copy wrap |

### Fused double LSTM training (new capability)
A `<double>` LSTM under a gradient tape previously **threw** and was forced down the decomposed per-op path (hundreds of tape nodes per sequence). Added `LstmSequenceForwardDoubleTrain` + `LstmSequenceBackwardDouble` mirroring the float fast path: **one fused BPTT tape node**, pooled per-step scratch, the big and per-step GEMMs on the parallel `BlasManaged.Gemm<double>`.

The per-step recurrent GEMM specifically had to avoid `MatrixMultiplyHelper.MultiplyBlocked`, which is **~128x slower** at that tiny shape (measured 320ms vs 2.5ms for a 32-step loop) and was the entire double-vs-float training gap.

**Result** at `[b64, s32, in32, h64]`: fused double fwd+bwd **42.2ms vs float 42.1ms = 1.00x time, 2.00x alloc** (just the bytes). Gradients validated against central finite differences (≤1e-6) for input, wIh, wHh, bIh, bHh, h0, c0 across `returnSequences` true/false and the no-bias/no-initial-state case.

### Validation
- New allocation regression guards (MHA / LSTM forward / BatchNorm double) + a fused double-BPTT finite-difference gradient test.
- All targeted op suites green; builds **net10.0 + net471**. The forward double MHA path throws under GraphMode like float, so training is unaffected by the forward fixes.
- One pre-existing failure (`LocallyConnectedConv2DBackwardWeights_Gpu_MatchesCpu`) is a GPU-vs-CPU kernel mismatch in a path this PR does not touch.

Fixes #478. Relates to AiDotNet #1675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
