### PR TITLE
feat(dcnv3): fused grouped/depthwise deformable convolution kernel [WIP]

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1509,6 +1509,34 @@ internal static class BackwardFunctions<T>
     }
 
     /// <summary>
+    /// DeformableConv2D backward WITH modulation mask (DCN v2): routes gradient to input, kernel, offset
+    /// AND mask. inputs[0]=input, inputs[1]=kernel, inputs[2]=offset, inputs[3]=mask.
+    /// savedState layout: [stride, padding, dilation].
+    /// </summary>
+    internal static void DeformableConv2DBackwardWithMask(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var stride = (int[])savedState[0];
+        var padding = (int[])savedState[1];
+        var dilation = (int[])savedState[2];
+        var mask = inputs[3];
+
+        var gradInput = engine.DeformableConv2DBackwardInput(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, inputs[0]._shape, stride, padding, dilation);
+        var gradKernel = engine.DeformableConv2DBackwardKernel(
+            gradOutput, inputs[0], inputs[2], mask, inputs[1]._shape, stride, padding, dilation);
+        var gradOffset = engine.DeformableConv2DBackwardOffset(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, stride, padding, dilation);
+        var gradMask = engine.DeformableConv2DBackwardMask(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, stride, padding, dilation);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradOffset, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[3], gradMask, engine);
+    }
+
+    /// <summary>
     /// Grouped/depthwise DeformableConv2D backward (DCNv3, DCN v1 / mask=null): routes gradient to
     /// input, kernel, offset via the engine's grouped backward kernels. savedState layout:
     /// [stride, padding, dilation, groups (boxed int), deformGroups (boxed int)].
@@ -1534,6 +1562,36 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[2], gradOffset, engine);
+    }
+
+    /// <summary>
+    /// Grouped DeformableConv2D backward WITH modulation mask (DCN v2 / v3): routes gradient to
+    /// input, kernel, offset AND mask. inputs[0]=input, inputs[1]=kernel, inputs[2]=offset, inputs[3]=mask.
+    /// savedState layout: [stride, padding, dilation, groups (boxed int), deformGroups (boxed int)].
+    /// </summary>
+    internal static void DeformableConv2DGroupedBackwardWithMask(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var stride = (int[])savedState[0];
+        var padding = (int[])savedState[1];
+        var dilation = (int[])savedState[2];
+        int groups = (int)savedState[3];
+        int deformGroups = (int)savedState[4];
+        var mask = inputs[3];
+
+        var gradInput = engine.DeformableConv2DGroupedBackwardInput(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, inputs[0]._shape, stride, padding, dilation, groups, deformGroups);
+        var gradKernel = engine.DeformableConv2DGroupedBackwardKernel(
+            gradOutput, inputs[0], inputs[2], mask, inputs[1]._shape, stride, padding, dilation, groups, deformGroups);
+        var gradOffset = engine.DeformableConv2DGroupedBackwardOffset(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, stride, padding, dilation, groups, deformGroups);
+        var gradMask = engine.DeformableConv2DGroupedBackwardMask(
+            gradOutput, inputs[0], inputs[1], inputs[2], mask, stride, padding, dilation, groups, deformGroups);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradOffset, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[3], gradMask, engine);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1509,6 +1509,34 @@ internal static class BackwardFunctions<T>
     }
 
     /// <summary>
+    /// Grouped/depthwise DeformableConv2D backward (DCNv3, DCN v1 / mask=null): routes gradient to
+    /// input, kernel, offset via the engine's grouped backward kernels. savedState layout:
+    /// [stride, padding, dilation, groups (boxed int), deformGroups (boxed int)].
+    /// inputs[0]=input, inputs[1]=kernel, inputs[2]=offset. The modulation-mask (DCN v2) variant is not
+    /// yet wired; tape recording only runs when mask is null in the forward call.
+    /// </summary>
+    internal static void DeformableConv2DGroupedBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var stride = (int[])savedState[0];
+        var padding = (int[])savedState[1];
+        var dilation = (int[])savedState[2];
+        int groups = (int)savedState[3];
+        int deformGroups = (int)savedState[4];
+
+        var gradInput = engine.DeformableConv2DGroupedBackwardInput(
+            gradOutput, inputs[0], inputs[1], inputs[2], null, inputs[0]._shape, stride, padding, dilation, groups, deformGroups);
+        var gradKernel = engine.DeformableConv2DGroupedBackwardKernel(
+            gradOutput, inputs[0], inputs[2], null, inputs[1]._shape, stride, padding, dilation, groups, deformGroups);
+        var gradOffset = engine.DeformableConv2DGroupedBackwardOffset(
+            gradOutput, inputs[0], inputs[1], inputs[2], null, stride, padding, dilation, groups, deformGroups);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[2], gradOffset, engine);
+    }
+
+    /// <summary>
     /// GraphAttention backward: dL flows to nodeFeatures + the two attention
     /// weight vectors. Edge index tensors are non-trainable and live in
     /// savedState as portable int[] data + int[] shape pairs (so the tape

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -283,6 +283,8 @@ internal static class OpRegistry
         "LocallyConnectedConv2DBackwardInput", "LocallyConnectedConv2DBackwardWeights", "LocallyConnectedConv2DBackwardBias",
         "DeformableConv2DBackwardInput", "DeformableConv2DBackwardKernel",
         "DeformableConv2DBackwardOffset", "DeformableConv2DBackwardMask",
+        "DeformableConv2DGroupedBackwardInput", "DeformableConv2DGroupedBackwardKernel",
+        "DeformableConv2DGroupedBackwardOffset", "DeformableConv2DGroupedBackwardMask",
         "GridSampleBackwardInput", "GridSampleBackwardGrid",
         "BatchNormBackward", "LayerNormBackward", "GroupNormBackward", "RMSNormBackward", "InstanceNormBackward",
         "DropoutBackward", "EmbeddingBackward",
@@ -457,6 +459,7 @@ internal static class OpRegistry
 
         // Deformable conv (complex, delegates to sub-ops)
         "DeformableConv2D",
+        "DeformableConv2DGrouped", // DCNv3 grouped/depthwise (#1691)
 
         // Additional delegators for IEngine wrappers
         "TensorSELU",          // -> SELU (records)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17034,12 +17034,48 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
         }
-        else if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
+        else
         {
-            throw new NotSupportedException(
-                "DeformableConv2D autograd with a modulation mask (DCN v2) is not yet wired. " +
-                "Either pass mask=null (DCN v1) or wrap the call in a NoGradScope<T>() to opt out " +
-                "of autograd for this op.");
+            // DCN v2 (modulation mask): record input/kernel/offset AND mask so dL flows to all four.
+            var savedState = new object[]
+            {
+                (int[])stride.Clone(), (int[])padding.Clone(), (int[])dilation.Clone(),
+            };
+            DifferentiableOps.RecordIfActive("DeformableConv2D", result,
+                new[] { input, kernel, offset, mask },
+                BackwardFunctions<T>.DeformableConv2DBackwardWithMask,
+                savedState);
+
+            if (GraphMode.IsActive)
+            {
+                var scope = GraphMode.Current;
+                if (scope != null)
+                {
+                    var capturedInput = input;
+                    var capturedKernel = kernel;
+                    var capturedOffset = offset;
+                    var capturedMask = mask;
+                    var capturedStride = (int[])stride.Clone();
+                    var capturedPadding = (int[])padding.Clone();
+                    var capturedDilation = (int[])dilation.Clone();
+                    var outShape = (int[])result._shape.Clone();
+                    return scope.RecordVariadic(
+                        LazyNodeType.Custom,
+                        "DeformableConv2D",
+                        new[] { input, kernel, offset, mask },
+                        outShape,
+                        (eng, output) =>
+                        {
+                            var replayed = eng.DeformableConv2D(
+                                capturedInput, capturedKernel, capturedOffset,
+                                capturedMask,
+                                capturedStride, capturedPadding, capturedDilation);
+                            DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
+                        },
+                        BackwardFunctions<T>.DeformableConv2DBackwardWithMask,
+                        savedState);
+                }
+            }
         }
         return result;
     }
