### PR TITLE
fix(streaming): defer ReleaseToPool drop on shared storage (refcount > 1)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -1104,7 +1104,24 @@ public static class WeightRegistry
         if (weight.Lifetime != WeightLifetime.Streaming) return;
         if (weight.StreamingPoolHandle < 0) return;
         if (weight.DataVector.Length == 0) return; // already released
-        weight.DropStorageForStreaming();
+        // Soft-defer drop — mirrors the RegisterWeight #430 fix. A streaming
+        // weight's storage can be SHARED (refcount > 1) at release time when a
+        // peer holds a second reference for the duration of the layer's Forward:
+        //   - a copy-on-write clone (#624) taken inside the op (O(1) until write),
+        //   - a RebindStorageFrom peer (CompiledInferencePlan / MemoryPlanning),
+        //   - an int8/int4 quant-resident alias (#629),
+        //   - an autodiff tape input capture (training).
+        // The strict DropStorageForStreaming() throws "requires sole storage
+        // ownership; refcount is 2" in that window, which the foundation-scale
+        // streaming-inference path surfaces as the MaterializeScope.Dispose
+        // AggregateException that breaks every paper-scale VLM forward (Phi3Vision,
+        // SmolVLM, Whisper, …). DEFER instead: leave the bytes resident for the
+        // peer and mark StreamingDropDeferred so TryFinalizeDeferredDrop retries
+        // once the peer ref releases. A deferred (still-resident) weight is never
+        // corrupt — only un-evicted — so this can only cost a little extra
+        // residency, never correctness.
+        bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
+        weight.StreamingDropDeferred = !dropped;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -216,6 +216,72 @@ public class WeightRegistryStreamingTests : IDisposable
     }
 
     [Fact]
