### PR TITLE
perf(gemm): exceed OpenBLAS — JIT small-GEMM (1.5–6×) + scientific multi-thread routing/pinning wins on diffusion shapes

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
@@ -63,6 +63,14 @@ internal static class AutotuneDispatcher
             return FallbackToHeuristic(m, n, k, mr, nr, procs, isDeterministic);
         }
 
+        // #475 blocking override active (test/bench only): skip cache lookup AND store so the
+        // forced block choice never leaks into the persisted heuristic cache, and use the
+        // (clamped) heuristic path directly. FallbackToHeuristic applies + clamps the overrides.
+        if (BlockingOverrideActive)
+        {
+            return FallbackToHeuristic(m, n, k, mr, nr, procs, isDeterministic);
+        }
+
         var shape = BlasManagedAutotune.EncodeShape<T>(m, n, k, transA, transB, mr, nr, hasEpilogue, isDeterministic);
 
         // Cache hit?
@@ -180,6 +188,15 @@ internal static class AutotuneDispatcher
     internal static int? s_overrideMc, s_overrideNc, s_overrideKc;
 
     /// <summary>
+    /// True while any of the #475 blocking overrides (<see cref="s_overrideMc"/>,
+    /// <see cref="s_overrideNc"/>, <see cref="s_overrideKc"/>) is set. When active,
+    /// <see cref="Decide{T}"/> bypasses the autotune cache lookup AND store so a
+    /// test/bench-only block choice never poisons the persisted heuristic cache.
+    /// </summary>
+    private static bool BlockingOverrideActive
+        => s_overrideMc.HasValue || s_overrideNc.HasValue || s_overrideKc.HasValue;
+
+    /// <summary>
     /// Use the AxisSelector heuristic to choose an axis, with default blocking
     /// parameters. The heuristic itself is shape-aware (m, n, k, mr, nr, procs).
     ///
@@ -234,9 +251,18 @@ internal static class AutotuneDispatcher
         }
 
         // #475 medium/large blocking A/B — force OpenBLAS-style P/Q/R to probe the single-core gap.
-        if (s_overrideMc is int omc) mc = omc;
-        if (s_overrideNc is int onc) nc = onc;
-        if (s_overrideKc is int okc) kc = okc;
+        // These are test/bench-only knobs; route them through ClampBlocking so an unvalidated
+        // override (e.g. kc=0 or a negative value) can never reach the strategy pipeline and hang a
+        // downstream `pc += kc` loop. Decide<T> additionally bypasses the cache while any override is
+        // active so the bench value never persists in the heuristic cache.
+        if (BlockingOverrideActive)
+        {
+            if (s_overrideMc is int omc) mc = omc;
+            if (s_overrideNc is int onc) nc = onc;
+            if (s_overrideKc is int okc) kc = okc;
+            (mc, nc, kc) = ClampBlocking(mc, nc, kc, m, n, k, mr, nr);
+            return (axis, mc, nc, kc, procs);
+        }
 
         // Round mc down to mr alignment, nc down to nr alignment.
         if (mr > 0) mc = (mc / mr) * mr;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
@@ -174,6 +174,11 @@ internal static class AutotuneDispatcher
     /// </summary>
     [ThreadStatic] internal static bool ForceMeasureOnMiss;
 
+    // #475 medium/large blocking A/B: when set, override the heuristic's Mc/Nc/Kc to test
+    // OpenBLAS-style Zen blocking (sgemm P/Q = 320/320, R large) against the single-core gap.
+    // Null = the heuristic. Test/bench only.
+    internal static int? s_overrideMc, s_overrideNc, s_overrideKc;
+
     /// <summary>
     /// Use the AxisSelector heuristic to choose an axis, with default blocking
     /// parameters. The heuristic itself is shape-aware (m, n, k, mr, nr, procs).
@@ -223,6 +228,11 @@ internal static class AutotuneDispatcher
                 if (targetMc < mc) mc = targetMc;
             }
         }
+
+        // #475 medium/large blocking A/B — force OpenBLAS-style P/Q/R to probe the single-core gap.
+        if (s_overrideMc is int omc) mc = omc;
+        if (s_overrideNc is int onc) nc = onc;
+        if (s_overrideKc is int okc) kc = okc;
 
         // Round mc down to mr alignment, nc down to nr alignment.
         if (mr > 0) mc = (mc / mr) * mr;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -333,6 +333,19 @@ public static partial class BlasManaged
         return false;
     }
 
+    // Validate that <paramref name="span"/> backs a [rows × cols] row-major tile with the given
+    // leading dimension (ld) — i.e. the last element the JIT kernel touches,
+    // (rows-1)*ld + cols, is in bounds. Used to gate the unsafe JIT GEMM path: if any operand fails
+    // this check we fall back to the bounds-checked managed path instead of issuing raw native
+    // loads/stores past the end of a span (invalid lda/ldb/ldc or a caller-truncated buffer).
+    private static bool HasRowMajorTile<T>(ReadOnlySpan<T> span, int rows, int cols, int ld)
+    {
+        if (rows <= 0 || cols <= 0) return true;
+        if (ld < cols) return false;
+        long required = (long)(rows - 1) * ld + cols;
+        return required <= span.Length;
+    }
+
     // Diagnostic timing wrapper (#475 shape audit). When GemmShapeHistogram.Enabled it times
     // only the TOP-LEVEL Gemm call (a ThreadStatic guard skips internal re-dispatches so a
     // shape is attributed once, to the outer call). Disabled → a single bool read + straight
@@ -412,6 +425,12 @@ public static partial class BlasManaged
             && options.PackingMode == PackingMode.Auto
             && options.PackedA is null && options.PackedB is null
             && n <= JitMaxN && m <= JitMaxM && k <= JitMaxK
+            // Validate the row-major tiles BEFORE the unsafe JIT path pins the spans and issues raw
+            // native loads/stores: an invalid lda/ldb/ldc or a short span would otherwise become an
+            // out-of-bounds native access instead of falling back to the bounds-checked managed path.
+            && HasRowMajorTile(a, m, k, lda)
+            && HasRowMajorTile(b, k, n, ldb)
+            && HasRowMajorTile(c, m, n, ldc)
             && JitGemmGenerator.IsSupported)
         {
             var jitEpi = options.Epilogue;
@@ -421,9 +440,14 @@ public static partial class BlasManaged
             {
                 // Phase 4: fuse bias + ReLU into the kernel store when the epilogue is ONLY those
                 // (no skip/dropout/scale, activation None or ReLU). Anything else → plain JIT + Apply.
-                bool fuseable = (eflags & ~(EpilogueFlags.HasBias | EpilogueFlags.HasActivation)) == 0
-                    && (jitEpi.Activation == FusedActivationType.None || jitEpi.Activation == FusedActivationType.ReLU);
                 bool wantBias = (eflags & EpilogueFlags.HasBias) != 0;
+                // A fused bias reads bias[col] per output column inside the kernel, so a short BiasN
+                // would be an out-of-bounds native read. If bias is requested but BiasN is shorter
+                // than n, drop OUT of the fused path so the bounds-checked managed epilogue
+                // (EpilogueChain.Apply) applies/validates the bias instead of the raw kernel store.
+                bool fuseable = (eflags & ~(EpilogueFlags.HasBias | EpilogueFlags.HasActivation)) == 0
+                    && (jitEpi.Activation == FusedActivationType.None || jitEpi.Activation == FusedActivationType.ReLU)
+                    && (!wantBias || jitEpi.BiasN.Length >= n);
                 bool wantRelu = jitEpi.Activation == FusedActivationType.ReLU;
                 System.ReadOnlySpan<float> biasSpan = (fuseable && wantBias) ? MemoryMarshal.Cast<T, float>(jitEpi.BiasN) : default;
                 unsafe
@@ -1351,6 +1375,7 @@ public static partial class BlasManaged
     {
         BlasManagedStatsTracker.Reset();
         JittedKernelCache.Clear();
+        JitGemmGenerator.ClearCache(); // release retained executable JIT-GEMM kernels (#475)
         BlasManagedAutotune.ClearStrategyMemo(); // in-memory strategy memo (#375 G13)
         // Future: clear weight pre-pack cache entries that are still in memory.
     }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -197,6 +197,12 @@ public static partial class BlasManaged
     /// </summary>
     public static bool PreferManaged { get; set; } = false;
 
+    // #475 Phase 1: route small FP32 GEMMs to the libxsmm-style JIT generator, which exceeds OpenBLAS
+    // 1.5-6x for n<=128 (measured --ab-jit). Gate to the win region (large-N unpacked streaming loses
+    // to OpenBLAS's blocking — Phase 1 extension adds K-blocking). A/B toggle; default on.
+    internal static bool s_useJitGemm = true;
+    private const int JitMaxN = 128, JitMaxM = 256, JitMaxK = 1024;
+
     /// <summary>
     /// Sub-F3 (#374 follow-up): when true, the <see cref="Helpers.BlasProvider"/>
     /// <c>TryGemm</c> / <c>TryGemmEx</c> entry points consult
@@ -390,6 +396,31 @@ public static partial class BlasManaged
                     Mode = options.Mode,
                 });
             return;
+        }
+
+        // #475 Phase 1: small FP32 GEMMs go to the JIT generator (exceeds OpenBLAS 1.5-6x for n<=128).
+        // It writes C := A·B directly (no pre-zero needed), then the managed epilogue is applied.
+        // Gated to the win region + Auto packing + no transpose + n a multiple of 8.
+        if (s_useJitGemm && typeof(T) == typeof(float) && !transA && !transB
+            && options.PackingMode == PackingMode.Auto
+            && options.PackedA is null && options.PackedB is null
+            && n <= JitMaxN && m <= JitMaxM && k <= JitMaxK && (n & 7) == 0
+            && JitGemmGenerator.IsSupported)
+        {
+            bool jitOk;
+            unsafe
+            {
+                fixed (float* pa = MemoryMarshal.Cast<T, float>(a))
+                fixed (float* pb = MemoryMarshal.Cast<T, float>(b))
+                fixed (float* pc = MemoryMarshal.Cast<T, float>(c))
+                    jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k);
+            }
+            if (jitOk)
+            {
+                var jitEpi = options.Epilogue;
+                EpilogueChain.Apply<T>(c, ldc, m, n, in jitEpi);
+                return;
+            }
         }
 
         // Strategies do read-modify-write on C; zero it here so the first call

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -398,23 +398,32 @@ public static partial class BlasManaged
             return;
         }
 
-        // #475 Phase 1: small FP32 GEMMs go to the JIT generator (exceeds OpenBLAS 1.5-6x for n<=128).
-        // It writes C := A·B directly (no pre-zero needed), then the managed epilogue is applied.
-        // Gated to the win region + Auto packing + no transpose + n a multiple of 8.
-        if (s_useJitGemm && typeof(T) == typeof(float) && !transA && !transB
+        // #475 Phase 1: small FP32/FP64 GEMMs go to the JIT generator (exceeds OpenBLAS 1.5-6x for
+        // n<=128). It writes C := A·B directly (no pre-zero needed), then the managed epilogue is
+        // applied. Gated to the win region + Auto packing + no transpose + n a multiple of the lane.
+        if (s_useJitGemm && !transA && !transB
             && options.PackingMode == PackingMode.Auto
             && options.PackedA is null && options.PackedB is null
-            && n <= JitMaxN && m <= JitMaxM && k <= JitMaxK && (n & 7) == 0
+            && n <= JitMaxN && m <= JitMaxM && k <= JitMaxK
             && JitGemmGenerator.IsSupported)
         {
-            bool jitOk;
-            unsafe
-            {
-                fixed (float* pa = MemoryMarshal.Cast<T, float>(a))
-                fixed (float* pb = MemoryMarshal.Cast<T, float>(b))
-                fixed (float* pc = MemoryMarshal.Cast<T, float>(c))
-                    jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k);
-            }
+            bool jitOk = false;
+            if (typeof(T) == typeof(float) && (n & 7) == 0)
+                unsafe
+                {
+                    fixed (float* pa = MemoryMarshal.Cast<T, float>(a))
+                    fixed (float* pb = MemoryMarshal.Cast<T, float>(b))
+                    fixed (float* pc = MemoryMarshal.Cast<T, float>(c))
+                        jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k);
+                }
+            else if (typeof(T) == typeof(double) && (n & 3) == 0)
+                unsafe
+                {
+                    fixed (double* pa = MemoryMarshal.Cast<T, double>(a))
+                    fixed (double* pb = MemoryMarshal.Cast<T, double>(b))
+                    fixed (double* pc = MemoryMarshal.Cast<T, double>(c))
+                        jitOk = JitGemmGenerator.TryRunFp64(pa, lda, pb, ldb, pc, ldc, m, n, k);
+                }
             if (jitOk)
             {
                 var jitEpi = options.Epilogue;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -407,15 +407,37 @@ public static partial class BlasManaged
             && n <= JitMaxN && m <= JitMaxM && k <= JitMaxK
             && JitGemmGenerator.IsSupported)
         {
-            bool jitOk = false;
+            var jitEpi = options.Epilogue;
+            var eflags = EpilogueFlagsCompute.Compute<T>(in jitEpi);
+            bool jitOk = false, fused = false;
             if (typeof(T) == typeof(float) && (n & 7) == 0)
+            {
+                // Phase 4: fuse bias + ReLU into the kernel store when the epilogue is ONLY those
+                // (no skip/dropout/scale, activation None or ReLU). Anything else → plain JIT + Apply.
+                bool fuseable = (eflags & ~(EpilogueFlags.HasBias | EpilogueFlags.HasActivation)) == 0
+                    && (jitEpi.Activation == FusedActivationType.None || jitEpi.Activation == FusedActivationType.ReLU);
+                bool wantBias = (eflags & EpilogueFlags.HasBias) != 0;
+                bool wantRelu = jitEpi.Activation == FusedActivationType.ReLU;
+                System.ReadOnlySpan<float> biasSpan = (fuseable && wantBias) ? MemoryMarshal.Cast<T, float>(jitEpi.BiasN) : default;
                 unsafe
                 {
                     fixed (float* pa = MemoryMarshal.Cast<T, float>(a))
                     fixed (float* pb = MemoryMarshal.Cast<T, float>(b))
                     fixed (float* pc = MemoryMarshal.Cast<T, float>(c))
-                        jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k);
+                    fixed (float* pbias = biasSpan)
+                    {
+                        if (fuseable)
+                        {
+                            jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k, wantBias ? pbias : null, wantRelu);
+                            fused = jitOk;
+                        }
+                        else
+                        {
+                            jitOk = JitGemmGenerator.TryRunFp32(pa, lda, pb, ldb, pc, ldc, m, n, k);
+                        }
+                    }
                 }
+            }
             else if (typeof(T) == typeof(double) && (n & 3) == 0)
                 unsafe
                 {
@@ -426,8 +448,7 @@ public static partial class BlasManaged
                 }
             if (jitOk)
             {
-                var jitEpi = options.Epilogue;
-                EpilogueChain.Apply<T>(c, ldc, m, n, in jitEpi);
+                if (!fused) EpilogueChain.Apply<T>(c, ldc, m, n, in jitEpi);
                 return;
             }
         }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
@@ -38,13 +38,14 @@ internal static unsafe class CcxGemmPool
     private static volatile bool _faulted; // a lane's compute threw → TryRun returns false (caller falls back)
     private static int _gr, _gc;      // 2D CCX grid (gr·gc = numCcx)
 
-    /// <summary>Min M·N·K for the CCX path. Below ~2G FLOP the per-K-panel BARRIERS dominate: PerfView
-    /// busy-core (2026-06-26) showed CCX on 1024³ stalls at 6/32 busy cores (237 GF/s) while barrier-free
-    /// RunParallel gets 13.3 cores (598). Clean A/B (--ab-ccx-vs-rp, DOP32): RunParallel beats CCX 1024³
-    /// 1.96×; CCX only amortizes its barriers and wins at 1536³ (1.23×). So gate CCX to ≥2G work where the
-    /// compute-per-barrier is large enough to hide the barrier latency; smaller balanced shapes (1024³-class)
-    /// fall through to RunParallel.</summary>
+    /// <summary>M·N·K WINDOW for the CCX path — its per-CCX L3-resident B-strip only beats barrier-free
+    /// RunParallel in a narrow sweet spot. Clean A/B (--ab-ccx-vs-rp, DOP32, 2026-06-26 square ladder):
+    /// 1024³ tie, 1280³ tie, **1536³ CCX 1135 vs 882 (1.29×, near-OB)**, 1792³ RunParallel 1.18×, 2048³
+    /// RunParallel 1.38×. Below ~2G the per-K-panel barriers dominate (PerfView: 1024³ stalled 6/32 busy
+    /// cores under sustained load); above ~4.5G the B-strip spills the CCX L3 and RunParallel's per-tile
+    /// L2 residency wins. So fire CCX only in [2G, 4.5G]; everything else → RunParallel.</summary>
     private const long CcxMinWork = 2L * 1024 * 1024 * 1024;
+    private const long CcxMaxWork = 4_500_000_000L;
 
     /// <summary>Test/diagnostic toggle (env AIDOTNET_DISABLE_CCX=1): force per-tile, for in-process A/B.</summary>
     internal static bool s_disable =
@@ -189,7 +190,8 @@ internal static unsafe class CcxGemmPool
         // Gate to the PROVEN balanced-square regime: m,n>=512 (DiT m=256 excluded — its deep-K MLP shapes
         // are barrier-heavy in 2D and the diffusion hot path must not regress; they stay on per-tile/PackBoth).
         if (m < s_minM || n < 512 || k < 256) return false;
-        if ((long)m * n * k < CcxMinWork) return false;
+        long work = (long)m * n * k;
+        if (work < CcxMinWork || work > CcxMaxWork) return false; // CCX win window only; else RunParallel
         if (CpuParallelSettings.MaxDegreeOfParallelism < _total) return false; // restricted budget → per-tile
 
         // Deep-K-aware kc for the 2D path: more K per panel ⇒ fewer (pc-panels × 2) per-CCX barriers, which

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
@@ -38,8 +38,13 @@ internal static unsafe class CcxGemmPool
     private static volatile bool _faulted; // a lane's compute threw → TryRun returns false (caller falls back)
     private static int _gr, _gc;      // 2D CCX grid (gr·gc = numCcx)
 
-    /// <summary>Min M·N·K for the CCX path (below this the pinned-pool + barrier overhead isn't worth it).</summary>
-    private const long CcxMinWork = 200L * 1024 * 1024;
+    /// <summary>Min M·N·K for the CCX path. Below ~2G FLOP the per-K-panel BARRIERS dominate: PerfView
+    /// busy-core (2026-06-26) showed CCX on 1024³ stalls at 6/32 busy cores (237 GF/s) while barrier-free
+    /// RunParallel gets 13.3 cores (598). Clean A/B (--ab-ccx-vs-rp, DOP32): RunParallel beats CCX 1024³
+    /// 1.96×; CCX only amortizes its barriers and wins at 1536³ (1.23×). So gate CCX to ≥2G work where the
+    /// compute-per-barrier is large enough to hide the barrier latency; smaller balanced shapes (1024³-class)
+    /// fall through to RunParallel.</summary>
+    private const long CcxMinWork = 2L * 1024 * 1024 * 1024;
 
     /// <summary>Test/diagnostic toggle (env AIDOTNET_DISABLE_CCX=1): force per-tile, for in-process A/B.</summary>
     internal static bool s_disable =

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
@@ -254,6 +254,7 @@ internal static unsafe class CcxGemmPool
             int mBlk = RoundUp((m + _gr - 1) / _gr, 6);
             if ((long)kc * nBlk > 1024L * 1024) return false; // 2D B-panel (kc×nBlk) > 4MB → per-tile
             mc = RoundMr(mBlk / _tpc); if (mc < 48) mc = 48; if (mc > 240) mc = 240;
+            if (s_mc2dOverride > 0) mc = s_mc2dOverride; // A/B knob for the mc blocking sweep
             nc = nBlk;
             need = GotoGemmFp32.PackedBPanelLen(nBlk, kc);
         }
@@ -311,6 +312,9 @@ internal static unsafe class CcxGemmPool
     /// <summary>A/B knob (env AIDOTNET_CCX_KC): override the 2D-path kc to sweep the barrier-vs-L1-fit tradeoff.</summary>
     internal static int s_kc2dOverride =
         int.TryParse(System.Environment.GetEnvironmentVariable("AIDOTNET_CCX_KC"), out var v) ? v : 0;
+
+    /// <summary>A/B knob: override the 2D-path mc to sweep ic-block count (load balance) vs A-panel reuse.</summary>
+    internal static int s_mc2dOverride;
 
     /// <summary>A/B knob (env AIDOTNET_CCX_MINM): override the min-M gate (default 512) to test CCX on the
     /// wide-N small-M DiT shapes (m=256). Lets the 1D-N path (pack B once per CCX) be measured there.</summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/CcxGemmPool.cs
@@ -26,6 +26,18 @@ internal static unsafe class CcxGemmPool
     private static ManualResetEventSlim[] _go = Array.Empty<ManualResetEventSlim>();
     private static CountdownEvent? _done;
     private static Barrier[] _bar = Array.Empty<Barrier>();
+    // #85 DEAD END (default OFF): a lock-free sense-reversing SPIN barrier (OpenBLAS spins with YIELDING).
+    // Hypothesis was that the .NET Barrier PARKS lanes → the 6/32-busy stall. DISPROVEN by --ab-spinbar
+    // (bit-exact, maxErr=0): spin is 10-20× SLOWER (1536³ barrier 1061 vs spin 49 GF/s). On this 32-thread
+    // box the 16 CCX lanes that spin-wait CONTEND for cores with the lanes doing useful pack/compute, so
+    // spinning craters throughput; the .NET Barrier (which parks, freeing the core) is correct here. The
+    // "6-core 1024³" reading that motivated this was measurement NOISE — the barrier was never the
+    // bottleneck (CCX's real limit is the L3 B-strip residency, hence the [2G,4.5G] window). Kept gated
+    // off as the measurement record. Sense-reversing: last arriver resets count, flips CCX sense.
+    private static int[] _sbCount = Array.Empty<int>();   // arrival count per CCX (reset to _tpc each round)
+    private static int[] _sbSense = Array.Empty<int>();   // released sense per CCX
+    private static int[] _localSense = Array.Empty<int>();// per-worker local sense (reset per dispatch)
+    internal static bool s_spinBarrier;                   // DEAD END (see above) — default OFF, .NET Barrier wins
     private static IntPtr[] _bbuf = Array.Empty<IntPtr>();
     private static long _bbufLen;
     private static int _initState; // 0 unstarted, 1 ready, 2 unavailable
@@ -51,6 +63,9 @@ internal static unsafe class CcxGemmPool
     internal static bool s_disable =
         System.Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_CCX") == "1";
 
+    /// <summary>Bench-only: bypass the [2G,4.5G] work window so CCX fires at any size (for spin-barrier A/B).</summary>
+    internal static bool s_ignoreWorkGate;
+
     private static void EnsureInit()
     {
         if (Volatile.Read(ref _initState) != 0) return;
@@ -70,6 +85,10 @@ internal static unsafe class CcxGemmPool
                 _done = new CountdownEvent(_total);
                 _bar = new Barrier[_numCcx];
                 for (int c = 0; c < _numCcx; c++) _bar[c] = new Barrier(_tpc);
+                _sbCount = new int[_numCcx];
+                _sbSense = new int[_numCcx];
+                for (int c = 0; c < _numCcx; c++) _sbCount[c] = _tpc;
+                _localSense = new int[_total];
                 _bbuf = new IntPtr[_numCcx];
                 for (int i = 0; i < _total; i++)
                 {
@@ -92,12 +111,35 @@ internal static unsafe class CcxGemmPool
         {
             _go[id].Wait();
             _go[id].Reset();
+            _localSense[id] = 0; // fresh sense each dispatch (TryRun reset _sbSense/_sbCount to match)
             // Backstop: compute faults are caught INSIDE DoWork/DoWork2D (around the compute, not the
             // barriers) so a faulting lane still completes its barrier sequence and never deadlocks siblings.
             // This catches any non-compute fault. Either way _faulted ⇒ TryRun returns false ⇒ caller re-runs.
             try { if (_use2D) DoWork2D(ccx, lane); else DoWork(ccx, lane); }
             catch { _faulted = true; }
             finally { _done!.Signal(); }
+        }
+    }
+
+    /// <summary>Per-CCX synchronization point. Spin (lock-free sense-reversing) when s_spinBarrier, else
+    /// the .NET Barrier. The spin path keeps lanes HOT across the short K-panel intervals instead of
+    /// parking them on a kernel event (the cause of the 6/32-busy stall). Bit-exact: pure ordering, no
+    /// effect on the reduction.</summary>
+    private static void Sync(int ccx, int lane)
+    {
+        if (!s_spinBarrier) { _bar[ccx].SignalAndWait(); return; }
+        int id = ccx * _tpc + lane;
+        int ls = _localSense[id] ^ 1;
+        _localSense[id] = ls;
+        if (System.Threading.Interlocked.Decrement(ref _sbCount[ccx]) == 0)
+        {
+            Volatile.Write(ref _sbCount[ccx], _tpc); // reset count BEFORE releasing sense (next round ready)
+            Volatile.Write(ref _sbSense[ccx], ls);   // release: spinners observe sense == their ls
+        }
+        else
+        {
+            var sw = new SpinWait();
+            while (Volatile.Read(ref _sbSense[ccx]) != ls) sw.SpinOnce();
         }
     }
 
@@ -110,21 +152,20 @@ internal static unsafe class CcxGemmPool
         int numIc = (_m + _mc - 1) / _mc;
         int jcStart = (int)((long)ccx * numJc / _numCcx);
         int jcEnd = (int)((long)(ccx + 1) * numJc / _numCcx);
-        var bar = _bar[ccx];
         float* pkb = (float*)_bbuf[ccx];
         for (int jb = jcStart; jb < jcEnd; jb++)
         {
             int jc = jb * _nc; int effNc = Math.Min(_nc, _n - jc);
-            if (effNc <= 0) { bar.SignalAndWait(); bar.SignalAndWait(); continue; }
+            if (effNc <= 0) { Sync(ccx, lane); Sync(ccx, lane); continue; }
             // Compute wrapped (NOT the barriers): a fault sets _faulted but the lane still hits every barrier.
             try { GotoGemmFp32.PackBPanel(_b, _ldb, jc, effNc, _k, _kc, pkb, lane, _tpc); } catch { _faulted = true; }
-            bar.SignalAndWait();
+            Sync(ccx, lane);
             for (int ib = lane; ib < numIc; ib += _tpc)
             {
                 int ic = ib * _mc; int effMc = Math.Min(_mc, _m - ic); if (effMc <= 0) continue;
                 try { GotoGemmFp32.RunTilePackedB(_a, _lda, _b, _ldb, _c, _ldc, ic, jc, effMc, effNc, _k, _mc, _nc, _kc, pkb); } catch { _faulted = true; }
             }
-            bar.SignalAndWait();
+            Sync(ccx, lane);
         }
     }
 
@@ -141,14 +182,13 @@ internal static unsafe class CcxGemmPool
         int m0 = r * mBlk, n0 = cc * nBlk;
         int effMblk = Math.Min(mBlk, _m - m0), effNblk = Math.Min(nBlk, _n - n0);
         if (effMblk <= 0 || effNblk <= 0) return; // empty CCX (grid > matrix): all its lanes skip; no barrier use
-        var bar = _bar[ccx];
         float* pkB = (float*)_bbuf[ccx];
         for (int pc = 0; pc < _k; pc += _kc)
         {
             int effKc = Math.Min(_kc, _k - pc);
             // Compute wrapped (NOT the barriers): a fault sets _faulted but the lane still hits every barrier.
             try { GotoGemmFp32.PackBPanelPc(_b, _ldb, n0, effNblk, pc, effKc, _kc, pkB, lane, _tpc); } catch { _faulted = true; }
-            bar.SignalAndWait();
+            Sync(ccx, lane);
             int ii = 0;
             for (int ic = m0; ic < m0 + effMblk; ic += _mc)
             {
@@ -156,7 +196,7 @@ internal static unsafe class CcxGemmPool
                 int effMc = Math.Min(_mc, m0 + effMblk - ic);
                 try { GotoGemmFp32.RunMacroPanelStep(_a, _lda, _b, _ldb, _c, _ldc, ic, n0, effMc, effNblk, pc, effKc, _mc, _kc, pkB, pc == 0); } catch { _faulted = true; }
             }
-            bar.SignalAndWait();
+            Sync(ccx, lane);
         }
     }
 
@@ -191,7 +231,7 @@ internal static unsafe class CcxGemmPool
         // are barrier-heavy in 2D and the diffusion hot path must not regress; they stay on per-tile/PackBoth).
         if (m < s_minM || n < 512 || k < 256) return false;
         long work = (long)m * n * k;
-        if (work < CcxMinWork || work > CcxMaxWork) return false; // CCX win window only; else RunParallel
+        if (!s_ignoreWorkGate && (work < CcxMinWork || work > CcxMaxWork)) return false; // CCX win window only; else RunParallel
         if (CpuParallelSettings.MaxDegreeOfParallelism < _total) return false; // restricted budget → per-tile
 
         // Deep-K-aware kc for the 2D path: more K per panel ⇒ fewer (pc-panels × 2) per-CCX barriers, which
@@ -249,6 +289,8 @@ internal static unsafe class CcxGemmPool
             _a = a; _b = b; _c = c; _lda = lda; _ldb = ldb; _ldc = ldc;
             _m = m; _n = n; _k = k; _mc = mc; _nc = nc; _kc = kc;
             _faulted = false;
+            // Fresh spin-barrier state for this dispatch (workers reset their own _localSense to 0).
+            for (int cc = 0; cc < _numCcx; cc++) { _sbCount[cc] = _tpc; _sbSense[cc] = 0; }
             _done!.Reset();
             for (int i = 0; i < _total; i++) _go[i].Set();
             _done.Wait();

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/CpuTopology.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/CpuTopology.cs
@@ -71,6 +71,51 @@ internal static class CpuTopology
         catch { return Array.Empty<Domain>(); }
     }
 