@@ -17083,8 +17119,14 @@ public partial class CpuEngine : ITensorLevelEngine
         int inCpg = inChannels / groups;
         int outCpg = outChannels / groups;
         if (kernelInChannels != inCpg) throw new ArgumentException($"Kernel in_channels ({kernelInChannels}) must equal inChannels/groups ({inCpg}).");
-        if (groups % deformGroups != 0 && deformGroups % groups != 0)
-            throw new ArgumentException($"deformGroups ({deformGroups}) and groups ({groups}) must divide one another.");
+        // deformGroups must DIVIDE groups: there each output group maps to exactly one deformable group
+        // (dg = g·deformGroups/groups), and that mapping coincides with the GPU kernel's per-input-channel
+        // mapping (ic/(inChannels/deformGroups)). The groups<deformGroups case (deformGroups not dividing
+        // groups) would put multiple deformable groups inside one group's channel span — the CPU
+        // composition path can't express that and would silently diverge from the GPU kernel — so reject it.
+        if (groups % deformGroups != 0)
+            throw new ArgumentException($"deformGroups ({deformGroups}) must divide groups ({groups}). " +
+                "The groups<deformGroups configuration is not supported (it would diverge between the CPU and GPU paths).");
 
         int strideH = stride[0], strideW = stride[1];
         int padH = padding[0], padW = padding[1];
@@ -17198,12 +17240,51 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
         }
-        else if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
+        else
         {
-            throw new NotSupportedException(
-                "DeformableConv2DGrouped autograd with a modulation mask (DCN v2) is not yet wired. " +
-                "Either pass mask=null (DCN v1) or wrap the call in a NoGradScope<T>() to opt out " +
-                "of autograd for this op.");
+            // DCN v2 / v3 (modulation mask): record input/kernel/offset AND mask so dL flows to all four.
+            var savedState = new object[]
+            {
+                (int[])stride.Clone(), (int[])padding.Clone(), (int[])dilation.Clone(), groups, deformGroups,
+            };
+            DifferentiableOps.RecordIfActive("DeformableConv2DGrouped", result,
+                new[] { input, kernel, offset, mask },
+                BackwardFunctions<T>.DeformableConv2DGroupedBackwardWithMask,
+                savedState);
+
+            if (GraphMode.IsActive)
+            {
+                var scope = GraphMode.Current;
+                if (scope != null)
+                {
+                    var capturedInput = input;
+                    var capturedKernel = kernel;
+                    var capturedOffset = offset;
+                    var capturedMask = mask;
+                    var capturedStride = (int[])stride.Clone();
+                    var capturedPadding = (int[])padding.Clone();
+                    var capturedDilation = (int[])dilation.Clone();
+                    int capturedGroups = groups;
+                    int capturedDeformGroups = deformGroups;
+                    var outShape = (int[])result._shape.Clone();
+                    return scope.RecordVariadic(
+                        LazyNodeType.Custom,
+                        "DeformableConv2DGrouped",
+                        new[] { input, kernel, offset, mask },
+                        outShape,
+                        (eng, output) =>
+                        {
+                            var replayed = eng.DeformableConv2DGrouped(
+                                capturedInput, capturedKernel, capturedOffset,
+                                capturedMask,
+                                capturedStride, capturedPadding, capturedDilation,
+                                capturedGroups, capturedDeformGroups);
+                            DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
+                        },
+                        BackwardFunctions<T>.DeformableConv2DGroupedBackwardWithMask,
+                        savedState);
+                }
+            }
         }
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17153,6 +17153,139 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    // ---- Grouped DCNv3 backward (#1691). Composition over the tested groups=1 backward kernels:
+    // groups are channel-independent for input/kernel grads (concatenate); the offset/mask grad of a
+    // deformable group is the SUM over the output groups that share it. (Single-pass fusion of the
+    // backward is a later optimization; the forward is the perf-critical path.) ----
+
+    private static (int b, int inC, int H, int W, int outC, int kk, int inCpg, int outCpg) GroupDims<T>(
+        int[] inputShape, Tensor<T> kernel, int groups)
+    {
+        int outC = kernel._shape[0];
+        int kk = kernel._shape[2] * kernel._shape[3];
+        return (inputShape[0], inputShape[1], inputShape[2], inputShape[3], outC, kk,
+                inputShape[1] / groups, outC / groups);
+    }
+
+    /// <summary>Grouped <see cref="DeformableConv2D{T}"/> gradient w.r.t. input (#1691).</summary>
+    public virtual Tensor<T> DeformableConv2DGroupedBackwardInput<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> kernel, Tensor<T> offset, Tensor<T>? mask,
+        int[] inputShape, int[] stride, int[] padding, int[] dilation, int groups, int deformGroups)
+    {
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2DBackwardInput(gradOutput, input, kernel, offset, mask, inputShape, stride, padding, dilation);
+        var d = GroupDims(inputShape, kernel, groups);
+        var parts = new Tensor<T>[groups];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var goG = gradOutput.Slice(1, g * d.outCpg, (g + 1) * d.outCpg);
+            var kG = kernel.Slice(0, g * d.outCpg, (g + 1) * d.outCpg);
+            var inG = input.Slice(1, g * d.inCpg, (g + 1) * d.inCpg);
+            var offG = offset.Slice(1, dg * 2 * d.kk, (dg + 1) * 2 * d.kk);
+            var mkG = mask?.Slice(1, dg * d.kk, (dg + 1) * d.kk);
+            parts[g] = DeformableConv2DBackwardInput(goG, inG, kG, offG, mkG, new[] { d.b, d.inCpg, d.H, d.W }, stride, padding, dilation);
+        }
+        return Tensor<T>.Concatenate(parts, axis: 1);
+    }
+
+    /// <summary>Grouped <see cref="DeformableConv2D{T}"/> gradient w.r.t. kernel (#1691).</summary>
+    public virtual Tensor<T> DeformableConv2DGroupedBackwardKernel<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> offset, Tensor<T>? mask,
+        int[] kernelShape, int[] stride, int[] padding, int[] dilation, int groups, int deformGroups)
+    {
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2DBackwardKernel(gradOutput, input, offset, mask, kernelShape, stride, padding, dilation);
+        int outC = kernelShape[0], inCpg = kernelShape[1], kH = kernelShape[2], kW = kernelShape[3], kk = kH * kW;
+        int inC = input._shape[1], outCpg = outC / groups; int kkChans = 2 * kk;
+        var parts = new Tensor<T>[groups];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var goG = gradOutput.Slice(1, g * outCpg, (g + 1) * outCpg);
+            var inG = input.Slice(1, g * inCpg, (g + 1) * inCpg);
+            var offG = offset.Slice(1, dg * kkChans, (dg + 1) * kkChans);
+            var mkG = mask?.Slice(1, dg * kk, (dg + 1) * kk);
+            parts[g] = DeformableConv2DBackwardKernel(goG, inG, offG, mkG, new[] { outCpg, inCpg, kH, kW }, stride, padding, dilation);
+        }
+        return Tensor<T>.Concatenate(parts, axis: 0); // concat over output-channel axis -> [outC, inCpg, kH, kW]
+    }
+
+    /// <summary>Grouped <see cref="DeformableConv2D{T}"/> gradient w.r.t. offset (#1691). The grad of a
+    /// deformable group is the sum over the output groups sharing it.</summary>
+    public virtual Tensor<T> DeformableConv2DGroupedBackwardOffset<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> kernel, Tensor<T> offset, Tensor<T>? mask,
+        int[] stride, int[] padding, int[] dilation, int groups, int deformGroups)
+    {
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2DBackwardOffset(gradOutput, input, kernel, offset, mask, stride, padding, dilation);
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int inC = input._shape[1], outC = kernel._shape[0], kk = kernel._shape[2] * kernel._shape[3];
+        int inCpg = inC / groups, outCpg = outC / groups, blk = 2 * kk;
+        var gradOffset = AutoTensorCache.RentOrAllocate<T>(offset._shape);
+        var goData = gradOffset.GetDataArray();
+        Array.Clear(goData, 0, (int)gradOffset.Length);
+        int fullC = offset._shape[1];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var goG = gradOutput.Slice(1, g * outCpg, (g + 1) * outCpg);
+            var kG = kernel.Slice(0, g * outCpg, (g + 1) * outCpg);
+            var inG = input.Slice(1, g * inCpg, (g + 1) * inCpg);
+            var offG = offset.Slice(1, dg * blk, (dg + 1) * blk);
+            var mkG = mask?.Slice(1, dg * kk, (dg + 1) * kk);
+            var part = DeformableConv2DBackwardOffset(goG, inG, kG, offG, mkG, stride, padding, dilation);
+            var pData = part.GetDataArray();
+            int B = part._shape[0], pc = part._shape[1], oHW = part._shape[2] * part._shape[3];
+            for (int bb = 0; bb < B; bb++)
+                for (int c = 0; c < pc; c++)
+                    for (int s = 0; s < oHW; s++)
+                    {
+                        int dst = ((bb * fullC + dg * blk + c) * oHW) + s;
+                        int src = ((bb * pc + c) * oHW) + s;
+                        goData[dst] = numOps.Add(goData[dst], pData[src]);
+                    }
+        }
+        return gradOffset;
+    }
+
+    /// <summary>Grouped <see cref="DeformableConv2D{T}"/> gradient w.r.t. modulation mask (#1691).</summary>
+    public virtual Tensor<T> DeformableConv2DGroupedBackwardMask<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> kernel, Tensor<T> offset, Tensor<T> mask,
+        int[] stride, int[] padding, int[] dilation, int groups, int deformGroups)
+    {
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2DBackwardMask(gradOutput, input, kernel, offset, mask, stride, padding, dilation);
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int inC = input._shape[1], outC = kernel._shape[0], kk = kernel._shape[2] * kernel._shape[3];
+        int inCpg = inC / groups, outCpg = outC / groups, blk = 2 * kk;
+        var gradMask = AutoTensorCache.RentOrAllocate<T>(mask._shape);
+        var gmData = gradMask.GetDataArray();
+        Array.Clear(gmData, 0, (int)gradMask.Length);
+        int fullC = mask._shape[1];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var goG = gradOutput.Slice(1, g * outCpg, (g + 1) * outCpg);
+            var kG = kernel.Slice(0, g * outCpg, (g + 1) * outCpg);
+            var inG = input.Slice(1, g * inCpg, (g + 1) * inCpg);
+            var offG = offset.Slice(1, dg * blk, (dg + 1) * blk);
+            var mkG = mask.Slice(1, dg * kk, (dg + 1) * kk);
+            var part = DeformableConv2DBackwardMask(goG, inG, kG, offG, mkG, stride, padding, dilation);
+            var pData = part.GetDataArray();
+            int B = part._shape[0], pc = part._shape[1], oHW = part._shape[2] * part._shape[3];
+            for (int bb = 0; bb < B; bb++)
+                for (int c = 0; c < pc; c++)
+                    for (int s = 0; s < oHW; s++)
+                    {
+                        int dst = ((bb * fullC + dg * kk + c) * oHW) + s;
+                        int src = ((bb * pc + c) * oHW) + s;
+                        gmData[dst] = numOps.Add(gmData[dst], pData[src]);
+                    }
+        }
+        return gradMask;
+    }
+
     /// <summary>
     /// Performs bilinear sampling at a fractional position.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17150,6 +17150,61 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
             }
         });
