### PR TITLE
build: add net8.0 target (stop net8/net9 falling back to net471)

### DIFF
--- a/src/AiDotNet.Tensors.Onnx/AiDotNet.Tensors.Onnx.csproj
+++ b/src/AiDotNet.Tensors.Onnx/AiDotNet.Tensors.Onnx.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net471</TargetFrameworks>
+    <!-- net8.0 added so net8/net9 consumers get a real modern asset instead of
+         the net471 .NET Framework fallback (NU1701). Matches the base
+         AiDotNet.Tensors matrix; see issue #679 for net462 + netstandard2.0. -->
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -1,6 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net471</TargetFrameworks>
+    <!--
+      net10.0 — latest; full AVX2/AVX-512 + AVX-VNNI int8/int4 kernels (serves net10/net11)
+      net8.0  — LTS; AVX2/AVX-512 intrinsics. (AVX-VNNI is [RequiresPreviewFeatures] on
+                net8 — compiled out via #if NET9_0_OR_GREATER — so it routes to AVX2/scalar.)
+                Without this target, net8/net9 consumers had no compatible modern asset and
+                NuGet's AssetTargetFallback silently selected the net471 .NET Framework build
+                (NU1701). See issue #679 for extending to net462 + netstandard2.0.
+      net471  — .NET Framework 4.7.1–4.8.1 (scalar fallback, no System.Runtime.Intrinsics)
+    -->
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int4GroupScaledVnni.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int4GroupScaledVnni.cs
@@ -26,9 +26,14 @@ namespace AiDotNet.Tensors.Engines.Simd;
 
 internal static partial class SimdGemm
 {
-    /// <summary>True when the int4-native VNNI path can run (AVX-VNNI present).</summary>
+    /// <summary>
+    /// True when the int4-native VNNI path can run (AVX-VNNI present).
+    /// Gated NET9_0_OR_GREATER (not NET8): <see cref="AvxVnni"/> is
+    /// <c>[RequiresPreviewFeatures]</c> on net8.0 (CA2252) and only stable from
+    /// .NET 9. Below that the dispatcher uses the fp32 weight-only fallback.
+    /// </summary>
     internal static bool Int4VnniAvailable =>
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
         AvxVnni.IsSupported;
 #else
         false;
@@ -115,7 +120,7 @@ internal static partial class SimdGemm
                 int dot = 0, wsum = 0;
                 int aOff = (int)(aBase + p);
                 int wOff = (int)(wBase + p);
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
                 int t = 0;
                 if (vnni && len >= 32)
                 {

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8Int8.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8Int8.cs
@@ -43,13 +43,20 @@ internal static partial class SimdGemm
     internal static bool Int8Int8Avx2Available => false;
 #endif
 
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     /// <summary>
     /// True when the AVX-VNNI <c>VPDPBUSD</c> fast path can run (256-bit AVX-VNNI).
     /// VNNI accumulates the int8 dot product directly into int32 in a single
     /// instruction — no int16 intermediate, so (unlike the AVX2 emulation) it does
     /// not saturate and is both faster and more accurate.
     /// </summary>
+    /// <remarks>
+    /// Gated NET9_0_OR_GREATER (not NET8): <see cref="AvxVnni"/> is marked
+    /// <c>[RequiresPreviewFeatures]</c> on net8.0 (CA2252) and only became a stable,
+    /// non-preview intrinsic in .NET 9. On net8.0 / net6.0 / netstandard2.0 / net462
+    /// this path is compiled out and the dispatcher falls back to the AVX2 emulation
+    /// (net6.0+) or the scalar kernel.
+    /// </remarks>
     internal static bool Int8Int8VnniAvailable => AvxVnni.IsSupported;
 #else
     internal static bool Int8Int8VnniAvailable => false;
@@ -133,7 +140,7 @@ internal static partial class SimdGemm
 #endif
     }
 
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
     /// <summary>
     /// Phase 2 VNNI fast path: same contract as <see cref="MatMulInt8Int8Avx2"/> but
     /// uses <c>VPDPBUSD</c> (<see cref="AvxVnni.MultiplyWideningAndAdd"/>) to accumulate
@@ -247,7 +254,7 @@ internal static partial class SimdGemm
         ReadOnlySpan<float> actScale, ReadOnlySpan<float> wScale,
         Span<float> c, int m, int k, int n)
     {
-#if NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
         if (Int8Int8VnniAvailable)
         {
             MatMulInt8Int8Vnni(aU8, bI8, bRowSum, actScale, wScale, c, m, k, n);


### PR DESCRIPTION
## Problem

`AiDotNet.Tensors` and `AiDotNet.Tensors.Onnx` shipped only **net10.0 + net471**. A **net8.0/net9.0** consumer has no compatible modern asset (net10.0 is a higher major; net471 is .NET Framework), so NuGet's `AssetTargetFallback` silently selected the **net471** build (`NU1701`). That build compiles the scalar/no-intrinsics paths and a different dependency set, so types misresolve at the consumer (e.g. `Matrix` "not found" on a net8.0 project).

Repro (before): a `net8.0` project referencing the package restores with
`warning NU1701: Package 'AiDotNet ...' was restored using '.NETFramework,Version=v4.6.1 … v4.8.1' instead of … 'net8.0'`.

## Fix

Add **net8.0** to both packages → `net10.0;net8.0;net471`:

| Runtime | Asset |
|---|---|
| .NET Framework 4.7.1–4.8.1 | net471 |
| .NET 8 / 9 | **net8.0** (new) |
| .NET 10 / 11 | net10.0 |

net8.0 required guarding the **AVX-VNNI** int8/int4 GEMM kernels: `System.Runtime.Intrinsics.X86.AvxVnni` is `[RequiresPreviewFeatures]` on net8.0 (CA2252) and only stable from .NET 9, so the gates move from `#if NET8_0_OR_GREATER` to `#if NET9_0_OR_GREATER`. The int8/int4 dispatchers already fall back to AVX2/scalar, so **net8.0 keeps full AVX2/AVX-512** and just skips the VNNI fast path; **net10.0 is unchanged** (`10 >= 9` keeps VNNI).

## Verification

- ✅ net8.0, net10.0, net471 all build clean.
- ✅ Packed `.nupkg` contains `lib/net8.0`, `lib/net10.0`, `lib/net471`.
- ✅ A net8.0 consumer of the packed package restores with **no NU1701**.

## Follow-up

Extending to **net462** (.NET Framework 4.6.2) and **netstandard2.0** (.NET 5/6/7 + Unity/Mono) is tracked in #679 — larger scalar-port efforts (Vector512 is net8+, `AggressiveOptimization` / `System.Reflection.Emit` gaps, abandoned `#if !NET462` scaffolding). The main **AiDotNet** package also needs net8.0 mirrored once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)