+    /// <summary>Enumerate PHYSICAL cores — one <see cref="Domain"/> per core, Mask = that core's logical
+    /// procs (its SMT siblings). Lets a pool pin exactly one thread per physical core (no SMT contention),
+    /// matching OpenBLAS's 1-thread-per-core decomposition. Empty on non-Windows / failure.</summary>
+    internal static Domain[] DetectPhysicalCores()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return Array.Empty<Domain>();
+        try
+        {
+            const int RelationProcessorCore = 0;
+            uint len = 0;
+            GetLogicalProcessorInformationEx(RelationProcessorCore, IntPtr.Zero, ref len);
+            if (len == 0) return Array.Empty<Domain>();
+            IntPtr buf = Marshal.AllocHGlobal((int)len);
+            try
+            {
+                if (!GetLogicalProcessorInformationEx(RelationProcessorCore, buf, ref len)) return Array.Empty<Domain>();
+                var list = new List<Domain>();
+                long ptr = (long)buf, end = ptr + len;
+                while (ptr < end)
+                {
+                    int rel = Marshal.ReadInt32((IntPtr)ptr);
+                    int size = Marshal.ReadInt32((IntPtr)(ptr + 4));
+                    if (size <= 0) break;
+                    // PROCESSOR_RELATIONSHIP at +8: Flags@8, EfficiencyClass@9, Reserved[20]@10,
+                    // GroupCount@30 (WORD), GroupMask[0] (GROUP_AFFINITY) @32 { Mask@32 (8B), Group@40 (2B) }.
+                    if (rel == RelationProcessorCore)
+                    {
+                        ushort groupCount = (ushort)Marshal.ReadInt16((IntPtr)(ptr + 30));
+                        if (groupCount >= 1)
+                        {
+                            ulong mask = (ulong)Marshal.ReadInt64((IntPtr)(ptr + 32));
+                            ushort group = (ushort)Marshal.ReadInt16((IntPtr)(ptr + 40));
+                            int cores = System.Numerics.BitOperations.PopCount(mask);
+                            if (cores > 0) list.Add(new Domain(mask, group, cores));
+                        }
+                    }
+                    ptr += size;
+                }
+                return list.ToArray();
+            }
+            finally { Marshal.FreeHGlobal(buf); }
+        }
+        catch { return Array.Empty<Domain>(); }
+    }
+
     /// <summary>Pin the calling thread to a domain's cores (best-effort; correctness is independent of it).</summary>
     internal static bool TryPinCurrentThread(in Domain d)
     {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
@@ -65,26 +65,24 @@ internal static class AxisSelector
     /// <param name="nr">Microkernel column-tile width.</param>
     /// <param name="procs">Available processor count (≥ 1).</param>
     /// <param name="isDeterministic">True if BlasProvider.IsDeterministicMode is set.</param>
-    /// <summary>
-    /// A/B test hook (#475 medium-axis routing). When non-null on the calling thread,
-    /// <see cref="Select"/> returns this axis directly, bypassing the heuristic — used by
-    /// the in-process axis-routing bench to measure each axis on the same shape. Null in
-    /// production (the default); thread-static so a bench thread can pin an axis without
-    /// perturbing the dispatcher on other threads.
-    /// </summary>
-    [ThreadStatic] internal static ParallelismAxis? ForceAxisForTest;
-
     public static ParallelismAxis Select(
         int m, int n, int k,
         int mr, int nr,
         int procs,
         bool isDeterministic)
     {
-        var forced = ForceAxisForTest;
-        if (forced.HasValue) return forced.Value;
-
+        // Universal guards run FIRST, before any forced-axis override, so a test/bench hook can
+        // never route a shape that production would refuse to parallelize (procs<=1 or below the
+        // work threshold) or pick an axis that violates the active mode (K-axis under determinism).
         if (procs <= 1) return ParallelismAxis.None;
         if ((long)m * n * k < ParallelWorkThreshold) return ParallelismAxis.None;
+
+        // A/B test hook (#475 medium-axis routing): honor a pinned axis only AFTER the universal
+        // guards above, and reject a forced K-axis in deterministic mode (the same gate the
+        // heuristic enforces below). Null in production, so this is a no-op on the hot path.
+        var forced = ForceAxisForTest;
+        if (forced.HasValue && !(forced.Value == ParallelismAxis.K && isDeterministic))
+            return forced.Value;
 
         // M-axis: enough M-blocks to spread across cores. Also gated on K size:
         // when K is large, pack overhead amortizes better with finer-grained
@@ -107,4 +105,14 @@ internal static class AxisSelector
         // Fallback.
         return ParallelismAxis.M;
     }
+
+    /// <summary>
+    /// A/B test hook (#475 medium-axis routing). When non-null on the calling thread,
+    /// <see cref="Select"/> returns this axis — but only AFTER the universal procs/work-threshold
+    /// guards and only when the axis is legal for the active mode (a forced K-axis is ignored in
+    /// deterministic mode). Used by the in-process axis-routing bench to measure each axis on the
+    /// same shape. Null in production (the default); thread-static so a bench thread can pin an axis
+    /// without perturbing the dispatcher on other threads.
+    /// </summary>
+    [ThreadStatic] internal static ParallelismAxis? ForceAxisForTest;
 }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
@@ -65,12 +65,24 @@ internal static class AxisSelector
     /// <param name="nr">Microkernel column-tile width.</param>
     /// <param name="procs">Available processor count (≥ 1).</param>
     /// <param name="isDeterministic">True if BlasProvider.IsDeterministicMode is set.</param>
+    /// <summary>
+    /// A/B test hook (#475 medium-axis routing). When non-null on the calling thread,
+    /// <see cref="Select"/> returns this axis directly, bypassing the heuristic — used by
+    /// the in-process axis-routing bench to measure each axis on the same shape. Null in
+    /// production (the default); thread-static so a bench thread can pin an axis without
+    /// perturbing the dispatcher on other threads.
+    /// </summary>
+    [ThreadStatic] internal static ParallelismAxis? ForceAxisForTest;
+
     public static ParallelismAxis Select(
         int m, int n, int k,
         int mr, int nr,
         int procs,
         bool isDeterministic)
     {
+        var forced = ForceAxisForTest;
+        if (forced.HasValue) return forced.Value;
+
         if (procs <= 1) return ParallelismAxis.None;
         if ((long)m * n * k < ParallelWorkThreshold) return ParallelismAxis.None;
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
@@ -58,7 +58,7 @@ internal static class GotoGemmFp32
     internal static bool BeatsPackBoth(int m, int n, int k)
         => m >= 512
         || (long)k >= 2L * n
-        || (m >= 128 && n >= 512 && ((long)n < 2L * k || (m % 6) != 0));
+        || (m >= 128 && n >= 512 && ((long)n < 2L * k || (m % Mr) != 0));
 
     /// <summary>Shape-adaptive (Mc, Nc, Kc) for RunParallel, tuned on the 3990X (measured --ab-goto-par /
     /// --profile-gemm). Memory-bound regime: larger square shapes want larger tiles (fewer redundant DRAM

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
@@ -45,11 +45,20 @@ internal static class GotoGemmFp32
     /// 3990X via --ab-prod): large/balanced (M≥512) OR wide-K (K≥2N, e.g. MLP-fc2). PackBoth's wide-N
     /// N-axis path wins the small-M wide-N shapes (DiT QKV M256×N3456, MLP-fc1 M256×N4608 — GotoGemm was
     /// 0.86-0.88× there), so those are excluded to avoid a production regression on the diffusion forward.</summary>
-    // GotoGemm beats PackBoth for: large-M, deep-K (k>=2n), AND — since the short-M blocking fix (balanced
-    // mc, core-filling nc) — short-M with decent N. Measured routing A/B (--ab-shortm, same-run direct
-    // kernels) on the DiT shapes: GotoGemm/PackBoth = qkv 2.06x, attnout 2.65x, mlp1 1.24x, mlp2 7.92x. The
-    // old gate (m>=512 || k>=2n) was set BEFORE that fix and wrongly kept m=256 wide/square-N on PackBoth.
-    internal static bool BeatsPackBoth(int m, int n, int k) => m >= 512 || (long)k >= 2L * n || (m >= 128 && n >= 512);
+    // GotoGemm beats PackBoth for: large-M (m>=512), deep-K (k>=2n), AND moderate-M decent-N — EXCEPT
+    // thin-M VERY-wide-N (m<512 && n>=2k), where PackBoth's N-axis path wins by sharing A. PerfView PMC +
+    // OpenBLAS-source analysis (2026-06-26): RunParallel packs A/B into PRIVATE per-thread tile panels, so
+    // for thin-M wide-N it re-packs A ~n/nc times (the per-tile work shows 86% of LLC misses; per-core
+    // 19.6 GF/s vs N-axis's shared-A 32). Clean A/B (--ab-goto-vs-naxis, DOP32): N-axis beats RunParallel
+    // 384x2048x1024 1.17x, 384x4096x1536 1.32x, 384x6144x1536 1.31x; while GotoGemm still wins balanced
+    // 768x2048x2048 1.33x and 1536^3 1.49x. So claim large/deep/moderate, cede thin-M-very-wide-N.
+    // Cede thin-M very-wide-N ONLY when PackBoth's N-axis can actually take it (m % Mr == 0, Mr=6 for the
+    // FP32 6x16 kernel): for m%6!=0 (e.g. the m=256 DiT QKV/MLP shapes) N-axis is disabled and PackBoth
+    // falls to M-axis/2D which LOSES to GotoGemm (the old --ab-shortm 2.06x), so GotoGemm must keep those.
+    internal static bool BeatsPackBoth(int m, int n, int k)
+        => m >= 512
+        || (long)k >= 2L * n
+        || (m >= 128 && n >= 512 && ((long)n < 2L * k || (m % 6) != 0));
 
     /// <summary>Shape-adaptive (Mc, Nc, Kc) for RunParallel, tuned on the 3990X (measured --ab-goto-par /
     /// --profile-gemm). Memory-bound regime: larger square shapes want larger tiles (fewer redundant DRAM

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/ExecutableMemory.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/ExecutableMemory.cs
@@ -27,6 +27,9 @@ internal sealed class ExecutableMemory : IDisposable
     /// <summary>Base address of the executable region (call target). IntPtr.Zero if allocation failed.</summary>
     internal IntPtr Pointer => _ptr;
 
+    /// <summary>Size in bytes of the emitted code region (used by callers to bound their kernel caches).</summary>
+    internal long Size => (long)_size;
+
     private ExecutableMemory(IntPtr ptr, nuint size, bool isWindows)
     {
         _ptr = ptr;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
+#if NET5_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+#if NET5_0_OR_GREATER
 
 /// <summary>
 /// #475 Phase 1 — libxsmm-style JIT GEMM generator. Emits per-shape-SPECIALIZED FP32 microkernels
@@ -157,3 +161,12 @@ internal static class JitGemmGenerator
                 asm.VmovupsStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
     }
 }
+#else
+/// <summary>net471 stub — no intrinsics / function pointers; callers fall back to the managed path.</summary>
+internal static class JitGemmGenerator
+{
+    internal static bool Enabled { get; set; }
+    internal static bool IsSupported => false;
+    internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k) => false;
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -23,10 +23,24 @@ internal static class JitGemmGenerator
     internal static bool Enabled { get; set; } = true;
 
     // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc, f64, bias, relu) -> native entry point.
-    // ExecutableMemory is retained for process lifetime so the emitted pages stay mapped.
+    // ExecutableMemory is retained so the emitted pages stay mapped while a kernel pointer is live.
     private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc, bool F64, bool Bias, bool Relu), nint> s_cache = new();
-    private static readonly ConcurrentBag<ExecutableMemory> s_keepAlive = new();
+    // Guarded by s_emitLock (all mutation happens inside GetOrEmit's lock or ClearCache). A List —
+    // not a ConcurrentBag — so ClearCache can dispose every region and reset it. Total emitted bytes
+    // are tracked so the cache is bounded: callers vary lda/ldb/ldc, so without a cap a long-running
+    // process inside the small-shape gate could emit unboundedly many distinct executable kernels.
+    private static readonly System.Collections.Generic.List<ExecutableMemory> s_keepAlive = new();
+    private static long s_keepAliveBytes;
     private static readonly object s_emitLock = new();
+
+    /// <summary>
+    /// Upper bound on total emitted executable kernel bytes. Once exceeded, <see cref="GetOrEmit"/>
+    /// stops emitting NEW kernels (the caller falls back to the managed path) instead of evicting
+    /// retained code while another thread may be mid-call into it. The whole cache is reclaimed only
+    /// by <see cref="ClearCache"/> (the quiescent reset wired into <see cref="BlasManaged.ClearCaches"/>).
+    /// Mirrors <see cref="JittedKernelCache.DefaultMaxJitCacheBytes"/>.
+    /// </summary>
+    internal static long MaxJitCacheBytes { get; set; } = JittedKernelCache.DefaultMaxJitCacheBytes;
 
     private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -108,6 +122,11 @@ internal static class JitGemmGenerator
         lock (s_emitLock)
         {
             if (s_cache.TryGetValue(key, out p)) return p;
+            // Cache bound: once the retained executable code exceeds the cap, stop emitting new
+            // kernels (return 0 → caller takes the managed path). We do NOT evict here: another
+            // thread may be executing a retained kernel, and freeing its pages would be a
+            // use-after-free. Reclaim happens only in ClearCache() at a quiescent point.
+            if (s_keepAliveBytes >= MaxJitCacheBytes) return 0;
             nint entry = 0;
             try
             {
@@ -115,11 +134,28 @@ internal static class JitGemmGenerator
                     ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc, f64, hasBias, relu)
                     : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc, f64, hasBias, relu);
                 var mem = ExecutableMemory.TryAllocate(code);
-                if (mem is not null) { s_keepAlive.Add(mem); entry = mem.Pointer; }
+                if (mem is not null) { s_keepAlive.Add(mem); s_keepAliveBytes += mem.Size; entry = mem.Pointer; }
             }
             catch { entry = 0; }
             s_cache[key] = entry;
             return entry;
+        }
+    }
+
+    /// <summary>
+    /// Release every retained executable kernel and reset the cache. Wired into
+    /// <see cref="BlasManaged.ClearCaches"/>. NOTE: this disposes the executable pages, so it is
+    /// only safe when no GEMM is in flight on any thread (the same contract the rest of
+    /// <see cref="BlasManaged.ClearCaches"/> assumes).
+    /// </summary>
+    internal static void ClearCache()
+    {
+        lock (s_emitLock)
+        {
+            foreach (var mem in s_keepAlive) mem.Dispose();
+            s_keepAlive.Clear();
+            s_keepAliveBytes = 0;
+            s_cache.Clear();
         }
     }
 
@@ -209,8 +245,11 @@ internal static class JitGemmGenerator
         if (relu)
         {
             asm.Vxorps(Ascr, Ascr, Ascr); // 0.0
+            // ReLU = max(acc, 0). VMAXPS returns its SECOND source on a NaN/unordered compare, so the
+            // accumulator must be src2 (not the zero vector) to keep NaN accumulators as NaN — matching
+            // the managed reference ReLU (value<0 is false for NaN, so NaN passes through unchanged).
             for (int i = 0; i < mr; i++)
-                for (int v = 0; v < nVec; v++) asm.Vmaxps(i * nVec + v, i * nVec + v, Ascr);
+                for (int v = 0; v < nVec; v++) asm.Vmaxps(i * nVec + v, Ascr, i * nVec + v);
         }
 
         for (int i = 0; i < mr; i++)
@@ -231,9 +270,6 @@ internal static class JitGemmGenerator
     /// Avx512Bf16 capability, and vdpbf16ps faults without it). Enable only on verified BF16 HW / SDE.</summary>
     internal static bool EnableBf16 { get; set; }
 
-    /// <summary>Opt-in for the native AMX int8 GEMM path (default off; faults without AMX).</summary>
-    internal static bool EnableAmxInt8 { get; set; }
-
     /// <summary>BF16 GEMM C[m,n] += Σ_k A[m,k]·B[k,n] (raw BF16 bits, FP32 accumulate) via the
     /// SDE-verified vdpbf16ps microkernel. No-op (returns false) unless <see cref="EnableBf16"/>.</summary>
     internal static unsafe bool TryRunBf16(ReadOnlySpan<ushort> a, ReadOnlySpan<ushort> b, Span<float> c, int m, int k, int n)
@@ -246,9 +282,9 @@ internal static class JitGemmGenerator
     internal static bool Enabled { get; set; }
     internal static bool IsSupported => false;
     internal static bool EnableBf16 { get; set; }
-    internal static bool EnableAmxInt8 { get; set; }
     internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k, float* bias = null, bool relu = false) => false;
     internal static unsafe bool TryRunFp64(double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k) => false;
     internal static bool TryRunBf16(System.ReadOnlySpan<ushort> a, System.ReadOnlySpan<ushort> b, System.Span<float> c, int m, int k, int n) => false;
+    internal static void ClearCache() { /* no JIT cache on net471 — IsSupported is always false */ }
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -22,9 +22,9 @@ internal static class JitGemmGenerator
     /// <summary>Master switch (default on when supported). A/B + safety override.</summary>
     internal static bool Enabled { get; set; } = true;
 
-    // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc, f64) -> native entry point.
+    // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc, f64, bias, relu) -> native entry point.
     // ExecutableMemory is retained for process lifetime so the emitted pages stay mapped.
-    private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc, bool F64), nint> s_cache = new();
+    private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc, bool F64, bool Bias, bool Relu), nint> s_cache = new();
     private static readonly ConcurrentBag<ExecutableMemory> s_keepAlive = new();
     private static readonly object s_emitLock = new();
 
@@ -41,10 +41,12 @@ internal static class JitGemmGenerator
     /// Mr is tiled by 6, Nr by 16 then 8.
     /// </summary>
     internal static unsafe bool TryRunFp32(
-        float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k)
+        float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k,
+        float* bias = null, bool relu = false)
     {
         if (!IsSupported || m <= 0 || n <= 0 || k <= 0) return false;
         if ((n & 7) != 0) return false; // AVX2 has no mask; partial-8 columns fall back to the caller
+        bool hasBias = bias != null;
 
         for (int mi = 0; mi < m; mi += 6)
         {
@@ -52,24 +54,25 @@ internal static class JitGemmGenerator
             int nj = 0;
             for (; nj + 16 <= n; nj += 16)
             {
-                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: false);
+                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: false, hasBias, relu);
                 if (kern == 0) return false;
-                ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
-                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+                ((delegate* unmanaged<float*, float*, float*, long, float*, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k, hasBias ? bias + nj : null);
             }
             for (; nj + 8 <= n; nj += 8)
             {
-                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: false);
+                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: false, hasBias, relu);
                 if (kern == 0) return false;
-                ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
-                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+                ((delegate* unmanaged<float*, float*, float*, long, float*, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k, hasBias ? bias + nj : null);
             }
         }
         return true;
     }
 
     /// <summary>C[m×n] := A[m×k]·B[k×n] (row-major, overwrite) via specialized JIT tiles, FP64.
-    /// Returns false when N is not a multiple of 4 (no AVX2 mask), unsupported, or on emit failure.</summary>
+    /// Returns false when N is not a multiple of 4 (no AVX2 mask), unsupported, or on emit failure.
+    /// No fused epilogue (FP64 callers apply it managed).</summary>
     internal static unsafe bool TryRunFp64(
         double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k)
     {
@@ -82,25 +85,25 @@ internal static class JitGemmGenerator
             int nj = 0;
             for (; nj + 8 <= n; nj += 8)
             {
-                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: true);
+                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: true, hasBias: false, relu: false);
                 if (kern == 0) return false;
-                ((delegate* unmanaged<double*, double*, double*, long, void>)kern)(
-                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+                ((delegate* unmanaged<double*, double*, double*, long, double*, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k, null);
             }
             for (; nj + 4 <= n; nj += 4)
             {
-                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: true);
+                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: true, hasBias: false, relu: false);
                 if (kern == 0) return false;
-                ((delegate* unmanaged<double*, double*, double*, long, void>)kern)(
-                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+                ((delegate* unmanaged<double*, double*, double*, long, double*, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k, null);
             }
         }
         return true;
     }
 
-    private static nint GetOrEmit(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
+    private static nint GetOrEmit(int mr, int nVec, int lda, int ldb, int ldc, bool f64, bool hasBias, bool relu)
     {
-        var key = (mr, nVec, lda, ldb, ldc, f64);
+        var key = (mr, nVec, lda, ldb, ldc, f64, hasBias, relu);
         if (s_cache.TryGetValue(key, out var p)) return p;
         lock (s_emitLock)
         {
@@ -109,8 +112,8 @@ internal static class JitGemmGenerator
             try
             {
                 byte[] code = IsWindows
-                    ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc, f64)
-                    : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc, f64);
+                    ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc, f64, hasBias, relu)
+                    : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc, f64, hasBias, relu);
                 var mem = ExecutableMemory.TryAllocate(code);
                 if (mem is not null) { s_keepAlive.Add(mem); entry = mem.Pointer; }
             }
@@ -124,15 +127,16 @@ internal static class JitGemmGenerator
     // Canonical body register layout: rcx=A, rdx=B, r8=C, r9=K. Accumulators ymm0..(Mr*nVec-1)
     // (≤12), B-load scratch ymm12..(12+nVec-1), A-broadcast scratch ymm14. Mr≤6, nVec≤2.
 
-    private static byte[] EmitDirectTileWindows(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
+    private static byte[] EmitDirectTileWindows(int mr, int nVec, int lda, int ldb, int ldc, bool f64, bool hasBias, bool relu)
     {
-        const int RSP = 4;
+        const int RSP = 4, R10 = 10;
         var asm = new X64Assembler();
-        // Windows: rcx=A, rdx=B, r8=C, r9=K already in the canonical layout. Save xmm6–15 (the
-        // body uses ymm6–14, whose low 128 bits are nonvolatile).
+        // Windows: rcx=A, rdx=B, r8=C, r9=K. The 5th arg (bias) is at [rsp+0x28] — read it into r10
+        // (volatile, untouched by the body) BEFORE growing rsp. Save xmm6–15 (body uses ymm6–14).
+        if (hasBias) asm.MovRegFromRsp(R10, 0x28);
         asm.SubRsp(0xA0);
         for (int i = 0; i < 10; i++) asm.VmovupsXmmStoreD32(RSP, i * 0x10, 6 + i);
-        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64);
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64, hasBias, relu);
         for (int i = 0; i < 10; i++) asm.VmovupsXmmLoadD32(6 + i, RSP, i * 0x10);
         asm.AddRsp(0xA0);
         asm.Vzeroupper();
@@ -140,17 +144,19 @@ internal static class JitGemmGenerator
         return asm.ToArray();
     }
 
-    private static byte[] EmitDirectTileSysV(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
+    private static byte[] EmitDirectTileSysV(int mr, int nVec, int lda, int ldb, int ldc, bool f64, bool hasBias, bool relu)
     {
-        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, RSI = 6, RDI = 7;
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, R10 = 10, RSI = 6, RDI = 7;
         var asm = new X64Assembler();
+        // SysV 5th arg (bias) is r8 — save it to r10 before r8 is reused for C in the shuffle.
+        if (hasBias) asm.MovRegReg(R10, R8);
         // SysV: rdi=A, rsi=B, rdx=C, rcx=K → shuffle to rcx=A, rdx=B, r8=C, r9=K (no live clobber).
         asm.MovRegReg(R9, RCX);   // r9 = K
         asm.MovRegReg(R8, RDX);   // r8 = C
         asm.MovRegReg(RDX, RSI);  // rdx = B
         asm.MovRegReg(RCX, RDI);  // rcx = A
         // All ymm are volatile on SysV — no save needed.
-        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64);
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64, hasBias, relu);
         asm.Vzeroupper();
         asm.Ret();
         return asm.ToArray();
@@ -160,10 +166,10 @@ internal static class JitGemmGenerator
     /// rdx=B, r8=C, r9=K. Each ymm spans 32 B regardless of dtype, so the v·32 displacements and
     /// the +32 store strides are shared; only the element size, FMA, broadcast, and load/store
     /// opcodes differ between FP32 and FP64.</summary>
-    private static void EmitDirectBody(X64Assembler asm, int mr, int nVec, int lda, int ldb, int ldc, bool f64)
+    private static void EmitDirectBody(X64Assembler asm, int mr, int nVec, int lda, int ldb, int ldc, bool f64, bool hasBias, bool relu)
     {
-        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9;
-        const int Bscr = 12, Ascr = 14; // ymm12..13 = B rows, ymm14 = A broadcast
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, R10 = 10;
+        const int Bscr = 12, Ascr = 14; // ymm12..13 = B rows, ymm14 = A broadcast (free after K-loop)
         int esz = f64 ? 8 : 4;
         int ldaB = lda * esz, ldbB = ldb * esz, ldcB = ldc * esz;
 
@@ -192,6 +198,21 @@ internal static class JitGemmGenerator
         asm.JnzLabel32(loop);
         asm.MarkLabel(done);
 
+        // Fused epilogue (FP32 only — FP64 callers never set these). r10 = bias ptr for this N-tile.
+        // Reuses the now-free K-loop scratch (Bscr for the bias vectors, Ascr for the ReLU zero).
+        if (hasBias)
+        {
+            for (int v = 0; v < nVec; v++) asm.VmovupsLoad(Bscr + v, R10, (sbyte)(v * 32)); // bias[nj + v·8]
+            for (int i = 0; i < mr; i++)
+                for (int v = 0; v < nVec; v++) asm.Vaddps(i * nVec + v, i * nVec + v, Bscr + v);
+        }
+        if (relu)
+        {
+            asm.Vxorps(Ascr, Ascr, Ascr); // 0.0
+            for (int i = 0; i < mr; i++)
+                for (int v = 0; v < nVec; v++) asm.Vmaxps(i * nVec + v, i * nVec + v, Ascr);
+        }
+
         for (int i = 0; i < mr; i++)
             for (int v = 0; v < nVec; v++)
                 if (f64) asm.VmovupdStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
@@ -204,7 +225,7 @@ internal static class JitGemmGenerator
 {
     internal static bool Enabled { get; set; }
     internal static bool IsSupported => false;
-    internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k) => false;
+    internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k, float* bias = null, bool relu = false) => false;
     internal static unsafe bool TryRunFp64(double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k) => false;
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -218,6 +218,26 @@ internal static class JitGemmGenerator
                 if (f64) asm.VmovupdStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
                 else asm.VmovupsStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
     }
+
+    // ── #475 Phase 2: native low-precision GEMM folded into the JIT framework ───
+    // These reuse the existing SDE-verified machine-code microkernels (vdpbf16ps for BF16,
+    // AMX tdpb* for int8), which use instructions this AVX2 host lacks. They are perf-validatable
+    // ONLY on real AVX-512-BF16 / AMX hardware (or for correctness under Intel SDE) — hence the
+    // explicit opt-in flags (default OFF): auto-using them here would #UD. Ship opt-in; the
+    // structural encoding is gated by MachineKernel*Tests + the `--verify-bf16gemm`/`--verify-amx-gemm`
+    // SDE entrypoints, exactly like the existing AVX-512 kernels.
+
+    /// <summary>Opt-in for the native AVX-512-BF16 GEMM path (default off; .NET exposes no
+    /// Avx512Bf16 capability, and vdpbf16ps faults without it). Enable only on verified BF16 HW / SDE.</summary>
+    internal static bool EnableBf16 { get; set; }
+
+    /// <summary>Opt-in for the native AMX int8 GEMM path (default off; faults without AMX).</summary>
+    internal static bool EnableAmxInt8 { get; set; }
+
+    /// <summary>BF16 GEMM C[m,n] += Σ_k A[m,k]·B[k,n] (raw BF16 bits, FP32 accumulate) via the
+    /// SDE-verified vdpbf16ps microkernel. No-op (returns false) unless <see cref="EnableBf16"/>.</summary>
+    internal static unsafe bool TryRunBf16(ReadOnlySpan<ushort> a, ReadOnlySpan<ushort> b, Span<float> c, int m, int k, int n)
+        => Enabled && EnableBf16 && Jit.MachineCodeBf16Kernel.TryGemm(a, b, c, m, k, n);
 }
 #else
 /// <summary>net471 stub — no intrinsics / function pointers; callers fall back to the managed path.</summary>
@@ -225,7 +245,10 @@ internal static class JitGemmGenerator
 {
     internal static bool Enabled { get; set; }
     internal static bool IsSupported => false;
+    internal static bool EnableBf16 { get; set; }
+    internal static bool EnableAmxInt8 { get; set; }
     internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k, float* bias = null, bool relu = false) => false;
     internal static unsafe bool TryRunFp64(double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k) => false;
