### PR TITLE
test(blas): serialize ParallelPackB + SgemmInt8Cached with the determinism-flag mutators

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ParallelPackBTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ParallelPackBTest.cs
@@ -12,6 +12,12 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// shapes where serial pack-B previously dominated total time should now
 /// pack faster, and produce bit-identical output to the serial path.
 /// </summary>
+// Join the single serial collection for tests that touch the process-global GEMM state
+// (CpuParallelSettings.DeterministicReductions / BlasProvider.IsDeterministicMode). xUnit only
+// serializes WITHIN a collection, so an uncollected bit-exact test runs in parallel with the
+// determinism-flag mutators (DeterministicParallelGemmContractTests, PrePackConcurrencyStress, …)
+// and intermittently observes a flipped flag mid-GEMM, drifting parallel-vs-serial output. (#675 CI flake)
+[Collection("BlasManaged-Stats-Serial")]
 public class ParallelPackBTest
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmInt8CachedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmInt8CachedTests.cs
@@ -13,6 +13,10 @@ namespace AiDotNet.Tensors.Tests.Engines.Simd;
 /// <para>Guarded with NET5_0_OR_GREATER because the kernel only compiles
 /// on NET5+ (requires <c>System.Runtime.Intrinsics</c>).</para>
 /// </summary>
+// Serialize with the process-global GEMM-state mutators (DeterministicReductions / IsDeterministicMode):
+// the int8-vs-float SNR margin drifts if a concurrent determinism-flag flip changes this run's reduction
+// order. The collection name is assembly-global, so joining it from this namespace is fine. (#675 CI flake)
+[Collection("BlasManaged-Stats-Serial")]
 public class SgemmInt8CachedTests
 {
     [Theory]


### PR DESCRIPTION
## The flake that randomly reddens PRs (it hit #675)

`#675`'s CI failed on 4 GEMM/quant tests — `ParallelPackB_Wide_N_Matches_Serial_FP32`, `SgemmInt8CachedTests.Int8MatchesFloat32WithinSnrBudget`, and `QuantizedComputeW8A8Tests`. #675 only touches compiled-replay (`RecordOp` delegates) and can't affect GEMM output; all 4 pass locally and on `main`. A re-run went green — i.e. an intermittent flake, not a regression.

## Root cause

`BlasManaged-Stats-Serial` is documented as the **single** serial collection for "every test that mutates process-wide global state affecting the GEMM path … especially `BlasProvider.IsDeterministicMode`" (and `CpuParallelSettings.DeterministicReductions`). The catch: **xUnit only serializes tests *within* a collection** — different collections, and uncollected classes, still run in parallel with each other.

`ParallelPackBTest` (bit-exact parallel-vs-serial pack-B) and `Engines.Simd.SgemmInt8CachedTests` (int8-vs-float SNR margin) were **uncollected**, so they ran concurrently with the flag mutators that *are* in the collection (`DeterministicParallelGemmContractTests`, `PrePackConcurrencyStress`, `Conv2DBackwardChannelParallelTests`, `ParallelForOrSerialDispatchTests`). When a mutator flips `DeterministicReductions` mid-run, these tests observe a changed reduction order and their bit-exact / SNR assertions drift.

## Fix

Add `[Collection("BlasManaged-Stats-Serial")]` to both classes (the collection name is assembly-global, so the `Simd`-namespace class can join it). The collection has no fixture, so no constructor change is needed — a test-only, 2-class change, no production code touched.

## Validation

- Both classes pass under the collection (9 tests green); net10.0 builds.
- They can no longer run concurrently with the determinism-flag mutators, which is what xUnit's same-collection sequential-execution contract guarantees.

(`QuantizedComputeW8A8Tests` is already in this collection; if it ever flakes again it's a separate int8-on-CI-hardware question, not this contamination.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several test suites to run in a single, coordinated sequence instead of in parallel.
  * This reduces intermittent CI failures caused by timing-sensitive differences in numeric results during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->