+
+        // Tape + lazy-graph registration — only DCN v1 (mask null) for now, mirroring DeformableConv2D.
+        // The grouped backward (input/kernel/offset) is wired; the modulation-mask (DCN v2) grad isn't,
+        // so fail fast under an active tape/graph rather than silently dropping dL when a mask is passed.
+        if (mask is null)
+        {
+            var savedState = new object[]
+            {
+                (int[])stride.Clone(), (int[])padding.Clone(), (int[])dilation.Clone(), groups, deformGroups,
+            };
+            DifferentiableOps.RecordIfActive("DeformableConv2DGrouped", result,
+                new[] { input, kernel, offset },
+                BackwardFunctions<T>.DeformableConv2DGroupedBackward,
+                savedState);
+
+            if (GraphMode.IsActive)
+            {
+                var scope = GraphMode.Current;
+                if (scope != null)
+                {
+                    var capturedInput = input;
+                    var capturedKernel = kernel;
+                    var capturedOffset = offset;
+                    var capturedStride = (int[])stride.Clone();
+                    var capturedPadding = (int[])padding.Clone();
+                    var capturedDilation = (int[])dilation.Clone();
+                    int capturedGroups = groups;
+                    int capturedDeformGroups = deformGroups;
+                    var outShape = (int[])result._shape.Clone();
+                    return scope.RecordVariadic(
+                        LazyNodeType.Custom,
+                        "DeformableConv2DGrouped",
+                        new[] { input, kernel, offset },
+                        outShape,
+                        (eng, output) =>
+                        {
+                            var replayed = eng.DeformableConv2DGrouped(
+                                capturedInput, capturedKernel, capturedOffset,
+                                mask: null,
+                                capturedStride, capturedPadding, capturedDilation,
+                                capturedGroups, capturedDeformGroups);
+                            DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
+                        },
+                        BackwardFunctions<T>.DeformableConv2DGroupedBackward,
+                        savedState);
+                }
+            }
+        }
+        else if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
+        {
+            throw new NotSupportedException(
+                "DeformableConv2DGrouped autograd with a modulation mask (DCN v2) is not yet wired. " +
+                "Either pass mask=null (DCN v1) or wrap the call in a NoGradScope<T>() to opt out " +
+                "of autograd for this op.");
+        }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17045,6 +17045,115 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <summary>
+    /// Fused grouped / depthwise deformable convolution (DCNv3, Wang et al. 2023). Single-pass kernel:
+    /// the channels are split into <paramref name="groups"/>; output channel <c>oc</c> (group
+    /// <c>g = oc / (outChannels/groups)</c>) convolves only its group's <c>inChannels/groups</c> input
+    /// channels against kernel rows shaped <c>[outChannels, inChannels/groups, kH, kW]</c>, sampling with
+    /// its deformable-group (<paramref name="deformGroups"/>) offset/mask slice. With
+    /// <c>groups == deformGroups == 1</c> this reduces exactly to <see cref="DeformableConv2D{T}"/>.
+    /// <para>Reference CPU implementation for the fused DCNv3 kernel (#1691). The offset/mask channel
+    /// layout matches the per-group composition path: contiguous per-deformable-group blocks of
+    /// <c>2·kH·kW</c> (Y then X) for offsets and <c>kH·kW</c> for the modulation mask.</para>
+    /// </summary>
+    public virtual Tensor<T> DeformableConv2DGrouped<T>(
+        Tensor<T> input, Tensor<T> kernel, Tensor<T> offset, Tensor<T>? mask,
+        int[] stride, int[] padding, int[] dilation, int groups, int deformGroups)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (kernel == null) throw new ArgumentNullException(nameof(kernel));
+        if (offset == null) throw new ArgumentNullException(nameof(offset));
+        if (groups < 1) throw new ArgumentOutOfRangeException(nameof(groups), "Groups must be at least 1.");
+        if (deformGroups < 1) throw new ArgumentOutOfRangeException(nameof(deformGroups), "Deformable groups must be at least 1.");
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2D(input, kernel, offset, mask, stride, padding, dilation);
+        if (input.Rank != 4) throw new ArgumentException($"DeformableConv2DGrouped requires 4D input. Got rank {input.Rank}.", nameof(input));
+        if (kernel.Rank != 4) throw new ArgumentException($"DeformableConv2DGrouped requires 4D kernel. Got rank {kernel.Rank}.", nameof(kernel));
+
+        int batch = input._shape[0];
+        int inChannels = input._shape[1];
+        int height = input._shape[2];
+        int width = input._shape[3];
+        int outChannels = kernel._shape[0];
+        int kernelInChannels = kernel._shape[1];
+        int kernelHeight = kernel._shape[2];
+        int kernelWidth = kernel._shape[3];
+
+        if (inChannels % groups != 0) throw new ArgumentException($"Input channels ({inChannels}) must be divisible by groups ({groups}).");
+        if (outChannels % groups != 0) throw new ArgumentException($"Output channels ({outChannels}) must be divisible by groups ({groups}).");
+        int inCpg = inChannels / groups;
+        int outCpg = outChannels / groups;
+        if (kernelInChannels != inCpg) throw new ArgumentException($"Kernel in_channels ({kernelInChannels}) must equal inChannels/groups ({inCpg}).");
+        if (groups % deformGroups != 0 && deformGroups % groups != 0)
+            throw new ArgumentException($"deformGroups ({deformGroups}) and groups ({groups}) must divide one another.");
+
+        int strideH = stride[0], strideW = stride[1];
+        int padH = padding[0], padW = padding[1];
+        int dilationH = dilation[0], dilationW = dilation[1];
+        int effectiveKernelH = dilationH * (kernelHeight - 1) + 1;
+        int effectiveKernelW = dilationW * (kernelWidth - 1) + 1;
+        int outputHeight = (height + 2 * padH - effectiveKernelH) / strideH + 1;
+        int outputWidth = (width + 2 * padW - effectiveKernelW) / strideW + 1;
+        int numKernelPositions = kernelHeight * kernelWidth;
+        int offChans = 2 * numKernelPositions * deformGroups;
+        int maskChans = numKernelPositions * deformGroups;
+        var numOps = MathHelper.GetNumericOperations<T>();
+
+        var inputData = input.GetDataArray();
+        var kernelData = kernel.GetDataArray();
+        var offsetData = offset.GetDataArray();
+        var maskData = mask?.GetDataArray();
+        var result = TensorAllocator.Rent<T>([batch, outChannels, outputHeight, outputWidth]);
+        var outputData = result.GetDataArray();
+
+        CpuParallelSettings.ParallelForOrSerial(0, batch * outChannels, outputData.Length, idx =>
+        {
+            int b = idx / outChannels;
+            int oc = idx % outChannels;
+            int g = oc / outCpg;                                   // output group
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups; // deformable group
+            int icBase = g * inCpg;                                // first input channel of this group
+            int offBlock = dg * 2 * numKernelPositions;            // offset channel base for this deform group
+            int maskBlock = dg * numKernelPositions;
+
+            for (int oh = 0; oh < outputHeight; oh++)
+            {
+                for (int ow = 0; ow < outputWidth; ow++)
+                {
+                    T sum = numOps.Zero;
+                    for (int ic = 0; ic < inCpg; ic++)
+                    {
+                        int icGlobal = icBase + ic;
+                        for (int kh = 0; kh < kernelHeight; kh++)
+                        {
+                            for (int kw = 0; kw < kernelWidth; kw++)
+                            {
+                                int kp = kh * kernelWidth + kw;
+                                int offYIdx = ((b * offChans + offBlock + kp) * outputHeight + oh) * outputWidth + ow;
+                                int offXIdx = ((b * offChans + offBlock + numKernelPositions + kp) * outputHeight + oh) * outputWidth + ow;
+                                double offsetY = numOps.ToDouble(offsetData[offYIdx]);
+                                double offsetX = numOps.ToDouble(offsetData[offXIdx]);
+                                double sampledH = oh * strideH - padH + kh * dilationH + offsetY;
+                                double sampledW = ow * strideW - padW + kw * dilationW + offsetX;
+                                T sampledValue = BilinearSample(inputData, b, icGlobal, inChannels, height, width, sampledH, sampledW, numOps);
+                                if (maskData != null)
+                                {
+                                    int maskIdx = ((b * maskChans + maskBlock + kp) * outputHeight + oh) * outputWidth + ow;
+                                    sampledValue = numOps.Multiply(sampledValue, maskData[maskIdx]);
+                                }
+                                int kernelIdx = ((oc * inCpg + ic) * kernelHeight + kh) * kernelWidth + kw;
+                                sum = numOps.Add(sum, numOps.Multiply(sampledValue, kernelData[kernelIdx]));
+                            }
+                        }
+                    }
+                    int outputIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
+                    outputData[outputIdx] = sum;
+                }
+            }
+        });
+        return result;
+    }
+
+    /// <summary>
     /// Performs bilinear sampling at a fractional position.
     /// </summary>
     private static T BilinearSample<T>(

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8562,11 +8562,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
-    /// Grouped/depthwise deformable convolution (DCNv3). Interim GPU path: per-group composition over the
-    /// validated groups=1 GPU <see cref="DeformableConv2D{T}"/> kernel plus a GPU concat — every group runs a
-    /// real GPU kernel (no CPU fallback). A fused single-launch grouped GPU kernel (passing groups/deformGroups
-    /// straight to the backend with on-hardware parity) is tracked in AiDotNet #1691. The grouped backward is
-    /// inherited from <see cref="CpuEngine"/> and composes over the virtual groups=1 GPU backward kernels.
+    /// Grouped/depthwise deformable convolution (DCNv3). Single-launch GPU path: passes groups/deformGroups
+    /// straight to the backend's grouped <c>deformable_conv2d</c> kernel (one launch), which all six backends
+    /// implement with the same blocked offset layout as the CPU reference. Falls back to the CPU fused kernel
+    /// only when GPU is unavailable / inputs are non-4D / a launch throws. The grouped backward is inherited
+    /// from <see cref="CpuEngine"/> and composes over the virtual groups=1 GPU backward kernels.
     /// </summary>
     public override Tensor<T> DeformableConv2DGrouped<T>(
         Tensor<T> input,
@@ -8581,26 +8581,61 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (groups == 1 && deformGroups == 1)
             return DeformableConv2D(input, kernel, offset, mask, stride, padding, dilation);
-        if (!TryGetBackend(out _) || input.Rank != 4 || kernel.Rank != 4)
+        if (!TryGetBackend(out var backend) || input.Rank != 4 || kernel.Rank != 4 || offset.Rank != 4)
             return base.DeformableConv2DGrouped(input, kernel, offset, mask, stride, padding, dilation, groups, deformGroups);
 
-        int inC = input.Shape._dims[1];
-        int outC = kernel.Shape._dims[0];
-        int kk = kernel.Shape._dims[2] * kernel.Shape._dims[3];
-        int inCpg = inC / groups;
-        int outCpg = outC / groups;
-        var parts = new Tensor<T>[groups];
-        for (int g = 0; g < groups; g++)
+        if (stride == null || stride.Length != 2) throw new ArgumentException("Stride must be an array of 2 elements", nameof(stride));
+        if (padding == null || padding.Length != 2) throw new ArgumentException("Padding must be an array of 2 elements", nameof(padding));
+        if (dilation == null || dilation.Length != 2) throw new ArgumentException("Dilation must be an array of 2 elements", nameof(dilation));
+
+        int batch = input.Shape._dims[0];
+        int inChannels = input.Shape._dims[1];
+        int inHeight = input.Shape._dims[2];
+        int inWidth = input.Shape._dims[3];
+        int outChannels = kernel.Shape._dims[0];   // kernel: [outC, inC/groups, kH, kW]
+        int kernelH = kernel.Shape._dims[2];
+        int kernelW = kernel.Shape._dims[3];
+
+        int outHeight = (inHeight + 2 * padding[0] - dilation[0] * (kernelH - 1) - 1) / stride[0] + 1;
+        int outWidth = (inWidth + 2 * padding[1] - dilation[1] * (kernelW - 1) - 1) / stride[1] + 1;
+        if (outHeight <= 0 || outWidth <= 0)
+            return base.DeformableConv2DGrouped(input, kernel, offset, mask, stride, padding, dilation, groups, deformGroups);
+
+        int outputSize = batch * outChannels * outHeight * outWidth;
+
+        using var inputBuffer = GetOrAllocateBuffer(backend, input);
+        using var weightsBuffer = GetOrCacheWeightBuffer(backend, kernel.GetDataArray(), PersistentTensorRole.Weights);
+        using var offsetsBuffer = GetOrAllocateBuffer(backend, offset);
+        using var outputBuffer = AllocateOutputBuffer(backend, outputSize);
+
+        try
         {
-            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
-            var inG = input.Slice(1, g * inCpg, (g + 1) * inCpg);
-            var kG = kernel.Slice(0, g * outCpg, (g + 1) * outCpg);
-            var offG = offset.Slice(1, dg * 2 * kk, (dg + 1) * 2 * kk);
-            var mkG = mask?.Slice(1, dg * kk, (dg + 1) * kk);
-            // virtual dispatch -> the groups=1 GPU DeformableConv2D kernel above
-            parts[g] = DeformableConv2D(inG, kG, offG, mkG, stride, padding, dilation);
+            OwnedBuffer? maskBuffer = mask != null ? GetOrAllocateBuffer(backend, mask) : null;
+            try
+            {
+                backend.DeformableConv2D(
+                    inputBuffer.Buffer, weightsBuffer.Buffer, offsetsBuffer.Buffer, maskBuffer?.Buffer, outputBuffer.Buffer,
+                    batch, inChannels, inHeight, inWidth,
+                    outChannels, outHeight, outWidth,
+                    kernelH, kernelW, stride[0], stride[1], padding[0], padding[1],
+                    dilation[0], dilation[1], groups, deformGroups);
+
+                float[] resultFloat = new float[outputSize];
+                backend.DownloadBuffer(outputBuffer.Buffer, resultFloat);
+
+                T[] resultData = DirectGpuEngine.FromFloatArray<T>(resultFloat);
+                return new Tensor<T>(resultData, new[] { batch, outChannels, outHeight, outWidth });
+            }
+            finally
+            {
+                maskBuffer?.Dispose();
+            }
         }
-        return Tensor<T>.Concatenate(parts, axis: 1);
+        catch
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.DeformableConv2DGrouped(input, kernel, offset, mask, stride, padding, dilation, groups, deformGroups);
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8562,6 +8562,48 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
+    /// Grouped/depthwise deformable convolution (DCNv3). Interim GPU path: per-group composition over the
+    /// validated groups=1 GPU <see cref="DeformableConv2D{T}"/> kernel plus a GPU concat — every group runs a
+    /// real GPU kernel (no CPU fallback). A fused single-launch grouped GPU kernel (passing groups/deformGroups
+    /// straight to the backend with on-hardware parity) is tracked in AiDotNet #1691. The grouped backward is
+    /// inherited from <see cref="CpuEngine"/> and composes over the virtual groups=1 GPU backward kernels.
+    /// </summary>
+    public override Tensor<T> DeformableConv2DGrouped<T>(
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T> offset,
+        Tensor<T>? mask,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups)
+    {
+        if (groups == 1 && deformGroups == 1)
+            return DeformableConv2D(input, kernel, offset, mask, stride, padding, dilation);
+        if (!TryGetBackend(out _) || input.Rank != 4 || kernel.Rank != 4)
+            return base.DeformableConv2DGrouped(input, kernel, offset, mask, stride, padding, dilation, groups, deformGroups);
+
+        int inC = input.Shape._dims[1];
+        int outC = kernel.Shape._dims[0];
+        int kk = kernel.Shape._dims[2] * kernel.Shape._dims[3];
+        int inCpg = inC / groups;
+        int outCpg = outC / groups;
+        var parts = new Tensor<T>[groups];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var inG = input.Slice(1, g * inCpg, (g + 1) * inCpg);
+            var kG = kernel.Slice(0, g * outCpg, (g + 1) * outCpg);
+            var offG = offset.Slice(1, dg * 2 * kk, (dg + 1) * 2 * kk);
+            var mkG = mask?.Slice(1, dg * kk, (dg + 1) * kk);
+            // virtual dispatch -> the groups=1 GPU DeformableConv2D kernel above
+            parts[g] = DeformableConv2D(inG, kG, offG, mkG, stride, padding, dilation);
+        }
+        return Tensor<T>.Concatenate(parts, axis: 1);
+    }
+
+    /// <summary>
     /// GPU-accelerated deformable conv2D backward pass for input gradients.
     /// Falls back to CPU implementation if GPU is unavailable.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -3464,6 +3464,150 @@ public interface IEngine
         int[] dilation);
 
     /// <summary>