+    internal static bool TryRunBf16(System.ReadOnlySpan<ushort> a, System.ReadOnlySpan<ushort> b, System.Span<float> c, int m, int k, int n) => false;
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// #475 Phase 1 — libxsmm-style JIT GEMM generator. Emits per-shape-SPECIALIZED FP32 microkernels
+/// that bake the tile geometry (Mr, Nr) and the leading dimensions (lda, ldb, ldc) as immediates
+/// and address A/B/C directly (no packing), then caches each by signature. The structural win over
+/// AOT OpenBLAS for small/medium GEMM: zero runtime stride arithmetic, no generic edge loops, and
+/// a tile schedule fixed at emit time. Operates on row-major A[M×K], B[K×N], C[M×N]; computes
+/// C := A·B (overwrite — accumulators zero-init). net5+ only (function pointers + W^X memory).
+/// </summary>
+internal static class JitGemmGenerator
+{
+    /// <summary>Master switch (default on when supported). A/B + safety override.</summary>
+    internal static bool Enabled { get; set; } = true;
+
+    // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc) -> native entry point. ExecutableMemory
+    // is retained for process lifetime so the emitted pages stay mapped.
+    private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc), nint> s_cache = new();
+    private static readonly ConcurrentBag<ExecutableMemory> s_keepAlive = new();
+    private static readonly object s_emitLock = new();
+
+    private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    internal static bool IsSupported =>
+        Enabled && Fma.IsSupported && Avx2.IsSupported &&
+        RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
+        (IsWindows || RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
+    /// <summary>
+    /// C[m×n] := A[m×k]·B[k×n] (row-major, overwrite) via specialized JIT tiles. Returns false
+    /// (caller falls back) when N is not a multiple of 8, when unsupported, or on any emit failure.
+    /// Mr is tiled by 6, Nr by 16 then 8.
+    /// </summary>
+    internal static unsafe bool TryRunFp32(
+        float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k)
+    {
+        if (!IsSupported || m <= 0 || n <= 0 || k <= 0) return false;
+        if ((n & 7) != 0) return false; // AVX2 has no mask; partial-8 columns fall back to the caller
+
+        for (int mi = 0; mi < m; mi += 6)
+        {
+            int mr = Math.Min(6, m - mi);
+            int nj = 0;
+            for (; nj + 16 <= n; nj += 16)
+            {
+                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc);
+                if (kern == 0) return false;
+                ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+            }
+            for (; nj + 8 <= n; nj += 8)
+            {
+                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc);
+                if (kern == 0) return false;
+                ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+            }
+        }
+        return true;
+    }
+
+    private static nint GetOrEmit(int mr, int nVec, int lda, int ldb, int ldc)
+    {
+        var key = (mr, nVec, lda, ldb, ldc);
+        if (s_cache.TryGetValue(key, out var p)) return p;
+        lock (s_emitLock)
+        {
+            if (s_cache.TryGetValue(key, out p)) return p;
+            nint entry = 0;
+            try
+            {
+                byte[] code = IsWindows
+                    ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc)
+                    : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc);
+                var mem = ExecutableMemory.TryAllocate(code);
+                if (mem is not null) { s_keepAlive.Add(mem); entry = mem.Pointer; }
+            }
+            catch { entry = 0; }
+            s_cache[key] = entry;
+            return entry;
+        }
+    }
+
+    // ── Emitters ────────────────────────────────────────────────────────────
+    // Canonical body register layout: rcx=A, rdx=B, r8=C, r9=K. Accumulators ymm0..(Mr*nVec-1)
+    // (≤12), B-load scratch ymm12..(12+nVec-1), A-broadcast scratch ymm14. Mr≤6, nVec≤2.
+
+    private static byte[] EmitDirectTileWindows(int mr, int nVec, int lda, int ldb, int ldc)
+    {
+        const int RSP = 4;
+        var asm = new X64Assembler();
+        // Windows: rcx=A, rdx=B, r8=C, r9=K already in the canonical layout. Save xmm6–15 (the
+        // body uses ymm6–14, whose low 128 bits are nonvolatile).
+        asm.SubRsp(0xA0);
+        for (int i = 0; i < 10; i++) asm.VmovupsXmmStoreD32(RSP, i * 0x10, 6 + i);
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc);
+        for (int i = 0; i < 10; i++) asm.VmovupsXmmLoadD32(6 + i, RSP, i * 0x10);
+        asm.AddRsp(0xA0);
+        asm.Vzeroupper();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    private static byte[] EmitDirectTileSysV(int mr, int nVec, int lda, int ldb, int ldc)
+    {
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, RSI = 6, RDI = 7;
+        var asm = new X64Assembler();
+        // SysV: rdi=A, rsi=B, rdx=C, rcx=K → shuffle to rcx=A, rdx=B, r8=C, r9=K (no live clobber).
+        asm.MovRegReg(R9, RCX);   // r9 = K
+        asm.MovRegReg(R8, RDX);   // r8 = C
+        asm.MovRegReg(RDX, RSI);  // rdx = B
+        asm.MovRegReg(RCX, RDI);  // rcx = A
+        // All ymm are volatile on SysV — no save needed.
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc);
+        asm.Vzeroupper();
+        asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>Mr×(8·nVec) FP32 tile, lda/ldb/ldc baked. rcx=A, rdx=B, r8=C, r9=K. C is RMW.</summary>
+    private static void EmitDirectBody(X64Assembler asm, int mr, int nVec, int lda, int ldb, int ldc)
+    {
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9;
+        const int Bscr = 12, Ascr = 14; // ymm12..13 = B rows, ymm14 = A broadcast
+        int ldaB = lda * sizeof(float), ldbB = ldb * sizeof(float), ldcB = ldc * sizeof(float);
+
+        // Zero the accumulators (C := A·B overwrite — no dependence on C's prior content).
+        for (int i = 0; i < mr; i++)
+            for (int v = 0; v < nVec; v++)
+                asm.Vxorps(i * nVec + v, i * nVec + v, i * nVec + v);
+
+        int done = asm.NewLabel();
+        asm.TestRegSelf(R9);
+        asm.JzLabel32(done);
+        int loop = asm.NewLabel();
+        asm.MarkLabel(loop);
+        // One K-step: load the B row (nVec ymm), broadcast each A column element, FMA.
+        for (int v = 0; v < nVec; v++) asm.VmovupsLoad(Bscr + v, RDX, (sbyte)(v * 32));
+        for (int i = 0; i < mr; i++)
+        {
+            asm.VbroadcastSsD32(Ascr, RCX, i * ldaB);          // A[i][k] = [rcx + i*lda*4]
+            for (int v = 0; v < nVec; v++) asm.Vfmadd231ps(i * nVec + v, Ascr, Bscr + v);
+        }
+        asm.AddRegImm8(RCX, sizeof(float));                    // A col ptr += 1 float (k++)
+        asm.AddRegImm32(RDX, ldbB);                            // B row ptr += ldb floats (k++)
+        asm.DecReg(R9);
+        asm.JnzLabel32(loop);
+        asm.MarkLabel(done);
+
+        for (int i = 0; i < mr; i++)
+            for (int v = 0; v < nVec; v++)
+                asm.VmovupsStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/JitGemmGenerator.cs
@@ -22,9 +22,9 @@ internal static class JitGemmGenerator
     /// <summary>Master switch (default on when supported). A/B + safety override.</summary>
     internal static bool Enabled { get; set; } = true;
 
-    // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc) -> native entry point. ExecutableMemory
-    // is retained for process lifetime so the emitted pages stay mapped.
-    private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc), nint> s_cache = new();
+    // Specialized-kernel cache: (Mr, nVec, lda, ldb, ldc, f64) -> native entry point.
+    // ExecutableMemory is retained for process lifetime so the emitted pages stay mapped.
+    private static readonly ConcurrentDictionary<(int Mr, int NVec, int Lda, int Ldb, int Ldc, bool F64), nint> s_cache = new();
     private static readonly ConcurrentBag<ExecutableMemory> s_keepAlive = new();
     private static readonly object s_emitLock = new();
 
@@ -52,14 +52,14 @@ internal static class JitGemmGenerator
             int nj = 0;
             for (; nj + 16 <= n; nj += 16)
             {
-                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc);
+                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: false);
                 if (kern == 0) return false;
                 ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
                     a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
             }
             for (; nj + 8 <= n; nj += 8)
             {
-                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc);
+                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: false);
                 if (kern == 0) return false;
                 ((delegate* unmanaged<float*, float*, float*, long, void>)kern)(
                     a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
@@ -68,9 +68,39 @@ internal static class JitGemmGenerator
         return true;
     }
 
-    private static nint GetOrEmit(int mr, int nVec, int lda, int ldb, int ldc)
+    /// <summary>C[m×n] := A[m×k]·B[k×n] (row-major, overwrite) via specialized JIT tiles, FP64.
+    /// Returns false when N is not a multiple of 4 (no AVX2 mask), unsupported, or on emit failure.</summary>
+    internal static unsafe bool TryRunFp64(
+        double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k)
     {
-        var key = (mr, nVec, lda, ldb, ldc);
+        if (!IsSupported || m <= 0 || n <= 0 || k <= 0) return false;
+        if ((n & 3) != 0) return false; // YMM holds 4 doubles; partial-4 columns fall back
+
+        for (int mi = 0; mi < m; mi += 6)
+        {
+            int mr = Math.Min(6, m - mi);
+            int nj = 0;
+            for (; nj + 8 <= n; nj += 8)
+            {
+                nint kern = GetOrEmit(mr, 2, lda, ldb, ldc, f64: true);
+                if (kern == 0) return false;
+                ((delegate* unmanaged<double*, double*, double*, long, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+            }
+            for (; nj + 4 <= n; nj += 4)
+            {
+                nint kern = GetOrEmit(mr, 1, lda, ldb, ldc, f64: true);
+                if (kern == 0) return false;
+                ((delegate* unmanaged<double*, double*, double*, long, void>)kern)(
+                    a + (long)mi * lda, b + nj, c + (long)mi * ldc + nj, k);
+            }
+        }
+        return true;
+    }
+
+    private static nint GetOrEmit(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
+    {
+        var key = (mr, nVec, lda, ldb, ldc, f64);
         if (s_cache.TryGetValue(key, out var p)) return p;
         lock (s_emitLock)
         {
@@ -79,8 +109,8 @@ internal static class JitGemmGenerator
             try
             {
                 byte[] code = IsWindows
-                    ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc)
-                    : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc);
+                    ? EmitDirectTileWindows(mr, nVec, lda, ldb, ldc, f64)
+                    : EmitDirectTileSysV(mr, nVec, lda, ldb, ldc, f64);
                 var mem = ExecutableMemory.TryAllocate(code);
                 if (mem is not null) { s_keepAlive.Add(mem); entry = mem.Pointer; }
             }
@@ -94,7 +124,7 @@ internal static class JitGemmGenerator
     // Canonical body register layout: rcx=A, rdx=B, r8=C, r9=K. Accumulators ymm0..(Mr*nVec-1)
     // (≤12), B-load scratch ymm12..(12+nVec-1), A-broadcast scratch ymm14. Mr≤6, nVec≤2.
 
-    private static byte[] EmitDirectTileWindows(int mr, int nVec, int lda, int ldb, int ldc)
+    private static byte[] EmitDirectTileWindows(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
     {
         const int RSP = 4;
         var asm = new X64Assembler();
@@ -102,7 +132,7 @@ internal static class JitGemmGenerator
         // body uses ymm6–14, whose low 128 bits are nonvolatile).
         asm.SubRsp(0xA0);
         for (int i = 0; i < 10; i++) asm.VmovupsXmmStoreD32(RSP, i * 0x10, 6 + i);
-        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc);
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64);
         for (int i = 0; i < 10; i++) asm.VmovupsXmmLoadD32(6 + i, RSP, i * 0x10);
         asm.AddRsp(0xA0);
         asm.Vzeroupper();
@@ -110,7 +140,7 @@ internal static class JitGemmGenerator
         return asm.ToArray();
     }
 
-    private static byte[] EmitDirectTileSysV(int mr, int nVec, int lda, int ldb, int ldc)
+    private static byte[] EmitDirectTileSysV(int mr, int nVec, int lda, int ldb, int ldc, bool f64)
     {
         const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, RSI = 6, RDI = 7;
         var asm = new X64Assembler();
@@ -120,20 +150,24 @@ internal static class JitGemmGenerator
         asm.MovRegReg(RDX, RSI);  // rdx = B
         asm.MovRegReg(RCX, RDI);  // rcx = A
         // All ymm are volatile on SysV — no save needed.
-        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc);
+        EmitDirectBody(asm, mr, nVec, lda, ldb, ldc, f64);
         asm.Vzeroupper();
         asm.Ret();
         return asm.ToArray();
     }
 
-    /// <summary>Mr×(8·nVec) FP32 tile, lda/ldb/ldc baked. rcx=A, rdx=B, r8=C, r9=K. C is RMW.</summary>
-    private static void EmitDirectBody(X64Assembler asm, int mr, int nVec, int lda, int ldb, int ldc)
+    /// <summary>Mr×(laneW·nVec) tile (laneW = 8 floats / 4 doubles), lda/ldb/ldc baked. rcx=A,
+    /// rdx=B, r8=C, r9=K. Each ymm spans 32 B regardless of dtype, so the v·32 displacements and
+    /// the +32 store strides are shared; only the element size, FMA, broadcast, and load/store
+    /// opcodes differ between FP32 and FP64.</summary>
+    private static void EmitDirectBody(X64Assembler asm, int mr, int nVec, int lda, int ldb, int ldc, bool f64)
     {
         const int RCX = 1, RDX = 2, R8 = 8, R9 = 9;
         const int Bscr = 12, Ascr = 14; // ymm12..13 = B rows, ymm14 = A broadcast
-        int ldaB = lda * sizeof(float), ldbB = ldb * sizeof(float), ldcB = ldc * sizeof(float);
+        int esz = f64 ? 8 : 4;
+        int ldaB = lda * esz, ldbB = ldb * esz, ldcB = ldc * esz;
 
-        // Zero the accumulators (C := A·B overwrite — no dependence on C's prior content).
+        // Zero the accumulators (C := A·B overwrite). vxorps clears all bits → 0.0 for both dtypes.
         for (int i = 0; i < mr; i++)
             for (int v = 0; v < nVec; v++)
                 asm.Vxorps(i * nVec + v, i * nVec + v, i * nVec + v);
@@ -144,21 +178,24 @@ internal static class JitGemmGenerator
         int loop = asm.NewLabel();
         asm.MarkLabel(loop);
         // One K-step: load the B row (nVec ymm), broadcast each A column element, FMA.
-        for (int v = 0; v < nVec; v++) asm.VmovupsLoad(Bscr + v, RDX, (sbyte)(v * 32));
+        for (int v = 0; v < nVec; v++)
+            if (f64) asm.VmovupdLoad(Bscr + v, RDX, (sbyte)(v * 32)); else asm.VmovupsLoad(Bscr + v, RDX, (sbyte)(v * 32));
         for (int i = 0; i < mr; i++)
         {
-            asm.VbroadcastSsD32(Ascr, RCX, i * ldaB);          // A[i][k] = [rcx + i*lda*4]
-            for (int v = 0; v < nVec; v++) asm.Vfmadd231ps(i * nVec + v, Ascr, Bscr + v);
+            if (f64) asm.VbroadcastSdD32(Ascr, RCX, i * ldaB); else asm.VbroadcastSsD32(Ascr, RCX, i * ldaB);
+            for (int v = 0; v < nVec; v++)
+                if (f64) asm.Vfmadd231pd(i * nVec + v, Ascr, Bscr + v); else asm.Vfmadd231ps(i * nVec + v, Ascr, Bscr + v);
         }
-        asm.AddRegImm8(RCX, sizeof(float));                    // A col ptr += 1 float (k++)
-        asm.AddRegImm32(RDX, ldbB);                            // B row ptr += ldb floats (k++)
+        asm.AddRegImm8(RCX, (sbyte)esz);    // A col ptr += 1 element (k++)
+        asm.AddRegImm32(RDX, ldbB);  // B row ptr += ldb elements (k++)
         asm.DecReg(R9);
         asm.JnzLabel32(loop);
         asm.MarkLabel(done);
 
         for (int i = 0; i < mr; i++)
             for (int v = 0; v < nVec; v++)
-                asm.VmovupsStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
+                if (f64) asm.VmovupdStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
+                else asm.VmovupsStoreD32(R8, i * ldcB + v * 32, i * nVec + v);
     }
 }
 #else
@@ -168,5 +205,6 @@ internal static class JitGemmGenerator
     internal static bool Enabled { get; set; }
     internal static bool IsSupported => false;
     internal static unsafe bool TryRunFp32(float* a, int lda, float* b, int ldb, float* c, int ldc, int m, int n, int k) => false;
+    internal static unsafe bool TryRunFp64(double* a, int lda, double* b, int ldb, double* c, int ldc, int m, int n, int k) => false;
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
@@ -17,6 +17,11 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 /// </summary>
 internal static class MachineCodeFmaKernel
 {
+    // #475 Phase-0 A/B knob: K-unroll factor for the FP32 6×16 panel loop. OpenBLAS's Zen sgemm
+    // kernel unrolls 8; ours shipped 4. Baked at emit time — change requires re-emitting the
+    // panel/macro kernels (MachineKernelGemm.ResetFp32Kernels). Default 4 until A/B confirms 8.
+    internal static int PanelKUnroll = 4;
+
     /// <summary>Emit the Windows-x64 12-accumulator FP64 FMA loop. Returns the machine-code bytes.</summary>
     internal static byte[] EmitFp64x12Windows()
     {
@@ -357,7 +362,7 @@ internal static class MachineCodeFmaKernel
 
         int store = asm.NewLabel();
         int ktail = asm.NewLabel();
-        const int U = 4; // K-unroll factor
+        int U = Math.Max(1, PanelKUnroll); // K-unroll factor (#475 A/B knob; OpenBLAS uses 8)
 
         // Tuned prefetch distance for the next packed-B stripe (bytes ahead of rdx). 512 B = 8
         // cache lines ≈ one Nr=16 tile's worth of K-steps ahead — far enough to hide the L2→L1
@@ -378,7 +383,7 @@ internal static class MachineCodeFmaKernel
         // prefetching A is pure redundant load-port traffic (PR #656: A+B −14%, B-only −2% in
         // the single-tile kernel). Here B is cold for the NEXT tile in the panel macro-loop, so
         // it's a real win. Pure hint, bit-exact.
-        asm.CmpRegImm8(R10, U);
+        asm.CmpRegImm8(R10, (sbyte)U);
         asm.JlLabel32(ktail);          // kc < U → straight to the 1-step tail
         int kmain = asm.NewLabel();
         asm.MarkLabel(kmain);
@@ -393,15 +398,17 @@ internal static class MachineCodeFmaKernel
             for (int r = 0; r < Mr; r++)
             {
                 int areg = (r % 2 == 0) ? A0 : A1;
-                asm.VbroadcastSs(areg, RCX, (sbyte)(ku * Mr * 4 + r * 4)); // max 3*24+20=92 → disp8
+                int aOff = ku * Mr * 4 + r * 4;   // U=4 max 92 → disp8; U=8 max 188 → disp32
+                if (aOff <= 127) asm.VbroadcastSs(areg, RCX, (sbyte)aOff);
+                else asm.VbroadcastSsD32(areg, RCX, aOff);
                 asm.Vfmadd231ps(2 * r, areg, BLO);
                 asm.Vfmadd231ps(2 * r + 1, areg, BHI);
             }
         }
-        asm.AddRegImm32(RCX, U * Mr * 4);  // A += 24 floats
-        asm.AddRegImm32(RDX, U * Nr * 4);  // B += 64 floats
+        asm.AddRegImm32(RCX, U * Mr * 4);  // A += U*6 floats
+        asm.AddRegImm32(RDX, U * Nr * 4);  // B += U*16 floats
         asm.SubRegImm8(R10, (sbyte)U);
-        asm.CmpRegImm8(R10, U);
+        asm.CmpRegImm8(R10, (sbyte)U);
         asm.JlLabel32(ktail);          // remaining < U → tail
         asm.JmpLabel32(kmain);         // else another unrolled round
 
@@ -592,7 +599,7 @@ internal static class MachineCodeFmaKernel
         int rem = asm.NewLabel();
         int store = asm.NewLabel();
         asm.MarkLabel(cond);
-        asm.CmpRegImm8(R10, U);
+        asm.CmpRegImm8(R10, (sbyte)U);
         asm.JlLabel32(rem);
         for (int s = 0; s < U; s++)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineCodeFmaKernel.cs
@@ -230,6 +230,99 @@ internal static class MachineCodeFmaKernel
         return asm.ToArray();
     }
 
+    // ── #475 macro-kernel: the whole Mr-sweep in machine code ──────────────────
+    // Takes RyuJIT off the hot path. One call does numMr Mr-blocks × njr N-tiles × kc K-steps
+    // for one K-panel, reusing the same packed-B across Mr-blocks (B stays hot, no managed
+    // per-Mr-block call / span construction). Signature (both ABIs, via delegate* unmanaged):
+    //   (float* aBase, float* bBase, float* cBase, long ldc, long kc, long njr,
+    //    long numMr, long aStrideBytes)
+    // where aStrideBytes = effKc*Mr*4 (the byte gap between packed-A Mr-stripes), and cBase
+    // advances by Mr*ldc*4 (6 rows) per Mr-block. Bit-identical to the per-Mr-block panel path
+    // (same per-tile FMA order; C tiles disjoint; K accumulates ascending).
+    internal static byte[] EmitFp32_6x16_MacroWindows()
+    {
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, R10 = 10, R11 = 11, RAX = 0,
+                  RSI = 6, RDI = 7, RBX = 3, RBP = 5, R12 = 12, R13 = 13, R14 = 14, R15 = 15, RSP = 4;
+        var asm = new X64Assembler();
+        // Read stack args BEFORE growing rsp (Windows: arg5 @ +0x28 .. arg8 @ +0x40).
+        asm.MovRegFromRsp(R10, 0x28);  // r10 = kc
+        asm.MovRegFromRsp(RAX, 0x30);  // rax = njr
+        asm.MovRegFromRsp(R11, 0x38);  // r11 = numMr
+        // Preserve nonvolatiles used by the macro wrapper + panel body.
+        asm.PushReg(RSI); asm.PushReg(RDI); asm.PushReg(RBX); asm.PushReg(RBP);
+        asm.PushReg(R12); asm.PushReg(R13); asm.PushReg(R14); asm.PushReg(R15);
+        asm.SubRsp(0xA0); // frame to save xmm6–15 (panel body uses ymm6–15)
+        for (int i = 0; i < 10; i++) asm.VmovupsXmmStoreD32(RSP, i * 0x10, 6 + i);
+        // arg8 aStrideBytes: entry [rsp+0x40] shifted by 8 pushes (0x40) + 0xA0 frame → [rsp+0x120].
+        asm.MovRegFromRspD32(RDI, 0x40 + 0x40 + 0xA0); // rdi = aStrideBytes
+        // Masters.
+        asm.MovRegReg(RSI, RCX);   // rsi = A-base master
+        asm.MovRegReg(R14, RDX);   // r14 = B-base master
+        asm.MovRegReg(R15, R8);    // r15 = C-base master
+        asm.MovRegReg(RBX, R11);   // rbx = numMr counter
+        asm.MovRegReg(RBP, RAX);   // rbp = njr master
+        asm.MovRegReg(R12, R10);   // r12 = kc
+        asm.LeaRaxIndexScale4(R9); // rax = ldc*4 (row stride); r9 = ldc preserved
+
+        EmitMacroPanelLoop_Fp32_6x16(asm);
+
+        for (int i = 0; i < 10; i++) asm.VmovupsXmmLoadD32(6 + i, RSP, i * 0x10);
+        asm.AddRsp(0xA0);
+        asm.PopReg(R15); asm.PopReg(R14); asm.PopReg(R13); asm.PopReg(R12);
+        asm.PopReg(RBP); asm.PopReg(RBX); asm.PopReg(RDI); asm.PopReg(RSI);
+        asm.Vzeroupper(); asm.Ret();
+        return asm.ToArray();
+    }
+
+    internal static byte[] EmitFp32_6x16_MacroSysV()
+    {
+        const int RCX = 1, RDX = 2, R8 = 8, R9 = 9, R10 = 10, R11 = 11,
+                  RSI = 6, RDI = 7, RBX = 3, RBP = 5, R12 = 12, R13 = 13, R14 = 14, R15 = 15;
+        var asm = new X64Assembler();
+        // SysV args: rdi=A, rsi=B, rdx=C, rcx=ldc, r8=kc, r9=njr, [rsp+8]=numMr, [rsp+0x10]=aStrideBytes.
+        asm.MovRegFromRsp(R10, 0x08);  // r10 = numMr
+        asm.MovRegFromRsp(R11, 0x10);  // r11 = aStrideBytes
+        asm.PushReg(RBX); asm.PushReg(RBP); asm.PushReg(R12); asm.PushReg(R13); asm.PushReg(R14); asm.PushReg(R15);
+        // Shuffle into the canonical layout (rsi/rdi/rax are volatile on SysV).
+        asm.MovRegReg(R14, RSI);   // r14 = B   (rsi held B)
+        asm.MovRegReg(RSI, RDI);   // rsi = A   (rdi held A)
+        asm.MovRegReg(R15, RDX);   // r15 = C
+        asm.MovRegReg(RDI, R11);   // rdi = aStrideBytes
+        asm.MovRegReg(RBX, R10);   // rbx = numMr
+        asm.MovRegReg(RBP, R9);    // rbp = njr
+        asm.MovRegReg(R12, R8);    // r12 = kc
+        asm.MovRegReg(R9, RCX);    // r9 = ldc
+        asm.LeaRaxIndexScale4(R9); // rax = ldc*4
+
+        EmitMacroPanelLoop_Fp32_6x16(asm);
+
+        asm.PopReg(R15); asm.PopReg(R14); asm.PopReg(R13); asm.PopReg(R12); asm.PopReg(RBP); asm.PopReg(RBX);
+        asm.Vzeroupper(); asm.Ret();
+        return asm.ToArray();
+    }
+
+    /// <summary>Outer Mr-loop wrapping the panel tile-loop. Assumes rsi=A-base, r14=B-base,
+    /// r15=C-base, rbx=numMr, rbp=njr, r12=kc, rdi=aStrideBytes, rax=ldc*4, r9=ldc. EmitPanelLoop
+    /// touches none of rsi/r14/r15/rbx/rbp/rdi/r9, so the masters survive each tile sweep.</summary>
+    private static void EmitMacroPanelLoop_Fp32_6x16(X64Assembler asm)
+    {
+        const int RDX = 2, R8 = 8, R13 = 13, RSI = 6, RDI = 7, RBX = 3, RBP = 5, R14 = 14, R15 = 15, RAX = 0;
+        int macroDone = asm.NewLabel();
+        asm.TestRegSelf(RBX);          // numMr == 0 → nothing to do
+        asm.JzLabel32(macroDone);
+        int mrLoop = asm.NewLabel();
+        asm.MarkLabel(mrLoop);
+        asm.MovRegReg(RDX, R14);       // B = base (panel advances rdx through the tiles)
+        asm.MovRegReg(R8, R15);        // C = this Mr-block's base (panel advances r8)
+        asm.MovRegReg(R13, RBP);       // njr counter = master (panel decrements r13)
+        EmitPanelLoop_Fp32_6x16(asm);  // numMr-th Mr-block: njr tiles × kc K-steps
+        asm.AddRegReg(RSI, RDI);       // A-base += aStrideBytes (next packed-A Mr-stripe)
+        for (int r = 0; r < 6; r++) asm.AddRegReg(R15, RAX); // C-base += Mr(6) × ldc*4 rows
+        asm.DecReg(RBX);
+        asm.JnzLabel32(mrLoop);
+        asm.MarkLabel(macroDone);
+    }
+
     /// <summary>Register-level FP32 6×16 panel loop. Assumes rsi=A-base, r12=kc, r13=njr,
     /// rax=ldc*4 (row stride bytes), r8=C, r9=ldc; clobbers ymm0–15, rcx, rdx, r10, r11,
     /// advances r8/r13/rdx; rsi/r12/rax preserved across iterations. ABI-agnostic.</summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
@@ -119,16 +119,29 @@ internal static class MachineKernelGemm
         kern(aBase, bBase, cBase, ldc, kc, njr, numMr, aStrideBytes);
     }
 
+    // #475 Phase-0 A/B support: superseded panel/macro kernels are RETIRED here (never disposed)
+    // so their RX code pages stay mapped for the process lifetime. ResetFp32Kernels re-emits with a
+    // changed PanelKUnroll; a previously-handed-out kernel pointer may still be mid-call on another
+    // thread, so the old ExecutableMemory must NOT be freed (that would munmap/VirtualFree code a
+    // thread is executing → use-after-free). Retaining the handful of A/B generations is bounded.
+    private static readonly System.Collections.Generic.List<ExecutableMemory> _retiredKernels = new();
+
     /// <summary>
     /// #475 Phase-0 A/B support: drop the cached FP32 panel + macro kernels so the next
     /// IsFp32PanelAvailable/IsFp32MacroAvailable re-emits them with the current
-    /// MachineCodeFmaKernel.PanelKUnroll (and other emit-time knobs). Test/bench use only —
-    /// the old ExecutableMemory is left to the GC. Not thread-safe vs in-flight kernel calls.
+    /// MachineCodeFmaKernel.PanelKUnroll (and other emit-time knobs). Test/bench use only.
+    /// <para>
+    /// The superseded <see cref="ExecutableMemory"/> is moved to <c>_retiredKernels</c> rather than
+    /// freed, so any kernel pointer still in flight on another thread keeps executing valid mapped
+    /// code (dropping it to the GC could unmap pages a thread is mid-call into — a use-after-free).
+    /// </para>
     /// </summary>
     internal static void ResetFp32Kernels()
     {
         lock (_lock)
         {
+            if (_memPanel32 is not null) _retiredKernels.Add(_memPanel32);
+            if (_memMacro32 is not null) _retiredKernels.Add(_memMacro32);
             _triedPanel32 = false; _kernPanel32 = 0; _memPanel32 = null;
             _triedMacro32 = false; _kernMacro32 = 0; _memMacro32 = null;
         }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
@@ -119,6 +119,21 @@ internal static class MachineKernelGemm
         kern(aBase, bBase, cBase, ldc, kc, njr, numMr, aStrideBytes);
     }
 
+    /// <summary>
+    /// #475 Phase-0 A/B support: drop the cached FP32 panel + macro kernels so the next
+    /// IsFp32PanelAvailable/IsFp32MacroAvailable re-emits them with the current
+    /// MachineCodeFmaKernel.PanelKUnroll (and other emit-time knobs). Test/bench use only —
+    /// the old ExecutableMemory is left to the GC. Not thread-safe vs in-flight kernel calls.
+    /// </summary>
+    internal static void ResetFp32Kernels()
+    {
+        lock (_lock)
+        {
+            _triedPanel32 = false; _kernPanel32 = 0; _memPanel32 = null;
+            _triedMacro32 = false; _kernMacro32 = 0; _memMacro32 = null;
+        }
+    }
+
     private static bool TryInitMacroFp32()
     {
         if (_triedMacro32) return _kernMacro32 != 0;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
@@ -440,6 +440,13 @@ internal static class MachineKernelGemm
         Span<float> c, int ldc, int kc, int njr) =>
         throw new PlatformNotSupportedException(
             "RunPanelFp32 requires the net5.0+ machine-code JIT path; gate on IsFp32PanelAvailable before calling.");
+    internal static bool IsFp32MacroAvailable => false;
+    internal static unsafe void RunMacroPanelFp32(
+        float* aBase, float* bBase, float* cBase,
+        int ldc, int kc, int njr, int numMr, int aStrideBytes) =>
+        throw new PlatformNotSupportedException(
+            "RunMacroPanelFp32 requires the net5.0+ machine-code JIT path; gate on IsFp32MacroAvailable before calling.");
+    internal static void ResetFp32Kernels() { }
     internal static int ActiveFp64Nr => Fp64Nr;
     internal static int ActiveFp32Nr => Fp32Nr;
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/MachineKernelGemm.cs
@@ -75,9 +75,9 @@ internal static class MachineKernelGemm
     private static bool UseAvx512Fp32 => EnableAvx512 && Avx512F.IsSupported && TryInitAvx512Fp32();
 
     private static readonly object _lock = new();
-    private static bool _tried64, _tried32, _triedZ64, _triedZ32, _triedPanel32;
-    private static ExecutableMemory? _mem64, _mem32, _memZ64, _memZ32, _memPanel32; // kept alive for the process
-    private static nint _kern64, _kern32, _kernZ64, _kernZ32, _kernPanel32;
+    private static bool _tried64, _tried32, _triedZ64, _triedZ32, _triedPanel32, _triedMacro32;
+    private static ExecutableMemory? _mem64, _mem32, _memZ64, _memZ32, _memPanel32, _memMacro32; // kept alive for the process
+    private static nint _kern64, _kern32, _kernZ64, _kernZ32, _kernPanel32, _kernMacro32;
 
     // #663: expose the #653 panel kernel to the N-axis path (PackBothStrategy.RunNAxisParallelUnsafe).
     // Shares _kernPanel32 + TryInitPanelFp32 with the internal RunPacked panel use (both branches
@@ -100,6 +100,44 @@ internal static class MachineKernelGemm
         fixed (float* pb = packedB)
         fixed (float* pc = c)
             kern(pa, pb, pc, ldc, kc, njr);
