### PR TITLE
fix(blas): SysV-ABI GotoGemm tile kernel — re-enable FP32 GEMM on Linux (replaces #695's Windows-gate band-aid)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
@@ -117,7 +117,7 @@ internal static class GotoGemmFp32
             {
                 if (s_kernelInit == 0)
                 {
-                    var code = MachineCodeFmaKernel.EmitFp32TileWindows(Mr, NrYmm);
+                    var code = MachineCodeFmaKernel.EmitFp32TileAbi(Mr, NrYmm, false);
                     s_kernelMem = ExecutableMemory.TryAllocate(code);
                     s_kernel = s_kernelMem?.Pointer ?? IntPtr.Zero;
                     Volatile.Write(ref s_kernelInit, 1);
@@ -141,7 +141,7 @@ internal static class GotoGemmFp32
             {
                 if (s_kernelOwInit == 0)
                 {
-                    var code = MachineCodeFmaKernel.EmitFp32TileWindows(Mr, NrYmm, true);
+                    var code = MachineCodeFmaKernel.EmitFp32TileAbi(Mr, NrYmm, true);
                     s_kernelOwMem = ExecutableMemory.TryAllocate(code);
                     s_kernelOw = s_kernelOwMem?.Pointer ?? IntPtr.Zero;
                     Volatile.Write(ref s_kernelOwInit, 1);
@@ -184,15 +184,12 @@ internal static class GotoGemmFp32
         for (int r = 0; r < mFull; r++) { float* cr = c + (long)(ic + r) * ldc + jc; for (int col = nFull; col < effNc; col++) cr[col] = 0f; }
     }
 
-    /// <summary>True when the machine-code microkernel is available on this CPU/OS (AVX2+FMA, Windows x64).
-    /// The tile kernels (EmitFp32TileWindows/EmitBf16BTileWindows) use the Microsoft x64 ABI — RCX/RDX/R8/R9
-    /// args + the 5th arg (kc) read from the [rsp+0x28] shadow space — so they are ONLY valid when invoked
-    /// via the platform-default unmanaged convention on Windows. On Linux/macOS that convention is SysV
-    /// (no shadow space, different arg registers), so calling these kernels there reads garbage → SIGSEGV.
-    /// Gate to Windows until a SysV tile kernel exists; non-Windows falls back to MachineKernelGemm/PackBoth.</summary>
-    internal static unsafe bool IsAvailable =>
-        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
-        && MachineKernelGemm.IsFp32Available && Kernel() != null;
+    /// <summary>True when the machine-code microkernel is available on this CPU/OS (AVX2+FMA, x64). The tile
+    /// kernel is emitted for the CURRENT OS's ABI via MachineCodeFmaKernel.EmitFp32TileAbi — Microsoft x64 on
+    /// Windows, System V AMD64 on Linux/macOS — so it matches the platform-default `delegate* unmanaged`
+    /// convention on both. (A Windows-ABI kernel on Linux read the kc arg from the [rsp+0x28] shadow space
+    /// that SysV doesn't have → SIGSEGV; the SysV kernel reads it from r8.)</summary>
+    internal static unsafe bool IsAvailable => MachineKernelGemm.IsFp32Available && Kernel() != null;
 
     /// <summary>
     /// Single-thread C = A·B (row-major). A[M,K] lda, B[K,N] ldb, C[M,N] ldc (element strides).

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
@@ -138,6 +138,65 @@ internal static class MachineCodeFmaKernel
         return asm.ToArray();
     }
 
+    /// <summary>System V AMD64 (Linux/macOS) ABI variant of <see cref="EmitFp32TileWindows(int,int,bool)"/>.
+    /// `delegate* unmanaged` uses the platform-default convention, which is SysV off Windows, so the
+    /// Win-x64 kernel (shadow-space kc read + RCX/RDX/R8/R9 args) segfaults there. SysV args:
+    /// rdi=packedA, rsi=packedB, rdx=c, rcx=ldcBytes, r8=kc — and ALL xmm are caller-saved, so there is no
+    /// save/restore frame (no SubRsp/xmm6-15 spill). Body (FMA loop + SAVE) is otherwise identical to the
+    /// Win-x64 kernel, so it produces bit-identical results.</summary>
+    internal static byte[] EmitFp32TileSysV(int mr, int nrYmm, bool overwrite)
+    {
+        const int RCX = 1, RDX = 2, RSI = 6, RDI = 7, R8 = 8, R10 = 10, R11 = 11;
+        int regA = RDI, regB = RSI, regC = RDX, regLdc = RCX; // SysV arg registers
+        int accN = mr * nrYmm;
+        int bBase = 12;
+        int aReg = 12 + nrYmm;
+        var asm = new X64Assembler();
+
+        asm.MovRegReg(R10, R8);                         // r10 = kc (5th arg in r8; no shadow space on SysV)
+        for (int i = 0; i < accN; i++) asm.Vxorps(i);   // zero accumulators
+
+        int store = asm.NewLabel();
+        asm.TestRegSelf(R10);                           // kc==0 guard (mirror the Win kernel)
+        asm.JzLabel32(store);
+        int loop = asm.NewLabel();
+        asm.MarkLabel(loop);
+        for (int j = 0; j < nrYmm; j++) asm.VmovupsLoad(bBase + j, regB, (sbyte)(j * 32));
+        for (int r = 0; r < mr; r++)
+        {
+            asm.VbroadcastSs(aReg, regA, (sbyte)(r * 4));
+            for (int j = 0; j < nrYmm; j++) asm.Vfmadd231ps(r * nrYmm + j, aReg, bBase + j);
+        }
+        asm.AddRegImm8(regA, (sbyte)(mr * 4));
+        asm.AddRegImm8(regB, (sbyte)(nrYmm * 32));
+        asm.DecReg(R10);
+        asm.JnzLabel32(loop);
+
+        asm.MarkLabel(store);
+        asm.MovRegReg(R11, regC);                       // r11 walks c (rdx) by ldcBytes (rcx)
+        int cTmp = bBase;
+        for (int r = 0; r < mr; r++)
+        {
+            for (int j = 0; j < nrYmm; j++)
+            {
+                if (!overwrite) { asm.VmovupsLoad(cTmp, R11, (sbyte)(j * 32)); asm.Vaddps(r * nrYmm + j, r * nrYmm + j, cTmp); }
+                asm.VmovupsStore(R11, (sbyte)(j * 32), r * nrYmm + j);
+            }
+            if (r < mr - 1) asm.AddRegReg(R11, regLdc);
+        }
+
+        asm.Vzeroupper();                               // no xmm restore / AddRsp on SysV (caller-saved, no frame)
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>Emit the FP32 tile kernel for the CURRENT OS's ABI (Win-x64 vs SysV) — the GEMM driver uses
+    /// this so the kernel matches the platform-default <c>delegate* unmanaged</c> convention.</summary>
+    internal static byte[] EmitFp32TileAbi(int mr, int nrYmm, bool overwrite)
+        => System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+            ? EmitFp32TileWindows(mr, nrYmm, overwrite)
+            : EmitFp32TileSysV(mr, nrYmm, overwrite);
+
     /// <summary>bf16-B microkernel: C[mr,nr] += packedA(fp32)·packedB(bf16), fp32 accumulate. B is stored
     /// bf16 (half the bytes → 2× the L2/L3/DRAM bandwidth headroom for the re-read operand); each K-iter
     /// loads 8 bf16 per nr-YMM (vpmovzxwd m128→8×u32) and widens to fp32 in-register (vpslld 16 — bf16 is

--- a/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/AisEvalHeadToHeadBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/AisEvalHeadToHeadBench.cs
@@ -656,6 +656,10 @@ internal static class AisEvalHeadToHeadBench
     {
         torch.set_grad_enabled(false);
         int P = Environment.ProcessorCount;
+        // The bf16-B kernel (EmitBf16BTileWindows) is Win-x64 ABI only — no SysV variant (it's a negative
+        // experiment, not production). Skip on non-Windows so it never invokes the Win kernel via SysV → SIGSEGV.
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        { Console.WriteLine("bf16-B kernel is Win-x64 ABI only; skipped on non-Windows"); return; }
         if (!AiDotNet.Tensors.Engines.BlasManaged.GotoGemmFp32.IsAvailable) { Console.WriteLine("not available"); return; }
         int saved = CpuParallelSettings.MaxDegreeOfParallelism;
         CpuParallelSettings.MaxDegreeOfParallelism = P;

--- a/tools/ConvParallelProbe/Program.cs
+++ b/tools/ConvParallelProbe/Program.cs
@@ -56,6 +56,7 @@ internal static class Program
         if (args.Length > 0 && args[0] == "--attnblock") return RunAttnBlock(eng, args);
         if (args.Length > 0 && args[0] == "--act") return RunAct(eng, args);
         if (args.Length > 0 && args[0] == "--gemm") return RunGemm(eng, args);
+        if (args.Length > 0 && args[0] == "--gemmverify") return RunGemmVerify(eng, args);
         if (args.Length > 0 && args[0] == "--gemmaudit") return RunGemmAudit(eng, args);
         if (args.Length > 0 && args[0] == "--gemmprofile") return RunGemmProfile(eng, args);
         if (args.Length > 0 && args[0] == "--gpu") return RunGpu(args);
@@ -675,6 +676,39 @@ internal static class Program
             $"GEMM M={M} K={K} N={N} fma={(double)M * K * N:E1} maxdop={maxdop} procs={Environment.ProcessorCount} " +
             $"median_ms={times[reps / 2]:F3} min_ms={times[0]:F3} max_ms={times[times.Length - 1]:F3} (sink={sink:E1}){u}");
         return 0;
+    }
+
+    // Correctness check: GotoGemm (the machine-code kernel — SysV on Linux) vs PackBoth (the cross-platform
+    // managed reference), same inputs. They must agree to fp-reassociation noise (~1e-6). A wrong-ABI kernel
+    // would produce garbage / NaN here, not a ~1e-6 match.
+    private static int RunGemmVerify(CpuEngine eng, string[] a)
+    {
+        int M = ArgI(a, "--m", 256), K = ArgI(a, "--k", 512), N = ArgI(a, "--n", 1024);
+        var rng = new Random(1);
+        var lhs = Rand(new[] { M, K }, rng);
+        var rhs = Rand(new[] { K, N }, rng);
+        var bm = typeof(CpuEngine).Assembly.GetType("AiDotNet.Tensors.Engines.BlasManaged.BlasManaged");
+        var fld = bm?.GetField("s_disableGotoGemm", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (fld is null) { Console.Error.WriteLine("[verify] s_disableGotoGemm not found"); return 2; }
+        fld.SetValue(null, false);                       // GotoGemm (SysV kernel on Linux)
+        var cGoto = eng.BatchMatMul(lhs, rhs);
+        fld.SetValue(null, true);                        // PackBoth reference
+        var cRef = eng.BatchMatMul(lhs, rhs);
+        fld.SetValue(null, false);
+        // Frobenius-relative ||cGoto - cRef|| / ||cRef|| — robust to the near-zero cancellation that makes
+        // per-element relative error meaningless (random A,B → many ~0 dot products). True fp32 reassociation
+        // noise between two reduction orders is ~1e-6..1e-5; a wrong-ABI kernel would be O(1) or NaN.
+        int total = M * N;
+        double sumD2 = 0, sumR2 = 0;
+        for (int i = 0; i < total; i++)
+        {
+            double g = cGoto[i], r = cRef[i];
+            double d = g - r; sumD2 += d * d; sumR2 += r * r;
+        }
+        double frob = sumR2 > 0 ? Math.Sqrt(sumD2 / sumR2) : 0;
+        bool ok = frob < 1e-4 && !double.IsNaN(frob);
+        Console.WriteLine($"GEMM-VERIFY {M}x{K}x{N} Frobenius||GotoGemm-PackBoth||/||PackBoth|| = {frob:E2} -> {(ok ? "OK" : "MISMATCH")}");
+        return ok ? 0 : 1;
     }
 
     // P4 (#653): single-thread pack-vs-kernel attribution via PackBothProfiler (reflection,


### PR DESCRIPTION
## Problem
PR #695 shipped a **workaround** for the Linux CI crashes: it Windows-gated `GotoGemmFp32.IsAvailable`, which *disabled* the managed FP32 GEMM (GotoGemm + CCX) on Linux/macOS entirely. So the GEMM perf work (and the diffusion-timeout fix) only applied on Windows, and any path that re-enabled GotoGemm on Linux would still segfault.

Root cause: the tile kernel (`EmitFp32TileWindows`) is **Microsoft-x64 ABI** — args in RCX/RDX/R8/R9 and the 5th arg (`kc`) read from the `[rsp+0x28]` shadow space. `delegate* unmanaged` uses the platform-default convention, which is **System V** off Windows (no shadow space, args in RDI/RSI/RDX/RCX/R8). Calling the Win kernel under SysV reads garbage → SIGSEGV.

## Fix
Add the real SysV kernel so GotoGemm works cross-platform (band-aid removed):
- **`EmitFp32TileSysV`** — SysV args (rdi/rsi/rdx/rcx/r8), `kc` from r8, and **no** xmm6–15 save/restore frame (all xmm are caller-saved on SysV). The FMA loop + SAVE body is identical to the Win-x64 kernel, so results are bit-identical.
- **`EmitFp32TileAbi`** picks Win-x64 vs SysV by `RuntimeInformation`; `GotoGemmFp32` uses it; `IsAvailable` is no longer Windows-gated.
- The bf16-B experiment kernel stays Win-x64-only (a non-production negative experiment); the `--ab-bf16` bench now skips on non-Windows so it can't invoke the Win kernel under SysV.

## Verified in a .NET 10 Linux container (the CI environment, via Docker)
- Before: GotoGemm on Linux segfaulted (the gemm-bench probe `rc=-11`, the build test-host crash).
- After: `--gemm 512x1024x4096` returns `rc=0`; a new `--gemmverify` (GotoGemm vs PackBoth) reports Frobenius `‖Δ‖/‖ref‖ = 3.9e-7 … 1.3e-6` across square / wide-N / deep-K shapes — pure fp32 reassociation noise (a wrong-ABI kernel would be O(1)/NaN).
- Windows unchanged: `EmitFp32TileAbi` → the byte-identical Win kernel; 121/121 determinism + kernel + conv gate; net10 + net471 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)