+    /// Computes a grouped/depthwise deformable convolution (DCNv3, Wang et al. 2023).
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="input">Input tensor [batch, inChannels, height, width].</param>
+    /// <param name="kernel">Convolution kernel [outChannels, inChannels/groups, kH, kW].</param>
+    /// <param name="offset">Offset tensor [batch, 2·kH·kW·deformGroups, outH, outW] (per-deformable-group blocks).</param>
+    /// <param name="mask">Optional modulation mask [batch, kH·kW·deformGroups, outH, outW] (null for DCNv1).</param>
+    /// <param name="stride">The stride [strideH, strideW].</param>
+    /// <param name="padding">The padding [padH, padW].</param>
+    /// <param name="dilation">The dilation [dilationH, dilationW].</param>
+    /// <param name="groups">Number of convolution groups (channels partitioned independently).</param>
+    /// <param name="deformGroups">Number of deformable groups sharing offset/mask fields.</param>
+    /// <returns>Output tensor [batch, outChannels, outH, outW].</returns>
+    /// <remarks>
+    /// <para>
+    /// DCNv3's parameter efficiency comes from grouping: each output group convolves only its slice of
+    /// input channels, and offsets/masks are predicted per deformable group. With
+    /// <paramref name="groups"/> = <paramref name="deformGroups"/> = 1 this reduces exactly to
+    /// <see cref="DeformableConv2D{T}"/>. <paramref name="groups"/> and <paramref name="deformGroups"/>
+    /// must divide one another (covers depthwise deformGroups==groups and shared deformGroups==1).
+    /// </para>
+    /// </remarks>
+    Tensor<T> DeformableConv2DGrouped<T>(
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T> offset,
+        Tensor<T>? mask,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups);
+
+    /// <summary>
+    /// Computes the gradient of <see cref="DeformableConv2DGrouped{T}"/> with respect to the input.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="gradOutput">The gradient flowing back from the output.</param>
+    /// <param name="input">The original input tensor from forward pass.</param>
+    /// <param name="kernel">The convolution kernel from forward pass.</param>
+    /// <param name="offset">The offset tensor from forward pass.</param>
+    /// <param name="mask">The modulation mask from forward pass (null for DCNv1).</param>
+    /// <param name="inputShape">The shape of the original input tensor.</param>
+    /// <param name="stride">The stride used in forward pass.</param>
+    /// <param name="padding">The padding used in forward pass.</param>
+    /// <param name="dilation">The dilation used in forward pass.</param>
+    /// <param name="groups">Number of convolution groups.</param>
+    /// <param name="deformGroups">Number of deformable groups.</param>
+    /// <returns>The gradient with respect to the input tensor.</returns>
+    Tensor<T> DeformableConv2DGroupedBackwardInput<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T> offset,
+        Tensor<T>? mask,
+        int[] inputShape,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups);
+
+    /// <summary>
+    /// Computes the gradient of <see cref="DeformableConv2DGrouped{T}"/> with respect to the kernel.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="gradOutput">The gradient flowing back from the output.</param>
+    /// <param name="input">The original input tensor from forward pass.</param>
+    /// <param name="offset">The offset tensor from forward pass.</param>
+    /// <param name="mask">The modulation mask from forward pass (null for DCNv1).</param>
+    /// <param name="kernelShape">The shape of the kernel tensor [outChannels, inChannels/groups, kH, kW].</param>
+    /// <param name="stride">The stride used in forward pass.</param>
+    /// <param name="padding">The padding used in forward pass.</param>
+    /// <param name="dilation">The dilation used in forward pass.</param>
+    /// <param name="groups">Number of convolution groups.</param>
+    /// <param name="deformGroups">Number of deformable groups.</param>
+    /// <returns>The gradient with respect to the kernel tensor.</returns>
+    Tensor<T> DeformableConv2DGroupedBackwardKernel<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        Tensor<T> offset,
+        Tensor<T>? mask,
+        int[] kernelShape,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups);
+
+    /// <summary>
+    /// Computes the gradient of <see cref="DeformableConv2DGrouped{T}"/> with respect to the offset.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="gradOutput">The gradient flowing back from the output.</param>
+    /// <param name="input">The original input tensor from forward pass.</param>
+    /// <param name="kernel">The convolution kernel from forward pass.</param>
+    /// <param name="offset">The offset tensor from forward pass.</param>
+    /// <param name="mask">The modulation mask from forward pass (null for DCNv1).</param>
+    /// <param name="stride">The stride used in forward pass.</param>
+    /// <param name="padding">The padding used in forward pass.</param>
+    /// <param name="dilation">The dilation used in forward pass.</param>
+    /// <param name="groups">Number of convolution groups.</param>
+    /// <param name="deformGroups">Number of deformable groups.</param>
+    /// <returns>The gradient with respect to the offset tensor.</returns>
+    Tensor<T> DeformableConv2DGroupedBackwardOffset<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T> offset,
+        Tensor<T>? mask,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups);
+
+    /// <summary>
+    /// Computes the gradient of <see cref="DeformableConv2DGrouped{T}"/> with respect to the modulation mask.
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="gradOutput">The gradient flowing back from the output.</param>
+    /// <param name="input">The original input tensor from forward pass.</param>
+    /// <param name="kernel">The convolution kernel from forward pass.</param>
+    /// <param name="offset">The offset tensor from forward pass.</param>
+    /// <param name="mask">The modulation mask from forward pass.</param>
+    /// <param name="stride">The stride used in forward pass.</param>
+    /// <param name="padding">The padding used in forward pass.</param>
+    /// <param name="dilation">The dilation used in forward pass.</param>
+    /// <param name="groups">Number of convolution groups.</param>
+    /// <param name="deformGroups">Number of deformable groups.</param>
+    /// <returns>The gradient with respect to the modulation mask tensor.</returns>
+    Tensor<T> DeformableConv2DGroupedBackwardMask<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        Tensor<T> kernel,
+        Tensor<T> offset,
+        Tensor<T> mask,
+        int[] stride,
+        int[] padding,
+        int[] dilation,
+        int groups,
+        int deformGroups);
+
+    /// <summary>
     /// Computes the gradient of GridSample with respect to the input (NHWC format).
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -121,6 +121,44 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
                     "DeformableConv2D");
     }
 