+    }
+
+    /// <summary>True when the FP32 6×16 MACRO kernel (whole Mr-sweep in asm) is usable.</summary>
+    internal static bool IsFp32MacroAvailable => Enabled && EnablePanelKernel && TryInitMacroFp32();
+
+    /// <summary>
+    /// Run the FP32 6×16 macro kernel: for a single K-panel, does numMr Mr-blocks × njr Nr=16
+    /// tiles × kc K-steps entirely in machine code, reusing packedB across Mr-blocks. C is
+    /// read-modify-write. aBase points at the panel's first Mr-stripe; consecutive stripes are
+    /// aStrideBytes apart; C advances Mr·ldc rows per Mr-block. Caller guarantees availability.
+    /// </summary>
+    internal static unsafe void RunMacroPanelFp32(
+        float* aBase, float* bBase, float* cBase,
+        int ldc, int kc, int njr, int numMr, int aStrideBytes)
+    {
+        var kern = (delegate* unmanaged<float*, float*, float*, long, long, long, long, long, void>)_kernMacro32;
+        kern(aBase, bBase, cBase, ldc, kc, njr, numMr, aStrideBytes);
+    }
+
+    private static bool TryInitMacroFp32()
+    {
+        if (_triedMacro32) return _kernMacro32 != 0;
+        lock (_lock)
+        {
+            if (_triedMacro32) return _kernMacro32 != 0;
+            _triedMacro32 = true;
+            if (!PlatformOk()) return false;
+            try
+            {
+                byte[] code = IsWindows
+                    ? MachineCodeFmaKernel.EmitFp32_6x16_MacroWindows()
+                    : MachineCodeFmaKernel.EmitFp32_6x16_MacroSysV();
+                _memMacro32 = ExecutableMemory.TryAllocate(code);
+                if (_memMacro32 is not null) _kernMacro32 = _memMacro32.Pointer;
+            }
+            catch { _memMacro32 = null; _kernMacro32 = 0; }
+            return _kernMacro32 != 0;
+        }
     }
 
     private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -414,6 +414,12 @@ internal sealed class X64Assembler
     /// <summary>vxorps ymm_dst, s1, s2. VEX.256.0F.WIG 57 /r. Zeroes a register via dst,dst,dst.</summary>
     internal void Vxorps(int dst, int s1, int s2) => VexRR(Map0F, PpNone, 0, 1, 0x57, dst, s1, s2);
 
+    /// <summary>vaddps ymm_dst, s1, s2 (dst = s1 + s2). VEX.256.0F.WIG 58 /r. For fused bias.</summary>
+    internal void Vaddps(int dst, int s1, int s2) => VexRR(Map0F, PpNone, 0, 1, 0x58, dst, s1, s2);
+
+    /// <summary>vmaxps ymm_dst, s1, s2 (dst = max(s1, s2)). VEX.256.0F.WIG 5F /r. For fused ReLU.</summary>
+    internal void Vmaxps(int dst, int s1, int s2) => VexRR(Map0F, PpNone, 0, 1, 0x5F, dst, s1, s2);
+
     /// <summary>vbroadcastss ymm_dst, [base+disp8]. VEX.256.66.0F38.W0 18.</summary>
     internal void VbroadcastSs(int dst, int baseReg, sbyte disp8) => VexMemDisp8(Map0F38, Pp66, 0, 1, 0x18, dst, baseReg, disp8);
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -146,6 +146,9 @@ internal sealed class X64Assembler
     /// <summary>vmovups ymm_dst, [base+disp32] (FP32 256-bit load).</summary>
     internal void VmovupsLoadD32(int dst, int baseReg, int disp32) => VexMemDisp32(Map0F, PpNone, 0, 1, 0x10, dst, baseReg, disp32);
 
+    /// <summary>vmovups [base+disp32], ymm_src (FP32 256-bit store). Op 0x11; src in ModRM.reg.</summary>
+    internal void VmovupsStoreD32(int baseReg, int disp32, int src) => VexMemDisp32(Map0F, PpNone, 0, 1, 0x11, src, baseReg, disp32);
+
     /// <summary>vbroadcastss ymm_dst, [base+disp32].</summary>
     internal void VbroadcastSsD32(int dst, int baseReg, int disp32) => VexMemDisp32(Map0F38, Pp66, 0, 1, 0x18, dst, baseReg, disp32);
 
@@ -404,6 +407,9 @@ internal sealed class X64Assembler
 
     /// <summary>vfmadd231ps dst, s1, s2 (dst += s1*s2). VEX.DDS.256.66.0F38.W0 B8.</summary>
     internal void Vfmadd231ps(int dst, int s1, int s2) => VexRR(Map0F38, Pp66, 0, 1, 0xB8, dst, s1, s2);
+
+    /// <summary>vxorps ymm_dst, s1, s2. VEX.256.0F.WIG 57 /r. Zeroes a register via dst,dst,dst.</summary>
+    internal void Vxorps(int dst, int s1, int s2) => VexRR(Map0F, PpNone, 0, 1, 0x57, dst, s1, s2);
 
     /// <summary>vbroadcastss ymm_dst, [base+disp8]. VEX.256.66.0F38.W0 18.</summary>
     internal void VbroadcastSs(int dst, int baseReg, sbyte disp8) => VexMemDisp8(Map0F38, Pp66, 0, 1, 0x18, dst, baseReg, disp8);

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -201,6 +201,15 @@ internal sealed class X64Assembler
         B(rex, 0x8B, (byte)(0x40 | ((dst & 7) << 3) | 4), 0x24, (byte)disp);
     }
 
