### PR TITLE
perf(conv): batch=1 conv-backward-kernel writes gradient into dest (bound foundation-scale training memory)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -15365,9 +15365,71 @@ public partial class CpuEngine : ITensorLevelEngine
                 return;
             }
 
-            var gradKernelD = new double[totalLen];
             var kPoolD = System.Buffers.ArrayPool<double>.Shared;
             long im2colWorkKD = (long)inChannels * kernelHeight * kernelWidth * colW;
+
+            // #1688: batch==1 fast path — GEMM the kernel gradient straight into
+            // `dest` with the accumulate β, so NEITHER the per-image localGrad NOR
+            // the gradKernelD accumulator is allocated. Each of those is
+            // outC·inC·kH·kW doubles — e.g. 302 MB for a single 2048→2048 3×3 conv —
+            // and is too large for ArrayPool.Shared to pool (it exceeds the shared
+            // bucket cap, so Rent/`new` allocates fresh and Return discards). Across
+            // a deep many-channel backbone the general path below churns GBs of such
+            // transient per backward pass, which OOMs the 16 GB CI runner even though
+            // the model fits. A single-image backward needs no cross-batch
+            // accumulation, so the GEMM result IS the kernel gradient — write it to
+            // dest directly and the only large buffer left is dest itself (the
+            // gradient that must exist). The im2col buffer is colH·colW, which is
+            // small here (tiny spatial). Bit-identical to the general path: same
+            // gradOut · im2col^T GEMM, just targeting dest with β=accumulate.
+            if (batch == 1)
+            {
+                var im2colBuf = kPoolD.Rent(colH * colW);
+                try
+                {
+                    CpuParallelSettings.ParallelForOrSerial(0, inChannels, im2colWorkKD, c =>
+                    {
+                        Helpers.Im2ColHelper.Im2ColStridedSingleChannelRange(
+                            new ReadOnlySpan<double>(inputD, 0, inputSliceSize),
+                            new Span<double>(im2colBuf, 0, colH * colW), colW, 0,
+                            c, c + 1, height, width, kernelHeight, kernelWidth,
+                            strideH, strideW, padH, padW, dilationH, dilationW, outputHeight, outputWidth);
+                    }, deterministicSafe: true);
+                    if (Helpers.BlasProvider.TryGemmExBeta(
+                        outChannels, colH, colW,
+                        gradOutputD, 0, colW, false,
+                        im2colBuf, 0, colW, true,
+                        destD, destOff, colH,
+                        alpha: 1.0, beta: accumulate ? 1.0 : 0.0))
+                    {
+                        return;
+                    }
+                    // No-BLAS cold fallback (BLAS is normally present): transpose +
+                    // blocked multiply into a bounded temp, then merge per accumulate.
+                    var localGradCold = kPoolD.Rent(totalLen);
+                    var im2colT = kPoolD.Rent(colW * colH);
+                    try
+                    {
+                        for (int r = 0; r < colH; r++)
+                            for (int cc = 0; cc < colW; cc++)
+                                im2colT[cc * colH + r] = im2colBuf[r * colW + cc];
+                        Helpers.Im2ColHelper.MultiplyMatrixBlockedDouble(
+                            new ReadOnlySpan<double>(gradOutputD, 0, outChannels * colW),
+                            new ReadOnlySpan<double>(im2colT, 0, colW * colH),
+                            new Span<double>(localGradCold, 0, totalLen),
+                            outChannels, colW, colH);
+                        if (accumulate)
+                            for (int i = 0; i < totalLen; i++) destD[destOff + i] += localGradCold[i];
+                        else
+                            Array.Copy(localGradCold, 0, destD, destOff, totalLen);
+                    }
+                    finally { kPoolD.Return(localGradCold); kPoolD.Return(im2colT); }
+                }
+                finally { kPoolD.Return(im2colBuf); }
+                return;
+            }
+
+            var gradKernelD = new double[totalLen];
 
             // Per-image im2col + GEMM into localGrad (overwrite). See the float
             // counterpart ComputeBatchGradF for the channel-parallel rationale.


### PR DESCRIPTION
## Problem

`CpuEngine.Conv2DBackwardKernelInto`'s **double** path allocated two
`outChannels·inChannels·kH·kW`-element buffers per call — a `new double[totalLen]`
accumulator plus a rented `localGrad` — e.g. **302 MB each** for a single
`2048→2048` 3×3 conv. Those exceed `ArrayPool<double>.Shared`'s bucket cap, so they
are **not** pooled (`Rent` allocates fresh, `Return` discards), and a deep
many-channel backbone churns **GBs of transient per backward pass** — enough to OOM
a memory-constrained runner even when the model itself fits. (The float path already
pools its counterpart; only the double path `new`s the accumulator.)

This is the dominant single conv-backward allocation behind the foundation-scale
segmentation-model training OOMs tracked in ooples/AiDotNet#1688 (the spatial is
tiny there, so the im2col is *not* the consumer — this kernel-gradient buffer is).

## Fix

A single-image (`batch == 1`) backward — every B=1 training step — needs no
cross-batch accumulation, so the GEMM result **is** the kernel gradient. Add a
`batch == 1` fast path that builds the (small) im2col and GEMMs `gradOut @ im2col^T`
**straight into `dest`** with `β = accumulate`, eliminating both `totalLen`-sized
temps. The only large buffer left is `dest` itself (the gradient that must exist).
Falls through to a bounded cold path when BLAS is unavailable.

Bit-identical to the general path (same `gradOut · im2col^T` GEMM, just targeting
`dest` with `β`).

## Validation

- `Conv2DBackwardIntoTests` + `Conv2DBackwardChannelParallelTests` — **14/14 green**.
- End-to-end: a 228K-reported / ~170M-real-param segmentation model (MaskDINO) that
  OOM'd at a 4 GiB heap cap in `Conv2DBackwardKernelInto` now trains there cleanly.

This is one increment in the foundation-scale training-memory effort (ooples/AiDotNet#1688);
it bounds the conv-backward peak but is not a complete fix for the shard on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved gradient computation performance for single-item batches in double-precision workloads.
  * Added a fallback path to keep results reliable when the faster linear algebra route is unavailable.

* **Bug Fixes**
  * Reduced temporary memory usage during certain training operations.
  * Ensured rented memory is always released properly after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->