+    // ---- DeformableConv2DGrouped (DCNv3): single-launch fused grouped GPU kernel vs CPU oracle (#1691) ----
+    [SkippableTheory]
+    [InlineData(2, 2)]   // grouped, one deform group per output group
+    [InlineData(4, 4)]   // depthwise-ish
+    [InlineData(2, 1)]   // shared deform group across output groups
+    public void DeformableConv2DGrouped_Gpu_MatchesCpu(int groups, int deformGroups)
+    {
+        SkipIfUnavailable();
+        const int B = 1, inC = 8, outC = 8, H = 6, W = 6, k = 3, kk = 9;
+        int inCpg = inC / groups;
+        var input = R(20, B, inC, H, W);
+        var kernel = R(21, outC, inCpg, k, k);                 // [outC, inC/groups, kH, kW]
+        var offset = R(22, B, 2 * kk * deformGroups, H, W);    // [B, 2*kH*kW*deformGroups, H, W]
+        int[] stride = { 1, 1 }, pad = { 1, 1 }, dil = { 1, 1 };
+        AssertClose(
+            _cpu.DeformableConv2DGrouped(input, kernel, offset, null, stride, pad, dil, groups, deformGroups),
+            _gpu.DeformableConv2DGrouped(input, kernel, offset, null, stride, pad, dil, groups, deformGroups),
+            $"DeformableConv2DGrouped(g={groups},dg={deformGroups})");
+    }
+
+    // DCNv3 with modulation mask — exercises the masked single-launch grouped GPU path.
+    [SkippableFact]
+    public void DeformableConv2DGroupedWithMask_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        const int B = 1, inC = 8, outC = 8, H = 6, W = 6, k = 3, kk = 9, groups = 2, deformGroups = 2;
+        int inCpg = inC / groups;
+        var input = R(23, B, inC, H, W);
+        var kernel = R(24, outC, inCpg, k, k);
+        var offset = R(25, B, 2 * kk * deformGroups, H, W);
+        var mask = R(26, B, kk * deformGroups, H, W);
+        int[] stride = { 1, 1 }, pad = { 1, 1 }, dil = { 1, 1 };
+        AssertClose(
+            _cpu.DeformableConv2DGrouped(input, kernel, offset, mask, stride, pad, dil, groups, deformGroups),
+            _gpu.DeformableConv2DGrouped(input, kernel, offset, mask, stride, pad, dil, groups, deformGroups),
+            "DeformableConv2DGroupedWithMask");
+    }
+
     [SkippableFact]
     public void DeformableConv2DBackwardInput_Gpu_MatchesCpu()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -442,6 +442,9 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         // MaxPool2DBackwardGpuCorrectnessTests). These were hidden from this gate by a `public new`
         // hide on DirectGpuTensorEngine until it was converted to `override`.
         "DeformableConv2D(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