+    /// <summary>mov dst64, [rsp+disp32]. REX.W[.R] 8B /r, mod=10, rm=100 (SIB rsp), disp32.
+    /// For reading a stack argument after the frame has grown past the disp8 (±127) range.</summary>
+    internal void MovRegFromRspD32(int dst, int disp32)
+    {
+        byte rex = (byte)(0x48 | (dst >= 8 ? 4 : 0));
+        B(rex, 0x8B, (byte)(0x80 | ((dst & 7) << 3) | 4), 0x24);
+        Imm32(disp32);
+    }
+
     /// <summary>lea rax, [idx*8]. REX.W[.X] 8D, mod=00 reg=rax rm=100, SIB(scale8,idx,base=disp32), disp32=0.</summary>
     internal void LeaRaxIndexScale8(int idx)
     {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Jit/X64Assembler.cs
@@ -149,6 +149,9 @@ internal sealed class X64Assembler
     /// <summary>vmovups [base+disp32], ymm_src (FP32 256-bit store). Op 0x11; src in ModRM.reg.</summary>
     internal void VmovupsStoreD32(int baseReg, int disp32, int src) => VexMemDisp32(Map0F, PpNone, 0, 1, 0x11, src, baseReg, disp32);
 
+    /// <summary>vmovupd [base+disp32], ymm_src (FP64 256-bit store). 66 prefix; op 0x11.</summary>
+    internal void VmovupdStoreD32(int baseReg, int disp32, int src) => VexMemDisp32(Map0F, Pp66, 0, 1, 0x11, src, baseReg, disp32);
+
     /// <summary>vbroadcastss ymm_dst, [base+disp32].</summary>
     internal void VbroadcastSsD32(int dst, int baseReg, int disp32) => VexMemDisp32(Map0F38, Pp66, 0, 1, 0x18, dst, baseReg, disp32);
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
@@ -15,13 +15,14 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 /// </summary>
 internal static class PinnedParallel
 {
-    private static int _n, _initState; // _initState: 0 unstarted, 1 ready, 2 unavailable
+    private static int _n, _initState, _domainCount; // _initState: 0 unstarted, 1 ready, 2 unavailable
     private static readonly object _initGate = new(), _runGate = new();
     private static ManualResetEventSlim[] _go = Array.Empty<ManualResetEventSlim>();
     private static CountdownEvent? _done;
     private static Action<int>? _body;
     private static int _from, _to, _next;
     private static volatile bool _faulted;
+    [ThreadStatic] private static int _curDomain; // this worker's L3-domain (CCX) index, 0..DomainCount-1
 
     /// <summary>Route the FP32 N-axis parallel-for through the L3-domain-pinned pool. Default ON — measured
     /// 1.08-1.16x bit-exact on the diffusion thin-M wide-N shapes (--ab-pinned). Opt out with
@@ -30,7 +31,21 @@ internal static class PinnedParallel
     internal static bool s_enabled =
         System.Environment.GetEnvironmentVariable("AIDOTNET_PIN_NAXIS") != "0";
 
+    /// <summary>Per-CCX A-replication (env AIDOTNET_PIN_REPLICATE=1): the N-axis packs one packed-A copy
+    /// per L3 domain and each pinned worker reads its CCX-local copy via <see cref="CurrentDomain"/>,
+    /// killing cross-CCX shared-A reads. Correctness is independent (copies are identical; copy 0 is the
+    /// fallback on any non-pinned thread).</summary>
+    internal static bool s_replicate =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_PIN_REPLICATE") == "1";
+
     internal static bool IsAvailable { get { EnsureInit(); return _initState == 1; } }
+
+    /// <summary>Distinct L3 domains (CCX) the pool spans (≥1).</summary>
+    internal static int DomainCount { get { EnsureInit(); return _domainCount < 1 ? 1 : _domainCount; } }
+
+    /// <summary>The running worker's L3-domain index; 0 on threadpool/non-pool threads (so reading copy 0
+    /// is always valid).</summary>
+    internal static int CurrentDomain => _curDomain;
 
     private static void EnsureInit()
     {
@@ -40,19 +55,31 @@ internal static class PinnedParallel
             if (_initState != 0) return;
             try
             {
-                // Build the per-thread pin target list. Per-core mode (AIDOTNET_PIN_PERCORE=1, OB-exact):
-                // ONE thread per physical core, pinned to that core's mask — no SMT contention. Default:
-                // L3-domain mode — Domain.Cores threads per CCX, each pinned to the CCX mask.
+                // Build (pin target, L3-domain index) per thread. The domain index groups threads by CCX
+                // so per-CCX A-replication can hand each worker its local copy. Per-core mode
+                // (AIDOTNET_PIN_PERCORE=1): one thread per physical core (no SMT), mapped back to its L3
+                // domain. Default: Domain.Cores threads per CCX, each pinned to the CCX mask.
+                var l3 = CpuTopology.DetectL3Domains();
+                _domainCount = l3.Length;
                 var pins = new System.Collections.Generic.List<CpuTopology.Domain>();
+                var domIdx = new System.Collections.Generic.List<int>();
                 if (System.Environment.GetEnvironmentVariable("AIDOTNET_PIN_PERCORE") == "1")
-                    foreach (var core in CpuTopology.DetectPhysicalCores()) pins.Add(core);
+                {
+                    foreach (var core in CpuTopology.DetectPhysicalCores())
+                    {
+                        int di = 0;
+                        for (int j = 0; j < l3.Length; j++) if ((l3[j].Mask & core.Mask) == core.Mask) { di = j; break; }
+                        pins.Add(core); domIdx.Add(di);
+                    }
+                }
                 if (pins.Count < 2)
                 {
-                    pins.Clear();
-                    foreach (var dom in CpuTopology.DetectL3Domains())
-                        for (int c = 0; c < dom.Cores; c++) pins.Add(dom);
+                    pins.Clear(); domIdx.Clear();
+                    for (int di = 0; di < l3.Length; di++)
+                        for (int c = 0; c < l3[di].Cores; c++) { pins.Add(l3[di]); domIdx.Add(di); }
                 }
                 if (pins.Count < 2) { Volatile.Write(ref _initState, 2); return; }
+                if (_domainCount < 1) _domainCount = 1;
                 _n = pins.Count;
                 _go = new ManualResetEventSlim[_n];
                 _done = new CountdownEvent(_n);
@@ -60,8 +87,9 @@ internal static class PinnedParallel
                 {
                     int myId = id;
                     var pin = pins[id];
+                    int myDom = domIdx[id];
                     _go[myId] = new ManualResetEventSlim(false);
-                    new Thread(() => Worker(myId, pin)) { IsBackground = true, Name = $"aidotnet-pin-{myId}" }.Start();
+                    new Thread(() => Worker(myId, pin, myDom)) { IsBackground = true, Name = $"aidotnet-pin-{myId}" }.Start();
                 }
                 Volatile.Write(ref _initState, 1);
             }
@@ -69,9 +97,10 @@ internal static class PinnedParallel
         }
     }
 
-    private static void Worker(int id, CpuTopology.Domain dom)
+    private static void Worker(int id, CpuTopology.Domain dom, int domainIndex)
     {
         CpuTopology.TryPinCurrentThread(dom); // pin to L3 domain (best-effort; correctness is pin-independent)
+        _curDomain = domainIndex;             // expose the worker's CCX index for per-CCX A-replication
         while (true)
         {
             _go[id].Wait();
@@ -123,7 +152,10 @@ namespace AiDotNet.Tensors.Engines.BlasManaged;
 internal static class PinnedParallel
 {
     internal static bool s_enabled;
+    internal static bool s_replicate;
     internal static bool IsAvailable => false;
+    internal static int DomainCount => 1;
+    internal static int CurrentDomain => 0;
     internal static bool For(int from, int to, System.Action<int> body) => false;
 }
 #endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
@@ -40,24 +40,28 @@ internal static class PinnedParallel
             if (_initState != 0) return;
             try
             {
-                var domains = CpuTopology.DetectL3Domains();
-                int total = 0;
-                foreach (var d in domains) total += d.Cores;
-                if (domains.Length < 1 || total < 2) { Volatile.Write(ref _initState, 2); return; }
-                _n = total;
+                // Build the per-thread pin target list. Per-core mode (AIDOTNET_PIN_PERCORE=1, OB-exact):
+                // ONE thread per physical core, pinned to that core's mask — no SMT contention. Default:
+                // L3-domain mode — Domain.Cores threads per CCX, each pinned to the CCX mask.
+                var pins = new System.Collections.Generic.List<CpuTopology.Domain>();
+                if (System.Environment.GetEnvironmentVariable("AIDOTNET_PIN_PERCORE") == "1")
+                    foreach (var core in CpuTopology.DetectPhysicalCores()) pins.Add(core);
+                if (pins.Count < 2)
+                {
+                    pins.Clear();
+                    foreach (var dom in CpuTopology.DetectL3Domains())
+                        for (int c = 0; c < dom.Cores; c++) pins.Add(dom);
+                }
+                if (pins.Count < 2) { Volatile.Write(ref _initState, 2); return; }
+                _n = pins.Count;
                 _go = new ManualResetEventSlim[_n];
                 _done = new CountdownEvent(_n);
-                int id = 0;
-                for (int di = 0; di < domains.Length; di++)
+                for (int id = 0; id < _n; id++)
                 {
-                    for (int c = 0; c < domains[di].Cores; c++)
-                    {
-                        int myId = id;
-                        var dom = domains[di];
-                        _go[myId] = new ManualResetEventSlim(false);
-                        new Thread(() => Worker(myId, dom)) { IsBackground = true, Name = $"aidotnet-pin-{myId}" }.Start();
-                        id++;
-                    }
+                    int myId = id;
+                    var pin = pins[id];
+                    _go[myId] = new ManualResetEventSlim(false);
+                    new Thread(() => Worker(myId, pin)) { IsBackground = true, Name = $"aidotnet-pin-{myId}" }.Start();
                 }
                 Volatile.Write(ref _initState, 1);
             }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/PinnedParallel.cs
@@ -1,0 +1,125 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// #85 EXPERIMENT (gated <see cref="s_enabled"/>, default OFF): run a parallel-for on PERSISTENT worker
+/// threads PINNED per L3 domain. OpenBLAS hits ~59 GF/s/core on pinned physical cores; our threadpool
+/// N-axis gets ~42 (thread migration + SMT-sibling contention, per the PerfView/busy-core diagnosis).
+/// This is a GENERIC dispatch: it runs the caller's UNCHANGED <c>body(i)</c> work-stealing across the
+/// pinned threads, so any GEMM routed through it is BIT-EXACT (identical compute, only the threads
+/// differ). Windows-only pinning (via <see cref="CpuTopology.TryPinCurrentThread"/>); on other OSes or
+/// when unavailable, <see cref="For"/> returns false and the caller uses the threadpool path.
+/// </summary>
+internal static class PinnedParallel
+{
+    private static int _n, _initState; // _initState: 0 unstarted, 1 ready, 2 unavailable
+    private static readonly object _initGate = new(), _runGate = new();
+    private static ManualResetEventSlim[] _go = Array.Empty<ManualResetEventSlim>();
+    private static CountdownEvent? _done;
+    private static Action<int>? _body;
+    private static int _from, _to, _next;
+    private static volatile bool _faulted;
+
+    /// <summary>Route the FP32 N-axis parallel-for through the L3-domain-pinned pool. Default ON — measured
+    /// 1.08-1.16x bit-exact on the diffusion thin-M wide-N shapes (--ab-pinned). Opt out with
+    /// AIDOTNET_PIN_NAXIS=0. Self-limiting: only the N-axis path consults it, and <see cref="For"/> falls
+    /// back to the threadpool when the pool is busy/nested/unavailable.</summary>
+    internal static bool s_enabled =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_PIN_NAXIS") != "0";
+
+    internal static bool IsAvailable { get { EnsureInit(); return _initState == 1; } }
+
+    private static void EnsureInit()
+    {
+        if (Volatile.Read(ref _initState) != 0) return;
+        lock (_initGate)
+        {
+            if (_initState != 0) return;
+            try
+            {
+                var domains = CpuTopology.DetectL3Domains();
+                int total = 0;
+                foreach (var d in domains) total += d.Cores;
+                if (domains.Length < 1 || total < 2) { Volatile.Write(ref _initState, 2); return; }
+                _n = total;
+                _go = new ManualResetEventSlim[_n];
+                _done = new CountdownEvent(_n);
+                int id = 0;
+                for (int di = 0; di < domains.Length; di++)
+                {
+                    for (int c = 0; c < domains[di].Cores; c++)
+                    {
+                        int myId = id;
+                        var dom = domains[di];
+                        _go[myId] = new ManualResetEventSlim(false);
+                        new Thread(() => Worker(myId, dom)) { IsBackground = true, Name = $"aidotnet-pin-{myId}" }.Start();
+                        id++;
+                    }
+                }
+                Volatile.Write(ref _initState, 1);
+            }
+            catch { Volatile.Write(ref _initState, 2); }
+        }
+    }
+
+    private static void Worker(int id, CpuTopology.Domain dom)
+    {
+        CpuTopology.TryPinCurrentThread(dom); // pin to L3 domain (best-effort; correctness is pin-independent)
+        while (true)
+        {
+            _go[id].Wait();
+            _go[id].Reset();
+            try
+            {
+                var body = _body;
+                if (body != null)
+                {
+                    int i;
+                    // Work-stealing: each thread grabs the next index until the range is drained.
+                    while ((i = Interlocked.Increment(ref _next) - 1 + _from) < _to) body(i);
+                }
+            }
+            catch { _faulted = true; }
+            finally { _done!.Signal(); }
+        }
+    }
+
+    /// <summary>
+    /// Run <paramref name="body"/> for every index in [from, to) on the pinned pool, work-stealing.
+    /// Returns false (C UNTOUCHED — safe to fall back to the threadpool) when the pool is unavailable or
+    /// busy. THROWS if a body invocation faulted mid-run (C may be partial; caller must not silently
+    /// fall back — a deterministic GEMM body never throws, so this only fires on a real defect).
+    /// </summary>
+    internal static bool For(int from, int to, Action<int> body)
+    {
+        if (!IsAvailable) return false;
+        if (to <= from) return true;
+        if (!Monitor.TryEnter(_runGate)) return false; // nested/concurrent use → threadpool
+        try
+        {
+            _body = body; _from = from; _to = to; _next = 0; _faulted = false;
+            _done!.Reset();
+            for (int i = 0; i < _n; i++) _go[i].Set();
+            _done.Wait();
+            _body = null;
+            if (_faulted) throw new InvalidOperationException("PinnedParallel body faulted.");
+            return true;
+        }
+        finally { Monitor.Exit(_runGate); }
+    }
+}
+#else
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+// net471 has no function-pointer/JIT GEMM path and no affinity pinning here; the N-axis stays on the
+// threadpool. Stub so callers compile; For always returns false (→ threadpool).
+internal static class PinnedParallel
+{
+    internal static bool s_enabled;
+    internal static bool IsAvailable => false;
+    internal static bool For(int from, int to, System.Action<int> body) => false;
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -229,6 +229,10 @@ internal static class PackBothStrategy
             int numNBlocksN = (n + ncN - 1) / ncN;
             bool useNAxis = !s_disableNAxis
                 && MachineKernelGemm.IsFp32PanelAvailable
+                // The N-axis path computes with RunPanelFp32 = the 6×16 panel kernel (mr=6), but packs A
+                // with `mr`. Under AVX-512 the strategy selects the 16×16 microkernel (mr=16), so the A-pack
+                // (16-row stripes) would mismatch the 6-row panel kernel → garbage. Gate to the panel's mr.
+                && mr == MachineKernelGemm.Fp32Mr
                 && typeof(T) == typeof(float)
                 && !transA && !transB
                 && options.PackedA is null && options.PackedB is null

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -53,22 +53,6 @@ internal static class PackBothStrategy
     // loop body). A/B toggle; default off until bit-exactness is validated, then flipped on.
     internal static bool s_macroKernel;
 
-    // #85 low-barrier jc-blocked GotoBLAS path (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block once
-    // into shared L3, ONE parallel region per Nc-block, shared packed-A read by DISJOINT rows.
-    // DEAD END — kept only as a measurement record (s_forceGotoBlas + the --ab-gotoblas* benches).
-    //
-    // WHY DEAD: the early "1.1-1.4x medium win" was a MEASUREMENT ARTIFACT. The production large-float
-    // path is GotoGemmFp32 at BlasManaged.cs:542 (its own GotoBLAS macro-kernel + CCX pool), gated by
-    // BeatsPackBoth = m≥512 || k≥2n || (m≥128 && n≥512). Every shape in this path's intended envelope
-    // (k≤n≤2k with m≥128, k≥512 ⇒ n≥512) satisfies (m≥128 && n≥512) ⇒ routes to GotoGemmFp32 and NEVER
-    // reaches PackBoth. So toggling s_forceGotoBlas changed nothing for those shapes — the "win" was
-    // ±25% box noise. Forcing the path for real (AIDOTNET_DISABLE_GOTO=1 ⇒ falls to PackBoth) measured
-    // it SLOWER than the N-axis path: ffn 0.40x, medium ~1.0x — the jc-outer-serial barrier-per-Nc-block
-    // structure throttles wide-N (the single-region path exists precisely to avoid that barrier).
-    // Conclusion: GotoGemmFp32 already owns this regime; this PackBoth variant adds nothing. Default OFF.
-    internal static bool s_forceGotoBlas;
-    internal static bool s_gotoBlasAuto; // default OFF — dead end (see above); GotoGemmFp32 owns this regime
-
     // #653 software-prefetch microkernel (env AIDOTNET_GEMM_PREFETCH=1, default off). Routes the
     // FP32 6×16 tile through Avx2Fp32_6x16.RunPrefetch (PREFETCHT0 of packed-B ahead) — same inlined
     // intrinsic kernel, so NO per-tile call/fixed overhead (unlike the machine-code-per-tile path
@@ -246,37 +230,6 @@ internal static class PackBothStrategy
                 && numNBlocksN >= 2 && numNBlocksN >= Math.Min(4, effProcs)
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
-            // #85 low-barrier jc-blocked GotoBLAS path. Same FP32 / no-transpose / no-prepack /
-            // no-epilogue / m%mr==0 envelope as the N-axis path. s_gotoBlasAuto is DEAD (default off):
-            // every shape in the k≤n≤2k gate satisfies BeatsPackBoth's (m≥128 && n≥512) clause and is
-            // claimed by GotoGemmFp32 at BlasManaged.cs:542 before PackBoth is ever reached; when forced
-            // onto PackBoth (AIDOTNET_DISABLE_GOTO=1) this path measured SLOWER than N-axis (ffn 0.40x).
-            // The gate stays only so s_forceGotoBlas can still drive the --ab-gotoblas* measurement record.
-            bool gotoEnvelope =
-                MachineKernelGemm.IsFp32PanelAvailable
-                && typeof(T) == typeof(float)
-                && !transA && !transB
-                && options.PackedA is null && options.PackedB is null
-                && (m % mr) == 0 && m >= mr
-                && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
-                && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
-            bool gotoAutoGate = s_gotoBlasAuto
-                && m >= 128 && k >= 512
-                && (long)n >= (long)k && (long)n <= 2L * k;
-            if (gotoEnvelope && (s_forceGotoBlas || gotoAutoGate))
-            {
-                fixed (T* aPtrG = a)
-                fixed (T* bPtrG = b)
-                fixed (T* cPtrG = c)
-                {
-                    RunGotoBlasParallelUnsafe<T>(
-                        aPtrG, a.Length, lda,
-                        bPtrG, b.Length, ldb,
-                        cPtrG, c.Length, ldc,
-                        m, n, k, mc, nc, kc, mr, nr, elemSize);
-                }
-                return;
-            }
 
             if (useNAxis)
             {
@@ -1196,143 +1149,6 @@ internal static class PackBothStrategy
         {
             System.Buffers.ArrayPool<byte>.Shared.Return(packBArr);
         }
-    }
-
-    /// <summary>
-    /// #85 low-barrier jc-blocked GotoBLAS path (FP32). Packs ALL of A once into a shared Mr-stripe
-    /// buffer — each ic-block reads its DISJOINT rows, so there is no cross-thread A contention
-    /// (unlike the N-axis path, where every thread re-reads the whole shared A for its N-block). Then
-    /// for each Nc-block of N (serial outer, disjoint C columns) it packs that block's B once into a
-    /// shared, L3-resident buffer and runs ONE parallel region over ic-blocks, each thread walking the
-    /// full K-loop for its rows. This is the BLIS persistent-team structure that no existing path has:
-    /// low barrier count (one region per Nc-block, not per (jc,pc) macro-tile like RunParallelUnsafe),
-    /// B blocked to stay L3-resident (vs single-region's all-B), shared packed-B (vs 2D's redundant
-    /// per-thread B-pack), and disjoint-row shared-A (vs N-axis's whole-A-per-thread re-read).
-    /// Bit-identical to the other paths: each C[i,j] reduces over k in ascending panel order and
-    /// ic-blocks own disjoint C rows.
-    /// </summary>
-    private static unsafe void RunGotoBlasParallelUnsafe<T>(
-        T* aPtr, int aLen, int lda,
-        T* bPtr, int bLen, int ldb,
-        T* cPtr, int cLen, int ldc,
-        int m, int n, int k,
-        int mc, int nc, int kc, int mr, int nr, int elemSize) where T : unmanaged
-    {
-        int numKPanels = (k + kc - 1) / kc;
-        int numStripesM = (m + mr - 1) / mr;
-        int packedM = numStripesM * mr;
-        long packAElems = (long)numKPanels * kc * packedM;
-
-        const int Align = 32;
-        byte[] packAArr = System.Buffers.ArrayPool<byte>.Shared.Rent((int)(packAElems * elemSize) + Align - 1);
-        int packAOff;
-        fixed (byte* pa0 = packAArr)
-        {
-            nuint addr = (nuint)pa0; nuint mask = Align - 1;
-            packAOff = (int)((Align - (uint)(addr & mask)) & mask);
-        }
-
-        nint aI = (nint)aPtr, bI = (nint)bPtr, cI = (nint)cPtr;
-        int ldaC = lda, ldbC = ldb, ldcC = ldc, kC = k, mC = m, nC = n, aLenC = aLen, bLenC = bLen, cLenC = cLen;
-        int kcC = kc, mrC = mr, nrC = nr, numKPanelsC = numKPanels, packedMC = packedM, numStripesMC = numStripesM;
-        byte[] packAArrC = packAArr; int packAOffC = packAOff;
-
-        try
-        {
-            // ── Pack ALL of A once: (panel × m-stripe) shared, Mr-stripe layout ──
-            int numPackAItems = numKPanelsC * numStripesMC;
-            CpuParallelSettings.ParallelForOrSerial(0, numPackAItems, packAElems, item =>
-            {
-                int panel = item / numStripesMC;
-                int mstripe = item % numStripesMC;
-                int pc = panel * kcC;
-                int effKc = Math.Min(kcC, kC - pc);
-                int row = mstripe * mrC;
-                int effMr = Math.Min(mrC, mC - row);
-                long panelBase = (long)panel * packedMC * kcC;
-                long stripeOff = (long)mstripe * effKc * mrC;
-                int aOff = row * ldaC + pc;
-                ReadOnlySpan<T> aSlice = new ReadOnlySpan<T>((T*)aI + aOff, aLenC - aOff);
-                Span<T> dst = MemoryMarshal.Cast<byte, T>(
-                    packAArrC.AsSpan(packAOffC + (int)((panelBase + stripeOff) * elemSize), effKc * mrC * elemSize));
-                Avx2Pack.PackA<T>(aSlice, ldaC, false, dst, effMr, effKc, mrC);
-            }, deterministicSafe: true);
-
-            // ── Per Nc-block: pack that block's B once (shared, L3) + ONE ic parallel region ──
-            int numIcBlocks = (mC + mc - 1) / mc;
-            int mcC = mc;
-            for (int jc = 0; jc < nC; jc += nc)
-            {
-                int effNc = Math.Min(nc, nC - jc);
-                int numStripesN = (effNc + nrC - 1) / nrC;
-                int packedNc = numStripesN * nrC;
-                long packBElems = (long)numKPanelsC * kcC * packedNc;
-                byte[] packBArr = System.Buffers.ArrayPool<byte>.Shared.Rent((int)(packBElems * elemSize) + Align - 1);
-                int packBOff;
-                fixed (byte* pb0 = packBArr)
-                {
-                    nuint addr = (nuint)pb0; nuint mask = Align - 1;
-                    packBOff = (int)((Align - (uint)(addr & mask)) & mask);
-                }
-                byte[] packBArrC = packBArr; int packBOffC = packBOff;
-                int jcC = jc, effNcC = effNc, numStripesNC = numStripesN, packedNcC = packedNc;
-                try
-                {
-                    // Pack B[*, jc:jc+effNc] once: (panel × n-stripe) shared.
-                    int numPackBItems = numKPanelsC * numStripesNC;
-                    CpuParallelSettings.ParallelForOrSerial(0, numPackBItems, packBElems, item =>
-                    {
-                        int panel = item / numStripesNC;
-                        int nstripe = item % numStripesNC;
-                        int pc = panel * kcC;
-                        int effKc = Math.Min(kcC, kC - pc);
-                        long panelBase = (long)panel * packedNcC * kcC;
-                        long stripeOff = (long)nstripe * effKc * nrC;
-                        int bOff = pc * ldbC + jcC;
-                        ReadOnlySpan<T> bSlice = new ReadOnlySpan<T>((T*)bI + bOff, bLenC - bOff);
-                        Span<T> dst = MemoryMarshal.Cast<byte, T>(
-                            packBArrC.AsSpan(packBOffC + (int)((panelBase + stripeOff) * elemSize), effKc * nrC * elemSize));
-                        Avx2Pack.PackBStripeRange<T>(bSlice, ldbC, false, dst, nstripe, 1, effNcC, effKc, nrC);
-                    }, deterministicSafe: true);
-
-                    // ONE parallel region over ic-blocks; each thread walks the full K-loop for its rows.
-                    long compWork = (long)mC * effNc * kC;
-                    CpuParallelSettings.ParallelForOrSerial(0, numIcBlocks, compWork, icIdx =>
-                    {
-                        int ic = icIdx * mcC;
-                        int effMc = Math.Min(mcC, mC - ic);
-                        for (int panel = 0; panel < numKPanelsC; panel++)
-                        {
-                            int pc = panel * kcC;
-                            int effKc = Math.Min(kcC, kC - pc);
-                            long panelBaseA = (long)panel * packedMC * kcC;
-                            long panelBaseB = (long)panel * packedNcC * kcC;
-                            for (int jr = 0; jr < effNcC; jr += nrC)
-                            {
-                                int effNr = Math.Min(nrC, effNcC - jr);
-                                long bStripeOff = panelBaseB + (long)(jr / nrC) * effKc * nrC;
-                                Span<T> packBStripe = MemoryMarshal.Cast<byte, T>(
-                                    packBArrC.AsSpan(packBOffC + (int)(bStripeOff * elemSize), effKc * nrC * elemSize));
-                                for (int ir = 0; ir < effMc; ir += mrC)
-                                {
-                                    if (ir + mrC > effMc) break;
-                                    int globalStripe = (ic + ir) / mrC;
-                                    long aStripeOff = panelBaseA + (long)globalStripe * effKc * mrC;
-                                    Span<T> packAStripe = MemoryMarshal.Cast<byte, T>(
-                                        packAArrC.AsSpan(packAOffC + (int)(aStripeOff * elemSize), effKc * mrC * elemSize));
-                                    int cOff = (ic + ir) * ldcC + jcC + jr;
-                                    Span<T> cTile = new Span<T>((T*)cI + cOff, cLenC - cOff);
-                                    DispatchMicrokernelWithTail<T>(
-                                        packAStripe, packBStripe, cTile, ldcC, effKc, mrC, nrC, effNr);
-                                }
-                            }
-                        }
-                    }, deterministicSafe: true);
-                }
-                finally { System.Buffers.ArrayPool<byte>.Shared.Return(packBArr); }
-            }
-        }
-        finally { System.Buffers.ArrayPool<byte>.Shared.Return(packAArr); }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -253,9 +253,14 @@ internal static class PackBothStrategy
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
             // Auto-gate = the measured win envelope k ≤ n ≤ 2k (the N-axis regime, n≥k, where the
             // crossover ladder showed 1.06-1.41x). Below k is narrow-N (other paths, not A/B'd here);
-            // above 2k N-axis wins. s_forceGotoBlas (test-only) ignores the gate for the full A/B.
-            if (gotoEnvelope && (s_forceGotoBlas
-                    || (s_gotoBlasAuto && (long)n >= (long)k && (long)n <= 2L * k)))
+            // above 2k N-axis wins. The m≥128 / k≥512 floor keeps routing inside the validated regime
+            // (measured at m∈{384,768}, k∈{1024,1536}) — small/skinny shapes, where GotoBLAS's ic
+            // fan-out is unvalidated, keep their existing routing. s_forceGotoBlas (test-only) ignores
+            // the gate for the full A/B.
+            bool gotoAutoGate = s_gotoBlasAuto
+                && m >= 128 && k >= 512
+                && (long)n >= (long)k && (long)n <= 2L * k;
+            if (gotoEnvelope && (s_forceGotoBlas || gotoAutoGate))
             {
                 fixed (T* aPtrG = a)
                 fixed (T* bPtrG = b)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -53,6 +53,14 @@ internal static class PackBothStrategy
     // loop body). A/B toggle; default off until bit-exactness is validated, then flipped on.
     internal static bool s_macroKernel;
 
+    // #85 thread-scaling A/B: force the low-barrier jc-blocked GotoBLAS path
+    // (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block once into shared L3, ONE parallel region
+    // per Nc-block over an (ic × jr) work-grid with private per-thread packed-A. This is the BLIS
+    // standard structure that no existing path has: N-axis shares A (cross-CCX contention),
+    // M-axis is high-barrier (per-(jc,pc) region), single-region packs ALL B (busts L3), 2D
+    // re-packs B per thread. Default off; flipped on per-shape only if the A/B proves a win.
+    internal static bool s_forceGotoBlas;
+
     // #653 software-prefetch microkernel (env AIDOTNET_GEMM_PREFETCH=1, default off). Routes the
     // FP32 6×16 tile through Avx2Fp32_6x16.RunPrefetch (PREFETCHT0 of packed-B ahead) — same inlined
     // intrinsic kernel, so NO per-tile call/fixed overhead (unlike the machine-code-per-tile path
@@ -226,6 +234,30 @@ internal static class PackBothStrategy
                 && numNBlocksN >= 2 && numNBlocksN >= Math.Min(4, effProcs)
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
+            // #85 thread-scaling A/B: low-barrier jc-blocked GotoBLAS path. Same FP32 / no-transpose /
+            // no-prepack / no-epilogue / m%mr==0 envelope as the N-axis path so the A/B is apples-to-apples.
+            if (s_forceGotoBlas
+                && MachineKernelGemm.IsFp32PanelAvailable
+                && typeof(T) == typeof(float)
+                && !transA && !transB
+                && options.PackedA is null && options.PackedB is null
+                && (m % mr) == 0 && m >= mr
+                && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
+                && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty)
+            {
+                fixed (T* aPtrG = a)
+                fixed (T* bPtrG = b)
+                fixed (T* cPtrG = c)
+                {
+                    RunGotoBlasParallelUnsafe<T>(
+                        aPtrG, a.Length, lda,
+                        bPtrG, b.Length, ldb,
+                        cPtrG, c.Length, ldc,
+                        m, n, k, mc, nc, kc, mr, nr, elemSize);
+                }
+                return;
+            }
+
             if (useNAxis)
             {
                 System.Threading.Interlocked.Increment(ref s_nAxisRunCount); // test observable (see s_nAxisRunCount)
@@ -1139,6 +1171,143 @@ internal static class PackBothStrategy
         {
             System.Buffers.ArrayPool<byte>.Shared.Return(packBArr);
         }
+    }
+
+    /// <summary>
+    /// #85 low-barrier jc-blocked GotoBLAS path (FP32). Packs ALL of A once into a shared Mr-stripe
+    /// buffer — each ic-block reads its DISJOINT rows, so there is no cross-thread A contention
+    /// (unlike the N-axis path, where every thread re-reads the whole shared A for its N-block). Then
+    /// for each Nc-block of N (serial outer, disjoint C columns) it packs that block's B once into a
+    /// shared, L3-resident buffer and runs ONE parallel region over ic-blocks, each thread walking the
+    /// full K-loop for its rows. This is the BLIS persistent-team structure that no existing path has:
+    /// low barrier count (one region per Nc-block, not per (jc,pc) macro-tile like RunParallelUnsafe),
+    /// B blocked to stay L3-resident (vs single-region's all-B), shared packed-B (vs 2D's redundant
+    /// per-thread B-pack), and disjoint-row shared-A (vs N-axis's whole-A-per-thread re-read).
+    /// Bit-identical to the other paths: each C[i,j] reduces over k in ascending panel order and
+    /// ic-blocks own disjoint C rows.
+    /// </summary>
+    private static unsafe void RunGotoBlasParallelUnsafe<T>(
+        T* aPtr, int aLen, int lda,
+        T* bPtr, int bLen, int ldb,
+        T* cPtr, int cLen, int ldc,
+        int m, int n, int k,
+        int mc, int nc, int kc, int mr, int nr, int elemSize) where T : unmanaged
+    {
+        int numKPanels = (k + kc - 1) / kc;
+        int numStripesM = (m + mr - 1) / mr;
+        int packedM = numStripesM * mr;
+        long packAElems = (long)numKPanels * kc * packedM;
+
+        const int Align = 32;
+        byte[] packAArr = System.Buffers.ArrayPool<byte>.Shared.Rent((int)(packAElems * elemSize) + Align - 1);
+        int packAOff;
+        fixed (byte* pa0 = packAArr)
+        {
+            nuint addr = (nuint)pa0; nuint mask = Align - 1;
+            packAOff = (int)((Align - (uint)(addr & mask)) & mask);
+        }
+
+        nint aI = (nint)aPtr, bI = (nint)bPtr, cI = (nint)cPtr;
+        int ldaC = lda, ldbC = ldb, ldcC = ldc, kC = k, mC = m, nC = n, aLenC = aLen, bLenC = bLen, cLenC = cLen;
+        int kcC = kc, mrC = mr, nrC = nr, numKPanelsC = numKPanels, packedMC = packedM, numStripesMC = numStripesM;
+        byte[] packAArrC = packAArr; int packAOffC = packAOff;
+
+        try
+        {
+            // ── Pack ALL of A once: (panel × m-stripe) shared, Mr-stripe layout ──
+            int numPackAItems = numKPanelsC * numStripesMC;
+            CpuParallelSettings.ParallelForOrSerial(0, numPackAItems, packAElems, item =>
+            {
+                int panel = item / numStripesMC;
+                int mstripe = item % numStripesMC;
+                int pc = panel * kcC;
+                int effKc = Math.Min(kcC, kC - pc);
+                int row = mstripe * mrC;
+                int effMr = Math.Min(mrC, mC - row);
+                long panelBase = (long)panel * packedMC * kcC;
+                long stripeOff = (long)mstripe * effKc * mrC;
+                int aOff = row * ldaC + pc;
+                ReadOnlySpan<T> aSlice = new ReadOnlySpan<T>((T*)aI + aOff, aLenC - aOff);
+                Span<T> dst = MemoryMarshal.Cast<byte, T>(
+                    packAArrC.AsSpan(packAOffC + (int)((panelBase + stripeOff) * elemSize), effKc * mrC * elemSize));
+                Avx2Pack.PackA<T>(aSlice, ldaC, false, dst, effMr, effKc, mrC);
+            }, deterministicSafe: true);
+
+            // ── Per Nc-block: pack that block's B once (shared, L3) + ONE ic parallel region ──
+            int numIcBlocks = (mC + mc - 1) / mc;
+            int mcC = mc;
+            for (int jc = 0; jc < nC; jc += nc)
+            {
+                int effNc = Math.Min(nc, nC - jc);
+                int numStripesN = (effNc + nrC - 1) / nrC;
+                int packedNc = numStripesN * nrC;
+                long packBElems = (long)numKPanelsC * kcC * packedNc;
+                byte[] packBArr = System.Buffers.ArrayPool<byte>.Shared.Rent((int)(packBElems * elemSize) + Align - 1);
+                int packBOff;
+                fixed (byte* pb0 = packBArr)
+                {
+                    nuint addr = (nuint)pb0; nuint mask = Align - 1;
+                    packBOff = (int)((Align - (uint)(addr & mask)) & mask);
+                }
+                byte[] packBArrC = packBArr; int packBOffC = packBOff;
+                int jcC = jc, effNcC = effNc, numStripesNC = numStripesN, packedNcC = packedNc;
+                try
+                {
+                    // Pack B[*, jc:jc+effNc] once: (panel × n-stripe) shared.
+                    int numPackBItems = numKPanelsC * numStripesNC;
+                    CpuParallelSettings.ParallelForOrSerial(0, numPackBItems, packBElems, item =>
+                    {
+                        int panel = item / numStripesNC;
+                        int nstripe = item % numStripesNC;
+                        int pc = panel * kcC;
+                        int effKc = Math.Min(kcC, kC - pc);
+                        long panelBase = (long)panel * packedNcC * kcC;
+                        long stripeOff = (long)nstripe * effKc * nrC;
+                        int bOff = pc * ldbC + jcC;
+                        ReadOnlySpan<T> bSlice = new ReadOnlySpan<T>((T*)bI + bOff, bLenC - bOff);
+                        Span<T> dst = MemoryMarshal.Cast<byte, T>(
+                            packBArrC.AsSpan(packBOffC + (int)((panelBase + stripeOff) * elemSize), effKc * nrC * elemSize));
+                        Avx2Pack.PackBStripeRange<T>(bSlice, ldbC, false, dst, nstripe, 1, effNcC, effKc, nrC);
+                    }, deterministicSafe: true);
+
+                    // ONE parallel region over ic-blocks; each thread walks the full K-loop for its rows.
+                    long compWork = (long)mC * effNc * kC;
+                    CpuParallelSettings.ParallelForOrSerial(0, numIcBlocks, compWork, icIdx =>
+                    {
+                        int ic = icIdx * mcC;
+                        int effMc = Math.Min(mcC, mC - ic);
+                        for (int panel = 0; panel < numKPanelsC; panel++)
+                        {
+                            int pc = panel * kcC;
+                            int effKc = Math.Min(kcC, kC - pc);
+                            long panelBaseA = (long)panel * packedMC * kcC;
+                            long panelBaseB = (long)panel * packedNcC * kcC;
+                            for (int jr = 0; jr < effNcC; jr += nrC)
+                            {
+                                int effNr = Math.Min(nrC, effNcC - jr);
+                                long bStripeOff = panelBaseB + (long)(jr / nrC) * effKc * nrC;
+                                Span<T> packBStripe = MemoryMarshal.Cast<byte, T>(
+                                    packBArrC.AsSpan(packBOffC + (int)(bStripeOff * elemSize), effKc * nrC * elemSize));
+                                for (int ir = 0; ir < effMc; ir += mrC)
+                                {
+                                    if (ir + mrC > effMc) break;
+                                    int globalStripe = (ic + ir) / mrC;
+                                    long aStripeOff = panelBaseA + (long)globalStripe * effKc * mrC;
+                                    Span<T> packAStripe = MemoryMarshal.Cast<byte, T>(
+                                        packAArrC.AsSpan(packAOffC + (int)(aStripeOff * elemSize), effKc * mrC * elemSize));
+                                    int cOff = (ic + ir) * ldcC + jcC + jr;
+                                    Span<T> cTile = new Span<T>((T*)cI + cOff, cLenC - cOff);
+                                    DispatchMicrokernelWithTail<T>(
+                                        packAStripe, packBStripe, cTile, ldcC, effKc, mrC, nrC, effNr);
+                                }
+                            }
+                        }
+                    }, deterministicSafe: true);
+                }
+                finally { System.Buffers.ArrayPool<byte>.Shared.Return(packBArr); }
+            }
+        }
+        finally { System.Buffers.ArrayPool<byte>.Shared.Return(packAArr); }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -908,8 +908,13 @@ internal static class PackBothStrategy
         // Panel pc occupies numMr * effKc * mr floats; pc panels are laid end to end with a
         // fixed per-panel stride of numMr * kc * mr so a worker can index (pc, ir) directly.
         int aPanelStride = numMr * kc * mr;
-        long packAElems = (long)numKPanels * aPanelStride;
-        var packAArr = System.Buffers.ArrayPool<float>.Shared.Rent((int)packAElems);
+        long packAElemsPerCopy = (long)numKPanels * aPanelStride;
+        // Per-CCX A-replication: pack ONE packed-A copy per L3 domain so each pinned worker reads its
+        // CCX-local copy (no cross-CCX shared-A reads). Copies are identical ⇒ bit-exact; a non-pinned
+        // thread (CurrentDomain==0) reads copy 0. Only when the pinned pool + replication are both on.
+        int nCopies = (PinnedParallel.s_enabled && PinnedParallel.s_replicate && PinnedParallel.DomainCount > 1)
+            ? PinnedParallel.DomainCount : 1;
+        var packAArr = System.Buffers.ArrayPool<float>.Shared.Rent((int)(packAElemsPerCopy * nCopies));
         try
         {
             for (int pIdx = 0; pIdx < numKPanels; pIdx++)
@@ -922,9 +927,14 @@ internal static class PackBothStrategy
                     packAArr.AsSpan(pIdx * aPanelStride, numMr * effKc * mr),
                     mc: m, kc: effKc, mr);
             }
+            // Replicate copy 0 into the remaining per-CCX copies.
+            for (int cp = 1; cp < nCopies; cp++)
+                Array.Copy(packAArr, 0L, packAArr, cp * packAElemsPerCopy, packAElemsPerCopy);
 
-            nint aPackAddr = 0, bAddr = (nint)bPtr, cAddr = (nint)cPtr;
-            fixed (float* paBase = packAArr) { aPackAddr = (nint)paBase;
+            nint bAddr = (nint)bPtr, cAddr = (nint)cPtr;
+            int aCopyStrideBytes = (int)(packAElemsPerCopy * sizeof(float));
+            int nCopiesL = nCopies;
+            fixed (float* paBase = packAArr) { nint aPackAddr = (nint)paBase;
 
             int kcL = kc, ncL = nc, nrL = nr, mrL = mr, ldbL = ldb, ldcL = ldc;
             int numKPanelsL = numKPanels, numMrL = numMr, aPanelStrideL = aPanelStride;
@@ -944,7 +954,10 @@ internal static class PackBothStrategy
                 byte[] packBArr = System.Buffers.ArrayPool<byte>.Shared.Rent(numKPanelsL * bPanelStride * sizeof(float));
                 try
                 {
-                    float* pa = (float*)aPackAddr;
+                    // Per-CCX A-replication: read this worker's CCX-local packed-A copy (copy 0 otherwise).
+                    int cp = nCopiesL > 1 ? PinnedParallel.CurrentDomain : 0;
+                    if (cp < 0 || cp >= nCopiesL) cp = 0;
+                    float* pa = (float*)(aPackAddr + (nint)cp * aCopyStrideBytes);
                     float* bb = (float*)bAddr;
                     float* cc = (float*)cAddr;
                     var packBSpan = MemoryMarshal.Cast<byte, float>(packBArr.AsSpan());

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -148,7 +148,9 @@ internal static class PackBothStrategy
             // to fill all cores via M-axis parallel alone. ShouldUse2DGrid returns
             // true when (numMBlocks * 2 < procs && numNBlocks > 1) — i.e., the
             // existing M-axis split would leave half or more cores idle.
-            int procs = options.NumThreads > 0 ? options.NumThreads : Environment.ProcessorCount;
+            // #475: default fan-out caps at PHYSICAL cores (FMA-bound GEMM regresses on SMT threads —
+            // measured ffn peak at 16, regress at 24/32). An explicit NumThreads request is honoured.
+            int procs = options.NumThreads > 0 ? options.NumThreads : CpuParallelSettings.GemmThreadCount(Environment.ProcessorCount);
             if (options.NumThreads < 0) procs = 1;
             int numMBlocks = (m + mc - 1) / mc;
             int numNBlocks = (n + nc - 1) / nc;

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -978,7 +978,7 @@ internal static class PackBothStrategy
             int kL = k, nL = n, bLenL = bLen, cLenL = cLen;
             long totalWork = (long)m * n * k * 2;
 
-            CpuParallelSettings.ParallelForOrSerial(0, numNBlocks, totalWork, jcIdx =>
+            Action<int> nAxisBody = jcIdx =>
             {
                 int jc = jcIdx * ncL;
                 int effNc = Math.Min(ncL, nL - jc);
@@ -1071,7 +1071,12 @@ internal static class PackBothStrategy
                     }
                 }
                 finally { System.Buffers.ArrayPool<byte>.Shared.Return(packBArr); }
-            }, deterministicSafe: true); // N-axis split: disjoint C columns, fixed-order K reduction
+            }; // N-axis body: disjoint C columns, fixed-order K reduction (bit-exact regardless of dispatch)
+            // #85 EXPERIMENT (gated): route the N-block parallel-for through the L3-domain-PINNED pool to
+            // test whether pinning closes the per-core gap to OpenBLAS (59 vs our ~42). Same body ⇒
+            // bit-exact. Returns false (→ threadpool) when unavailable/busy; throws only on a real fault.
+            if (!(PinnedParallel.s_enabled && PinnedParallel.For(0, numNBlocks, nAxisBody)))
+                CpuParallelSettings.ParallelForOrSerial(0, numNBlocks, totalWork, nAxisBody, deterministicSafe: true);
             }
         }
         finally { System.Buffers.ArrayPool<float>.Shared.Return(packAArr); }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -53,13 +53,19 @@ internal static class PackBothStrategy
     // loop body). A/B toggle; default off until bit-exactness is validated, then flipped on.
     internal static bool s_macroKernel;
 
-    // #85 thread-scaling A/B: force the low-barrier jc-blocked GotoBLAS path
-    // (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block once into shared L3, ONE parallel region
-    // per Nc-block over an (ic × jr) work-grid with private per-thread packed-A. This is the BLIS
-    // standard structure that no existing path has: N-axis shares A (cross-CCX contention),
-    // M-axis is high-barrier (per-(jc,pc) region), single-region packs ALL B (busts L3), 2D
-    // re-packs B per thread. Default off; flipped on per-shape only if the A/B proves a win.
+    // #85 low-barrier jc-blocked GotoBLAS path (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block
+    // once into shared L3, ONE parallel region per Nc-block, with shared packed-A read by DISJOINT
+    // rows (no cross-thread A contention). The BLIS standard structure no existing path had: N-axis
+    // shares the WHOLE A re-read per thread, M-axis is high-barrier (per-(jc,pc) region),
+    // single-region packs ALL B (busts L3), 2D re-packs B per thread.
+    //
+    // AUTO-ROUTING (s_gotoBlasAuto, default ON): the clean A/B (--ab-gotoblas-x) measured a robust
+    // win for the moderate-N envelope n/k ≤ 2 (1.06-1.41x vs N-axis at n/k 1.0-2.0, crossing at
+    // ~2.5x). N-axis wins for very wide N (its private-L2-B amortizes; GotoBLAS plateaus ~390 GF/s
+    // as the shared B is re-read by every ic-block). So route n ≤ 2k here, keep wide-N on N-axis.
+    // Bit-exact (maxErr=0 vs N-axis). s_forceGotoBlas (test-only) overrides the n≤2k gate for A/B.
     internal static bool s_forceGotoBlas;
+    internal static bool s_gotoBlasAuto = true;
 
     // #653 software-prefetch microkernel (env AIDOTNET_GEMM_PREFETCH=1, default off). Routes the
     // FP32 6×16 tile through Avx2Fp32_6x16.RunPrefetch (PREFETCHT0 of packed-B ahead) — same inlined
@@ -234,16 +240,22 @@ internal static class PackBothStrategy
                 && numNBlocksN >= 2 && numNBlocksN >= Math.Min(4, effProcs)
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
-            // #85 thread-scaling A/B: low-barrier jc-blocked GotoBLAS path. Same FP32 / no-transpose /
-            // no-prepack / no-epilogue / m%mr==0 envelope as the N-axis path so the A/B is apples-to-apples.
-            if (s_forceGotoBlas
-                && MachineKernelGemm.IsFp32PanelAvailable
+            // #85 low-barrier jc-blocked GotoBLAS path. Same FP32 / no-transpose / no-prepack /
+            // no-epilogue / m%mr==0 envelope as the N-axis path. Auto-routed within the measured win
+            // envelope (n ≤ 2k); s_forceGotoBlas overrides the n-gate for the A/B bench.
+            bool gotoEnvelope =
+                MachineKernelGemm.IsFp32PanelAvailable
                 && typeof(T) == typeof(float)
                 && !transA && !transB
                 && options.PackedA is null && options.PackedB is null
                 && (m % mr) == 0 && m >= mr
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
-                && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty)
+                && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
+            // Auto-gate = the measured win envelope k ≤ n ≤ 2k (the N-axis regime, n≥k, where the
+            // crossover ladder showed 1.06-1.41x). Below k is narrow-N (other paths, not A/B'd here);
+            // above 2k N-axis wins. s_forceGotoBlas (test-only) ignores the gate for the full A/B.
+            if (gotoEnvelope && (s_forceGotoBlas
+                    || (s_gotoBlasAuto && (long)n >= (long)k && (long)n <= 2L * k)))
             {
                 fixed (T* aPtrG = a)
                 fixed (T* bPtrG = b)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -47,6 +47,12 @@ internal static class PackBothStrategy
     // chunks of ~256, while chunking still amortizes per-tile dispatch. Settable for sweeps.
     internal static int MaxPanelTiles = 256;
 
+    // #475: route the FP32 N-axis compute loop's Mr-sweep through the machine-code MACRO kernel
+    // (RunMacroPanelFp32) — the whole numMr × njr × kc sweep in one asm call, taking RyuJIT off the
+    // hot path (PerfView showed ~36% of single-thread time in the managed RunNAxisParallelUnsafe
+    // loop body). A/B toggle; default off until bit-exactness is validated, then flipped on.
+    internal static bool s_macroKernel;
+
     // #653 software-prefetch microkernel (env AIDOTNET_GEMM_PREFETCH=1, default off). Routes the
     // FP32 6×16 tile through Avx2Fp32_6x16.RunPrefetch (PREFETCHT0 of packed-B ahead) — same inlined
     // intrinsic kernel, so NO per-tile call/fixed overhead (unlike the machine-code-per-tile path
@@ -949,36 +955,63 @@ internal static class PackBothStrategy
 
                     // Compute: for each K-panel (ascending → correct C accumulation), each
                     // Mr-block does one chunked panel call over the N-block's full tiles + tail.
-                    for (int pIdx = 0; pIdx < numKPanelsL; pIdx++)
+                    // #475: when enabled, the whole Mr-sweep runs in the machine-code MACRO kernel
+                    // (one asm call per K-panel/N-chunk), taking RyuJIT off the hot path.
+                    bool useMacro = s_macroKernel && njrFull > 0 && MachineKernelGemm.IsFp32MacroAvailable;
+                    fixed (float* pbPacked = packBSpan)
                     {
-                        int pc = pIdx * kcL;
-                        int effKc = Math.Min(kcL, kL - pc);
-                        var bPanel = packBSpan.Slice(pIdx * bPanelStride, effKc * packedNc);
-                        for (int ir = 0; ir < numMrL; ir++)
+                        for (int pIdx = 0; pIdx < numKPanelsL; pIdx++)
                         {
-                            var aPanel = new ReadOnlySpan<float>(pa + pIdx * aPanelStrideL + ir * effKc * mrL, effKc * mrL);
-                            int cOff = (ir * mrL) * ldcL + jc;
-                            if (njrFull > 0)
+                            int pc = pIdx * kcL;
+                            int effKc = Math.Min(kcL, kL - pc);
+                            var bPanel = packBSpan.Slice(pIdx * bPanelStride, effKc * packedNc);
+                            int maxPanelTiles = Math.Max(1, MaxPanelTiles); // guard sweep-set 0/negative
+
+                            if (useMacro)
                             {
-                                int maxPanelTiles = Math.Max(1, MaxPanelTiles); // guard sweep-set 0/negative
+                                float* aBase0 = pa + pIdx * aPanelStrideL;
+                                float* bBase0 = pbPacked + pIdx * bPanelStride;
+                                int aStrideBytes = effKc * mrL * sizeof(float);
                                 for (int jb = 0; jb < njrFull; jb += maxPanelTiles)
                                 {
                                     int chunk = Math.Min(maxPanelTiles, njrFull - jb);
-                                    MachineKernelGemm.RunPanelFp32(
-                                        aPanel,
-                                        bPanel.Slice(jb * effKc * nrL, chunk * effKc * nrL),
-                                        new Span<float>(cc + cOff + jb * nrL, cLenL - (cOff + jb * nrL)),
-                                        ldcL, effKc, chunk);
+                                    MachineKernelGemm.RunMacroPanelFp32(
+                                        aBase0, bBase0 + jb * effKc * nrL, cc + jc + jb * nrL,
+                                        ldcL, effKc, chunk, numMrL, aStrideBytes);
                                 }
                             }
+                            else if (njrFull > 0)
+                            {
+                                for (int ir = 0; ir < numMrL; ir++)
+                                {
+                                    var aPanel = new ReadOnlySpan<float>(pa + pIdx * aPanelStrideL + ir * effKc * mrL, effKc * mrL);
+                                    int cOff = (ir * mrL) * ldcL + jc;
+                                    for (int jb = 0; jb < njrFull; jb += maxPanelTiles)
+                                    {
+                                        int chunk = Math.Min(maxPanelTiles, njrFull - jb);
+                                        MachineKernelGemm.RunPanelFp32(
+                                            aPanel,
+                                            bPanel.Slice(jb * effKc * nrL, chunk * effKc * nrL),
+                                            new Span<float>(cc + cOff + jb * nrL, cLenL - (cOff + jb * nrL)),
+                                            ldcL, effKc, chunk);
+                                    }
+                                }
+                            }
+
+                            // Nr tail (effNc % nr != 0): per-Mr-block managed dispatch (small).
                             if (nrTail > 0)
                             {
                                 int jrTail = njrFull * nrL;
-                                DispatchMicrokernelWithTail<float>(
-                                    aPanel,
-                                    bPanel.Slice(njrFull * effKc * nrL, effKc * nrL),
-                                    new Span<float>(cc + cOff + jrTail, cLenL - (cOff + jrTail)),
-                                    ldcL, effKc, mrL, nrL, nrTail);
+                                var bTail = bPanel.Slice(njrFull * effKc * nrL, effKc * nrL);
+                                for (int ir = 0; ir < numMrL; ir++)
+                                {
+                                    var aPanel = new ReadOnlySpan<float>(pa + pIdx * aPanelStrideL + ir * effKc * mrL, effKc * mrL);
+                                    int cOff = (ir * mrL) * ldcL + jc + jrTail;
+                                    DispatchMicrokernelWithTail<float>(
+                                        aPanel, bTail,
+                                        new Span<float>(cc + cOff, cLenL - cOff),
+                                        ldcL, effKc, mrL, nrL, nrTail);
+                                }
                             }
                         }
                     }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -53,19 +53,21 @@ internal static class PackBothStrategy
     // loop body). A/B toggle; default off until bit-exactness is validated, then flipped on.
     internal static bool s_macroKernel;
 
-    // #85 low-barrier jc-blocked GotoBLAS path (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block
-    // once into shared L3, ONE parallel region per Nc-block, with shared packed-A read by DISJOINT
-    // rows (no cross-thread A contention). The BLIS standard structure no existing path had: N-axis
-    // shares the WHOLE A re-read per thread, M-axis is high-barrier (per-(jc,pc) region),
-    // single-region packs ALL B (busts L3), 2D re-packs B per thread.
+    // #85 low-barrier jc-blocked GotoBLAS path (RunGotoBlasParallelUnsafe) — pack-B-per-Nc-block once
+    // into shared L3, ONE parallel region per Nc-block, shared packed-A read by DISJOINT rows.
+    // DEAD END — kept only as a measurement record (s_forceGotoBlas + the --ab-gotoblas* benches).
     //
-    // AUTO-ROUTING (s_gotoBlasAuto, default ON): the clean A/B (--ab-gotoblas-x) measured a robust
-    // win for the moderate-N envelope n/k ≤ 2 (1.06-1.41x vs N-axis at n/k 1.0-2.0, crossing at
-    // ~2.5x). N-axis wins for very wide N (its private-L2-B amortizes; GotoBLAS plateaus ~390 GF/s
-    // as the shared B is re-read by every ic-block). So route n ≤ 2k here, keep wide-N on N-axis.
-    // Bit-exact (maxErr=0 vs N-axis). s_forceGotoBlas (test-only) overrides the n≤2k gate for A/B.
+    // WHY DEAD: the early "1.1-1.4x medium win" was a MEASUREMENT ARTIFACT. The production large-float
+    // path is GotoGemmFp32 at BlasManaged.cs:542 (its own GotoBLAS macro-kernel + CCX pool), gated by
+    // BeatsPackBoth = m≥512 || k≥2n || (m≥128 && n≥512). Every shape in this path's intended envelope
+    // (k≤n≤2k with m≥128, k≥512 ⇒ n≥512) satisfies (m≥128 && n≥512) ⇒ routes to GotoGemmFp32 and NEVER
+    // reaches PackBoth. So toggling s_forceGotoBlas changed nothing for those shapes — the "win" was
+    // ±25% box noise. Forcing the path for real (AIDOTNET_DISABLE_GOTO=1 ⇒ falls to PackBoth) measured
+    // it SLOWER than the N-axis path: ffn 0.40x, medium ~1.0x — the jc-outer-serial barrier-per-Nc-block
+    // structure throttles wide-N (the single-region path exists precisely to avoid that barrier).
+    // Conclusion: GotoGemmFp32 already owns this regime; this PackBoth variant adds nothing. Default OFF.
     internal static bool s_forceGotoBlas;
-    internal static bool s_gotoBlasAuto = true;
+    internal static bool s_gotoBlasAuto; // default OFF — dead end (see above); GotoGemmFp32 owns this regime
 
     // #653 software-prefetch microkernel (env AIDOTNET_GEMM_PREFETCH=1, default off). Routes the
     // FP32 6×16 tile through Avx2Fp32_6x16.RunPrefetch (PREFETCHT0 of packed-B ahead) — same inlined
@@ -241,8 +243,11 @@ internal static class PackBothStrategy
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
             // #85 low-barrier jc-blocked GotoBLAS path. Same FP32 / no-transpose / no-prepack /
-            // no-epilogue / m%mr==0 envelope as the N-axis path. Auto-routed within the measured win
-            // envelope (n ≤ 2k); s_forceGotoBlas overrides the n-gate for the A/B bench.
+            // no-epilogue / m%mr==0 envelope as the N-axis path. s_gotoBlasAuto is DEAD (default off):
+            // every shape in the k≤n≤2k gate satisfies BeatsPackBoth's (m≥128 && n≥512) clause and is
+            // claimed by GotoGemmFp32 at BlasManaged.cs:542 before PackBoth is ever reached; when forced
+            // onto PackBoth (AIDOTNET_DISABLE_GOTO=1) this path measured SLOWER than N-axis (ffn 0.40x).
+            // The gate stays only so s_forceGotoBlas can still drive the --ab-gotoblas* measurement record.
             bool gotoEnvelope =
                 MachineKernelGemm.IsFp32PanelAvailable
                 && typeof(T) == typeof(float)
@@ -251,12 +256,6 @@ internal static class PackBothStrategy
                 && (m % mr) == 0 && m >= mr
                 && options.Epilogue.Activation == AiDotNet.Tensors.Engines.FusedActivationType.None
                 && options.Epilogue.BiasN.IsEmpty && options.Epilogue.SkipMxN.IsEmpty;
-            // Auto-gate = the measured win envelope k ≤ n ≤ 2k (the N-axis regime, n≥k, where the
-            // crossover ladder showed 1.06-1.41x). Below k is narrow-N (other paths, not A/B'd here);
-            // above 2k N-axis wins. The m≥128 / k≥512 floor keeps routing inside the validated regime
-            // (measured at m∈{384,768}, k∈{1024,1536}) — small/skinny shapes, where GotoBLAS's ic
-            // fan-out is unvalidated, keep their existing routing. s_forceGotoBlas (test-only) ignores
-            // the gate for the full A/B.
             bool gotoAutoGate = s_gotoBlasAuto
                 && m >= 128 && k >= 512
                 && (long)n >= (long)k && (long)n <= 2L * k;

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -65,11 +65,18 @@ public static class CpuParallelSettings
         return Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// Value of <see cref="SystemLogicalProcessorInformation.Relationship"/> that denotes a physical
+    /// processor core (Win32 <c>LOGICAL_PROCESSOR_RELATIONSHIP.RelationProcessorCore</c>). Encodes the
+    /// native interop contract instead of testing the raw <c>0</c> in the scan loop.
+    /// </summary>
+    private const int RelationProcessorCore = 0;
+
     [StructLayout(LayoutKind.Sequential)]
     private struct SystemLogicalProcessorInformation
     {
         public UIntPtr ProcessorMask;
-        public int Relationship;   // RelationProcessorCore == 0
+        public int Relationship;   // RelationProcessorCore
         private readonly int _pad;
         private readonly ulong _u0, _u1; // union (16 bytes)
     }
@@ -89,17 +96,20 @@ public static class CpuParallelSettings
             if (!GetLogicalProcessorInformation(buf, ref len)) return Environment.ProcessorCount;
             int n = (int)(len / structSize), cores = 0;
             var p = (SystemLogicalProcessorInformation*)buf;
-            for (int i = 0; i < n; i++) if (p[i].Relationship == 0) cores++;
+            for (int i = 0; i < n; i++) if (p[i].Relationship == RelationProcessorCore) cores++;
             return cores > 0 ? cores : Environment.ProcessorCount;
         }
         finally { Marshal.FreeHGlobal(buf); }
     }
 
+    /// <summary>Linux file that lists per-logical-processor topology used for physical-core counting.</summary>
+    private const string LinuxCpuInfoPath = "/proc/cpuinfo";
+
     private static int DetectPhysicalCoresLinux()
     {
         var seen = new HashSet<string>();
         string phys = "";
-        foreach (var line in File.ReadLines("/proc/cpuinfo"))
+        foreach (var line in File.ReadLines(LinuxCpuInfoPath))
         {
             if (line.StartsWith("physical id", StringComparison.Ordinal)) phys = line;
             else if (line.StartsWith("core id", StringComparison.Ordinal)) seen.Add(phys + "|" + line);

--- a/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
+++ b/src/AiDotNet.Tensors/Helpers/CpuParallelSettings.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +25,87 @@ public static class CpuParallelSettings
     /// Set to 1 to disable parallelism.
     /// </remarks>
     public static int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
+
+    // #475 thread-scaling: FMA-bound GEMM gets nothing from SMT and the 2nd-thread contention HURTS
+    // (measured: ffn scaling peaks at 16 physical cores, regresses at 24/32). GEMM fan-out should cap
+    // at PHYSICAL cores, not the logical Environment.ProcessorCount. Detected once; any failure falls
+    // back to the logical count (no cap — safe). Other (memory-bound) ops keep the logical count.
+    private static int _physicalCores;
+
+    /// <summary>Physical (non-SMT) core count; falls back to <see cref="Environment.ProcessorCount"/>
+    /// on any detection failure. Cached after first use.</summary>
+    public static int PhysicalCoreCount
+    {
+        get
+        {
+            if (_physicalCores == 0) _physicalCores = DetectPhysicalCores();
+            return _physicalCores;
+        }
+    }
+
+    /// <summary>GEMM fan-out cap at <see cref="PhysicalCoreCount"/>. DEFAULT OFF — a clean same-process
+    /// A/B measured it as a LOSS (medium 0.77×, ffn 0.91×): more threads beat fewer even on a 16-physical
+    /// box, so FMA-bound GEMM is NOT SMT-oversubscribed here (the noisy scaling curve that suggested it
+    /// was wrong). Kept as a knob; the detection is reused elsewhere.</summary>
+    public static bool CapGemmAtPhysicalCores { get; set; } = false;
+
+    /// <summary>The thread count the GEMM strategies should fan out to: the requested count capped at
+    /// physical cores when <see cref="CapGemmAtPhysicalCores"/> (FMA-bound work hates SMT).</summary>
+    public static int GemmThreadCount(int requested)
+        => CapGemmAtPhysicalCores ? Math.Min(requested, PhysicalCoreCount) : requested;
+
+    private static int DetectPhysicalCores()
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return DetectPhysicalCoresWindows();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return DetectPhysicalCoresLinux();
+        }
+        catch { /* any failure → no cap */ }
+        return Environment.ProcessorCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SystemLogicalProcessorInformation
+    {
+        public UIntPtr ProcessorMask;
+        public int Relationship;   // RelationProcessorCore == 0
+        private readonly int _pad;
+        private readonly ulong _u0, _u1; // union (16 bytes)
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetLogicalProcessorInformation(IntPtr buffer, ref uint returnLength);
+
+    private static unsafe int DetectPhysicalCoresWindows()
+    {
+        uint len = 0;
+        GetLogicalProcessorInformation(IntPtr.Zero, ref len); // probe size (expected to "fail" with len set)
+        if (len == 0) return Environment.ProcessorCount;
+        int structSize = Marshal.SizeOf<SystemLogicalProcessorInformation>();
+        IntPtr buf = Marshal.AllocHGlobal((int)len);
+        try
+        {
+            if (!GetLogicalProcessorInformation(buf, ref len)) return Environment.ProcessorCount;
+            int n = (int)(len / structSize), cores = 0;
+            var p = (SystemLogicalProcessorInformation*)buf;
+            for (int i = 0; i < n; i++) if (p[i].Relationship == 0) cores++;
+            return cores > 0 ? cores : Environment.ProcessorCount;
+        }
+        finally { Marshal.FreeHGlobal(buf); }
+    }
+
+    private static int DetectPhysicalCoresLinux()
+    {
+        var seen = new HashSet<string>();
+        string phys = "";
+        foreach (var line in File.ReadLines("/proc/cpuinfo"))
+        {
+            if (line.StartsWith("physical id", StringComparison.Ordinal)) phys = line;
+            else if (line.StartsWith("core id", StringComparison.Ordinal)) seen.Add(phys + "|" + line);
+        }
+        return seen.Count > 0 ? seen.Count : Environment.ProcessorCount;
+    }
 
     /// <summary>
     /// Worker-thread count for the library's persistent custom thread pools (PersistentParallelExecutor,

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -165,6 +165,55 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// #475 Phase 0a: sweep the FP32 panel K-unroll (4/8/2/6) through the macro kernel, single- and
+    /// multi-thread, vs the U=4 reference, with a bit-exactness check. OpenBLAS's Zen sgemm uses 8.
+    /// Run: <c>--ab-kunroll</c>.
+    /// </summary>
+    public static void KUnrollSweep()
+    {
+        Console.WriteLine("=== #475 Phase 0a: FP32 panel K-unroll sweep (macro kernel) ===");
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up  384x6144x1536", 384, 6144, 1536),
+            ("ffn-big 384x4096x3456", 384, 4096, 3456),
+            ("medium  384x1024x1024", 384, 1024, 1024),
+        };
+        int[] unrolls = { 4, 8, 2, 6 };
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k);
+            var b = MakeRandom(k * n);
+            double flops = 2.0 * m * n * k;
+            // Reference: default kernel (U=4), managed base path, single thread.
+            MachineCodeFmaKernel.PanelKUnroll = 4; MachineKernelGemm.ResetFp32Kernels();
+            PackBothStrategy.s_macroKernel = false;
+            CpuParallelSettings.MaxDegreeOfParallelism = 1;
+            var cref = new float[m * n];
+            GemmOnce(a, b, cref, m, n, k);
+
+            var c = new float[m * n];
+            PackBothStrategy.s_macroKernel = true;
+            foreach (int u in unrolls)
+            {
+                MachineCodeFmaKernel.PanelKUnroll = u; MachineKernelGemm.ResetFp32Kernels();
+                _ = MachineKernelGemm.IsFp32MacroAvailable; // force re-emit
+                foreach (int dop in new[] { 1, 32 })
+                {
+                    CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                    Array.Clear(c, 0, c.Length); GemmOnce(a, b, c, m, n, k);
+                    double maxErr = 0;
+                    for (int i = 0; i < c.Length; i++) { double e = Math.Abs(c[i] - cref[i]); if (e > maxErr) maxErr = e; }
+                    double sec = TimeMinGemm(a, b, c, m, n, k);
+                    Console.WriteLine($"  {label} U={u} DOP={dop,2}: {flops / sec / 1e9,6:F0} GF/s  maxErr={maxErr:E1}");
+                }
+            }
+        }
+        MachineCodeFmaKernel.PanelKUnroll = 4; MachineKernelGemm.ResetFp32Kernels();
+        PackBothStrategy.s_macroKernel = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -582,6 +582,40 @@ public static class AxisRoutingAbBench
         }
     }
 
+    /// <summary>
+    /// #85 CCX pool vs RunParallel A/B: PerfView/busy-core showed the CCX pinned-pool barriers strand
+    /// cores (square 1024: 6/32 busy, 237 GF/s) while barrier-free RunParallel gets 13.3 cores / 598.
+    /// Toggle CcxGemmPool.s_disable in-process across balanced shapes to see if the barrier loss holds
+    /// at scale (it should — per-core is equal, so the lost cores are pure barrier stall). Run
+    /// <c>--ab-ccx-vs-rp</c>.
+    /// </summary>
+    public static void CcxVsRunParallelSweep()
+    {
+        Console.WriteLine("=== #85 CCX pool (barriers) vs RunParallel (barrier-free) ===");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        var shapes = new (int m, int n, int k)[]
+        {
+            (1024, 1024, 1024), (1536, 1536, 1536), (2048, 2048, 2048),
+            (1024, 2048, 2048), (2048, 1024, 1024),
+        };
+        foreach (var (m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            double bestCcx = 0, bestRp = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_disable = false;
+                bestCcx = Math.Max(bestCcx, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_disable = true;
+                bestRp = Math.Max(bestRp, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_disable = false;
+            string w = bestRp > bestCcx ? "RunParallel" : "CCX";
+            Console.WriteLine($"  {m}x{n}x{k}: CCX {bestCcx,5:F0}  RunParallel {bestRp,5:F0} GF/s  ({bestRp / bestCcx:F2}x)  -> {w}");
+        }
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -723,6 +723,46 @@ public static class AxisRoutingAbBench
         }
     }
 
+    /// <summary>
+    /// #85 pinned N-axis A/B: route the N-block parallel-for through the L3-domain-PINNED pool vs the
+    /// .NET threadpool. Tests the source-grounded hypothesis that pinning closes the per-core gap to
+    /// OpenBLAS (59 vs ~42). Same body ⇒ bit-exact (checked). Run <c>--ab-pinned</c>.
+    /// </summary>
+    public static void PinnedNAxisSweep()
+    {
+        Console.WriteLine("=== #85 N-axis: L3-domain-PINNED pool vs threadpool, DOP32 ===");
+        Console.WriteLine($"PinnedParallel.IsAvailable={AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.IsAvailable}");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up   384x6144x1536", 384, 6144, 1536),
+            ("ffn      384x4096x1536", 384, 4096, 1536),
+            ("medium2k 384x2048x1024", 384, 2048, 1024),
+            ("tall     768x4096x1024", 768, 4096, 1024),
+        };
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n);
+            var cTp = new float[m * n]; var cPin = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = false; GemmOnce(a, b, cTp, m, n, k);
+            AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = true; GemmOnce(a, b, cPin, m, n, k);
+            AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = false;
+            double maxErr = 0; for (int i = 0; i < cTp.Length; i++) maxErr = Math.Max(maxErr, Math.Abs(cTp[i] - cPin[i]));
+            var c = new float[m * n];
+            double bTp = 0, bPin = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = false;
+                bTp = Math.Max(bTp, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = true;
+                bPin = Math.Max(bPin, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            AiDotNet.Tensors.Engines.BlasManaged.PinnedParallel.s_enabled = false;
+            Console.WriteLine($"  {label}: threadpool {bTp,5:F0}  pinned {bPin,5:F0} GF/s  ({bPin / bTp:F2}x)  maxErr={maxErr:E1}");
+        }
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -266,6 +266,57 @@ public static class AxisRoutingAbBench
         return TimeMin(op, m, n, k);
     }
 
+    /// <summary>
+    /// #475 medium/large gap: sweep the PackBoth blocking (Mc/Nc/Kc) against OpenBLAS's Zen sgemm
+    /// P/Q/R (320/320/large) on the diffusion shapes, single- and multi-thread, vs the OpenBLAS bar.
+    /// Tests whether precise blocking closes the 1.3-1.7x single-core gap. Run: <c>--ab-blocking</c>.
+    /// </summary>
+    public static unsafe void BlockingSweep()
+    {
+        Console.WriteLine("=== #475 medium/large blocking A/B (vs OpenBLAS P/Q/R = 320/320) ===");
+        Console.WriteLine($"HasRawSgemm={BlasProvider.HasRawSgemm}  cores={Environment.ProcessorCount}");
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up 384x6144x1536", 384, 6144, 1536),
+            ("medium 384x1024x1024", 384, 1024, 1024),
+            ("square 1024x1024x1024", 1024, 1024, 1024),
+        };
+        var configs = new (string name, int? mc, int? nc, int? kc)[]
+        {
+            ("default", null, null, null), ("Kc512", null, null, 512),
+            ("Nc256", null, 256, null), ("Nc128", null, 128, null),
+            ("Nc256Kc512", null, 256, 512), ("Nc128Kc512", null, 128, 512),
+        };
+        PackBothStrategy.s_macroKernel = true;
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            Console.WriteLine($"  {label}:");
+            foreach (var (name, mc, nc, kc) in configs)
+            {
+                AutotuneDispatcher.s_overrideMc = mc; AutotuneDispatcher.s_overrideNc = nc; AutotuneDispatcher.s_overrideKc = kc;
+                foreach (int dop in new[] { 1, 32 })
+                {
+                    CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                    double sec = TimeMinGemm(a, b, c, m, n, k);
+                    Console.WriteLine($"    {name,-11} DOP={dop,2}: {flops / sec / 1e9,6:F0} GF/s");
+                }
+            }
+            AutotuneDispatcher.s_overrideMc = AutotuneDispatcher.s_overrideNc = AutotuneDispatcher.s_overrideKc = null;
+            if (BlasProvider.HasRawSgemm)
+                foreach (int dop in new[] { 1, 32 })
+                {
+                    CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                    double sec = TimeMinPtr(a, b, c, m, n, k, jit: false);
+                    Console.WriteLine($"    OpenBLAS    DOP={dop,2}: {flops / sec / 1e9,6:F0} GF/s");
+                }
+        }
+        AutotuneDispatcher.s_overrideMc = AutotuneDispatcher.s_overrideNc = AutotuneDispatcher.s_overrideKc = null;
+        PackBothStrategy.s_macroKernel = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -656,6 +656,37 @@ public static class AxisRoutingAbBench
         AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = true;
     }
 
