### PR TITLE
perf(#653): route StreamingStrategy GEMM dispatch onto low-latency PersistentParallelExecutor (~2x DiT inference)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
@@ -129,7 +129,7 @@ internal static class StreamingStrategy
                 int ldaLocal = lda, ldbLocal = ldb, ldcLocal = ldc;
                 bool taLocal = transA, tbLocal = transB;
 
-                StreamingWorkerPool.Dispatch(procsLocal, p =>
+                PersistentParallelExecutor.Instance.Execute(procsLocal, p =>
                 {
                     int mStart = (int)(((long)p * mLocal) / procsLocal);
                     int mEnd = (int)(((long)(p + 1) * mLocal) / procsLocal);
@@ -191,7 +191,7 @@ internal static class StreamingStrategy
                     bool taLocal = transA, tbLocal = transB;
                     int procsLocal = procs;
 
-                    StreamingWorkerPool.Dispatch(procsLocal, p =>
+                    PersistentParallelExecutor.Instance.Execute(procsLocal, p =>
                     {
                         var (kStart, kLen) = KAxisDriver.GetThreadRange(k, procsLocal, p);
                         if (kLen <= 0) return;
@@ -237,7 +237,7 @@ internal static class StreamingStrategy
                     bool taLocal = transA, tbLocal = transB;
                     int procsLocal = procs;
 
-                    StreamingWorkerPool.Dispatch(procsLocal, p =>
+                    PersistentParallelExecutor.Instance.Execute(procsLocal, p =>
                     {
                         var (kStart, kLen) = KAxisDriver.GetThreadRange(k, procsLocal, p);
                         if (kLen <= 0) return;
@@ -304,7 +304,7 @@ internal static class StreamingStrategy
                 int ldaLocal = lda, ldbLocal = ldb, ldcLocal = ldc;
                 bool taLocal = transA, tbLocal = transB;
 
-                StreamingWorkerPool.Dispatch(procsLocal, p =>
+                PersistentParallelExecutor.Instance.Execute(procsLocal, p =>
                 {
                     int nStart = (int)(((long)p * nLocal) / procsLocal);
                     int nEnd = (int)(((long)(p + 1) * nLocal) / procsLocal);


### PR DESCRIPTION
## Summary

Route the **Streaming GEMM strategy's** parallel dispatch off the park-and-wait `StreamingWorkerPool` and onto the low-latency `PersistentParallelExecutor` — the same migration #531 (ParallelForOrSerial) and #1478 (SDPA) did for the same "park/wakeup dominates rapid ops" reason.

## Why

Profiling one **ICEdit (SiT-XL / DiT-XL, 1152-dim × 28 layers)** `Predict` on CPU (`dotnet-trace`, `AIDOTNET_DISABLE_GPU=1`) — the workload behind the foundation-scale diffusion CI timeouts (AiDotNet #1672) — showed **~85% of wall time in worker park/wakeup + semaphore handshake and only ~5–7% in actual GEMM/attention compute**. The Streaming strategy fires thousands of medium GEMMs in rapid succession per denoising step; `StreamingWorkerPool` spins `IdleSpinBeforePark=1000` (~µs) then parks on a `ManualResetEventSlim`, so the inter-GEMM gap exceeds the spin budget and workers pay a wakeup on nearly every GEMM.

`PersistentParallelExecutor` is the low-latency cooperative pool that `PackBoth`/`SimdGemm` already use; moving Streaming onto it removes the per-GEMM park/wakeup floor.

## Change

The 4 `StreamingWorkerPool.Dispatch(procs, action)` sites in `StreamingStrategy` become `PersistentParallelExecutor.Instance.Execute(procs, action)`. **Same M-chunk partitioning, same wait-for-all barrier — only the executor changes.** `StreamingStrategy` was the pool's sole consumer, so this also retires the park-and-wait dispatch path.

## Validation

- **Perf:** one ICEdit `Predict` (DiT-XL, 32×32 latent, 16-thread CPU box): **>300 s → 155 s (~2×)**.
- **Correctness:** `865/901` GEMM / BLAS / MachineKernel / MathInvariant tests pass, **0 failures** (36 skipped). No GEMM result drift from the executor change — important because `StreamingWorkerPool`'s own comments warn that mishandling its dispatch produces nondeterministic GEMM drift; routing onto the already-concurrency-safe PPE avoids that surface entirely.

## Scope

This is **iteration 1** of the diffusion GEMM-efficiency work (AiDotNet #1672 foundation-scale CI timeouts / #653 core saturation). It banks the dispatch-pool win; ICEdit is still 155 s vs a 120 s test budget, so a follow-up will reduce the **per-forward dispatch count / join latency** (coarser GEMM chunking) — tracked separately. The machine-code microkernel itself is already healthy (~66 GF/s; A-prefetch is a documented −14% dead end per #656, C-prefetch neutral), so it is intentionally untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
