### PR TITLE
fix(streaming): quiesce in-flight prefetch workers before pool teardown

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -54,6 +54,11 @@ public static class WeightRegistry
             throw new PlatformNotSupportedException(
                 "WeightRegistry / StreamingTensorPool requires a little-endian host. " +
                 "Big-endian platforms (legacy IBM Power, certain ARM modes) are not supported in v1.");
+        // Quiesce background prefetch workers before (possibly) disposing/swapping
+        // the pool below — same fire-and-forget-outlives-the-pool hazard Reset()
+        // guards against. Must run outside _lock (workers take _lock in their
+        // finally). See DrainInFlightPrefetches.
+        DrainInFlightPrefetches();
         lock (_lock)
         {
             // Mid-flight guard: refuse to dispose a pool that holds live
@@ -1585,6 +1590,58 @@ public static class WeightRegistry
         new(initialCount: PrefetchMaxConcurrency, maxCount: PrefetchMaxConcurrency);
 
     /// <summary>
+    /// Blocks until every in-flight background prefetch worker (queued by
+    /// <see cref="PrefetchAsync{T}"/> / <see cref="PrefetchAsyncMany{T}"/>) has
+    /// finished, or <paramref name="timeoutMs"/> elapses; returns true iff the
+    /// subsystem fully quiesced.
+    /// <para>
+    /// Each worker holds exactly one <see cref="_prefetchSemaphore"/> permit for
+    /// its lifetime — acquired (<c>Wait(0)</c>) before it is queued, released in
+    /// its <c>finally</c>. Acquiring ALL <see cref="PrefetchMaxConcurrency"/>
+    /// permits therefore can only succeed once NO worker still holds one, i.e.
+    /// the prefetch subsystem is idle; we then release them so the pool is usable
+    /// again.
+    /// </para>
+    /// <para>
+    /// MUST be called WITHOUT holding <see cref="_lock"/>: a worker's <c>finally</c>
+    /// takes <c>_lock</c> (to remove its handle from <see cref="_inFlightPrefetches"/>)
+    /// BEFORE releasing its permit, so holding the lock here would deadlock the
+    /// drain against the very workers it is waiting for.
+    /// </para>
+    /// <para>
+    /// <see cref="Reset"/> / <see cref="Configure"/> call this before tearing the
+    /// pool down: a fire-and-forget worker that outlived its issuing forward must
+    /// not be left paging bytes against a pool we are about to dispose — or, worse,
+    /// against a SUCCESSOR pool that has reused the same handle id (the handle
+    /// counter restarts when the pool is recreated). Under ThreadPool starvation a
+    /// worker may not get a thread to release its permit in time; the timeout is the
+    /// safety valve, and the worker's own ObjectDisposedException / InvalidOperationException
+    /// guards keep the timed-out case from corrupting anything.
+    /// </para>
+    /// </summary>
+    internal static bool DrainInFlightPrefetches(int timeoutMs = 5000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int acquired = 0;
+        try
+        {
+            for (int i = 0; i < PrefetchMaxConcurrency; i++)
+            {
+                int remaining = timeoutMs - (int)sw.ElapsedMilliseconds;
+                if (remaining < 0) remaining = 0;
+                if (!_prefetchSemaphore.Wait(remaining))
+                    return false; // timed out with at least one worker still outstanding
+                acquired++;
+            }
+            return true;
+        }
+        finally
+        {
+            if (acquired > 0) _prefetchSemaphore.Release(acquired);
+        }
+    }
+
+    /// <summary>
     /// Returns a snapshot of streaming-pool telemetry counters. Caller
     /// typically reads this at end of inference / training pass and
     /// surfaces it in <c>PredictionModelResult.StreamingReport</c>.
@@ -1639,6 +1696,16 @@ public static class WeightRegistry
     /// </remarks>
     public static void Reset()
     {
+        // Quiesce background prefetch workers BEFORE taking _lock + disposing the
+        // pool. A fire-and-forget worker still paging bytes would otherwise touch
+        // the pool we are about to dispose AND race the NEXT pool's reused handle
+        // ids (the handle counter restarts on pool re-creation), corrupting the
+        // successor's resident set. Draining OUTSIDE the lock is mandatory — a
+        // worker's finally takes _lock before releasing its permit, so draining
+        // under _lock would deadlock. Best-effort: on ThreadPool starvation the
+        // drain times out and we proceed; the worker's own disposed-pool guards
+        // keep that safe.
+        DrainInFlightPrefetches();
         lock (_lock)
         {
             _streamingPool?.Dispose();
@@ -1646,6 +1713,10 @@ public static class WeightRegistry
             _offloadAllocator?.Dispose();
             _offloadAllocator = null;
             _ownerByHandle.Clear();
+            // Drop any straggler in-flight markers (a worker that timed out the
+            // drain above). Leaving them would suppress the NEXT pool's prefetch
+            // of a reused handle id (dedup sees it as "already in-flight").
+            _inFlightPrefetches.Clear();
             _options = new GpuOffloadOptions();
             // CodeRabbit #604: clear the training-mode hint too. Otherwise a
             // prior `false` (set by the last model's SetTrainingMode) persists

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryPrefetchDrainTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryPrefetchDrainTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// Covers <c>WeightRegistry.DrainInFlightPrefetches</c> and its use inside
+/// <see cref="WeightRegistry.Reset"/> / <see cref="WeightRegistry.Configure"/>.
+///
+/// <para>Prefetch workers are fire-and-forget (<see cref="WeightRegistry.PrefetchAsync{T}"/>):
+/// they capture the pool ref and run <c>Rehydrate</c> on the ThreadPool, releasing their
+/// in-flight marker + semaphore permit in a <c>finally</c>. Tearing the pool down
+/// (Reset/Configure) while a worker is still in flight is the hazard the drain guards: the
+/// worker must not be left paging bytes against a pool we are about to dispose, and — worse —
+/// the handle counter restarts when the pool is recreated, so a straggler in-flight marker for
+/// (reused) handle 0 would suppress the SUCCESSOR pool's prefetch of its own handle 0. The drain
+/// quiesces all workers before teardown; Reset additionally clears the in-flight set so no stale
+/// marker survives a timed-out drain.</para>
+///
+/// <para><c>[Collection("WeightRegistry")]</c> serializes against the other classes that mutate
+/// the process-wide <see cref="WeightRegistry"/> singleton.</para>
+/// </summary>
+[Collection("WeightRegistry")]
+public class WeightRegistryPrefetchDrainTests : IDisposable
+{
+    private readonly string _backingDir;
+
+    public WeightRegistryPrefetchDrainTests()
+    {
+        _backingDir = Path.Combine(Path.GetTempPath(), "aidotnet-wr-drain-test-" + Guid.NewGuid().ToString("N"));
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 32, // tight, so a filler evicts our weight and prefetch has real work
+            StreamingBackingStorePath = _backingDir,
+        });
+    }
+
+    public void Dispose()
+    {
+        WeightRegistry.Reset();
+        if (Directory.Exists(_backingDir))
+        {
+            try { Directory.Delete(_backingDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static Tensor<float> NewStreamingWeight(params float[] values)
+    {
+        var t = new Tensor<float>(values, new[] { values.Length });
+        t.Lifetime = WeightLifetime.Streaming;
+        return t;
+    }
+
+    [Fact]
+    public void DrainInFlightPrefetches_WhenIdle_ReturnsTrue_AndKeepsPoolUsable()
+    {
+        // With no worker in flight the drain acquires + releases every permit and reports quiesced.
+        Assert.True(WeightRegistry.DrainInFlightPrefetches(timeoutMs: 5000));
+
+        // Critically, the permits must be RELEASED again — otherwise the prefetch subsystem would be
+        // dead after one drain. Prove it by issuing a real prefetch afterwards and seeing it run.
+        var t = NewStreamingWeight(1f, 2f, 3f, 4f);
+        WeightRegistry.RegisterWeight(t);
+        var filler = NewStreamingWeight(new float[16]);
+        WeightRegistry.RegisterWeight(filler);            // evicts t
+        Assert.False(WeightRegistry.IsResidentInPool(t));
+        WeightRegistry.UnregisterWeight(filler);          // free budget so the prefetch can land
+
+        Assert.True(WeightRegistry.PrefetchAsyncForTesting(t).Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(WeightRegistry.IsResidentInPool(t),
+            "Prefetch after a drain must still run — the drain left the semaphore permits acquired.");
+    }
+
+    [Fact]
+    public async Task DrainInFlightPrefetches_WaitsForInFlightWorker_ToComplete()
+    {
+        // Behavioral proof that the drain BLOCKS until the worker's Rehydrate finishes, rather than
+        // returning early. Issue a prefetch (worker queued, doing a disk read), then drain WITHOUT
+        // awaiting the task. If the drain genuinely waits, the bytes are guaranteed resident the
+        // instant it returns true. If it returned early, residency would be a race.
+        var t = NewStreamingWeight(5f, 6f, 7f, 8f);
+        WeightRegistry.RegisterWeight(t);
+        var filler = NewStreamingWeight(new float[16]);
+        WeightRegistry.RegisterWeight(filler);            // evicts t
+        Assert.False(WeightRegistry.IsResidentInPool(t));
+        WeightRegistry.UnregisterWeight(filler);
+
+        var workerTask = WeightRegistry.PrefetchAsyncForTesting(t);
+
+        bool drained = WeightRegistry.DrainInFlightPrefetches(timeoutMs: 5000);
+
+        Assert.True(drained, "Drain should report full quiescence within the timeout.");
+        Assert.True(WeightRegistry.IsResidentInPool(t),
+            "Drain returned before the in-flight prefetch worker finished its Rehydrate — it did not wait.");
+
+        await workerTask; // already complete; observe it so nothing is left dangling
+    }
+
+    [Fact]
+    public void ResetDuringActivePrefetch_LeavesSuccessorPoolUsable_NoStaleSuppression()
+    {
+        // The race the drain exists to close: Reset() tears the pool down while a prefetch worker may
+        // still be in flight, and the successor pool restarts handle ids from 0 — so a straggler
+        // in-flight marker for handle 0 would suppress the successor's own handle-0 prefetch (dedup
+        // sees it as "already in flight") AND a worker could page into a pool being disposed.
+        //
+        // Stress phase: repeatedly register handle 0, fire a prefetch FIRE-AND-FORGET (production
+        // shape — never awaited), and immediately Reset. Each Reset must drain whatever it left in
+        // flight without throwing or hanging, and clear the in-flight set so nothing carries over.
+        const int rounds = 60;
+        for (int round = 0; round < rounds; round++)
+        {
+            WeightRegistry.Reset(); // drains + disposes the PRIOR round's pool (with its in-flight worker)
+            WeightRegistry.Configure(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 32,
+                StreamingBackingStorePath = _backingDir,
+            });
+
+            var t = NewStreamingWeight(1f, 2f, 3f, 4f);
+            WeightRegistry.RegisterWeight(t);             // handle 0 in this fresh pool
+            var filler = NewStreamingWeight(new float[16]);
+            WeightRegistry.RegisterWeight(filler);        // evicts t
+            WeightRegistry.UnregisterWeight(filler);
+
+            // Fire-and-forget — may still be running its Rehydrate when the next iteration's Reset
+            // disposes this pool. That is exactly the teardown-vs-prefetch race under test.
+            _ = WeightRegistry.PrefetchAsyncForTesting(t);
+        }
+
+        // Final deterministic round: prove the successor pool is fully usable after all that churn.
+        // A stale in-flight marker for handle 0 (i.e. a Reset that failed to drain+clear) would make
+        // this AWAITED prefetch dedup into a no-op, leaving t non-resident → the assert below fails.
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 32,
+            StreamingBackingStorePath = _backingDir,
+        });
+        var verify = NewStreamingWeight(11f, 22f, 33f, 44f);
+        WeightRegistry.RegisterWeight(verify);            // handle 0 again
+        var verifyFiller = NewStreamingWeight(new float[16]);
+        WeightRegistry.RegisterWeight(verifyFiller);      // evicts verify
+        Assert.False(WeightRegistry.IsResidentInPool(verify), "setup: verify should be evicted");
+        WeightRegistry.UnregisterWeight(verifyFiller);
+
+        // Await THIS prefetch (the only one in flight for handle 0) — it does the real Rehydrate.
+        Assert.True(WeightRegistry.PrefetchAsyncForTesting(verify).Wait(TimeSpan.FromSeconds(5)),
+            "final prefetch did not complete — a stale in-flight marker likely suppressed handle 0.");
+        Assert.True(WeightRegistry.IsResidentInPool(verify),
+            "handle 0 not resident after prefetch — Reset failed to drain/clear, leaving the successor unusable.");
+
+        WeightRegistry.Materialize(verify);
+        var span = verify.DataVector.AsSpan();
+        Assert.Equal(11f, span[0]);
+        Assert.Equal(44f, span[3]);
+    }
+}


### PR DESCRIPTION
## Summary

`WeightRegistry.PrefetchAsync` queues **fire-and-forget** workers that capture the pool ref and run `Rehydrate` on the ThreadPool, releasing their in-flight marker + semaphore permit in a `finally`. `Reset()`/`Configure()` could dispose/swap the streaming pool **while such a worker was still in flight**, with two consequences:

1. The worker pages bytes against a pool being disposed (today only mitigated by the worker's own `ObjectDisposedException`/`InvalidOperationException` catches).
2. The handle counter **restarts** when the pool is recreated, so a straggler in-flight marker for (reused) **handle 0** would suppress the *successor* pool's own handle-0 prefetch — the dedup path sees it as "already in flight" and skips the `Rehydrate`, leaving the weight silently non-resident.

## Fix

`DrainInFlightPrefetches(timeoutMs)` acquires all `PrefetchMaxConcurrency` semaphore permits — which can only succeed once **no worker still holds one**, i.e. the subsystem is idle — then releases them so the pool stays usable. It **must** run outside `_lock` (a worker's `finally` takes `_lock` before releasing its permit, so draining under the lock would deadlock).

- `Reset()` and `Configure()` call it **before** tearing the pool down.
- `Reset()` additionally clears `_inFlightPrefetches` so a timed-out straggler can't suppress the successor pool.
- Best-effort: on ThreadPool starvation the drain times out and proceeds; the worker's existing disposed-pool guards keep that safe.

## Tests (`WeightRegistryPrefetchDrainTests`, net10.0 — 3/3 green)

- **Idle drain** reports quiesced and leaves the pool usable (permits are released, a subsequent prefetch still runs).
- **Drain waits** until an in-flight worker's `Rehydrate` finishes — bytes are guaranteed resident the instant it returns true (proves it doesn't return early).
- **60-round teardown-during-active-prefetch stress**: fire-and-forget prefetch + immediate `Reset` each round, then a final deterministic round proves the successor pool is fully usable with correct bytes (no stale-handle suppression).

## Context

Surfaced while root-causing an AiDotNet CI flake; that flake turned out to be unrelated (non-reproducible weight init, fixed separately). This is an independent streaming-teardown hardening — no functional dependency on that work. No public API change (`DrainInFlightPrefetches` is `internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)