+    /// <summary>
+    /// #85 CCX blocking sweep: CCX hits OB-level (66 GF/s/core) only at 1536³; sweep the 2D kc
+    /// (AIDOTNET_CCX_KC / s_kc2dOverride) on the forced-CCX path to see if a different K-block extends
+    /// that to 1024³/2048³ (fewer K-panels = fewer barriers + better L1 fit). Run <c>--ab-ccx-block</c>.
+    /// </summary>
+    public static void CcxBlockingSweep()
+    {
+        Console.WriteLine("=== #85 CCX 2D kc blocking sweep (forced CCX) ===");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_ignoreWorkGate = true;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_disable = false;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = false;
+        int[] mcs = { 0, 48, 96, 144, 192, 240 }; // 0 = default heuristic
+        var shapes = new (int m, int n, int k)[] { (1024, 1024, 1024), (1536, 1536, 1536), (2048, 2048, 2048) };
+        foreach (var (m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            Console.WriteLine($"  {m}x{n}x{k}:");
+            foreach (int mc in mcs)
+            {
+                AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_mc2dOverride = mc;
+                double best = 0;
+                for (int rep = 0; rep < 3; rep++) best = Math.Max(best, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                Console.WriteLine($"    mc={(mc == 0 ? "dflt" : mc.ToString()),4}: {best,5:F0} GF/s   ({best / 16:F0}/core)");
+            }
+        }
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_mc2dOverride = 0;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_ignoreWorkGate = false;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -383,6 +383,7 @@ public static class AxisRoutingAbBench
     public static unsafe void GotoBlasSweep()
     {
         Console.WriteLine("=== #85 GotoBLAS jc-blocked path A/B (vs N-axis + OpenBLAS) ===");
+        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
         Console.WriteLine($"HasRawSgemm={BlasProvider.HasRawSgemm}  PhysicalCores={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
         var shapes = new (string label, int m, int n, int k)[]
         {
@@ -422,6 +423,81 @@ public static class AxisRoutingAbBench
         }
         PackBothStrategy.s_macroKernel = false;
         PackBothStrategy.s_forceGotoBlas = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
+    /// <summary>
+    /// #85 GotoBLAS nc tuning: the wide-N losses come from many small Nc-blocks (12 for ffn at
+    /// nc=512) = many barriers + a small shared B re-read by all ic-blocks. Sweep nc upward to cut
+    /// the barrier count (bigger shared B per block, still L3-resident up to ~9 MB) vs the N-axis
+    /// baseline, at the default DOP. Run <c>--ab-gotoblas-nc</c>.
+    /// </summary>
+    public static unsafe void GotoBlasNcSweep()
+    {
+        Console.WriteLine("=== #85 GotoBLAS nc tuning (cut wide-N barrier count) ===");
+        Console.WriteLine($"PhysicalCores={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
+        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up   384x6144x1536", 384, 6144, 1536),
+            ("tall-ffn 768x4096x1024", 768, 4096, 1024),
+            ("medium   384x1024x1024", 384, 1024, 1024),
+        };
+        int[] ncs = { 512, 1024, 1536, 2048, 3072, 6144 };
+        PackBothStrategy.s_macroKernel = true;
+        CpuParallelSettings.MaxDegreeOfParallelism = 32;
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            PackBothStrategy.s_forceGotoBlas = false;
+            AutotuneDispatcher.s_overrideNc = null;
+            double dN = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+            Console.WriteLine($"  {label}: N-axis baseline {dN,5:F0} GF/s");
+            PackBothStrategy.s_forceGotoBlas = true;
+            foreach (int nc in ncs)
+            {
+                if (nc > n) continue;
+                AutotuneDispatcher.s_overrideNc = nc;
+                double dG = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+                Console.WriteLine($"    GotoBLAS nc={nc,4}: {dG,5:F0} GF/s   ({dG / dN:F2}x)");
+            }
+            AutotuneDispatcher.s_overrideNc = null;
+            PackBothStrategy.s_forceGotoBlas = false;
+        }
+        PackBothStrategy.s_macroKernel = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
+    /// <summary>
+    /// #85 GotoBLAS crossover: at fixed m, k the GotoBLAS path wins for moderate N and loses for very
+    /// wide N. Ladder n/k from 1x to 4x to locate the routing threshold. Interleaved A/B (N-axis vs
+    /// GotoBLAS) per n, min-of-N, default DOP. Run <c>--ab-gotoblas-x</c>.
+    /// </summary>
+    public static unsafe void GotoBlasCrossover()
+    {
+        Console.WriteLine("=== #85 GotoBLAS crossover (n/k ladder, m=384 k=1024, nc=512) ===");
+        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
+        CpuParallelSettings.MaxDegreeOfParallelism = 32;
+        PackBothStrategy.s_macroKernel = true;
+        int m = 384, k = 1024;
+        foreach (int n in new[] { 1024, 1280, 1536, 2048, 2560, 3072, 4096 })
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            // 3 interleaved A/B reps to beat the box noise.
+            double bestN = 0, bestG = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                PackBothStrategy.s_forceGotoBlas = false; AutotuneDispatcher.s_overrideNc = null;
+                bestN = Math.Max(bestN, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                PackBothStrategy.s_forceGotoBlas = true; AutotuneDispatcher.s_overrideNc = 512;
+                bestG = Math.Max(bestG, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            PackBothStrategy.s_forceGotoBlas = false; AutotuneDispatcher.s_overrideNc = null;
+            Console.WriteLine($"  n={n,4} (n/k={n / 1024.0:F1}x): N-axis {bestN,5:F0}  GotoBLAS {bestG,5:F0}  ({bestG / bestN:F2}x)");
+        }
+        PackBothStrategy.s_macroKernel = false;
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// #475 medium-axis routing A/B. The deterministic-mode default heuristic
+/// (<see cref="AxisSelector"/>) skips the M-axis when <c>k &gt; 256</c> (intending finer
+/// K/2D splits for large K), but in deterministic mode the K-axis is forbidden, so a
+/// "medium" shape (m gives enough M-blocks, n only modestly large) falls through to the
+/// N-axis — which under-subscribes the cores vs the M-axis. This measures each forced
+/// axis vs the live default heuristic and vs native OpenBLAS, at full DOP, deterministic
+/// mode, warmed min-of-N, through the real <see cref="BlasManaged.Gemm{T}"/> strategy path.
+///
+/// <para>
+/// <c>PackingMode.DisableAutotune</c> is used so the heuristic (and thus the
+/// <see cref="AxisSelector.ForceAxisForTest"/> override) runs on every call instead of the
+/// cache returning a stored decision — by default autotune is heuristic-only, so this is
+/// representative of the production Auto path.
+/// </para>
+///
+/// <para>Run: <c>--ab-axis-routing</c>.</para>
+/// </summary>
+public static class AxisRoutingAbBench
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== #475 medium-axis routing A/B (FP32, full DOP, deterministic) ===");
+        Console.WriteLine($"Host: cores={Environment.ProcessorCount}  HasRawSgemm={BlasProvider.HasRawSgemm}  Deterministic={BlasProvider.IsDeterministicMode}");
+        Console.WriteLine("Per shape: native OpenBLAS bar, the live heuristic's pick, and each forced axis (GF/s, min-of-N).");
+        Console.WriteLine();
+
+        int procs = Environment.ProcessorCount;
+        const int mr = 6, nr = 16; // FP32 AVX2 6x16 panel tile
+
+        // (label, m, n, k) — diffusion-relevant FP32 GEMM shapes.
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("medium    384x1024x1024", 384, 1024, 1024),
+            ("square   1024x1024x1024", 1024, 1024, 1024),
+            ("attn-proj 256x1536x1536", 256, 1536, 1536),
+            ("ffn-up    384x6144x1536", 384, 6144, 1536),
+            ("ffn-big   384x4096x3456", 384, 4096, 3456),
+        };
+
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k);
+            var b = MakeRandom(k * n);
+            var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            var heuristic = AxisSelector.Select(m, n, k, mr, nr, procs, BlasProvider.IsDeterministicMode);
+
+            double obGf  = BlasProvider.HasRawSgemm ? Gf(flops, TimeMinNative(a, b, c, m, n, k)) : double.NaN;
+            double defGf = Gf(flops, TimeMinManaged(a, b, c, m, n, k, null));
+            double mGf   = Gf(flops, TimeMinManaged(a, b, c, m, n, k, ParallelismAxis.M));
+            double nGf   = Gf(flops, TimeMinManaged(a, b, c, m, n, k, ParallelismAxis.N));
+            double gGf   = Gf(flops, TimeMinManaged(a, b, c, m, n, k, ParallelismAxis.MN_2D));
+
+            double best = Math.Max(mGf, Math.Max(nGf, gGf));
+            string bestAxis = best == mGf ? "M" : best == nGf ? "N" : "2D";
+
+            Console.WriteLine($"  {label}   (heuristic picks {heuristic})");
+            Console.WriteLine($"    OpenBLAS {obGf,6:F0} | default {defGf,6:F0} | M {mGf,6:F0}  N {nGf,6:F0}  2D {gGf,6:F0}  GF/s");
+            Console.WriteLine($"    best-forced {bestAxis} {best,6:F0} -> default is {defGf / best * 100,4:F0}% of best (gap {best - defGf,5:F0} GF/s)");
+            Console.WriteLine();
+        }
+    }
+
+    private static double Gf(double flops, double sec) => flops / sec / 1e9;
+
+    private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)
+        => TimeMin(() => { fixed (float* pa = a, pb = b, pc = c) BlasProvider.SgemmRaw(m, n, k, pa, k, pb, n, pc, n); }, m, n, k);
+
+    private static double TimeMinManaged(float[] a, float[] b, float[] c, int m, int n, int k, ParallelismAxis? force)
+    {
+        return TimeMin(() =>
+        {
+            var opts = new BlasOptions<float> { PackingMode = PackingMode.DisableAutotune };
+            AxisSelector.ForceAxisForTest = force;
+            try { BlasManaged.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k, in opts); }
+            finally { AxisSelector.ForceAxisForTest = null; }
+        }, m, n, k);
+    }
+
+    private static double TimeMin(Action op, int m, int n, int k)
+    {
+        double work = (double)m * n * k;
+        int iters = work > 2e9 ? 2 : work > 5e8 ? 4 : 10;
+        const int rounds = 12;
+        for (int i = 0; i < 3 * iters; i++) op(); // warm
+        var sw = new Stopwatch();
+        double best = double.MaxValue;
+        for (int r = 0; r < rounds; r++)
+        {
+            sw.Restart();
+            for (int i = 0; i < iters; i++) op();
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalSeconds / iters);
+        }
+        return best;
+    }
+
+    private static float[] MakeRandom(int len)
+    {
+        var rng = new Random(17);
+        var x = new float[len];
+        for (int i = 0; i < len; i++) x[i] = (float)(rng.NextDouble() * 2 - 1);
+        return x;
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -543,6 +543,45 @@ public static class AxisRoutingAbBench
         Console.WriteLine($"  per-busy-core {flops / (wall / iters) / 1e9 / busyCores:F1} GF/s/core   (OB on this box ~59/core)");
     }
 
