### PR TITLE
fix(gpu): correct swapped input/gradOutput params in OpenCL LC backward-weights launcher

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -6285,7 +6285,13 @@ KERNEL VARIANTS (A/B testing):
             k.Execute1D(globalSize, localSize);
         }
 
-        public void LocallyConnectedConv2DBackwardWeights(IGpuBuffer input, IGpuBuffer gradOutput, IGpuBuffer gradWeights,
+        // Parameter order MUST match IDirectGpuBackend (gradOutput, input, gradWeights): the engine
+        // calls this via the interface positionally, so a swapped (input, gradOutput) signature here
+        // silently fed gradOutput into the kernel's `input` slot and vice versa (C# binds interface
+        // impls by parameter type, not name — both are IGpuBuffer). The kernel reads gradOutput by
+        // [b,oc,oh,ow] and input by [b,ic,ih,iw]; swapping the buffers reads each at the other's
+        // index/shape, so the weight gradient was wrong (GpuConvKernelCoverageTests).
+        public void LocallyConnectedConv2DBackwardWeights(IGpuBuffer gradOutput, IGpuBuffer input, IGpuBuffer gradWeights,
             int batch, int inChannels, int inHeight, int inWidth,
             int outChannels, int outHeight, int outWidth,
             int kernelH, int kernelW, int strideH, int strideW)


### PR DESCRIPTION
## Real GPU kernel bug surfaced while validating #675

`GpuConvKernelCoverageTests.LocallyConnectedConv2DBackwardWeights_Gpu_MatchesCpu` fails on the AMD RX 5500 XT (OpenCL): `cpu=0.0415316 gpu=0.0296932 diff=0.012`. Pre-existing — not introduced by any recent change.

## Root cause

`OpenClBackend.LocallyConnectedConv2DBackwardWeights` declared its first two buffer parameters as `(input, gradOutput, …)`, but `IDirectGpuBackend` (and the CUDA/HIP backends, and the engine call site) use `(gradOutput, input, …)`. C# binds interface implementations by parameter **type**, not name — both are `IGpuBuffer` — so the swapped signature compiled cleanly while the engine's positional call fed `gradOutput` into the kernel's `input` slot and vice versa.

The kernel indexes `gradOutput` by `[b, oc, oh, ow]` and `input` by `[b, ic, ih, iw]` (different shapes/strides), so swapping the buffers makes each read at the other's index pattern → wrong weight gradient. The forward / `BackwardInput` / `BackwardBias` launchers already had the correct order (their coverage tests passed), so only `BackwardWeights` was affected.

## Fix

Reorder the parameters to `(gradOutput, input, gradWeights, …)` to match the interface. The kernel-arg binding in the body (`gradOutput` → slot 0, `input` → slot 1) was already correct and is unchanged — a 1-line signature fix.

## Validation (real AMD GPU / OpenCL)

- `LocallyConnectedConv2DBackwardWeights_Gpu_MatchesCpu` now **passes**.
- Full `GpuConvKernelCoverageTests` class **17/17 green**.
- Both TFMs (net10.0 + net471) build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