+        // DCNv3 grouped/depthwise single-launch GPU kernel — GPU-vs-CPU parity in
+        // GpuConvKernelCoverageTests.DeformableConv2DGrouped_Gpu_MatchesCpu (+ …WithMask) (#1691).
+        "DeformableConv2DGrouped(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[],Int32,Int32)",
         "DeformableConv2DBackwardInput(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[],Int32[])",
         "DeformableConv2DBackwardKernel(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[],Int32[])",
         "DeformableConv2DBackwardMask(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
@@ -71,3 +71,58 @@ public class GroupedDeformableConv2DTests
         for (int i = 0; i < baseOut.Length; i++) Assert.Equal(baseOut[i], grouped[i]);
     }
 }
+
+// Finite-difference verification of the grouped backward (double precision for numerical accuracy).
+public class GroupedDeformableConv2DBackwardTests
+{
+    private static Tensor<double> Rand(int seed, double scale, params int[] shape)
+    {
+        int n = 1; foreach (var s in shape) n *= s;
+        var d = new double[n];
+        var rng = new System.Random(seed);
+        for (int i = 0; i < n; i++) d[i] = (rng.NextDouble() - 0.5) * scale;
+        return new Tensor<double>(shape, new Vector<double>(d));
+    }
+
+    private static double Loss(CpuEngine e, Tensor<double> input, Tensor<double> kernel, Tensor<double> offset,
+        int[] s, int[] p, int[] dl, int groups, int dg)
+    {
+        var o = e.DeformableConv2DGrouped(input, kernel, offset, null, s, p, dl, groups, dg);
+        double sum = 0; for (int i = 0; i < o.Length; i++) sum += o[i];
+        return sum;
+    }
+
+    [Fact]
+    public void GroupedBackward_MatchesFiniteDifference()
+    {
+        var e = new CpuEngine();
+        const int groups = 2, dg = 2, inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9, inCpg = 2;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(1, 1.0, 1, inC, H, W);
+        var kernel = Rand(2, 1.0, outC, inCpg, k, k);
+        var offset = Rand(3, 0.6, 1, 2 * kk * dg, H, W);
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+
+        var gI = e.DeformableConv2DGroupedBackwardInput(gradOut, input, kernel, offset, null, [1, inC, H, W], s, p, dl, groups, dg);
+        var gK = e.DeformableConv2DGroupedBackwardKernel(gradOut, input, offset, null, [outC, inCpg, k, k], s, p, dl, groups, dg);
+        var gO = e.DeformableConv2DGroupedBackwardOffset(gradOut, input, kernel, offset, null, s, p, dl, groups, dg);
+
+        const double eps = 1e-5;
+        void Check(Tensor<double> t, Tensor<double> analytic, string name, double tol)
+        {
+            for (int i = 0; i < t.Length; i++)
+            {
+                double orig = t[i];
+                t[i] = orig + eps; double lp = Loss(e, input, kernel, offset, s, p, dl, groups, dg);
+                t[i] = orig - eps; double lm = Loss(e, input, kernel, offset, s, p, dl, groups, dg);
+                t[i] = orig;
+                double num = (lp - lm) / (2 * eps);
+                Assert.True(System.Math.Abs(num - analytic[i]) <= tol + 1e-2 * System.Math.Abs(num),
+                    $"{name}[{i}]: analytic={analytic[i]:F5} numeric={num:F5}");
+            }
+        }
+        Check(input, gI, "gradInput", 1e-3);
+        Check(kernel, gK, "gradKernel", 1e-3);
+        Check(offset, gO, "gradOffset", 5e-3);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
 using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -124,5 +125,44 @@ public class GroupedDeformableConv2DBackwardTests
         Check(input, gI, "gradInput", 1e-3);
         Check(kernel, gK, "gradKernel", 1e-3);
         Check(offset, gO, "gradOffset", 5e-3);
+    }
+
+    /// <summary>
+    /// The autodiff wiring (#1691): the grouped forward records on the tape and back-props through the
+    /// grouped backward kernels. With loss = sum(output), the upstream gradient is all-ones, so the tape
+    /// gradients must equal the manual grouped backward called with gradOut = ones (already finite-diff
+    /// verified above). This proves DeformableConv2DGrouped is differentiable via GradientTape.
+    /// </summary>
+    [Fact]
+    public void GroupedForward_OnTape_BackpropsThroughGroupedBackward()
+    {
+        var e = new CpuEngine();
+        const int groups = 2, dg = 2, inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9, inCpg = 2;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(11, 1.0, 1, inC, H, W);
+        var kernel = Rand(12, 1.0, outC, inCpg, k, k);
+        var offset = Rand(13, 0.6, 1, 2 * kk * dg, H, W);
+
+        using var tape = new GradientTape<double>();
+        var output = e.DeformableConv2DGrouped(input, kernel, offset, null, s, p, dl, groups, dg);
+        var loss = e.ReduceSum(output, null);
+        var grads = tape.ComputeGradients(loss, new[] { input, kernel, offset });
+
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+        var gI = e.DeformableConv2DGroupedBackwardInput(gradOut, input, kernel, offset, null, [1, inC, H, W], s, p, dl, groups, dg);
+        var gK = e.DeformableConv2DGroupedBackwardKernel(gradOut, input, offset, null, [outC, inCpg, k, k], s, p, dl, groups, dg);
+        var gO = e.DeformableConv2DGroupedBackwardOffset(gradOut, input, kernel, offset, null, s, p, dl, groups, dg);
+
+        void Same(Tensor<double> tape_, Tensor<double> manual, string name)
+        {
+            Assert.NotNull(tape_);
+            Assert.Equal(manual.Length, tape_.Length);
+            for (int i = 0; i < manual.Length; i++)
+                Assert.True(System.Math.Abs(tape_[i] - manual[i]) < 1e-9,
+                    $"{name}[{i}]: tape={tape_[i]:F9} manual={manual[i]:F9}");
+        }
+        Same(grads[input], gI, "gradInput");
+        Same(grads[kernel], gK, "gradKernel");
+        Same(grads[offset], gO, "gradOffset");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) AiDotNet. All rights reserved.
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Validates the fused grouped/depthwise deformable conv (DCNv3) CPU reference kernel (#1691) against
+/// the per-group composition over the existing groups=1 DeformableConv2D — the correctness oracle the
+/// future GPU backends must also match.
+/// </summary>
+public class GroupedDeformableConv2DTests
+{
+    private static Tensor<float> Rand(int seed, params int[] shape)
+    {
+        int n = 1; foreach (var s in shape) n *= s;
+        var d = new float[n];
+        var rng = new Random(seed);
+        for (int i = 0; i < n; i++) d[i] = (float)(rng.NextDouble() - 0.5);
+        return new Tensor<float>(shape, new Vector<float>(d));
+    }
+
+    [Theory]
+    [InlineData(2, 2)]   // groups=2, deformGroups=2
+    [InlineData(4, 4)]   // depthwise-ish
+    [InlineData(2, 1)]   // shared deformable group across output groups
+    public void FusedGrouped_MatchesPerGroupComposition(int groups, int deformGroups)
+    {
+        var engine = new CpuEngine();
+        const int B = 1, inC = 8, outC = 8, H = 8, W = 8, k = 3;
+        int inCpg = inC / groups, outCpg = outC / groups, kk = k * k;
+
+        var input = Rand(1, B, inC, H, W);
+        var kernel = Rand(2, outC, inCpg, k, k);                 // [outC, inC/groups, k, k]
+        var offset = Rand(3, B, 2 * kk * deformGroups, H, W);    // stride 1, pad 1 -> out = H,W
+        int[] stride = [1, 1], pad = [1, 1], dil = [1, 1];
+
+        var fused = engine.DeformableConv2DGrouped(input, kernel, offset, null, stride, pad, dil, groups, deformGroups);
+
+        // Reference: per-group groups=1 deformable conv over channel slices, concatenated.
+        var groupOuts = new Tensor<float>[groups];
+        for (int g = 0; g < groups; g++)
+        {
+            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            var inSlice = input.Slice(1, g * inCpg, (g + 1) * inCpg);
+            var wSlice = kernel.Slice(0, g * outCpg, (g + 1) * outCpg);
+            var offSlice = offset.Slice(1, dg * 2 * kk, (dg + 1) * 2 * kk);
+            groupOuts[g] = engine.DeformableConv2D(inSlice, wSlice, offSlice, null, stride, pad, dil);
+        }
+        var reference = Tensor<float>.Concatenate(groupOuts, axis: 1);
+
+        Assert.Equal(reference.Shape, fused.Shape);
+        for (int i = 0; i < reference.Length; i++)
+            Assert.True(MathF.Abs(reference[i] - fused[i]) < 1e-4f,
+                $"groups={groups} dg={deformGroups}: mismatch at {i}: ref={reference[i]} fused={fused[i]}");
+    }
+
+    [Fact]
+    public void Groups1_ReducesToBaseDeformableConv()
+    {
+        var engine = new CpuEngine();
+        const int B = 1, C = 4, H = 6, W = 6, k = 3, kk = 9;
+        var input = Rand(5, B, C, H, W);
+        var kernel = Rand(6, C, C, k, k);
+        var offset = Rand(7, B, 2 * kk, H, W);
+        int[] stride = [1, 1], pad = [1, 1], dil = [1, 1];
+        var baseOut = engine.DeformableConv2D(input, kernel, offset, null, stride, pad, dil);
+        var grouped = engine.DeformableConv2DGrouped(input, kernel, offset, null, stride, pad, dil, 1, 1);
+        for (int i = 0; i < baseOut.Length; i++) Assert.Equal(baseOut[i], grouped[i]);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
@@ -93,6 +93,14 @@ public class GroupedDeformableConv2DBackwardTests
         return sum;
     }
 
+    private static double LossM(CpuEngine e, Tensor<double> input, Tensor<double> kernel, Tensor<double> offset,
+        Tensor<double> mask, int[] s, int[] p, int[] dl, int groups, int dg)
+    {
+        var o = e.DeformableConv2DGrouped(input, kernel, offset, mask, s, p, dl, groups, dg);
+        double sum = 0; for (int i = 0; i < o.Length; i++) sum += o[i];
+        return sum;
+    }
+
     [Fact]
     public void GroupedBackward_MatchesFiniteDifference()
     {
@@ -164,5 +172,128 @@ public class GroupedDeformableConv2DBackwardTests
         Same(grads[input], gI, "gradInput");
         Same(grads[kernel], gK, "gradKernel");
         Same(grads[offset], gO, "gradOffset");
+    }
+
+    /// <summary>
+    /// DCN v2/v3 modulation-mask backward (#1691): finite-difference checks gradInput/gradKernel/
+    /// gradOffset/gradMask for a non-null modulation mask against the manual grouped backward kernels.
+    /// </summary>
+    [Fact]
+    public void GroupedBackward_WithMask_MatchesFiniteDifference()
+    {
+        var e = new CpuEngine();
+        const int groups = 2, dg = 2, inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9, inCpg = 2;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(21, 1.0, 1, inC, H, W);
+        var kernel = Rand(22, 1.0, outC, inCpg, k, k);
+        var offset = Rand(23, 0.6, 1, 2 * kk * dg, H, W);
+        var mask = Rand(24, 0.5, 1, kk * dg, H, W);  // modulation mask [B, kk*dg, H, W]
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+
+        var gI = e.DeformableConv2DGroupedBackwardInput(gradOut, input, kernel, offset, mask, [1, inC, H, W], s, p, dl, groups, dg);
+        var gK = e.DeformableConv2DGroupedBackwardKernel(gradOut, input, offset, mask, [outC, inCpg, k, k], s, p, dl, groups, dg);
+        var gO = e.DeformableConv2DGroupedBackwardOffset(gradOut, input, kernel, offset, mask, s, p, dl, groups, dg);
+        var gM = e.DeformableConv2DGroupedBackwardMask(gradOut, input, kernel, offset, mask, s, p, dl, groups, dg);
+
+        const double eps = 1e-5;
+        void Check(Tensor<double> t, Tensor<double> analytic, string name, double tol)
+        {
+            for (int i = 0; i < t.Length; i++)
+            {
+                double orig = t[i];
+                t[i] = orig + eps; double lp = LossM(e, input, kernel, offset, mask, s, p, dl, groups, dg);
+                t[i] = orig - eps; double lm = LossM(e, input, kernel, offset, mask, s, p, dl, groups, dg);
+                t[i] = orig;
+                double num = (lp - lm) / (2 * eps);
+                Assert.True(System.Math.Abs(num - analytic[i]) <= tol + 1e-2 * System.Math.Abs(num),
+                    $"{name}[{i}]: analytic={analytic[i]:F5} numeric={num:F5}");
+            }
+        }
+        Check(input, gI, "gradInput", 1e-3);
+        Check(kernel, gK, "gradKernel", 1e-3);
+        Check(offset, gO, "gradOffset", 5e-3);
+        Check(mask, gM, "gradMask", 1e-3);
+    }
+
+    /// <summary>
+    /// DCN v2/v3 autograd wiring (#1691): the masked grouped forward records all four inputs on the tape
+    /// and back-props to input/kernel/offset/mask. With loss=sum(output) the tape grads must equal the
+    /// manual masked grouped backward called with gradOut=ones (verified above by finite difference).
+    /// </summary>
+    [Fact]
+    public void MaskedGroupedForward_OnTape_BackpropsToAllFour()
+    {
+        var e = new CpuEngine();
+        const int groups = 2, dg = 2, inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9, inCpg = 2;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(31, 1.0, 1, inC, H, W);
+        var kernel = Rand(32, 1.0, outC, inCpg, k, k);
+        var offset = Rand(33, 0.6, 1, 2 * kk * dg, H, W);
+        var mask = Rand(34, 0.5, 1, kk * dg, H, W);
+
+        using var tape = new GradientTape<double>();
+        var output = e.DeformableConv2DGrouped(input, kernel, offset, mask, s, p, dl, groups, dg);
+        var loss = e.ReduceSum(output, null);
+        var grads = tape.ComputeGradients(loss, new[] { input, kernel, offset, mask });
+
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+        var gI = e.DeformableConv2DGroupedBackwardInput(gradOut, input, kernel, offset, mask, [1, inC, H, W], s, p, dl, groups, dg);
+        var gK = e.DeformableConv2DGroupedBackwardKernel(gradOut, input, offset, mask, [outC, inCpg, k, k], s, p, dl, groups, dg);
+        var gO = e.DeformableConv2DGroupedBackwardOffset(gradOut, input, kernel, offset, mask, s, p, dl, groups, dg);
+        var gM = e.DeformableConv2DGroupedBackwardMask(gradOut, input, kernel, offset, mask, s, p, dl, groups, dg);
+
+        void Same(Tensor<double> tape_, Tensor<double> manual, string name)
+        {
+            Assert.NotNull(tape_);
+            Assert.Equal(manual.Length, tape_.Length);
+            for (int i = 0; i < manual.Length; i++)
+                Assert.True(System.Math.Abs(tape_[i] - manual[i]) < 1e-9,
+                    $"{name}[{i}]: tape={tape_[i]:F9} manual={manual[i]:F9}");
+        }
+        Same(grads[input], gI, "gradInput");
+        Same(grads[kernel], gK, "gradKernel");
+        Same(grads[offset], gO, "gradOffset");
+        Same(grads[mask], gM, "gradMask");
+    }
+
+    /// <summary>
+    /// Base (non-grouped) DeformableConv2D DCN v2 autograd (#1691): closes the long-standing
+    /// "modulation mask not wired" gap. The masked forward now records input/kernel/offset/mask and
+    /// back-props to all four; tape grads equal the manual DCN v2 backward called with gradOut=ones.
+    /// </summary>
+    [Fact]
+    public void BaseDeformableConv2D_WithMask_OnTape_BackpropsToAllFour()
+    {
+        var e = new CpuEngine();
+        const int inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(41, 1.0, 1, inC, H, W);
+        var kernel = Rand(42, 1.0, outC, inC, k, k);   // base kernel [outC, inC, k, k]
+        var offset = Rand(43, 0.6, 1, 2 * kk, H, W);   // deformGroups=1
+        var mask = Rand(44, 0.5, 1, kk, H, W);
+
+        using var tape = new GradientTape<double>();
+        var output = e.DeformableConv2D(input, kernel, offset, mask, s, p, dl);
+        var loss = e.ReduceSum(output, null);
+        var grads = tape.ComputeGradients(loss, new[] { input, kernel, offset, mask });
+
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+        var gI = e.DeformableConv2DBackwardInput(gradOut, input, kernel, offset, mask, [1, inC, H, W], s, p, dl);
+        var gK = e.DeformableConv2DBackwardKernel(gradOut, input, offset, mask, [outC, inC, k, k], s, p, dl);
+        var gO = e.DeformableConv2DBackwardOffset(gradOut, input, kernel, offset, mask, s, p, dl);
+        var gM = e.DeformableConv2DBackwardMask(gradOut, input, kernel, offset, mask, s, p, dl);
+
+        void Same(Tensor<double> tape_, Tensor<double> manual, string name)
+        {
+            Assert.NotNull(tape_);
+            Assert.Equal(manual.Length, tape_.Length);
+            for (int i = 0; i < manual.Length; i++)
+                Assert.True(System.Math.Abs(tape_[i] - manual[i]) < 1e-9,
+                    $"{name}[{i}]: tape={tape_[i]:F9} manual={manual[i]:F9}");
+        }
+        Same(grads[input], gI, "gradInput");
+        Same(grads[kernel], gK, "gradKernel");
+        Same(grads[offset], gO, "gradOffset");
+        Same(grads[mask], gM, "gradMask");
     }
 }


### PR DESCRIPTION
**DRAFT / WIP** — production fused grouped/depthwise **deformable** convolution (DCNv3) kernel. Consumed by AiDotNet's faithful InternImage (AiDotNet #1691). AiDotNet PR #1689 uses a per-group composition as the unfused stand-in; this PR is the fused/engine version.

## Done (CPU + GPU + engine integration — verified)
- [x] **CPU fused forward** — `CpuEngine.DeformableConv2DGrouped` (single-pass). Parity vs per-group composition.
- [x] **CPU backward** — `DeformableConv2DGroupedBackward{Input,Kernel,Offset,Mask}`. **Finite-difference verified** (incl. gradMask).
- [x] **IEngine promotion** — 5 grouped signatures; only `CpuEngine` implements, `DirectGpuTensorEngine : CpuEngine` inherits → low-ripple (no DIMs; builds net10.0 + net471).
- [x] **Single-launch fused GPU kernel + on-hardware validation** — `DirectGpuTensorEngine.DeformableConv2DGrouped` issues one `backend.DeformableConv2D(..., groups, deformGroups)` launch (all 6 backends carry the grouped kernel). **Validated on NVIDIA GTX 1660 Ti / CUDA 13.1**: `GpuConvKernelCoverageTests.DeformableConv2DGrouped_Gpu_MatchesCpu` (groups 2/2, 4/4, 2/1) + `…WithMask_Gpu_MatchesCpu` match the CPU oracle (TF32-tolerant), with `ThrowOnGpuKernelFallback=true` so a CPU fallback fails the test (no false green). 0 skipped.
- [x] **Autodiff (DCN v1 + v2/v3)** — tape + lazy-graph recording for mask-null and **modulation-mask** paths (closes the long-standing DCN v2 mask-autograd gap on base `DeformableConv2D` too). Tape grads == manual backward to 1e-9 incl. gradMask. Makes true DCN v3 (InternImage `useModulation:true`) trainable.
- [x] **Group constraint** tightened to `deformGroups | groups` (CPU & GPU deform-group mappings provably coincide there; `groups<deformGroups` fails loud).

## Remaining
- [ ] On-hardware parity for the other 5 backends (HIP/OpenCL/Vulkan/WebGPU/Metal) — same kernel algorithm + the same `SkippableFact`, needs their respective hardware (CUDA validated here).
- [ ] Rewire AiDotNet `DeformableConvolutionalLayer.Forward` to the fused op — **gated on publishing this PR** (AiDotNet's referenced Tensors IEngine lacks the op until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)