+    /// <summary>
+    /// #85 routing fix A/B: GotoGemmFp32.RunParallel (per-tile private pack) vs the N-axis path
+    /// (shared-A) for thin-M m%6==0 shapes. PerfView pinned RunParallel's redundant per-tile A-repack
+    /// (~50x for wide-N) as the per-core killer; N-axis shares A. Toggled in-process via
+    /// BlasManaged.s_disableGotoGemm. Confirms the win + the M boundary before retuning BeatsPackBoth.
+    /// Run <c>--ab-goto-vs-naxis</c>.
+    /// </summary>
+    public static void GotoVsNaxisSweep()
+    {
+        Console.WriteLine("=== #85 GotoGemm RunParallel vs N-axis (thin-M, shared-A) ===");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("384x1024x1024 n=k  ", 384, 1024, 1024),
+            ("384x2048x1024 n=2k ", 384, 2048, 1024),
+            ("384x4096x1536 ffn  ", 384, 4096, 1536),
+            ("384x6144x1536 ffn-up", 384, 6144, 1536),
+            ("768x2048x2048 m=768", 768, 2048, 2048),
+            ("768x4096x1024 tall ", 768, 4096, 1024),
+            ("1536x1536x1536 sq  ", 1536, 1536, 1536),
+        };
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            double bestG = 0, bestN = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                BlasManaged.s_disableGotoGemm = false; // GotoGemmFp32 path
+                bestG = Math.Max(bestG, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                BlasManaged.s_disableGotoGemm = true;  // PackBoth (N-axis for thin-M wide-N)
+                bestN = Math.Max(bestN, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            BlasManaged.s_disableGotoGemm = false;
+            string winner = bestN > bestG ? "N-axis" : "GotoGemm";
+            Console.WriteLine($"  {label}: GotoGemm {bestG,5:F0}  N-axis {bestN,5:F0} GF/s  ({bestN / bestG:F2}x)  -> {winner}");
+        }
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -69,6 +69,50 @@ public static class AxisRoutingAbBench
         }
     }
 
+    /// <summary>
+    /// Single-thread GEMM profiling repro — pins MaxDOP=1 and hammers one shape through the
+    /// managed PackBoth path for a fixed wall-time, so a PMU profiler (PerfView CPU-counter
+    /// sampling) can attribute the single-core stall (the ~72 vs OpenBLAS ~103 GF/s gap).
+    /// Run: <c>--profile-gemm-st [seconds=25] [shape=ffn-up|ffn-big|square|attn|medium]</c>.
+    /// </summary>
+    public static void ProfileSingleThread(int seconds, string shape)
+    {
+        CpuParallelSettings.MaxDegreeOfParallelism = 1; // profile the single-core path
+        (int m, int n, int k) = shape switch
+        {
+            "ffn-big" => (384, 4096, 3456),
+            "square"  => (1024, 1024, 1024),
+            "attn"    => (256, 1536, 1536),
+            "medium"  => (384, 1024, 1024),
+            _         => (384, 6144, 1536), // ffn-up
+        };
+        var a = MakeRandom(m * k);
+        var b = MakeRandom(k * n);
+        var c = new float[m * n];
+        double flops = 2.0 * m * n * k;
+        Console.WriteLine($"=== single-thread GEMM profile repro: {shape} {m}x{n}x{k}  MaxDOP={CpuParallelSettings.MaxDegreeOfParallelism}  {seconds}s ===");
+        for (int i = 0; i < 5; i++) GemmOnce(a, b, c, m, n, k); // warm
+        var total = Stopwatch.StartNew();
+        var one = new Stopwatch();
+        long iters = 0;
+        double bestSec = double.MaxValue;
+        while (total.Elapsed.TotalSeconds < seconds)
+        {
+            one.Restart();
+            GemmOnce(a, b, c, m, n, k);
+            one.Stop();
+            bestSec = Math.Min(bestSec, one.Elapsed.TotalSeconds);
+            iters++;
+        }
+        Console.WriteLine($"iters={iters}  best {flops / bestSec / 1e9:F1} GF/s  avg {flops / (total.Elapsed.TotalSeconds / iters) / 1e9:F1} GF/s  (sink {c[0]:E2})");
+    }
+
+    private static void GemmOnce(float[] a, float[] b, float[] c, int m, int n, int k)
+    {
+        var opts = new BlasOptions<float> { PackingMode = PackingMode.DisableAutotune };
+        BlasManaged.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k, in opts);
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -373,6 +373,58 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// #85 GotoBLAS A/B: the low-barrier jc-blocked path (B packed per Nc-block into shared L3,
+    /// A packed once with disjoint-row reads, one parallel region per Nc-block) vs the current
+    /// N-axis path (whole shared A re-read by every thread per N-block) and OpenBLAS, on the wide-N
+    /// diffusion shapes at the default DOP. Also asserts bit-exactness vs the default path. Run
+    /// <c>--ab-gotoblas</c> (add AIDOTNET_USE_BLAS=1 for the OpenBLAS bar).
+    /// </summary>
+    public static unsafe void GotoBlasSweep()
+    {
+        Console.WriteLine("=== #85 GotoBLAS jc-blocked path A/B (vs N-axis + OpenBLAS) ===");
+        Console.WriteLine($"HasRawSgemm={BlasProvider.HasRawSgemm}  PhysicalCores={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up   384x6144x1536", 384, 6144, 1536),
+            ("medium   384x1024x1024", 384, 1024, 1024),
+            ("tall-ffn 768x4096x1024", 768, 4096, 1024),
+        };
+        PackBothStrategy.s_macroKernel = true;
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n);
+            var cRef = new float[m * n]; var cGoto = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            // Correctness: GotoBLAS path must be bit-identical to the default (same K-panel order).
+            PackBothStrategy.s_forceGotoBlas = false; GemmOnce(a, b, cRef, m, n, k);
+            PackBothStrategy.s_forceGotoBlas = true; GemmOnce(a, b, cGoto, m, n, k);
+            PackBothStrategy.s_forceGotoBlas = false;
+            double maxErr = 0;
+            for (int i = 0; i < cRef.Length; i++) maxErr = Math.Max(maxErr, Math.Abs(cRef[i] - cGoto[i]));
+            Console.WriteLine($"  {label}: maxErr(goto vs default)={maxErr:E2}");
+            var c = new float[m * n];
+            foreach (int dop in new[] { 16, 32 })
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                PackBothStrategy.s_forceGotoBlas = false;
+                double dN = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+                PackBothStrategy.s_forceGotoBlas = true;
+                double dG = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+                PackBothStrategy.s_forceGotoBlas = false;
+                Console.WriteLine($"    DOP={dop,2}: N-axis {dN,5:F0}   GotoBLAS {dG,5:F0} GF/s   ({dG / dN:F2}x)");
+            }
+            if (BlasProvider.HasRawSgemm)
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = 32;
+                Console.WriteLine($"    OpenBLAS (auto-threaded): {flops / TimeMinPtr(a, b, c, m, n, k, jit: false) / 1e9,5:F0} GF/s");
+            }
+        }
+        PackBothStrategy.s_macroKernel = false;
+        PackBothStrategy.s_forceGotoBlas = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -214,6 +214,58 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// #475 Phase 1: JIT specialized FP32 GEMM A/B vs native OpenBLAS on small/medium shapes (the
+    /// libxsmm regime). Correctness vs a double-precision scalar reference (small float-rounding
+    /// maxErr expected, not 0). Run: <c>--ab-jit</c>.
+    /// </summary>
+    public static unsafe void JitAb()
+    {
+        Console.WriteLine("=== #475 Phase 1: JIT specialized FP32 GEMM A/B (single-thread) ===");
+        Console.WriteLine($"JIT supported={JitGemmGenerator.IsSupported}  HasRawSgemm={BlasProvider.HasRawSgemm}");
+        var shapes = new (int m, int n, int k)[]
+        {
+            (6,16,64),(12,32,128),(24,48,128),(48,64,256),(64,64,128),
+            (96,96,256),(128,128,256),(64,512,512),(128,256,512),(256,256,256),
+        };
+        foreach (var (m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k);
+            var b = MakeRandom(k * n);
+            var cref = new float[m * n];
+            ScalarGemm(a, b, cref, m, n, k);
+            var c = new float[m * n];
+            bool ok;
+            fixed (float* pa = a, pb = b, pc = c) ok = JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k);
+            double maxErr = 0;
+            for (int i = 0; i < c.Length; i++) { double e = Math.Abs((double)c[i] - cref[i]); if (e > maxErr) maxErr = e; }
+            double flops = 2.0 * m * n * k;
+            double jitSec = ok ? TimeMinPtr(a, b, c, m, n, k, jit: true) : double.NaN;
+            double obSec = BlasProvider.HasRawSgemm ? TimeMinPtr(a, b, c, m, n, k, jit: false) : double.NaN;
+            string cmp = (BlasProvider.HasRawSgemm && ok) ? $"  {obSec / jitSec:F2}x vs OpenBLAS" : "";
+            Console.WriteLine($"  {m,4}x{n,4}x{k,4}  ok={ok} maxErr={maxErr:E1}  JIT {flops / jitSec / 1e9,5:F0}  OB {flops / obSec / 1e9,5:F0} GF/s{cmp}");
+        }
+    }
+
+    private static void ScalarGemm(float[] a, float[] b, float[] c, int m, int n, int k)
+    {
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double s = 0;
+                for (int p = 0; p < k; p++) s += (double)a[i * k + p] * b[p * n + j];
+                c[i * n + j] = (float)s;
+            }
+    }
+
+    private static unsafe double TimeMinPtr(float[] a, float[] b, float[] c, int m, int n, int k, bool jit)
+    {
+        Action op = jit
+            ? () => { fixed (float* pa = a, pb = b, pc = c) JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k); }
+            : () => { fixed (float* pa = a, pb = b, pc = c) BlasProvider.SgemmRaw(m, n, k, pa, k, pb, n, pc, n); };
+        return TimeMin(op, m, n, k);
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -687,6 +687,42 @@ public static class AxisRoutingAbBench
         AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_ignoreWorkGate = false;
     }
 
+    /// <summary>
+    /// #85 macro-kernel multi-thread A/B: PerfView on the production N-axis ffn path shows 42% of CPU in
+    /// the MANAGED RunNAxisParallelUnsafe loop (per-tile dispatch + Mr-sweep) — OpenBLAS does the whole
+    /// sweep in asm. We have the asm macro-kernel (s_macroKernel → RunMacroPanelFp32) but it's default OFF.
+    /// A/B it at full DOP with a bit-exact check on the diffusion shapes. Run <c>--ab-macro-mt</c>.
+    /// </summary>
+    public static void MacroMtSweep()
+    {
+        Console.WriteLine("=== #85 N-axis macro-kernel (asm Mr-sweep) vs managed loop, DOP32 ===");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn-up   384x6144x1536", 384, 6144, 1536),
+            ("ffn      384x4096x1536", 384, 4096, 1536),
+            ("medium2k 384x2048x1024", 384, 2048, 1024),
+        };
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n);
+            var cOff = new float[m * n]; var cOn = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            PackBothStrategy.s_macroKernel = false; GemmOnce(a, b, cOff, m, n, k);
+            PackBothStrategy.s_macroKernel = true; GemmOnce(a, b, cOn, m, n, k);
+            double maxErr = 0; for (int i = 0; i < cOff.Length; i++) maxErr = Math.Max(maxErr, Math.Abs(cOff[i] - cOn[i]));
+            var c = new float[m * n];
+            double bOff = 0, bOn = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                PackBothStrategy.s_macroKernel = false; bOff = Math.Max(bOff, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                PackBothStrategy.s_macroKernel = true; bOn = Math.Max(bOn, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            PackBothStrategy.s_macroKernel = false;
+            Console.WriteLine($"  {label}: managed {bOff,5:F0}  macro {bOn,5:F0} GF/s  ({bOn / bOff:F2}x)  maxErr={maxErr:E1}");
+        }
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -501,6 +501,48 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// #85 multi-thread diagnosis: GF/s + BUSY-CORE utilization (process CPU-time / wall / core) for the
+    /// production large-float path at full DOP. Busy-cores is the scientific discriminator vs OpenBLAS's
+    /// scaling: LOW busy-cores ⇒ we stall on barriers/sync (OB uses lock-free per-slice flags, not
+    /// barriers); HIGH busy-cores but low GF/s ⇒ memory-bandwidth bound (private per-thread buffers vs
+    /// OB's one shared sa/sb). Run <c>--profile-gemm-mt [seconds] [shape]</c>.
+    /// </summary>
+    public static void ProfileMultiThread(int seconds, string shape)
+    {
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        (int m, int n, int k) = shape switch
+        {
+            "ffn-big" => (384, 4096, 3456),
+            "square"  => (1024, 1024, 1024),
+            "attn"    => (256, 1536, 1536),
+            "medium"  => (384, 1024, 1024),
+            _         => (384, 6144, 1536), // ffn-up
+        };
+        var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+        double flops = 2.0 * m * n * k;
+        int cores = Environment.ProcessorCount;
+        Console.WriteLine($"=== multi-thread GEMM profile: {shape} {m}x{n}x{k}  DOP={cores}  {seconds}s ===");
+        for (int i = 0; i < 10; i++) GemmOnce(a, b, c, m, n, k); // warm
+        var proc = System.Diagnostics.Process.GetCurrentProcess();
+        var cpu0 = proc.TotalProcessorTime;
+        var total = Stopwatch.StartNew();
+        var one = new Stopwatch();
+        long iters = 0; double bestSec = double.MaxValue;
+        while (total.Elapsed.TotalSeconds < seconds)
+        {
+            one.Restart(); GemmOnce(a, b, c, m, n, k); one.Stop();
+            bestSec = Math.Min(bestSec, one.Elapsed.TotalSeconds);
+            iters++;
+        }
+        double wall = total.Elapsed.TotalSeconds;
+        double cpuSec = (proc.TotalProcessorTime - cpu0).TotalSeconds;
+        double busyCores = cpuSec / wall;
+        Console.WriteLine($"  best {flops / bestSec / 1e9:F0} GF/s   avg {flops / (wall / iters) / 1e9:F0} GF/s");
+        Console.WriteLine($"  busy-cores {busyCores:F1} / {cores}  ({busyCores / cores * 100:F0}% util)   iters={iters}  (sink {c[0]:E2})");
+        Console.WriteLine($"  per-busy-core {flops / (wall / iters) / 1e9 / busyCores:F1} GF/s/core   (OB on this box ~59/core)");
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -595,8 +595,8 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
         var shapes = new (int m, int n, int k)[]
         {
-            (1024, 1024, 1024), (1536, 1536, 1536), (2048, 2048, 2048),
-            (1024, 2048, 2048), (2048, 1024, 1024),
+            (1024, 1024, 1024), (1280, 1280, 1280), (1536, 1536, 1536),
+            (1792, 1792, 1792), (2048, 2048, 2048),
         };
         foreach (var (m, n, k) in shapes)
         {

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -616,6 +616,46 @@ public static class AxisRoutingAbBench
         }
     }
 
+    /// <summary>
+    /// #85 spin-barrier A/B: OpenBLAS spins (YIELDING) at its sync points; our CcxGemmPool used a .NET
+    /// Barrier that PARKS lanes (the 6/32-busy stall). Compare CCX with the lock-free spin barrier vs the
+    /// .NET Barrier — forced at all sizes (s_ignoreWorkGate) — for GF/s AND bit-exact output. If spin lifts
+    /// the small/large balanced shapes to the 1536³ per-core level, widen the CCX window. Run <c>--ab-spinbar</c>.
+    /// </summary>
+    public static void SpinBarrierSweep()
+    {
+        Console.WriteLine("=== #85 CCX spin barrier vs .NET Barrier (forced CCX, all sizes) ===");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_ignoreWorkGate = true;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_disable = false;
+        var shapes = new (int m, int n, int k)[]
+        {
+            (1024, 1024, 1024), (1536, 1536, 1536), (2048, 2048, 2048), (1280, 1280, 1280),
+        };
+        foreach (var (m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n);
+            var cBar = new float[m * n]; var cSpin = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            // Correctness: spin must be bit-identical to the barrier (same compute order).
+            AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = false; GemmOnce(a, b, cBar, m, n, k);
+            AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = true; GemmOnce(a, b, cSpin, m, n, k);
+            double maxErr = 0; for (int i = 0; i < cBar.Length; i++) maxErr = Math.Max(maxErr, Math.Abs(cBar[i] - cSpin[i]));
+            var c = new float[m * n];
+            double bestBar = 0, bestSpin = 0;
+            for (int rep = 0; rep < 3; rep++)
+            {
+                AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = false;
+                bestBar = Math.Max(bestBar, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = true;
+                bestSpin = Math.Max(bestSpin, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+            }
+            Console.WriteLine($"  {m}x{n}x{k}: barrier {bestBar,5:F0}  spin {bestSpin,5:F0} GF/s  ({bestSpin / bestBar:F2}x)  maxErr={maxErr:E1}");
+        }
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_ignoreWorkGate = false;
+        AiDotNet.Tensors.Engines.BlasManaged.CcxGemmPool.s_spinBarrier = true;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -113,6 +113,58 @@ public static class AxisRoutingAbBench
         BlasManaged.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k, in opts);
     }
 
+    private static double TimeMinGemm(float[] a, float[] b, float[] c, int m, int n, int k)
+    {
+        double work = (double)m * n * k;
+        int iters = work > 2e9 ? 2 : work > 5e8 ? 4 : 10;
+        for (int i = 0; i < 3 * iters; i++) GemmOnce(a, b, c, m, n, k);
+        var sw = new Stopwatch();
+        double best = double.MaxValue;
+        for (int r = 0; r < 12; r++) { sw.Restart(); for (int i = 0; i < iters; i++) GemmOnce(a, b, c, m, n, k); sw.Stop(); best = Math.Min(best, sw.Elapsed.TotalSeconds / iters); }
+        return best;
+    }
+
+    /// <summary>
+    /// #475 machine-code MACRO kernel A/B: the whole Mr-sweep in asm (RyuJIT off the hot path) vs
+    /// the current managed-loop path, single- and multi-thread, with a bit-exactness check.
+    /// Run: <c>--ab-macro</c>.
+    /// </summary>
+    public static void MacroAb()
+    {
+        Console.WriteLine("=== #475 MACRO kernel A/B (FP32) — whole Mr-sweep in machine code ===");
+        Console.WriteLine($"MacroAvailable={MachineKernelGemm.IsFp32MacroAvailable}  cores={Environment.ProcessorCount}");
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("medium  384x1024x1024", 384, 1024, 1024),
+            ("attn    256x1536x1536", 256, 1536, 1536),
+            ("ffn-up  384x6144x1536", 384, 6144, 1536),
+            ("ffn-big 384x4096x3456", 384, 4096, 3456),
+        };
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k);
+            var b = MakeRandom(k * n);
+            double flops = 2.0 * m * n * k;
+            var cref = new float[m * n];
+            var c = new float[m * n];
+            foreach (int dop in new[] { 1, 32 })
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                PackBothStrategy.s_macroKernel = false;
+                Array.Clear(cref, 0, cref.Length); GemmOnce(a, b, cref, m, n, k);
+                double baseSec = TimeMinGemm(a, b, c, m, n, k);
+                PackBothStrategy.s_macroKernel = true;
+                Array.Clear(c, 0, c.Length); GemmOnce(a, b, c, m, n, k);
+                double maxErr = 0;
+                for (int i = 0; i < c.Length; i++) { double e = Math.Abs(c[i] - cref[i]); if (e > maxErr) maxErr = e; }
+                double macroSec = TimeMinGemm(a, b, c, m, n, k);
+                PackBothStrategy.s_macroKernel = false;
+                Console.WriteLine($"  {label} DOP={dop,2}: base {flops / baseSec / 1e9,6:F0}  macro {flops / macroSec / 1e9,6:F0} GF/s  ({baseSec / macroSec:F2}x)  maxErr={maxErr:E1}");
+            }
+        }
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -317,6 +317,45 @@ public static class AxisRoutingAbBench
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
     }
 
+    /// <summary>
+    /// #475 thread-scaling curve: GF/s + scaling + efficiency at DOP 1..32 on the diffusion shapes,
+    /// vs OpenBLAS. Locates WHERE multi-thread scaling breaks (SMT/CCX/contention) before changing
+    /// anything. Run: <c>--ab-scaling</c> (with AIDOTNET_USE_BLAS=1 for the OB bar).
+    /// </summary>
+    public static unsafe void ScalingSweep()
+    {
+        Console.WriteLine("=== #475 thread-scaling curve (16C/32T Zen2) ===");
+        var shapes = new (string label, int m, int n, int k)[]
+        {
+            ("ffn    384x6144x1536", 384, 6144, 1536),
+            ("medium 384x1024x1024", 384, 1024, 1024),
+            ("square 1024x1024x1024", 1024, 1024, 1024),
+        };
+        int[] dops = { 1, 2, 4, 8, 16, 24, 32 };
+        PackBothStrategy.s_macroKernel = true;
+        foreach (var (label, m, n, k) in shapes)
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            Console.WriteLine($"  {label}:");
+            double s1 = 0;
+            foreach (int dop in dops)
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = dop;
+                double gf = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+                if (dop == 1) s1 = gf;
+                Console.WriteLine($"    DOP={dop,2}: {gf,6:F0} GF/s   {gf / s1,4:F1}x   eff={gf / s1 / dop * 100,3:F0}%");
+            }
+            if (BlasProvider.HasRawSgemm)
+            {
+                CpuParallelSettings.MaxDegreeOfParallelism = 32;
+                Console.WriteLine($"    OpenBLAS (auto-threaded): {flops / TimeMinPtr(a, b, c, m, n, k, jit: false) / 1e9,6:F0} GF/s");
+            }
+        }
+        PackBothStrategy.s_macroKernel = false;
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+    }
+
     private static double Gf(double flops, double sec) => flops / sec / 1e9;
 
     private static unsafe double TimeMinNative(float[] a, float[] b, float[] c, int m, int n, int k)

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -77,6 +77,9 @@ public static class AxisRoutingAbBench
     /// </summary>
     public static void ProfileSingleThread(int seconds, string shape)
     {
+        if (seconds <= 0)
+            throw new ArgumentOutOfRangeException(nameof(seconds), "Profile duration must be positive.");
+
         CpuParallelSettings.MaxDegreeOfParallelism = 1; // profile the single-core path
         (int m, int n, int k) = shape switch
         {
@@ -84,7 +87,10 @@ public static class AxisRoutingAbBench
             "square"  => (1024, 1024, 1024),
             "attn"    => (256, 1536, 1536),
             "medium"  => (384, 1024, 1024),
-            _         => (384, 6144, 1536), // ffn-up
+            "ffn-up"  => (384, 6144, 1536),
+            _         => throw new ArgumentException(
+                "Expected one of: ffn-up, ffn-big, square, attn, medium.",
+                nameof(shape)),
         };
         var a = MakeRandom(m * k);
         var b = MakeRandom(k * n);
@@ -374,134 +380,6 @@ public static class AxisRoutingAbBench
     }
 
     /// <summary>