+    public void ReleaseToPool_RefcountTwo_DefersDrop_DoesNotThrow()
+    {
+        // Regression for the foundation-scale streaming-inference break: during
+        // a layer's Forward a peer takes a SECOND ref on a materialized streaming
+        // weight's storage — a copy-on-write clone (#624), a RebindStorageFrom
+        // peer (CompiledInferencePlan / MemoryPlanning), or an int8/int4
+        // quant-resident alias (#629). ReleaseToPool used the STRICT
+        // DropStorageForStreaming(), which threw "requires sole storage
+        // ownership; refcount is 2" — surfaced to the consumer as the
+        // MaterializeScope.Dispose AggregateException that broke every paper-scale
+        // VLM forward (Phi3Vision / SmolVLM / Whisper / …). Post-fix it DEFERS,
+        // mirroring the RegisterWeight #430 fix.
+        var w = new Tensor<float>(new float[] { 1.5f, 2.5f, 3.5f, 4.5f }, new[] { 4 });
+        w.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(w);   // drops the resident copy to the pool
+        WeightRegistry.Materialize(w);      // page back in — resident, refcount 1
+        Assert.Equal(4, w.DataVector.Length);
+
+        // A peer shares the materialized storage for the duration of the forward.
+        var peer = new Tensor<float>(new[] { 4 });
+        peer.RebindStorageFrom(w);
+        Assert.Equal(2, w._storage.RefCount);
+
+        // Pre-fix this threw InvalidOperationException. Post-fix it defers.
+        WeightRegistry.ReleaseToPool(w);
+        Assert.True(w.StreamingDropDeferred, "Release must defer when storage is shared.");
+        Assert.Equal(4, w.DataVector.Length);            // still resident for the peer
+        Assert.Equal(1.5f, peer[0]);
+        Assert.Equal(4.5f, peer[3]);
+
+        // Once the peer releases, the deferred drop finalizes.
+        var fresh = new Tensor<float>(new[] { 4 });
+        peer.RebindStorageFrom(fresh);
+        Assert.Equal(1, w._storage.RefCount);
+        Assert.True(WeightRegistry.TryFinalizeDeferredDrop(w),
+            "Deferred drop should finalize once the peer ref releases.");
+        Assert.False(w.StreamingDropDeferred);
+        Assert.Equal(0, w.DataVector.Length);
+    }
+
+    [Fact]
+    public void MaterializeScope_Dispose_WithSharedWeight_DoesNotThrow()
+    {
+        // The exact CI failure mode: MaterializeScope.Dispose -> ReleaseToPool on
+        // a weight whose storage a forward-op peer still shares used to throw
+        // "One or more ReleaseToPool calls failed during MaterializeScope.Dispose".
+        var w = new Tensor<float>(new float[] { 1f, 2f, 3f, 4f }, new[] { 4 });
+        w.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(w);
+
+        var peer = new Tensor<float>(new[] { 4 });
+        using (WeightRegistry.MaterializeMany(new[] { w }))
+        {
+            // Inside the scope w is resident; a forward op shares its storage
+            // (e.g. a COW clone of the weight that outlives the op).
+            peer.RebindStorageFrom(w);
+            Assert.Equal(2, w._storage.RefCount);
+        } // Dispose -> ReleaseToPool(w): must NOT throw now (drop deferred).
+
+        Assert.True(w.StreamingDropDeferred, "Shared weight's drop is deferred, not forced.");
+        Assert.Equal(4, w.DataVector.Length);            // still resident, uncorrupted
+        Assert.Equal(1f, peer[0]);
+        Assert.Equal(4f, peer[3]);
+    }
+
+    [Fact]
     public void MaterializeMany_Scope_MaterializesOnEnter_ReleasesOnDispose()
     {
         var t1 = new Tensor<float>(new float[] { 1f, 2f }, new[] { 2 });


### PR DESCRIPTION
## Problem

Foundation-scale streaming inference (paper-scale VLMs: Phi3Vision, SmolVLM, Whisper, …) breaks with:

```
System.AggregateException : One or more ReleaseToPool calls failed during MaterializeScope.Dispose ...
  (Streaming drop requires sole storage ownership; storage refcount is 2 ...)
```

`WeightRegistry.ReleaseToPool` used the strict `DropStorageForStreaming()`, which throws when a peer holds a
second reference to a materialized streaming weight's storage during the layer's Forward — a copy-on-write
clone (#624), a `RebindStorageFrom` peer (CompiledInferencePlan / MemoryPlanning), an int8/int4
quant-resident alias (#629), or an autodiff tape capture. `MaterializeScope.Dispose` aggregates that throw
and rethrows, failing the forward.

This is the eviction-side twin of the #430 bug: `RegisterWeight` was already fixed to *defer* the drop on
shared refcount, but `ReleaseToPool` was never updated to match.

## Fix

Mirror the #430 soft-defer in `ReleaseToPool`: `TryDropStorageForStreaming(throwOnSharedRefcount: false)` +
`StreamingDropDeferred`, so the bytes stay resident for the peer and `TryFinalizeDeferredDrop` retries once
the peer releases. A deferred (still-resident) weight is never corrupt — only un-evicted — so this can cost
a little extra residency, never correctness.

## Tests

- `ReleaseToPool_RefcountTwo_DefersDrop_DoesNotThrow`
- `MaterializeScope_Dispose_WithSharedWeight_DoesNotThrow` (reproduces the exact consumer AggregateException)
- WeightRegistry streaming suite 56/56 green.

## Consumer impact

Root cause of the ooples/AiDotNet "ModelFamily – NeuralNetworks" CI shard failures: the near-master O-R shard
fails on Phi3Vision (10 tests), every one with exactly this `MaterializeScope.Dispose` AggregateException.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shared streaming weights so releasing them no longer throws when storage is still in use.
  * Deferred storage cleanup now completes automatically once the remaining reference is released.

* **Tests**
  * Added coverage for shared-storage release scenarios.
  * Verified both pool release and materialization scope disposal behave safely when a streaming weight is still shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->