### PR TITLE
fix(cpu): make seeded TensorDropoutMask bit-reproducible (per-element SplitMix64)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -32969,7 +32969,6 @@ public partial class CpuEngine : ITensorLevelEngine
         if (shape == null) throw new ArgumentNullException(nameof(shape));
 
         var numOps = MathHelper.GetNumericOperations<T>();
-        var random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.ThreadSafeRandom;
         var result = AutoTensorCache.RentOrAllocate<T>(shape);
         int totalElements = shape.Aggregate(1, (a, b) => a * b);
 
@@ -32978,43 +32977,95 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var resultData = result.GetDataArray();
 
-        if (totalElements > 10000)
+        if (seed.HasValue)
         {
-            // For seeded random with parallelism, we need thread-local randoms
-            if (seed.HasValue)
-            {
-                var baseRandom = RandomHelper.CreateSeededRandom(seed.Value);
-                var seeds = new int[CpuParallelSettings.MaxDegreeOfParallelism];
-                for (int i = 0; i < seeds.Length; i++)
-                    seeds[i] = baseRandom.Next();
+            // Deterministic per-element mask. Element i's keep/drop decision is a stateless
+            // SplitMix64 hash of (seed, i), so it depends ONLY on (seed, i) — never on which
+            // thread happens to process i, on how the parallel partitioner splits the index
+            // range, or on the chunk size. A seeded mask is therefore bit-reproducible across
+            // runs, across thread-pool states, AND across machines with different core counts.
+            //
+            // This is a strictly stronger guarantee than the chunk-id-seeded scheme used by
+            // TensorRandomUniformRangeInto (reproducible only at a fixed worker count), and it
+            // completes AiDotNet #1383: DropoutLayer already derives a per-call seed for
+            // reproducible masks, but the previous seeded path here created per-thread Randoms
+            // keyed on Thread.CurrentThread.ManagedThreadId and drew from them in
+            // nondeterministic chunk order, so any mask above the 10000-element parallel
+            // threshold was still nonreproducible — the root of intermittent "two trainings at
+            // the same seed diverge" model-family test failures.
+            ulong seedState = SplitMix64Seed(seed.Value);
 
-                CpuParallelSettings.ParallelForOrSerial(0, totalElements,
-                    totalElements,
-                    () => RandomHelper.CreateSeededRandom(seeds[Thread.CurrentThread.ManagedThreadId % seeds.Length]),
-                    (i, state, localRandom) =>
-                    {
-                        resultData[i] = localRandom.NextDouble() < dropoutRateD ? zero : scale;
-                        return localRandom;
-                    },
-                    _ => { });
+            if (totalElements > 10000)
+            {
+                CpuParallelSettings.ParallelForOrSerial(0, totalElements, totalElements, i =>
+                {
+                    resultData[i] = SplitMix64Uniform(seedState, i) < dropoutRateD ? zero : scale;
+                });
             }
             else
+            {
+                for (int i = 0; i < totalElements; i++)
+                {
+                    resultData[i] = SplitMix64Uniform(seedState, i) < dropoutRateD ? zero : scale;
+                }
+            }
+        }
+        else
+        {
+            // Unseeded: intentionally nondeterministic (shared thread-safe global RNG).
+            if (totalElements > 10000)
             {
                 CpuParallelSettings.ParallelForOrSerial(0, totalElements, totalElements, i =>
                 {
                     resultData[i] = RandomHelper.ThreadSafeRandom.NextDouble() < dropoutRateD ? zero : scale;
                 });
             }
-        }
-        else
-        {
-            for (int i = 0; i < totalElements; i++)
+            else
             {
-                resultData[i] = random.NextDouble() < dropoutRateD ? zero : scale;
+                for (int i = 0; i < totalElements; i++)
+                {
+                    resultData[i] = RandomHelper.ThreadSafeRandom.NextDouble() < dropoutRateD ? zero : scale;
+                }
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Mixes a 32-bit seed into a well-distributed 64-bit SplitMix64 base state. Running the seed
+    /// through the SplitMix64 finalizer first ensures adjacent seeds (e.g. consecutive per-call
+    /// dropout seeds) produce uncorrelated streams — without it, the counter-based offset in
+    /// <see cref="SplitMix64Uniform"/> would make element i of seed s collide with element i+1 of
+    /// seed s-1.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong SplitMix64Seed(int seed)
+    {
+        ulong z = unchecked((ulong)(uint)seed);
+        z = unchecked((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL);
+        z = unchecked((z ^ (z >> 27)) * 0x94D049BB133111EBUL);
+        return z ^ (z >> 31);
+    }
+
+    /// <summary>
+    /// Stateless SplitMix64 uniform in [0, 1) for a (seedState, index) pair. Returns the same value
+    /// as the (index+1)-th draw of a SplitMix64 stream seeded by <paramref name="seedState"/>, but
+    /// in O(1) and independent of evaluation order — so a parallel fill produces identical results
+    /// regardless of how the index range is partitioned across threads. SplitMix64 (the JDK
+    /// SplittableRandom finalizer; Steele, Lea &amp; Flood, OOPSLA 2014) has excellent
+    /// equidistribution, more than sufficient for dropout masks, which need only a well-distributed
+    /// uniform per element. The top 53 bits map to [0, 1) at the same resolution as
+    /// <see cref="System.Random.NextDouble"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double SplitMix64Uniform(ulong seedState, long index)
+    {
+        ulong z = unchecked(seedState + (ulong)(index + 1) * 0x9E3779B97F4A7C15UL);
+        z = unchecked((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL);
+        z = unchecked((z ^ (z >> 27)) * 0x94D049BB133111EBUL);
+        z ^= z >> 31;
+        return (z >> 11) * (1.0 / 9007199254740992.0); // top 53 bits / 2^53 -> [0, 1)
     }
 
     /// <inheritdoc/>

--- a/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MathInvariantExtendedTests.cs
@@ -175,10 +175,67 @@ public class MathInvariantExtendedTests
     [Fact] public void Diagonal_Shape() { var mat = R([4, 4], 1); Assert.Equal(new[] { 4 }, E.TensorDiagonal(mat).Shape.ToArray()); }
 
     // ================================================================
-    // TensorDropoutMask (2)
+    // TensorDropoutMask (7)
     // ================================================================
     [Fact] public void DropoutMask_ShapeCorrect() => Assert.Equal(new[] { 4, 8 }, E.TensorDropoutMask<float>(new[] { 4, 8 }, 0.3f, 1.0f / 0.7f, 42).Shape.ToArray());
     [Fact] public void DropoutMask_ValuesInRange() { var t = E.TensorDropoutMask<float>(new[] { 256 }, 0.5f, 2f, 99); var m = t.GetDataArray(); for (int i = 0; i < t.Length; i++) Assert.True(m[i] == 0f || Math.Abs(m[i] - 2f) < Tol, $"mask[{i}]={m[i]}"); }
+
+    // Reproducibility regression tests for the seeded path. The previous implementation keyed
+    // per-thread RNGs on Thread.CurrentThread.ManagedThreadId and drew from them in
+    // nondeterministic chunk order, so a seeded mask was NOT reproducible above the
+    // 10000-element parallel threshold (the root of intermittent "two trainings at the same
+    // seed diverge" model-family failures). A seeded mask must depend only on (seed, index).
+    [Fact]
+    public void DropoutMask_Seeded_ReproducibleAcrossCalls_LargeParallel()
+    {
+        var a = E.TensorDropoutMask<float>(new[] { 20000 }, 0.3f, 2f, 12345).GetDataArray();
+        for (int rep = 0; rep < 4; rep++)
+        {
+            var b = E.TensorDropoutMask<float>(new[] { 20000 }, 0.3f, 2f, 12345).GetDataArray();
+            for (int i = 0; i < a.Length; i++)
+                Assert.True(a[i] == b[i], $"seeded mask not reproducible at [{i}] (rep {rep}): {a[i]} vs {b[i]}");
+        }
+    }
+
+    [Fact]
+    public void DropoutMask_Seeded_ReproducibleAcrossCalls_Small()
+    {
+        var a = E.TensorDropoutMask<float>(new[] { 256 }, 0.5f, 2f, 777).GetDataArray();
+        var b = E.TensorDropoutMask<float>(new[] { 256 }, 0.5f, 2f, 777).GetDataArray();
+        for (int i = 0; i < a.Length; i++) Assert.True(a[i] == b[i], $"[{i}]: {a[i]} vs {b[i]}");
+    }
+
+    [Fact]
+    public void DropoutMask_Seeded_PathIndependent_SmallMatchesLargePrefix()
+    {
+        // The small (<=10000, serial) and large (>10000, parallel) seeded paths share the same
+        // per-element hash, so the small mask equals the prefix of the large mask at the same seed.
+        var large = E.TensorDropoutMask<float>(new[] { 20000 }, 0.4f, 2f, 2024).GetDataArray();
+        var small = E.TensorDropoutMask<float>(new[] { 9000 }, 0.4f, 2f, 2024).GetDataArray();
+        for (int i = 0; i < small.Length; i++)
+            Assert.True(small[i] == large[i], $"path mismatch at [{i}]: small {small[i]} vs large {large[i]}");
+    }
+
+    [Fact]
+    public void DropoutMask_Seeded_DifferentSeeds_DifferMasks()
+    {
+        var a = E.TensorDropoutMask<float>(new[] { 20000 }, 0.5f, 2f, 1).GetDataArray();
+        var b = E.TensorDropoutMask<float>(new[] { 20000 }, 0.5f, 2f, 2).GetDataArray();
+        int diff = 0;
+        for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) diff++;
+        // At rate 0.5, two independent seeds agree at a position with p=0.5, so ~half should flip.
+        Assert.True(diff > a.Length / 4, $"masks for distinct seeds barely differ: {diff}/{a.Length}");
+    }
+
+    [Fact]
+    public void DropoutMask_Seeded_DropRateApproximatelyCorrect_LargeParallel()
+    {
+        var m = E.TensorDropoutMask<float>(new[] { 50000 }, 0.3f, 1f / 0.7f, 99).GetDataArray();
+        int dropped = 0;
+        for (int i = 0; i < m.Length; i++) if (m[i] == 0f) dropped++;
+        double observed = (double)dropped / m.Length;
+        Assert.True(Math.Abs(observed - 0.3) < 0.02, $"drop rate {observed:F4} deviates from 0.3");
+    }
 
     // ================================================================
     // TensorExpandDims / TensorSqueeze (3)


### PR DESCRIPTION
## Summary

`CpuEngine.TensorDropoutMask` produced a **non-reproducible mask even when given a seed**, above the 10000-element parallel threshold. This is the root cause of the intermittent *"two trainings at the same seed diverge"* model-family test flakiness in AiDotNet (e.g. `CNNBiLSTMCRF` / `BiLSTMCRF` `MoreData_ShouldNotDegrade`, which pass in isolation but are ~50% flaky in the full suite).

## Root cause

The seeded parallel branch:

```csharp
var seeds = new int[CpuParallelSettings.MaxDegreeOfParallelism];
for (int i = 0; i < seeds.Length; i++) seeds[i] = baseRandom.Next();
CpuParallelSettings.ParallelForOrSerial(0, totalElements, totalElements,
    () => RandomHelper.CreateSeededRandom(seeds[Thread.CurrentThread.ManagedThreadId % seeds.Length]),
    (i, state, localRandom) => { resultData[i] = localRandom.NextDouble() < rate ? zero : scale; return localRandom; },
    _ => { });
```

has **two** independent sources of nondeterminism:

1. **Seed selection** — `seeds[Thread.CurrentThread.ManagedThreadId % seeds.Length]`. `ManagedThreadId` depends on thread-pool state, which varies run-to-run, so element `i` is drawn from a different seed across runs.
2. **Draw order** — each thread pulls `localRandom.NextDouble()` *in the order it processes its dynamically-assigned chunk*. Element `i`'s value depends on how many elements its thread happened to process before `i`, i.e. on the partitioner's chunk boundaries — not on `i`.

So a *seeded* mask was not reproducible. Worse, the small path (`<= 10000`, one sequential `Random`) used a different scheme entirely, so it didn't match the large path for the same seed either.

`DropoutLayer` already derives a deterministic per-call seed (#1383) and passes it to `TensorDropoutMask` — but this path defeated that intent for any layer with >10000 activations.

## Fix

For the **seeded** case, element `i`'s keep/drop decision is now a **stateless SplitMix64 hash of `(seed, i)`**:

```csharp
ulong seedState = SplitMix64Seed(seed.Value);             // mix seed once
... resultData[i] = SplitMix64Uniform(seedState, i) < rate ? zero : scale;
```

The value depends **only on `(seed, i)`** — never on the processing thread, the partitioning, or the chunk size. Consequences:

- **Bit-reproducible** across runs, thread-pool states, **and machines with different core counts**.
- The small (serial) and large (parallel) paths now produce **identical** masks for the same seed.
- Strictly stronger than the chunk-id-seeded scheme in `TensorRandomUniformRangeInto` (which is only reproducible at a fixed worker count).
- The seed is run through the SplitMix64 finalizer first so adjacent seeds (e.g. consecutive per-call dropout seeds) yield uncorrelated streams.
- SplitMix64 reuses the constants already established in `SimdRandom.SplitMix64`.

The **unseeded** path is unchanged — intentionally nondeterministic via the shared thread-safe RNG.

## Tests

5 new reproducibility invariants in `MathInvariantExtendedTests` (the seeded parallel path was previously **untested** — all prior dropout tests used tensors below the 10000 threshold):

- `DropoutMask_Seeded_ReproducibleAcrossCalls_LargeParallel` — 4 repeats of a 20 000-element seeded mask are byte-identical.
- `DropoutMask_Seeded_ReproducibleAcrossCalls_Small`.
- `DropoutMask_Seeded_PathIndependent_SmallMatchesLargePrefix` — small mask equals the prefix of the large mask at the same seed. **This reliably fails on the old code** (old small/large paths used entirely different RNG schemes).
- `DropoutMask_Seeded_DifferentSeeds_DifferMasks`.
- `DropoutMask_Seeded_DropRateApproximatelyCorrect_LargeParallel`.

All 16 dropout tests pass. Library builds clean on **net10.0** and **net471** (the net8.0 path is identical code).

## Scope / follow-ups

- **CPU only.** The GPU `DropoutGpu` path is a separate backend-kernel RNG (different signature, `ulong seed`); CI is CPU-only, so exact CPU↔GPU bit-parity of seeded masks is left as a separate GPU-backend change (it would need the kernel to use the same per-element hash and cannot be CI-verified here).
- The seedless convenience overload `Dropout<T>(input, rate, training, out mask)` is intentionally non-reproducible (no seed parameter) and is unchanged.
- **Downstream:** once this is released, bump `AiDotNet`'s `Directory.Packages.props` `AiDotNet.Tensors` version to consume it; that closes the residual `MoreData_ShouldNotDegrade` full-suite flakiness for high-dropout models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