-    /// #85 GotoBLAS A/B: the low-barrier jc-blocked path (B packed per Nc-block into shared L3,
-    /// A packed once with disjoint-row reads, one parallel region per Nc-block) vs the current
-    /// N-axis path (whole shared A re-read by every thread per N-block) and OpenBLAS, on the wide-N
-    /// diffusion shapes at the default DOP. Also asserts bit-exactness vs the default path. Run
-    /// <c>--ab-gotoblas</c> (add AIDOTNET_USE_BLAS=1 for the OpenBLAS bar).
-    /// </summary>
-    public static unsafe void GotoBlasSweep()
-    {
-        Console.WriteLine("=== #85 GotoBLAS jc-blocked path A/B (vs N-axis + OpenBLAS) ===");
-        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
-        Console.WriteLine($"HasRawSgemm={BlasProvider.HasRawSgemm}  PhysicalCores={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
-        var shapes = new (string label, int m, int n, int k)[]
-        {
-            ("ffn-up   384x6144x1536", 384, 6144, 1536),
-            ("medium   384x1024x1024", 384, 1024, 1024),
-            ("tall-ffn 768x4096x1024", 768, 4096, 1024),
-        };
-        PackBothStrategy.s_macroKernel = true;
-        foreach (var (label, m, n, k) in shapes)
-        {
-            var a = MakeRandom(m * k); var b = MakeRandom(k * n);
-            var cRef = new float[m * n]; var cGoto = new float[m * n];
-            double flops = 2.0 * m * n * k;
-            // Correctness: GotoBLAS path must be bit-identical to the default (same K-panel order).
-            PackBothStrategy.s_forceGotoBlas = false; GemmOnce(a, b, cRef, m, n, k);
-            PackBothStrategy.s_forceGotoBlas = true; GemmOnce(a, b, cGoto, m, n, k);
-            PackBothStrategy.s_forceGotoBlas = false;
-            double maxErr = 0;
-            for (int i = 0; i < cRef.Length; i++) maxErr = Math.Max(maxErr, Math.Abs(cRef[i] - cGoto[i]));
-            Console.WriteLine($"  {label}: maxErr(goto vs default)={maxErr:E2}");
-            var c = new float[m * n];
-            foreach (int dop in new[] { 16, 32 })
-            {
-                CpuParallelSettings.MaxDegreeOfParallelism = dop;
-                PackBothStrategy.s_forceGotoBlas = false;
-                double dN = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
-                PackBothStrategy.s_forceGotoBlas = true;
-                double dG = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
-                PackBothStrategy.s_forceGotoBlas = false;
-                Console.WriteLine($"    DOP={dop,2}: N-axis {dN,5:F0}   GotoBLAS {dG,5:F0} GF/s   ({dG / dN:F2}x)");
-            }
-            if (BlasProvider.HasRawSgemm)
-            {
-                CpuParallelSettings.MaxDegreeOfParallelism = 32;
-                Console.WriteLine($"    OpenBLAS (auto-threaded): {flops / TimeMinPtr(a, b, c, m, n, k, jit: false) / 1e9,5:F0} GF/s");
-            }
-        }
-        PackBothStrategy.s_macroKernel = false;
-        PackBothStrategy.s_forceGotoBlas = false;
-        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
-    }
-
-    /// <summary>
-    /// #85 GotoBLAS nc tuning: the wide-N losses come from many small Nc-blocks (12 for ffn at
-    /// nc=512) = many barriers + a small shared B re-read by all ic-blocks. Sweep nc upward to cut
-    /// the barrier count (bigger shared B per block, still L3-resident up to ~9 MB) vs the N-axis
-    /// baseline, at the default DOP. Run <c>--ab-gotoblas-nc</c>.
-    /// </summary>
-    public static unsafe void GotoBlasNcSweep()
-    {
-        Console.WriteLine("=== #85 GotoBLAS nc tuning (cut wide-N barrier count) ===");
-        Console.WriteLine($"PhysicalCores={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
-        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
-        var shapes = new (string label, int m, int n, int k)[]
-        {
-            ("ffn-up   384x6144x1536", 384, 6144, 1536),
-            ("tall-ffn 768x4096x1024", 768, 4096, 1024),
-            ("medium   384x1024x1024", 384, 1024, 1024),
-        };
-        int[] ncs = { 512, 1024, 1536, 2048, 3072, 6144 };
-        PackBothStrategy.s_macroKernel = true;
-        CpuParallelSettings.MaxDegreeOfParallelism = 32;
-        foreach (var (label, m, n, k) in shapes)
-        {
-            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
-            double flops = 2.0 * m * n * k;
-            PackBothStrategy.s_forceGotoBlas = false;
-            AutotuneDispatcher.s_overrideNc = null;
-            double dN = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
-            Console.WriteLine($"  {label}: N-axis baseline {dN,5:F0} GF/s");
-            PackBothStrategy.s_forceGotoBlas = true;
-            foreach (int nc in ncs)
-            {
-                if (nc > n) continue;
-                AutotuneDispatcher.s_overrideNc = nc;
-                double dG = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
-                Console.WriteLine($"    GotoBLAS nc={nc,4}: {dG,5:F0} GF/s   ({dG / dN:F2}x)");
-            }
-            AutotuneDispatcher.s_overrideNc = null;
-            PackBothStrategy.s_forceGotoBlas = false;
-        }
-        PackBothStrategy.s_macroKernel = false;
-        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
-    }
-
-    /// <summary>
-    /// #85 GotoBLAS crossover: at fixed m, k the GotoBLAS path wins for moderate N and loses for very
-    /// wide N. Ladder n/k from 1x to 4x to locate the routing threshold. Interleaved A/B (N-axis vs
-    /// GotoBLAS) per n, min-of-N, default DOP. Run <c>--ab-gotoblas-x</c>.
-    /// </summary>
-    public static unsafe void GotoBlasCrossover()
-    {
-        Console.WriteLine("=== #85 GotoBLAS crossover (n/k ladder, m=384 k=1024, nc=512) ===");
-        PackBothStrategy.s_gotoBlasAuto = false; // bench drives the path explicitly via s_forceGotoBlas
-        CpuParallelSettings.MaxDegreeOfParallelism = 32;
-        PackBothStrategy.s_macroKernel = true;
-        int m = 384, k = 1024;
-        foreach (int n in new[] { 1024, 1280, 1536, 2048, 2560, 3072, 4096 })
-        {
-            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
-            double flops = 2.0 * m * n * k;
-            // 3 interleaved A/B reps to beat the box noise.
-            double bestN = 0, bestG = 0;
-            for (int rep = 0; rep < 3; rep++)
-            {
-                PackBothStrategy.s_forceGotoBlas = false; AutotuneDispatcher.s_overrideNc = null;
-                bestN = Math.Max(bestN, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
-                PackBothStrategy.s_forceGotoBlas = true; AutotuneDispatcher.s_overrideNc = 512;
-                bestG = Math.Max(bestG, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
-            }
-            PackBothStrategy.s_forceGotoBlas = false; AutotuneDispatcher.s_overrideNc = null;
-            Console.WriteLine($"  n={n,4} (n/k={n / 1024.0:F1}x): N-axis {bestN,5:F0}  GotoBLAS {bestG,5:F0}  ({bestG / bestN:F2}x)");
-        }
-        PackBothStrategy.s_macroKernel = false;
-        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
-    }
-
-    /// <summary>
     /// #85 multi-thread diagnosis: GF/s + BUSY-CORE utilization (process CPU-time / wall / core) for the
     /// production large-float path at full DOP. Busy-cores is the scientific discriminator vs OpenBLAS's
     /// scaling: LOW busy-cores ⇒ we stall on barriers/sync (OB uses lock-free per-slice flags, not
@@ -510,6 +388,9 @@ public static class AxisRoutingAbBench
     /// </summary>
     public static void ProfileMultiThread(int seconds, string shape)
     {
+        if (seconds <= 0)
+            throw new ArgumentOutOfRangeException(nameof(seconds), "Profile duration must be positive.");
+
         CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
         (int m, int n, int k) = shape switch
         {
@@ -517,7 +398,10 @@ public static class AxisRoutingAbBench
             "square"  => (1024, 1024, 1024),
             "attn"    => (256, 1536, 1536),
             "medium"  => (384, 1024, 1024),
-            _         => (384, 6144, 1536), // ffn-up
+            "ffn-up"  => (384, 6144, 1536),
+            _         => throw new ArgumentException(
+                "Expected one of: ffn-up, ffn-big, square, attn, medium.",
+                nameof(shape)),
         };
         var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
         double flops = 2.0 * m * n * k;
@@ -572,11 +456,17 @@ public static class AxisRoutingAbBench
             for (int rep = 0; rep < 3; rep++)
             {
                 BlasManaged.s_disableGotoGemm = false; // GotoGemmFp32 path
+                AxisSelector.ForceAxisForTest = null;
                 bestG = Math.Max(bestG, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
+                // Baseline must be the N-axis route, not just "PackBoth": disabling GotoGemm only sends
+                // the shape to PackBoth — AxisSelector may still pick M/2D on some host/DOP. Pin N so the
+                // printed "N-axis" number is guaranteed to measure the N-axis path.
                 BlasManaged.s_disableGotoGemm = true;  // PackBoth (N-axis for thin-M wide-N)
+                AxisSelector.ForceAxisForTest = ParallelismAxis.N;
                 bestN = Math.Max(bestN, flops / TimeMinGemm(a, b, c, m, n, k) / 1e9);
             }
             BlasManaged.s_disableGotoGemm = false;
+            AxisSelector.ForceAxisForTest = null;
             string winner = bestN > bestG ? "N-axis" : "GotoGemm";
             Console.WriteLine($"  {label}: GotoGemm {bestG,5:F0}  N-axis {bestN,5:F0} GF/s  ({bestN / bestG:F2}x)  -> {winner}");
         }

--- a/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/AxisRoutingAbBench.cs
@@ -325,6 +325,23 @@ public static class AxisRoutingAbBench
     public static unsafe void ScalingSweep()
     {
         Console.WriteLine("=== #475 thread-scaling curve (16C/32T Zen2) ===");
+        Console.WriteLine($"PhysicalCoreCount={CpuParallelSettings.PhysicalCoreCount}  Logical={Environment.ProcessorCount}");
+        // Same-process A/B: the SMT cap ON vs OFF at the default DOP (noise-robust, min-of-N).
+        Console.WriteLine("--- SMT-cap A/B at default DOP (cap=physical vs cap=off) ---");
+        CpuParallelSettings.MaxDegreeOfParallelism = Environment.ProcessorCount;
+        PackBothStrategy.s_macroKernel = true;
+        foreach (var (m, n, k) in new[] { (384, 6144, 1536), (384, 1024, 1024), (1024, 1024, 1024) })
+        {
+            var a = MakeRandom(m * k); var b = MakeRandom(k * n); var c = new float[m * n];
+            double flops = 2.0 * m * n * k;
+            CpuParallelSettings.CapGemmAtPhysicalCores = true;
+            double on = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+            CpuParallelSettings.CapGemmAtPhysicalCores = false;
+            double off = flops / TimeMinGemm(a, b, c, m, n, k) / 1e9;
+            CpuParallelSettings.CapGemmAtPhysicalCores = true;
+            Console.WriteLine($"    {m}x{n}x{k}: cap-on {on,5:F0}  cap-off {off,5:F0} GF/s  ({on / off:F2}x)");
+        }
+        PackBothStrategy.s_macroKernel = false;
         var shapes = new (string label, int m, int n, int k)[]
         {
             ("ffn    384x6144x1536", 384, 6144, 1536),

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -140,6 +140,13 @@ class Program
             return;
         }
 
+        // #85 GotoGemm RunParallel vs N-axis (thin-M shared-A) routing A/B. (--ab-goto-vs-naxis)
+        if (args[0] == "--ab-goto-vs-naxis")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoVsNaxisSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -116,6 +116,20 @@ class Program
             return;
         }
 
+        // #85 GotoBLAS nc tuning sweep. (--ab-gotoblas-nc)
+        if (args[0] == "--ab-gotoblas-nc")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasNcSweep();
+            return;
+        }
+
+        // #85 GotoBLAS crossover ladder (n/k). (--ab-gotoblas-x)
+        if (args[0] == "--ab-gotoblas-x")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasCrossover();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -119,27 +119,6 @@ class Program
             return;
         }
 
-        // #85 GotoBLAS jc-blocked path A/B vs N-axis + OpenBLAS. (--ab-gotoblas)
-        if (args[0] == "--ab-gotoblas")
-        {
-            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasSweep();
-            return;
-        }
-
-        // #85 GotoBLAS nc tuning sweep. (--ab-gotoblas-nc)
-        if (args[0] == "--ab-gotoblas-nc")
-        {
-            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasNcSweep();
-            return;
-        }
-
-        // #85 GotoBLAS crossover ladder (n/k). (--ab-gotoblas-x)
-        if (args[0] == "--ab-gotoblas-x")
-        {
-            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasCrossover();
-            return;
-        }
-
         // #85 GotoGemm RunParallel vs N-axis (thin-M shared-A) routing A/B. (--ab-goto-vs-naxis)
         if (args[0] == "--ab-goto-vs-naxis")
         {
@@ -1021,6 +1000,21 @@ class Program
         Console.WriteLine("  --ab-ccx               : CCX-pinned-pool GEMM prototype (1D/2D)");
         Console.WriteLine("  --profile-gemm         : tight engine.TensorMatMul loop for an external profiler");
         Console.WriteLine("  --cpu-topology         : L3/CCX + NUMA topology (Windows-only)");
+        Console.WriteLine();
+        Console.WriteLine("#475 medium-axis routing + GEMM-profile A/B (managed BLAS):");
+        Console.WriteLine("  --ab-axis-routing      : forced M/N/2D vs the live heuristic vs OpenBLAS (diffusion shapes)");
+        Console.WriteLine("  --profile-gemm-st      : single-thread GEMM profile repro (--profile-gemm-st [seconds] [shape])");
+        Console.WriteLine("  --profile-gemm-mt      : multi-thread GEMM profile, GF/s + busy-core util (--profile-gemm-mt [seconds] [shape])");
+        Console.WriteLine("                           shape = ffn-up|ffn-big|square|attn|medium");
+        Console.WriteLine("  --ab-macro             : machine-code macro-kernel A/B (RyuJIT off the hot path)");
+        Console.WriteLine("  --ab-kunroll           : FP32 panel K-unroll sweep (4/8/2/6)");
+        Console.WriteLine("  --ab-jit               : JIT-specialized FP32 GEMM A/B vs OpenBLAS (small/medium)");
+        Console.WriteLine("  --ab-blocking          : medium/large blocking sweep vs OpenBLAS P/Q/R");
+        Console.WriteLine("  --ab-scaling           : thread-scaling curve (DOP 1..32) vs OpenBLAS");
+        Console.WriteLine("  --ab-goto-vs-naxis     : GotoGemm RunParallel vs N-axis (thin-M shared-A) routing A/B");
+        Console.WriteLine("  --ab-ccx-vs-rp         : CCX pool (barriers) vs RunParallel (barrier-free) on balanced shapes");
+        Console.WriteLine("  --ab-spinbar           : CCX spin-barrier vs .NET Barrier (forced CCX, bit-exact + perf)");
+        Console.WriteLine("  --ab-ccx-block         : CCX 2D kc blocking sweep (forced CCX)");
         Console.WriteLine();
         Console.WriteLine("PyTorch-comparison diagnostics:");
         Console.WriteLine("  --per-call-threads       : Per-call NumThreads sweep vs PyTorch");

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -168,6 +168,13 @@ class Program
             return;
         }
 
+        // #85 N-axis macro-kernel (asm Mr-sweep) vs managed loop, multi-thread. (--ab-macro-mt)
+        if (args[0] == "--ab-macro-mt")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.MacroMtSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -56,6 +56,14 @@ class Program
             return;
         }
 
+        // #475 medium-axis routing A/B — forced M/N/2D vs the live heuristic vs OpenBLAS
+        // on the diffusion FP32 shapes, full DOP, deterministic. (--ab-axis-routing)
+        if (args[0] == "--ab-axis-routing")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.Run();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -64,6 +64,16 @@ class Program
             return;
         }
 
+        // Single-thread GEMM profile repro for PerfView CPU-counter sampling.
+        // --profile-gemm-st [seconds=25] [shape=ffn-up|ffn-big|square|attn|medium]
+        if (args[0] == "--profile-gemm-st")
+        {
+            int secs = args.Length > 1 && int.TryParse(args[1], out var s) ? s : 25;
+            string shape = args.Length > 2 ? args[2] : "ffn-up";
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.ProfileSingleThread(secs, shape);
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -147,6 +147,13 @@ class Program
             return;
         }
 
+        // #85 CCX pool (barriers) vs RunParallel (barrier-free) on balanced shapes. (--ab-ccx-vs-rp)
+        if (args[0] == "--ab-ccx-vs-rp")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.CcxVsRunParallelSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -102,6 +102,13 @@ class Program
             return;
         }
 
+        // #475 thread-scaling curve (DOP 1..32) vs OpenBLAS. (--ab-scaling)
+        if (args[0] == "--ab-scaling")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.ScalingSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -154,6 +154,13 @@ class Program
             return;
         }
 
+        // #85 CCX spin-barrier vs .NET Barrier (forced CCX, bit-exact + perf). (--ab-spinbar)
+        if (args[0] == "--ab-spinbar")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.SpinBarrierSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -74,6 +74,16 @@ class Program
             return;
         }
 
+        // Multi-thread GEMM profile (GF/s + busy-core utilization) + PerfView PMU repro.
+        // --profile-gemm-mt [seconds=20] [shape=ffn-up|ffn-big|square|attn|medium]
+        if (args[0] == "--profile-gemm-mt")
+        {
+            int secs = args.Length > 1 && int.TryParse(args[1], out var s) ? s : 20;
+            string shape = args.Length > 2 ? args[2] : "ffn-up";
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.ProfileMultiThread(secs, shape);
+            return;
+        }
+
         // #475 machine-code macro-kernel A/B (RyuJIT off the hot path). (--ab-macro)
         if (args[0] == "--ab-macro")
         {

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -74,6 +74,13 @@ class Program
             return;
         }
 
+        // #475 machine-code macro-kernel A/B (RyuJIT off the hot path). (--ab-macro)
+        if (args[0] == "--ab-macro")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.MacroAb();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -161,6 +161,13 @@ class Program
             return;
         }
 
+        // #85 CCX 2D kc blocking sweep (forced CCX). (--ab-ccx-block)
+        if (args[0] == "--ab-ccx-block")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.CcxBlockingSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -109,6 +109,13 @@ class Program
             return;
         }
 
+        // #85 GotoBLAS jc-blocked path A/B vs N-axis + OpenBLAS. (--ab-gotoblas)
+        if (args[0] == "--ab-gotoblas")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.GotoBlasSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -88,6 +88,13 @@ class Program
             return;
         }
 
+        // #475 Phase 1: JIT specialized FP32 GEMM A/B vs OpenBLAS (small/medium). (--ab-jit)
+        if (args[0] == "--ab-jit")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.JitAb();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -95,6 +95,13 @@ class Program
             return;
         }
 
+        // #475 medium/large blocking sweep vs OpenBLAS P/Q/R. (--ab-blocking)
+        if (args[0] == "--ab-blocking")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.BlockingSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -81,6 +81,13 @@ class Program
             return;
         }
 
+        // #475 Phase 0a: FP32 panel K-unroll sweep (4/8/2/6). (--ab-kunroll)
+        if (args[0] == "--ab-kunroll")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.KUnrollSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -175,6 +175,13 @@ class Program
             return;
         }
 
+        // #85 N-axis pinned pool vs threadpool. (--ab-pinned)
+        if (args[0] == "--ab-pinned")
+        {
+            AiDotNet.Tensors.Benchmarks.AxisRoutingAbBench.PinnedNAxisSweep();
+            return;
+        }
+
         if (args[0] == "--ab-aiseval-dopsweep")
         {
             AiDotNet.Tensors.Benchmarks.PyTorchComparison.AisEvalHeadToHeadBench.DopSweep();

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerJoinParkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/CooperativeSchedulerJoinParkTests.cs
@@ -16,6 +16,13 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// out-live the caller's spin budget — and verify correctness with no lost wakeup or
 /// hang.
 /// </summary>
+// Serialized: this is a concurrency stress test (up to 200 dispatches that each
+// spin up a Task and park/wake on the cooperative scheduler). Under the parallel
+// test suite the thread-pool starvation made the park/wake handshake intermittently
+// miss its done.Wait deadline on CI (a 23s hang/timeout) while passing in isolation.
+// Membership in the serial perf collection gives it exclusive CPU time so the
+// bounded-spin-then-park timing assumptions hold.
+[Collection("BlasManaged-Perf-Serial")]
 public class CooperativeSchedulerJoinParkTests
 {
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
@@ -1,3 +1,7 @@
+// The JIT machine-code GEMM generator is net5+ only (it needs System.Runtime.Intrinsics),
+// so the BlasManaged.Jit namespace does not exist on net471. Guard the whole file to match
+// the src guard on JitGemmGenerator (#if NET5_0_OR_GREATER); otherwise net471 fails CS0234.
+#if NET5_0_OR_GREATER
 using System;
 using AiDotNet.Tensors.Engines.BlasManaged;
 using AiDotNet.Tensors.Engines.BlasManaged.Jit;
@@ -123,3 +127,4 @@ public class JitGemmGeneratorTests
         Assert.False(JitGemmGenerator.TryRunBf16(a, b, c, 2, 8, 2));
     }
 }
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
@@ -1,0 +1,102 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// #475 Phase 1/2/4: locks in the libxsmm-style JIT GEMM generator — the specialized FP32/FP64
+/// kernels (and the fused bias + ReLU epilogue) must match a double-precision scalar reference and
+/// must actually fire. This is the regression gate that protects the "we exceed OpenBLAS" win.
+/// </summary>
+public class JitGemmGeneratorTests
+{
+    private static float[] Rand(int n, int seed)
+    {
+        var r = new Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(r.NextDouble() * 2 - 1);
+        return a;
+    }
+
+    private static double MaxAbsErr(float[] got, double[] reference)
+    {
+        double e = 0;
+        for (int i = 0; i < got.Length; i++) e = Math.Max(e, Math.Abs((double)got[i] - reference[i]));
+        return e;
+    }
+
+    // C := relu?(A·B + bias?), row-major, double accumulation reference.
+    private static double[] ScalarRef(float[] a, float[] b, int m, int n, int k, float[] bias, bool relu)
+    {
+        var c = new double[m * n];
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double s = 0;
+                for (int p = 0; p < k; p++) s += (double)a[i * k + p] * b[p * n + j];
+                if (bias != null) s += bias[j];
+                if (relu && s < 0) s = 0;
+                c[i * n + j] = s;
+            }
+        return c;
+    }
+
+    public static TheoryData<int, int, int> Shapes() => new()
+    {
+        { 6, 16, 64 }, { 6, 8, 32 }, { 12, 32, 128 }, { 24, 48, 96 },
+        { 48, 64, 256 }, { 64, 64, 128 }, { 96, 96, 200 }, { 128, 128, 64 },
+        { 7, 8, 50 }, { 13, 24, 17 }, { 1, 16, 33 }, { 5, 40, 1 },
+    };
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public unsafe void Fp32_MatchesScalarReference(int m, int n, int k)
+    {
+        if (!JitGemmGenerator.IsSupported) return; // net471 / non-x64 — managed path covers it
+        var a = Rand(m * k, 1); var b = Rand(k * n, 2); var c = new float[m * n];
+        bool ok;
+        fixed (float* pa = a, pb = b, pc = c)
+            ok = JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k);
+        Assert.True(ok, $"JIT FP32 must fire for {m}x{n}x{k} (n%8==0)");
+        Assert.True(MaxAbsErr(c, ScalarRef(a, b, m, n, k, null, false)) < 1e-3, "FP32 result must match scalar ref");
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public unsafe void Fp32_FusedBiasRelu_MatchesScalarReference(int m, int n, int k)
+    {
+        if (!JitGemmGenerator.IsSupported) return;
+        var a = Rand(m * k, 3); var b = Rand(k * n, 4); var bias = Rand(n, 5); var c = new float[m * n];
+        bool ok;
+        fixed (float* pa = a, pb = b, pc = c, pbias = bias)
+            ok = JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k, pbias, relu: true);
+        Assert.True(ok, $"fused JIT must fire for {m}x{n}x{k}");
+        Assert.True(MaxAbsErr(c, ScalarRef(a, b, m, n, k, bias, relu: true)) < 1e-3, "fused relu(A·B+bias) must match scalar ref");
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public unsafe void Fp64_MatchesScalarReference(int m, int n, int k)
+    {
+        if (!JitGemmGenerator.IsSupported) return;
+        if ((n & 3) != 0) return; // FP64 lane is 4
+        var af = Rand(m * k, 6); var bf = Rand(k * n, 7);
+        var a = Array.ConvertAll(af, x => (double)x);
+        var b = Array.ConvertAll(bf, x => (double)x);
+        var c = new double[m * n];
+        bool ok;
+        fixed (double* pa = a, pb = b, pc = c)
+            ok = JitGemmGenerator.TryRunFp64(pa, k, pb, n, pc, n, m, n, k);
+        Assert.True(ok, $"JIT FP64 must fire for {m}x{n}x{k} (n%4==0)");
+        double e = 0;
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double s = 0;
+                for (int p = 0; p < k; p++) s += a[i * k + p] * b[p * n + j];
+                e = Math.Max(e, Math.Abs(c[i * n + j] - s));
+            }
+        Assert.True(e < 1e-9, "FP64 result must match scalar ref");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
@@ -3,6 +3,8 @@
 // the src guard on JitGemmGenerator (#if NET5_0_OR_GREATER); otherwise net471 fails CS0234.
 #if NET5_0_OR_GREATER
 using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 using AiDotNet.Tensors.Engines.BlasManaged;
 using AiDotNet.Tensors.Engines.BlasManaged.Jit;
 using Xunit;
@@ -16,6 +18,15 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// </summary>
 public class JitGemmGeneratorTests
 {
+    // The ISA/OS contract JitGemmGenerator.IsSupported must honor (everything EXCEPT the Enabled
+    // master switch). On a runner that meets this, IsSupported MUST be true — otherwise a silent
+    // support-gate regression has disabled the JIT path; the tests assert that rather than skipping.
+    // On a runner that does NOT meet it (no AVX2/FMA, non-x64), the JIT path must report unsupported
+    // and the TryRun* entrypoints must return false so callers fall back to the managed kernels.
+    private static bool HardwareSupportsJit =>
+        Fma.IsSupported && Avx2.IsSupported &&
+        RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
+        (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
     private static float[] Rand(int n, int seed)
     {
         var r = new Random(seed);
@@ -58,11 +69,19 @@ public class JitGemmGeneratorTests
     [MemberData(nameof(Shapes))]
     public unsafe void Fp32_MatchesScalarReference(int m, int n, int k)
     {
-        if (!JitGemmGenerator.IsSupported) return; // net471 / non-x64 — managed path covers it
         var a = Rand(m * k, 1); var b = Rand(k * n, 2); var c = new float[m * n];
         bool ok;
         fixed (float* pa = a, pb = b, pc = c)
             ok = JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k);
+        if (!HardwareSupportsJit)
+        {
+            // No AVX2/FMA or non-x64: the JIT path must report unsupported and decline so the caller
+            // takes the managed kernel. (Asserts the fallback contract instead of silently passing.)
+            Assert.False(JitGemmGenerator.IsSupported);
+            Assert.False(ok);
+            return;
+        }
+        Assert.True(JitGemmGenerator.IsSupported, "JIT must report supported on this AVX2/FMA x64 host");
         Assert.True(ok, $"JIT FP32 must fire for {m}x{n}x{k} (n%8==0)");
         Assert.True(MaxAbsErr(c, ScalarRef(a, b, m, n, k, null, false)) < 1e-3, "FP32 result must match scalar ref");
     }
@@ -71,11 +90,17 @@ public class JitGemmGeneratorTests
     [MemberData(nameof(Shapes))]
     public unsafe void Fp32_FusedBiasRelu_MatchesScalarReference(int m, int n, int k)
     {
-        if (!JitGemmGenerator.IsSupported) return;
         var a = Rand(m * k, 3); var b = Rand(k * n, 4); var bias = Rand(n, 5); var c = new float[m * n];
         bool ok;
         fixed (float* pa = a, pb = b, pc = c, pbias = bias)
             ok = JitGemmGenerator.TryRunFp32(pa, k, pb, n, pc, n, m, n, k, pbias, relu: true);
+        if (!HardwareSupportsJit)
+        {
+            Assert.False(JitGemmGenerator.IsSupported);
+            Assert.False(ok);
+            return;
+        }
+        Assert.True(JitGemmGenerator.IsSupported, "JIT must report supported on this AVX2/FMA x64 host");
         Assert.True(ok, $"fused JIT must fire for {m}x{n}x{k}");
         Assert.True(MaxAbsErr(c, ScalarRef(a, b, m, n, k, bias, relu: true)) < 1e-3, "fused relu(A·B+bias) must match scalar ref");
     }
@@ -84,8 +109,6 @@ public class JitGemmGeneratorTests
     [MemberData(nameof(Shapes))]
     public unsafe void Fp64_MatchesScalarReference(int m, int n, int k)
     {
-        if (!JitGemmGenerator.IsSupported) return;
-        if ((n & 3) != 0) return; // FP64 lane is 4
         var af = Rand(m * k, 6); var bf = Rand(k * n, 7);
         var a = Array.ConvertAll(af, x => (double)x);
         var b = Array.ConvertAll(bf, x => (double)x);
@@ -93,6 +116,20 @@ public class JitGemmGeneratorTests
         bool ok;
         fixed (double* pa = a, pb = b, pc = c)
             ok = JitGemmGenerator.TryRunFp64(pa, k, pb, n, pc, n, m, n, k);
+        if (!HardwareSupportsJit)
+        {
+            Assert.False(JitGemmGenerator.IsSupported);
+            Assert.False(ok);
+            return;
+        }
+        Assert.True(JitGemmGenerator.IsSupported, "JIT must report supported on this AVX2/FMA x64 host");
+        if ((n & 3) != 0)
+        {
+            // FP64 lane is 4: partial-4 columns are out of the JIT envelope, so it must DECLINE
+            // (return false) and let the managed path handle it — verify the decline, don't skip.
+            Assert.False(ok, $"JIT FP64 must decline n%4!=0 ({m}x{n}x{k})");
+            return;
+        }
         Assert.True(ok, $"JIT FP64 must fire for {m}x{n}x{k} (n%4==0)");
         double e = 0;
         for (int i = 0; i < m; i++)
@@ -111,7 +148,12 @@ public class JitGemmGeneratorTests
     [Fact]
     public void Bf16Microkernel_EmitsValidEncoding()
     {
-        if (!JitGemmGenerator.IsSupported) return;
+        if (!HardwareSupportsJit)
+        {
+            // Non-x64 / no AVX2: the JIT path is unsupported; the x64 EVEX emitter is not exercised.
+            Assert.False(JitGemmGenerator.IsSupported);
+            return;
+        }
         byte[] code = MachineCodeBf16Kernel.EmitGemmMicrokernelWindows();
         Assert.True(code.Length > 16, "BF16 microkernel must emit a non-trivial body");
         Assert.Equal(0xC3, code[^1]);          // ret

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/JitGemmGeneratorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Engines.BlasManaged.Jit;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
@@ -98,5 +99,27 @@ public class JitGemmGeneratorTests
                 e = Math.Max(e, Math.Abs(c[i * n + j] - s));
             }
         Assert.True(e < 1e-9, "FP64 result must match scalar ref");
+    }
+
+    // ── #475 Phase 2: native BF16 path (vdpbf16ps) — encoding-verified here; correctness/perf on
+    //    AVX-512-BF16 hardware or under Intel SDE (--verify-bf16gemm). ──────────────────────────
+
+    [Fact]
+    public void Bf16Microkernel_EmitsValidEncoding()
+    {
+        if (!JitGemmGenerator.IsSupported) return;
+        byte[] code = MachineCodeBf16Kernel.EmitGemmMicrokernelWindows();
+        Assert.True(code.Length > 16, "BF16 microkernel must emit a non-trivial body");
+        Assert.Equal(0xC3, code[^1]);          // ret
+        Assert.Contains((byte)0x62, code);     // EVEX prefix — vdpbf16ps is raw EVEX (no .NET intrinsic)
+    }
+
+    [Fact]
+    public void Bf16_StaysOffUntilExplicitlyEnabled()
+    {
+        // vdpbf16ps faults (#UD) without AVX-512-BF16, so the JIT BF16 path must never auto-run.
+        Assert.False(JitGemmGenerator.EnableBf16);
+        var a = new ushort[16]; var b = new ushort[16]; var c = new float[4];
+        Assert.False(JitGemmGenerator.TryRunBf16(a, b, c, 2, 8, 2));
     }
 }


### PR DESCRIPTION
## Summary

This branch began as a JIT small-GEMM generator and grew into a full campaign to **exceed OpenBLAS on the diffusion FFN/attention shapes**, driven by **PerfView PMU profiling + reading OpenBLAS's actual source** (`param.h`, `kernel/x86_64/sgemm_kernel_16x4_haswell.S`, `driver/level3/level3_thread.c`). Net: a JIT win on small GEMM **plus** a stack of validated, **bit-exact** multi-thread routing + thread-pinning wins on the diffusion hot path — with every dead-end measured and logged behind a default-off A/B flag.

## Part 1 — JIT small-GEMM (exceed OB 1.5–6×)

`JitGemmGenerator` emits per-shape-specialized FP32/FP64 microkernels (tile geometry + leading dims baked as immediates, direct/unpacked addressing), routed into `BlasManaged.GemmCore` (default on, gated to the win region); SYRK/SYMM/TRSM inherit it via `Gemm`. Bias+ReLU fused into the C store; capability-gated native BF16.

| shape | JIT GF/s | OpenBLAS | speedup |
|---|---|---|---|
| 6×16×64 | 47 | 8 | **6.08×** |
| 64×64×128 | 64 | 14 | **4.75×** |
| 96×96×256 | 87 | 39 | **2.24×** |
| 128×128×256 | 90 | 61 | **1.48×** |

The win is **runtime specialization** (libxsmm thesis), not microkernel tweaks — OB's own Zen `sgemm` uses the same 12-acc/16-reg/no-pipeline structure; K-unroll 8 and a whole-Mr-sweep macro kernel both measured neutral.

## Part 2 — Multi-thread campaign (the diffusion shapes)

PerfView PMC (CPU + LLC `CacheMisses`) + a busy-core profiler (`--profile-gemm-mt`) + OpenBLAS source pinned the multi-thread gap **scientifically**, not by guessing:
- ffn 447 GF/s = **16.6/32 busy cores, ~20 GF/s/core**; OpenBLAS 945 = 16 physical × **~59/core**.
- 86% of LLC misses sit in the per-tile compute → **per-core memory traffic from private per-thread packing**, not the FMA kernel (already 115 GF/s hot).

**Wins shipped (all bit-exact, maxErr=0 vs the prior path):**

| lever | shape | before → after |
|---|---|---|
| thin-M wide-N → N-axis (shared-A) | ffn 384×6144×1536 | 390 → **546** (1.40×) |
| gate `CcxGemmPool` to its [2G,4.5G] L3 window | square 1024³ | 199 → **525** (2.6×) |
| ″ | 2048³ | 606 → **~800** (1.38×) |
| L3-domain-pinned N-axis pool (`PinnedParallel`) | ffn / medium | **1.05–1.16×** |

- **N-axis routing** — `GotoGemmFp32.BeatsPackBoth` now cedes thin-M very-wide-N (m<512, n≥2k, m%6==0) to PackBoth's shared-A N-axis, where it beats the per-tile path 1.17–1.32× (per-core 20→32–42). The m%6≠0 DiT QKV/MLP shapes stay on GotoGemm (no regression).
- **CCX gating** — `CcxGemmPool` only wins in a narrow L3 sweet spot (1536³ = 1135 GF/s ≈ OpenBLAS, ~66/core); everywhere else the barrier-free `RunParallel` wins, so it's gated to work ∈ [2G, 4.5G].
- **Thread pinning** (the transferable OpenBLAS-source lever — they pin to cores, we used the unpinned .NET threadpool) — a persistent pool pinned per L3 domain runs the *unchanged* N-axis body work-stealing (bit-exact). Default-on, `AIDOTNET_PIN_NAXIS=0` opt-out, net471 stub.

## Dead-ends — measured, logged, gated default-off

| experiment | result |
|---|---|
| GotoBLAS jc-blocked PackBoth path | "win" was a measurement artifact (shapes route to GotoGemm, never reach PackBoth); slower when forced → retracted |
| CCX spin barrier (OB-style lock-free) | 10–20× slower (spinners contend with working lanes); the .NET Barrier is correct here |
| CCX kc/mc blocking sweep | kc=256 already optimal; mc=144 fixes the 2048³ C-tile spill but still loses to RunParallel |
| macro-kernel multi-thread | neutral — the 42% "managed loop" is real load/address work, not removable dispatch overhead |
| per-physical-core pinning | noisy, no consistent edge over domain pinning (`AIDOTNET_PIN_PERCORE=1`) |
| per-CCX A-replication | bit-exact but mixed — cross-CCX A-reads aren't dominant (A is L3-cacheable) (`AIDOTNET_PIN_REPLICATE=1`) |

OpenBLAS's other documented techniques don't transfer here: blocking 320/320 measured neutral; A-prefetch −14% (our broadcast-A is 24 B, already in L1); their 16×4 kernel is column-major (our 6×16 is correct for row-major C). The residual per-core gap (~45 vs 59) is the kernel's in-context IPC under memory pressure — the deeply-explored frontier.

## New tooling (A/B + diagnostics, default-off)

`--profile-gemm-mt` (GF/s + busy-core util), `--ab-goto-vs-naxis`, `--ab-ccx-vs-rp`, `--ab-spinbar`, `--ab-ccx-block`, `--ab-macro-mt`, `--ab-pinned`; PerfView PMC capture analyzed by `EtlAnalyze`; `CpuTopology.DetectPhysicalCores`.

## Validation

- Full `BlasManaged`/`MatMul`/`NAxis` correctness suite passes; the intermittent failures are pre-existing global-state parallelization flakes (verified pass in isolation).
- `JitGemmGeneratorTests` (38) + all new paths bit-exact (maxErr=0) vs the prior path.
- net10 + net471 build; CI AVX-512-verify drift fixed (48fd9711); flaky scheduler test hardened (37842807).

## Remaining (not in this PR)

- int8 AMX GEMM driver (SDE-verified tile primitive exists; needs AMX HW/SDE).
- Native BF16 (`vdpbf16ps`) folded in but capability-gated OFF (this Zen2 lacks AVX-512-BF16).
- Level-2 (GEMV/GBMV/GER) JIT; broader epilogue fusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
