### PR TITLE
perf(geometry): kill per-element indexer/numOps dispatch in sampling+distance kernels (GridSample ~50x +3)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -205,6 +205,10 @@ internal static class PackBothStrategy
             int numNBlocksN = (n + ncN - 1) / ncN;
             bool useNAxis = !s_disableNAxis
                 && MachineKernelGemm.IsFp32PanelAvailable
+                // The N-axis path computes with RunPanelFp32 = the 6×16 panel kernel (mr=6), but packs A
+                // with `mr`. Under AVX-512 the strategy selects the 16×16 microkernel (mr=16), so the A-pack
+                // (16-row stripes) would mismatch the 6-row panel kernel → garbage. Gate to the panel's mr.
+                && mr == MachineKernelGemm.Fp32Mr
                 && typeof(T) == typeof(float)
                 && !transA && !transB
                 && options.PackedA is null && options.PackedB is null

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7155,6 +7155,11 @@ public partial class CpuEngine : ITensorLevelEngine
         return result;
     }
 
+    // Named kernel constants (no magic numbers in src/** — CodeRabbit #702).
+    private const long TrilinearCornerCount = 8;          // corners summed per output channel (parallel work estimate)
+    private const double SampleUpperIndexEpsilon = 1e-3;  // clamp sample positions just below the top index: dim - 1 - eps
+    private const double ScatterWeightEpsilon = 1e-10;    // skip scatter contributions whose weight is negligibly small
+
     /// <inheritdoc/>
     public Tensor<T> TensorTrilinearInterpolate<T>(Tensor<T> grid, Tensor<T> positions)
     {
@@ -7194,7 +7199,7 @@ public partial class CpuEngine : ITensorLevelEngine
             double[] g = Unsafe.As<T[], double[]>(ref gridData);
             double[] p = Unsafe.As<T[], double[]>(ref posData);
             double[] r = Unsafe.As<T[], double[]>(ref resData);
-            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * TrilinearCornerCount, n =>
                 TrilinearRow(g, p, r, n, lD, lH, lW, lC));
         }
         else if (typeof(T) == typeof(float))
@@ -7202,16 +7207,16 @@ public partial class CpuEngine : ITensorLevelEngine
             float[] g = Unsafe.As<T[], float[]>(ref gridData);
             float[] p = Unsafe.As<T[], float[]>(ref posData);
             float[] r = Unsafe.As<T[], float[]>(ref resData);
-            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * TrilinearCornerCount, n =>
                 TrilinearRowF(g, p, r, n, lD, lH, lW, lC));
         }
         else
         {
-            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * TrilinearCornerCount, n =>
             {
-                double z = Math.Max(0, Math.Min(lD - 1.001, numOps.ToDouble(posData[n * 3 + 0])));
-                double y = Math.Max(0, Math.Min(lH - 1.001, numOps.ToDouble(posData[n * 3 + 1])));
-                double x = Math.Max(0, Math.Min(lW - 1.001, numOps.ToDouble(posData[n * 3 + 2])));
+                double z = Math.Max(0, Math.Min(lD - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(posData[n * 3 + 0])));
+                double y = Math.Max(0, Math.Min(lH - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(posData[n * 3 + 1])));
+                double x = Math.Max(0, Math.Min(lW - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(posData[n * 3 + 2])));
                 int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
                 int z1 = Math.Min(z0 + 1, lD - 1), y1 = Math.Min(y0 + 1, lH - 1), x1 = Math.Min(x0 + 1, lW - 1);
                 double fz = z - z0, fy = y - y0, fx = x - x0;
@@ -7242,9 +7247,9 @@ public partial class CpuEngine : ITensorLevelEngine
     // Same clamp, weights, and left-associative 8-corner sum as the generic path => bit-exact.
     private static void TrilinearRow(double[] g, double[] p, double[] r, int n, int D, int H, int W, int C)
     {
-        double z = Math.Max(0, Math.Min(D - 1.001, p[n * 3 + 0]));
-        double y = Math.Max(0, Math.Min(H - 1.001, p[n * 3 + 1]));
-        double x = Math.Max(0, Math.Min(W - 1.001, p[n * 3 + 2]));
+        double z = Math.Max(0, Math.Min(D - 1 - SampleUpperIndexEpsilon, p[n * 3 + 0]));
+        double y = Math.Max(0, Math.Min(H - 1 - SampleUpperIndexEpsilon, p[n * 3 + 1]));
+        double x = Math.Max(0, Math.Min(W - 1 - SampleUpperIndexEpsilon, p[n * 3 + 2]));
         int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
         int z1 = Math.Min(z0 + 1, D - 1), y1 = Math.Min(y0 + 1, H - 1), x1 = Math.Min(x0 + 1, W - 1);
         double fz = z - z0, fy = y - y0, fx = x - x0;
@@ -7264,9 +7269,9 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void TrilinearRowF(float[] g, float[] p, float[] r, int n, int D, int H, int W, int C)
     {
-        double z = Math.Max(0, Math.Min(D - 1.001, p[n * 3 + 0]));
-        double y = Math.Max(0, Math.Min(H - 1.001, p[n * 3 + 1]));
-        double x = Math.Max(0, Math.Min(W - 1.001, p[n * 3 + 2]));
+        double z = Math.Max(0, Math.Min(D - 1 - SampleUpperIndexEpsilon, p[n * 3 + 0]));
+        double y = Math.Max(0, Math.Min(H - 1 - SampleUpperIndexEpsilon, p[n * 3 + 1]));
+        double x = Math.Max(0, Math.Min(W - 1 - SampleUpperIndexEpsilon, p[n * 3 + 2]));
         int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
         int z1 = Math.Min(z0 + 1, D - 1), y1 = Math.Min(y0 + 1, H - 1), x1 = Math.Min(x0 + 1, W - 1);
         double fz = z - z0, fy = y - y0, fx = x - x0;
@@ -7327,9 +7332,9 @@ public partial class CpuEngine : ITensorLevelEngine
             T px = positions[n, 2];
 
             // Clamp to valid range and get integer and fractional parts
-            double z = Math.Max(0, Math.Min(depth - 1.001, numOps.ToDouble(pz)));
-            double y = Math.Max(0, Math.Min(height - 1.001, numOps.ToDouble(py)));
-            double x = Math.Max(0, Math.Min(width - 1.001, numOps.ToDouble(px)));
+            double z = Math.Max(0, Math.Min(depth - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(pz)));
+            double y = Math.Max(0, Math.Min(height - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(py)));
+            double x = Math.Max(0, Math.Min(width - 1 - SampleUpperIndexEpsilon, numOps.ToDouble(px)));
 
             int z0 = (int)Math.Floor(z);
             int y0 = (int)Math.Floor(y);
@@ -18402,7 +18407,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void ScatterPixelDouble(double[] gradData, double gradVal, int batch, int channel, int totalChannels, int height, int width, int h, int w, double weight, object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         int idx = ((batch * totalChannels + channel) * height + h) * width + w;
         double contrib = gradVal * weight;
         lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
@@ -18420,7 +18425,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void ScatterPixelFloat(float[] gradData, float gradVal, int batch, int channel, int totalChannels, int height, int width, int h, int w, double weight, object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         int idx = ((batch * totalChannels + channel) * height + h) * width + w;
         float contrib = gradVal * (float)weight;
         lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
@@ -18471,19 +18476,19 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void ScatterPixelDoubleNoLock(double[] gradData, double gradVal, int batch, int channel, int totalChannels, int height, int width, int h, int w, double weight)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         gradData[((batch * totalChannels + channel) * height + h) * width + w] += gradVal * weight;
     }
 
     private static void ScatterPixelFloatNoLock(float[] gradData, float gradVal, int batch, int channel, int totalChannels, int height, int width, int h, int w, double weight)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         gradData[((batch * totalChannels + channel) * height + h) * width + w] += gradVal * (float)weight;
     }
 
     private static void AddGradientToPixelNoLock<T>(T[] gradData, T gradVal, int batch, int channel, int totalChannels, int height, int width, int h, int w, double weight, INumericOperations<T> numOps)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         int idx = ((batch * totalChannels + channel) * height + h) * width + w;
         gradData[idx] = numOps.Add(gradData[idx], numOps.Multiply(gradVal, numOps.FromDouble(weight)));
     }
@@ -18505,7 +18510,7 @@ public partial class CpuEngine : ITensorLevelEngine
         INumericOperations<T> numOps,
         object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10)
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon)
             return;
 
         int idx = ((batch * totalChannels + channel) * height + h) * width + w;
@@ -18901,7 +18906,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void ScatterPixelDoubleNHWC(double[] gradData, double gradVal, int batch, int channel, int height, int width, int channels, int h, int w, double weight, object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         int idx = ((batch * height + h) * width + w) * channels + channel;
         double contrib = gradVal * weight;
         lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
@@ -18909,7 +18914,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
     private static void ScatterPixelFloatNHWC(float[] gradData, float gradVal, int batch, int channel, int height, int width, int channels, int h, int w, double weight, object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon) return;
         int idx = ((batch * height + h) * width + w) * channels + channel;
         float contrib = gradVal * (float)weight;
         lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
@@ -18932,7 +18937,7 @@ public partial class CpuEngine : ITensorLevelEngine
         INumericOperations<T> numOps,
         object[] locks)
     {
-        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10)
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < ScatterWeightEpsilon)
             return;
 
         // NHWC index: [batch, h, w, channel]

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -18870,11 +18870,49 @@ public partial class CpuEngine : ITensorLevelEngine
         double w10 = lh * (1 - lw);
         double w11 = lh * lw;
 
+        // Native double/float scatter (no numOps dispatch); generic falls through. Bit-exact.
+        if (typeof(T) == typeof(double))
+        {
+            double gv = Unsafe.As<T, double>(ref gradVal);
+            double[] gd = Unsafe.As<T[], double[]>(ref gradData);
+            ScatterPixelDoubleNHWC(gd, gv, batch, channel, height, width, channels, h0, w0, w00, locks);
+            ScatterPixelDoubleNHWC(gd, gv, batch, channel, height, width, channels, h0, w1, w01, locks);
+            ScatterPixelDoubleNHWC(gd, gv, batch, channel, height, width, channels, h1, w0, w10, locks);
+            ScatterPixelDoubleNHWC(gd, gv, batch, channel, height, width, channels, h1, w1, w11, locks);
+            return;
+        }
+        if (typeof(T) == typeof(float))
+        {
+            float gv = Unsafe.As<T, float>(ref gradVal);
+            float[] gd = Unsafe.As<T[], float[]>(ref gradData);
+            ScatterPixelFloatNHWC(gd, gv, batch, channel, height, width, channels, h0, w0, w00, locks);
+            ScatterPixelFloatNHWC(gd, gv, batch, channel, height, width, channels, h0, w1, w01, locks);
+            ScatterPixelFloatNHWC(gd, gv, batch, channel, height, width, channels, h1, w0, w10, locks);
+            ScatterPixelFloatNHWC(gd, gv, batch, channel, height, width, channels, h1, w1, w11, locks);
+            return;
+        }
+
         // Add gradient contributions to each of the 4 corners (NHWC layout)
         AddGradientToPixelNHWC(gradData, gradVal, batch, channel, height, width, channels, h0, w0, w00, numOps, locks);
         AddGradientToPixelNHWC(gradData, gradVal, batch, channel, height, width, channels, h0, w1, w01, numOps, locks);
         AddGradientToPixelNHWC(gradData, gradVal, batch, channel, height, width, channels, h1, w0, w10, numOps, locks);
         AddGradientToPixelNHWC(gradData, gradVal, batch, channel, height, width, channels, h1, w1, w11, numOps, locks);
+    }
+
+    private static void ScatterPixelDoubleNHWC(double[] gradData, double gradVal, int batch, int channel, int height, int width, int channels, int h, int w, double weight, object[] locks)
+    {
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        int idx = ((batch * height + h) * width + w) * channels + channel;
+        double contrib = gradVal * weight;
+        lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
+    }
+
+    private static void ScatterPixelFloatNHWC(float[] gradData, float gradVal, int batch, int channel, int height, int width, int channels, int h, int w, double weight, object[] locks)
+    {
+        if (h < 0 || h >= height || w < 0 || w >= width || Math.Abs(weight) < 1e-10) return;
+        int idx = ((batch * height + h) * width + w) * channels + channel;
+        float contrib = gradVal * (float)weight;
+        lock (locks[idx & (DeformScatterLockCount - 1)]) { gradData[idx] += contrib; }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7176,62 +7176,113 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var result = TensorAllocator.Rent<T>(new[] { numPositions, channels });
 
-        CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * channels * 8, n =>
+        // Rewritten from per-element Tensor-indexer access (grid[z,y,x,c] × 8 corners/channel +
+        // positions[n,i] + numOps.ToDouble/FromDouble dispatch) to raw-array access with native
+        // double/float fast paths. Interp already runs in double; the wins are killing the indexer
+        // (flat index instead of stride-resolve + bounds check) and the per-corner numOps boxing.
+        // Contiguity-guarded; tape records the original tensors.
+        var gridSrc = grid; var posSrc = positions;
+        if (!grid.IsContiguous) grid = grid.Contiguous();
+        if (!positions.IsContiguous) positions = positions.Contiguous();
+        var gridData = grid.GetDataArray();
+        var posData = positions.GetDataArray();
+        var resData = result.GetDataArray();
+        int lD = depth, lH = height, lW = width, lC = channels;
+
+        if (typeof(T) == typeof(double))
         {
-            // Get position (z, y, x)
-            T pz = positions[n, 0];
-            T py = positions[n, 1];
-            T px = positions[n, 2];
-
-            // Clamp to valid range and get integer and fractional parts
-            double z = Math.Max(0, Math.Min(depth - 1.001, numOps.ToDouble(pz)));
-            double y = Math.Max(0, Math.Min(height - 1.001, numOps.ToDouble(py)));
-            double x = Math.Max(0, Math.Min(width - 1.001, numOps.ToDouble(px)));
-
-            int z0 = (int)Math.Floor(z);
-            int y0 = (int)Math.Floor(y);
-            int x0 = (int)Math.Floor(x);
-            int z1 = Math.Min(z0 + 1, depth - 1);
-            int y1 = Math.Min(y0 + 1, height - 1);
-            int x1 = Math.Min(x0 + 1, width - 1);
-
-            double fz = z - z0;
-            double fy = y - y0;
-            double fx = x - x0;
-
-            // Trilinear interpolation weights for 8 corners
-            double w000 = (1 - fz) * (1 - fy) * (1 - fx);
-            double w001 = (1 - fz) * (1 - fy) * fx;
-            double w010 = (1 - fz) * fy * (1 - fx);
-            double w011 = (1 - fz) * fy * fx;
-            double w100 = fz * (1 - fy) * (1 - fx);
-            double w101 = fz * (1 - fy) * fx;
-            double w110 = fz * fy * (1 - fx);
-            double w111 = fz * fy * fx;
-
-            for (int c = 0; c < channels; c++)
+            double[] g = Unsafe.As<T[], double[]>(ref gridData);
+            double[] p = Unsafe.As<T[], double[]>(ref posData);
+            double[] r = Unsafe.As<T[], double[]>(ref resData);
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
+                TrilinearRow(g, p, r, n, lD, lH, lW, lC));
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            float[] g = Unsafe.As<T[], float[]>(ref gridData);
+            float[] p = Unsafe.As<T[], float[]>(ref posData);
+            float[] r = Unsafe.As<T[], float[]>(ref resData);
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
+                TrilinearRowF(g, p, r, n, lD, lH, lW, lC));
+        }
+        else
+        {
+            CpuParallelSettings.ParallelForOrSerial(0, numPositions, (long)numPositions * lC * 8, n =>
             {
-                // Get values at 8 corners
-                double v000 = numOps.ToDouble(grid[z0, y0, x0, c]);
-                double v001 = numOps.ToDouble(grid[z0, y0, x1, c]);
-                double v010 = numOps.ToDouble(grid[z0, y1, x0, c]);
-                double v011 = numOps.ToDouble(grid[z0, y1, x1, c]);
-                double v100 = numOps.ToDouble(grid[z1, y0, x0, c]);
-                double v101 = numOps.ToDouble(grid[z1, y0, x1, c]);
-                double v110 = numOps.ToDouble(grid[z1, y1, x0, c]);
-                double v111 = numOps.ToDouble(grid[z1, y1, x1, c]);
+                double z = Math.Max(0, Math.Min(lD - 1.001, numOps.ToDouble(posData[n * 3 + 0])));
+                double y = Math.Max(0, Math.Min(lH - 1.001, numOps.ToDouble(posData[n * 3 + 1])));
+                double x = Math.Max(0, Math.Min(lW - 1.001, numOps.ToDouble(posData[n * 3 + 2])));
+                int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
+                int z1 = Math.Min(z0 + 1, lD - 1), y1 = Math.Min(y0 + 1, lH - 1), x1 = Math.Min(x0 + 1, lW - 1);
+                double fz = z - z0, fy = y - y0, fx = x - x0;
+                double w000 = (1 - fz) * (1 - fy) * (1 - fx), w001 = (1 - fz) * (1 - fy) * fx,
+                       w010 = (1 - fz) * fy * (1 - fx), w011 = (1 - fz) * fy * fx,
+                       w100 = fz * (1 - fy) * (1 - fx), w101 = fz * (1 - fy) * fx,
+                       w110 = fz * fy * (1 - fx), w111 = fz * fy * fx;
+                for (int c = 0; c < lC; c++)
+                {
+                    double interpolated =
+                        w000 * numOps.ToDouble(gridData[(((z0 * lH + y0) * lW + x0) * lC) + c]) + w001 * numOps.ToDouble(gridData[(((z0 * lH + y0) * lW + x1) * lC) + c]) +
+                        w010 * numOps.ToDouble(gridData[(((z0 * lH + y1) * lW + x0) * lC) + c]) + w011 * numOps.ToDouble(gridData[(((z0 * lH + y1) * lW + x1) * lC) + c]) +
+                        w100 * numOps.ToDouble(gridData[(((z1 * lH + y0) * lW + x0) * lC) + c]) + w101 * numOps.ToDouble(gridData[(((z1 * lH + y0) * lW + x1) * lC) + c]) +
+                        w110 * numOps.ToDouble(gridData[(((z1 * lH + y1) * lW + x0) * lC) + c]) + w111 * numOps.ToDouble(gridData[(((z1 * lH + y1) * lW + x1) * lC) + c]);
+                    resData[n * lC + c] = numOps.FromDouble(interpolated);
+                }
+            });
+        }
 
-                // Weighted sum
-                double interpolated = w000 * v000 + w001 * v001 + w010 * v010 + w011 * v011 +
-                                     w100 * v100 + w101 * v101 + w110 * v110 + w111 * v111;
-
-                result[n, c] = numOps.FromDouble(interpolated);
-            }
-        });
+        grid = gridSrc; positions = posSrc;
 
         DifferentiableOps.RecordUnary("TensorTrilinearInterpolate", result, grid, BackwardFunctions<T>.TrilinearInterpolateBackward, new object[] { positions });
         { var cg = grid; var cp = positions; AutoTracer.RecordOp("TensorTrilinearInterpolate", result, eng => eng.TensorTrilinearInterpolate(cg, cp)); }
         return result;
+    }
+
+    // Native double/float row kernels for TensorTrilinearInterpolate (raw-array, no indexer/dispatch).
+    // Same clamp, weights, and left-associative 8-corner sum as the generic path => bit-exact.
+    private static void TrilinearRow(double[] g, double[] p, double[] r, int n, int D, int H, int W, int C)
+    {
+        double z = Math.Max(0, Math.Min(D - 1.001, p[n * 3 + 0]));
+        double y = Math.Max(0, Math.Min(H - 1.001, p[n * 3 + 1]));
+        double x = Math.Max(0, Math.Min(W - 1.001, p[n * 3 + 2]));
+        int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
+        int z1 = Math.Min(z0 + 1, D - 1), y1 = Math.Min(y0 + 1, H - 1), x1 = Math.Min(x0 + 1, W - 1);
+        double fz = z - z0, fy = y - y0, fx = x - x0;
+        double w000 = (1 - fz) * (1 - fy) * (1 - fx), w001 = (1 - fz) * (1 - fy) * fx,
+               w010 = (1 - fz) * fy * (1 - fx), w011 = (1 - fz) * fy * fx,
+               w100 = fz * (1 - fy) * (1 - fx), w101 = fz * (1 - fy) * fx,
+               w110 = fz * fy * (1 - fx), w111 = fz * fy * fx;
+        int b000 = ((z0 * H + y0) * W + x0) * C, b001 = ((z0 * H + y0) * W + x1) * C,
+            b010 = ((z0 * H + y1) * W + x0) * C, b011 = ((z0 * H + y1) * W + x1) * C,
+            b100 = ((z1 * H + y0) * W + x0) * C, b101 = ((z1 * H + y0) * W + x1) * C,
+            b110 = ((z1 * H + y1) * W + x0) * C, b111 = ((z1 * H + y1) * W + x1) * C;
+        int rb = n * C;
+        for (int c = 0; c < C; c++)
+            r[rb + c] = w000 * g[b000 + c] + w001 * g[b001 + c] + w010 * g[b010 + c] + w011 * g[b011 + c] +
+                        w100 * g[b100 + c] + w101 * g[b101 + c] + w110 * g[b110 + c] + w111 * g[b111 + c];
+    }
+
+    private static void TrilinearRowF(float[] g, float[] p, float[] r, int n, int D, int H, int W, int C)
+    {
+        double z = Math.Max(0, Math.Min(D - 1.001, p[n * 3 + 0]));
+        double y = Math.Max(0, Math.Min(H - 1.001, p[n * 3 + 1]));
+        double x = Math.Max(0, Math.Min(W - 1.001, p[n * 3 + 2]));
+        int z0 = (int)Math.Floor(z), y0 = (int)Math.Floor(y), x0 = (int)Math.Floor(x);
+        int z1 = Math.Min(z0 + 1, D - 1), y1 = Math.Min(y0 + 1, H - 1), x1 = Math.Min(x0 + 1, W - 1);
+        double fz = z - z0, fy = y - y0, fx = x - x0;
+        double w000 = (1 - fz) * (1 - fy) * (1 - fx), w001 = (1 - fz) * (1 - fy) * fx,
+               w010 = (1 - fz) * fy * (1 - fx), w011 = (1 - fz) * fy * fx,
+               w100 = fz * (1 - fy) * (1 - fx), w101 = fz * (1 - fy) * fx,
+               w110 = fz * fy * (1 - fx), w111 = fz * fy * fx;
+        int b000 = ((z0 * H + y0) * W + x0) * C, b001 = ((z0 * H + y0) * W + x1) * C,
+            b010 = ((z0 * H + y1) * W + x0) * C, b011 = ((z0 * H + y1) * W + x1) * C,
+            b100 = ((z1 * H + y0) * W + x0) * C, b101 = ((z1 * H + y0) * W + x1) * C,
+            b110 = ((z1 * H + y1) * W + x0) * C, b111 = ((z1 * H + y1) * W + x1) * C;
+        int rb = n * C;
+        // Interp accumulated in double (matching numOps.ToDouble path), result cast to float.
+        for (int c = 0; c < C; c++)
+            r[rb + c] = (float)(w000 * g[b000 + c] + w001 * g[b001 + c] + w010 * g[b010 + c] + w011 * g[b011 + c] +
+                                w100 * g[b100 + c] + w101 * g[b101 + c] + w110 * g[b110 + c] + w111 * g[b111 + c]);
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -31331,56 +31331,104 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var output = TensorAllocator.Rent<T>([batch, outH, outW, channels]);
 
-        T heightScale = numOps.FromDouble((inH - 1) / 2.0);
-        T widthScale = numOps.FromDouble((inW - 1) / 2.0);
+        // Rewritten from a serial Tensor-indexer loop (per-element [] access + Convert.ToDouble +
+        // INumericOperations<T> dispatch) to a parallel, raw-array kernel with native double/float
+        // fast paths (the typeof(T) branch folds at JIT). NHWC bilinear sample; same align-corners
+        // coordinate mapping and same left-associative interp accumulation as before. ~50x faster at
+        // [2,64,64,256] (222ms -> 4.4ms). Hot in flow-warp / spatial-transformer / deformable-attention.
+        // Raw-array access requires contiguous data; the indexer handled strides, so materialize a
+        // contiguous copy when needed. Keep the original refs so the tape records the user's tensors.
+        var inputOrig = input;
+        var gridOrig = grid;
+        if (!input.IsContiguous) input = input.Contiguous();
+        if (!grid.IsContiguous) grid = grid.Contiguous();
+        var inData = input.GetDataArray();
+        var gridData = grid.GetDataArray();
+        var outData = output.GetDataArray();
+        double widthScaleD = (inW - 1) / 2.0;
+        double heightScaleD = (inH - 1) / 2.0;
+        long totalWork = (long)batch * outH * outW * channels;
+        int lInH = inH, lInW = inW, lOutH = outH, lOutW = outW, lCh = channels;
 
-        for (int b = 0; b < batch; b++)
+        if (typeof(T) == typeof(double))
         {
-            for (int h = 0; h < outH; h++)
+            double[] inp = Unsafe.As<T[], double[]>(ref inData);
+            double[] gr = Unsafe.As<T[], double[]>(ref gridData);
+            double[] outp = Unsafe.As<T[], double[]>(ref outData);
+            CpuParallelSettings.ParallelForOrSerial(0, batch * lOutH, totalWork, bh =>
             {
-                for (int w = 0; w < outW; w++)
+                int b = bh / lOutH, h = bh % lOutH;
+                for (int w = 0; w < lOutW; w++)
                 {
-                    T gridX = grid[b, h, w, 0];
-                    T gridY = grid[b, h, w, 1];
-
-                    T srcX = numOps.Multiply(numOps.Add(gridX, numOps.One), widthScale);
-                    T srcY = numOps.Multiply(numOps.Add(gridY, numOps.One), heightScale);
-
-                    double srcXDouble = Convert.ToDouble(srcX);
-                    double srcYDouble = Convert.ToDouble(srcY);
-                    int x0 = Math.Max(0, Math.Min((int)Math.Floor(srcXDouble), inW - 1));
-                    int x1 = Math.Max(0, Math.Min(x0 + 1, inW - 1));
-                    int y0 = Math.Max(0, Math.Min((int)Math.Floor(srcYDouble), inH - 1));
-                    int y1 = Math.Max(0, Math.Min(y0 + 1, inH - 1));
-
-                    T wx1 = numOps.Subtract(srcX, numOps.FromDouble(x0));
-                    T wx0 = numOps.Subtract(numOps.One, wx1);
-                    T wy1 = numOps.Subtract(srcY, numOps.FromDouble(y0));
-                    T wy0 = numOps.Subtract(numOps.One, wy1);
-
-                    for (int c = 0; c < channels; c++)
-                    {
-                        T v00 = input[b, y0, x0, c];
-                        T v01 = input[b, y0, x1, c];
-                        T v10 = input[b, y1, x0, c];
-                        T v11 = input[b, y1, x1, c];
-
-                        T interp = numOps.Add(
-                            numOps.Add(
-                                numOps.Multiply(numOps.Multiply(v00, wx0), wy0),
-                                numOps.Multiply(numOps.Multiply(v01, wx1), wy0)),
-                            numOps.Add(
-                                numOps.Multiply(numOps.Multiply(v10, wx0), wy1),
-                                numOps.Multiply(numOps.Multiply(v11, wx1), wy1)));
-
-                        output[b, h, w, c] = interp;
-                    }
+                    int gBase = ((b * lOutH + h) * lOutW + w) * 2;
+                    double srcX = (gr[gBase] + 1.0) * widthScaleD;
+                    double srcY = (gr[gBase + 1] + 1.0) * heightScaleD;
+                    int x0 = Math.Max(0, Math.Min((int)Math.Floor(srcX), lInW - 1)), x1 = Math.Max(0, Math.Min(x0 + 1, lInW - 1));
+                    int y0 = Math.Max(0, Math.Min((int)Math.Floor(srcY), lInH - 1)), y1 = Math.Max(0, Math.Min(y0 + 1, lInH - 1));
+                    double wx1 = srcX - x0, wx0 = 1.0 - wx1, wy1 = srcY - y0, wy0 = 1.0 - wy1;
+                    int oBase = ((b * lOutH + h) * lOutW + w) * lCh;
+                    int i00 = ((b * lInH + y0) * lInW + x0) * lCh, i01 = ((b * lInH + y0) * lInW + x1) * lCh;
+                    int i10 = ((b * lInH + y1) * lInW + x0) * lCh, i11 = ((b * lInH + y1) * lInW + x1) * lCh;
+                    for (int c = 0; c < lCh; c++)
+                        outp[oBase + c] = (inp[i00 + c] * wx0 * wy0 + inp[i01 + c] * wx1 * wy0)
+                                        + (inp[i10 + c] * wx0 * wy1 + inp[i11 + c] * wx1 * wy1);
                 }
-            }
+            });
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            float[] inp = Unsafe.As<T[], float[]>(ref inData);
+            float[] gr = Unsafe.As<T[], float[]>(ref gridData);
+            float[] outp = Unsafe.As<T[], float[]>(ref outData);
+            CpuParallelSettings.ParallelForOrSerial(0, batch * lOutH, totalWork, bh =>
+            {
+                int b = bh / lOutH, h = bh % lOutH;
+                for (int w = 0; w < lOutW; w++)
+                {
+                    int gBase = ((b * lOutH + h) * lOutW + w) * 2;
+                    double srcX = (gr[gBase] + 1.0) * widthScaleD;
+                    double srcY = (gr[gBase + 1] + 1.0) * heightScaleD;
+                    int x0 = Math.Max(0, Math.Min((int)Math.Floor(srcX), lInW - 1)), x1 = Math.Max(0, Math.Min(x0 + 1, lInW - 1));
+                    int y0 = Math.Max(0, Math.Min((int)Math.Floor(srcY), lInH - 1)), y1 = Math.Max(0, Math.Min(y0 + 1, lInH - 1));
+                    float fwx1 = (float)(srcX - x0), fwx0 = 1f - fwx1, fwy1 = (float)(srcY - y0), fwy0 = 1f - fwy1;
+                    int oBase = ((b * lOutH + h) * lOutW + w) * lCh;
+                    int i00 = ((b * lInH + y0) * lInW + x0) * lCh, i01 = ((b * lInH + y0) * lInW + x1) * lCh;
+                    int i10 = ((b * lInH + y1) * lInW + x0) * lCh, i11 = ((b * lInH + y1) * lInW + x1) * lCh;
+                    for (int c = 0; c < lCh; c++)
+                        outp[oBase + c] = (inp[i00 + c] * fwx0 * fwy0 + inp[i01 + c] * fwx1 * fwy0)
+                                        + (inp[i10 + c] * fwx0 * fwy1 + inp[i11 + c] * fwx1 * fwy1);
+                }
+            });
+        }
+        else
+        {
+            CpuParallelSettings.ParallelForOrSerial(0, batch * lOutH, totalWork, bh =>
+            {
+                int b = bh / lOutH, h = bh % lOutH;
+                for (int w = 0; w < lOutW; w++)
+                {
+                    int gBase = ((b * lOutH + h) * lOutW + w) * 2;
+                    double srcX = (numOps.ToDouble(gridData[gBase]) + 1.0) * widthScaleD;
+                    double srcY = (numOps.ToDouble(gridData[gBase + 1]) + 1.0) * heightScaleD;
+                    int x0 = Math.Max(0, Math.Min((int)Math.Floor(srcX), lInW - 1)), x1 = Math.Max(0, Math.Min(x0 + 1, lInW - 1));
+                    int y0 = Math.Max(0, Math.Min((int)Math.Floor(srcY), lInH - 1)), y1 = Math.Max(0, Math.Min(y0 + 1, lInH - 1));
+                    T twx1 = numOps.FromDouble(srcX - x0), twx0 = numOps.Subtract(numOps.One, twx1);
+                    T twy1 = numOps.FromDouble(srcY - y0), twy0 = numOps.Subtract(numOps.One, twy1);
+                    int oBase = ((b * lOutH + h) * lOutW + w) * lCh;
+                    int i00 = ((b * lInH + y0) * lInW + x0) * lCh, i01 = ((b * lInH + y0) * lInW + x1) * lCh;
+                    int i10 = ((b * lInH + y1) * lInW + x0) * lCh, i11 = ((b * lInH + y1) * lInW + x1) * lCh;
+                    for (int c = 0; c < lCh; c++)
+                        outData[oBase + c] = numOps.Add(
+                            numOps.Add(numOps.Multiply(numOps.Multiply(inData[i00 + c], twx0), twy0),
+                                       numOps.Multiply(numOps.Multiply(inData[i01 + c], twx1), twy0)),
+                            numOps.Add(numOps.Multiply(numOps.Multiply(inData[i10 + c], twx0), twy1),
+                                       numOps.Multiply(numOps.Multiply(inData[i11 + c], twx1), twy1)));
+                }
+            });
         }
 
-        DifferentiableOps.RecordBinary("GridSample", output, input, grid, BackwardFunctions<T>.GridSampleBackward);
-        AutoTracer.RecordOp("GridSample", output, eng => eng.GridSample(input, grid));
+        DifferentiableOps.RecordBinary("GridSample", output, inputOrig, gridOrig, BackwardFunctions<T>.GridSampleBackward);
+        AutoTracer.RecordOp("GridSample", output, eng => eng.GridSample(inputOrig, gridOrig));
         return output;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -36834,52 +36834,90 @@ public partial class CpuEngine : ITensorLevelEngine
         var result = TensorAllocator.Rent<T>([n, m]);
         var numOps = MathHelper.GetNumericOperations<T>();
 
-        // Use the identity: ||x - y||^2 = ||x||^2 + ||y||^2 - 2 * x.y
-        // Compute ||x||^2 for each row of x
-        var xNormSq = new T[n];
-        for (int i = 0; i < n; i++)
-        {
-            T sum = numOps.Zero;
-            for (int k = 0; k < d; k++)
-            {
-                T val = x[i, k];
-                sum = numOps.Add(sum, numOps.Multiply(val, val));
-            }
-            xNormSq[i] = sum;
-        }
+        // Rewritten from a serial triple loop with per-element Tensor indexer (x[i,k]/y[j,k]) +
+        // numOps dispatch to a parallel raw-array kernel with native double/float fast paths.
+        // Same ||x-y||^2 = ||x||^2 + ||y||^2 - 2 x·y identity and same accumulation order (bit-exact).
+        var xc = x.IsContiguous ? x : x.Contiguous();
+        var yc = y.IsContiguous ? y : y.Contiguous();
+        var xData = xc.GetDataArray();
+        var yData = yc.GetDataArray();
+        var resData = result.GetDataArray();
 
-        // Compute ||y||^2 for each row of y
-        var yNormSq = new T[m];
-        for (int j = 0; j < m; j++)
+        if (typeof(T) == typeof(double))
         {
-            T sum = numOps.Zero;
-            for (int k = 0; k < d; k++)
-            {
-                T val = y[j, k];
-                sum = numOps.Add(sum, numOps.Multiply(val, val));
-            }
-            yNormSq[j] = sum;
+            PairwiseDistanceSquaredDouble(Unsafe.As<T[], double[]>(ref xData), Unsafe.As<T[], double[]>(ref yData), Unsafe.As<T[], double[]>(ref resData), n, m, d);
         }
-
-        // Compute result[i,j] = ||x[i]||^2 + ||y[j]||^2 - 2 * x[i].y[j]
-        T two = numOps.FromDouble(2.0);
-        for (int i = 0; i < n; i++)
+        else if (typeof(T) == typeof(float))
         {
+            PairwiseDistanceSquaredFloat(Unsafe.As<T[], float[]>(ref xData), Unsafe.As<T[], float[]>(ref yData), Unsafe.As<T[], float[]>(ref resData), n, m, d);
+        }
+        else
+        {
+            var xNormSq = new T[n];
+            for (int i = 0; i < n; i++)
+            {
+                T sum = numOps.Zero;
+                for (int k = 0; k < d; k++) { T val = xData[i * d + k]; sum = numOps.Add(sum, numOps.Multiply(val, val)); }
+                xNormSq[i] = sum;
+            }
+            var yNormSq = new T[m];
             for (int j = 0; j < m; j++)
             {
-                // Compute dot product x[i].y[j]
-                T dot = numOps.Zero;
-                for (int k = 0; k < d; k++)
-                {
-                    dot = numOps.Add(dot, numOps.Multiply(x[i, k], y[j, k]));
-                }
-                // ||x - y||^2 = ||x||^2 + ||y||^2 - 2 * x.y
-                T dist = numOps.Subtract(numOps.Add(xNormSq[i], yNormSq[j]), numOps.Multiply(two, dot));
-                result[i, j] = dist;
+                T sum = numOps.Zero;
+                for (int k = 0; k < d; k++) { T val = yData[j * d + k]; sum = numOps.Add(sum, numOps.Multiply(val, val)); }
+                yNormSq[j] = sum;
             }
+            T two = numOps.FromDouble(2.0);
+            CpuParallelSettings.ParallelForOrSerial(0, n, (long)n * m * d, i =>
+            {
+                int xb = i * d;
+                for (int j = 0; j < m; j++)
+                {
+                    int yb = j * d;
+                    T dot = numOps.Zero;
+                    for (int k = 0; k < d; k++) dot = numOps.Add(dot, numOps.Multiply(xData[xb + k], yData[yb + k]));
+                    resData[i * m + j] = numOps.Subtract(numOps.Add(xNormSq[i], yNormSq[j]), numOps.Multiply(two, dot));
+                }
+            });
         }
 
         return result;
+    }
+
+    private static void PairwiseDistanceSquaredDouble(double[] x, double[] y, double[] r, int n, int m, int d)
+    {
+        var xn = new double[n];
+        for (int i = 0; i < n; i++) { double s = 0; int b = i * d; for (int k = 0; k < d; k++) s += x[b + k] * x[b + k]; xn[i] = s; }
+        var yn = new double[m];
+        for (int j = 0; j < m; j++) { double s = 0; int b = j * d; for (int k = 0; k < d; k++) s += y[b + k] * y[b + k]; yn[j] = s; }
+        CpuParallelSettings.ParallelForOrSerial(0, n, (long)n * m * d, i =>
+        {
+            int xb = i * d; double xni = xn[i];
+            for (int j = 0; j < m; j++)
+            {
+                int yb = j * d; double dot = 0;
+                for (int k = 0; k < d; k++) dot += x[xb + k] * y[yb + k];
+                r[i * m + j] = (xni + yn[j]) - 2.0 * dot;
+            }
+        });
+    }
+
+    private static void PairwiseDistanceSquaredFloat(float[] x, float[] y, float[] r, int n, int m, int d)
+    {
+        var xn = new float[n];
+        for (int i = 0; i < n; i++) { float s = 0; int b = i * d; for (int k = 0; k < d; k++) s += x[b + k] * x[b + k]; xn[i] = s; }
+        var yn = new float[m];
+        for (int j = 0; j < m; j++) { float s = 0; int b = j * d; for (int k = 0; k < d; k++) s += y[b + k] * y[b + k]; yn[j] = s; }
+        CpuParallelSettings.ParallelForOrSerial(0, n, (long)n * m * d, i =>
+        {
+            int xb = i * d; float xni = xn[i];
+            for (int j = 0; j < m; j++)
+            {
+                int yb = j * d; float dot = 0;
+                for (int k = 0; k < d; k++) dot += x[xb + k] * y[yb + k];
+                r[i * m + j] = (xni + yn[j]) - 2f * dot;
+            }
+        });
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Profile-guided sweep for the per-element `Tensor`-indexer / `numOps`-virtual-dispatch anti-pattern in **non-GEMM custom compute kernels** (GEMM/conv are already native). Four kernels, each rewritten to raw-array access + native double/float fast paths (`typeof(T)` folds at JIT; generic `T` keeps a parallel `numOps` path). Bit-exact for double, finite-tolerance for float, contiguity-guarded, tape records originals.

1. **`GridSample` forward — ~50×** (222.1 → 4.4 ms @ `[2,64,64,256]`): was serial + indexer + `Convert.ToDouble` + `numOps`, no parallelism. Flow-warp / STN / deformable-attention.
2. **`TensorTrilinearInterpolate` forward**: indexer 8×/channel + per-corner `numOps.ToDouble`/`FromDouble` → raw-array native row kernels. Volumetric / NeRF.
3. **`BilinearBackwardInputNHWC`**: native double/float scatter (completes GridSample fwd+bwd + deformable NHWC grad; mirrors #698 NCHW).
4. **`PairwiseDistanceSquared`**: serial n·m·d triple-loop with indexer+`numOps` → parallel raw-array native (same `‖x‖²+‖y‖²−2x·y` identity). Point-cloud (PointNet++/DGCNN) / clustering.

## Verification
49/49 GridSample + Geometry + Deformable + Distance tests green on net10.0 (GPU-skipped on this box); net10.0 + net471 build clean.

Validates the agreed **profile-guided, targeted** strategy: the wins came from non-GEMM legacy scalar kernels, each stacking multiple co-located issues (indexer + boxing + dispatch + serial), not dispatch alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical correctness in several tensor operations by tightening the conditions for a parallel FP32 matrix path, preventing mismatched tile handling.
  * Fixed sampling, interpolation, and distance calculations to use more reliable contiguous-array execution paths in supported cases.
* **Performance**
  * Accelerated common tensor workloads with native `float` and `double` fast paths and parallel processing.
  * Reduced overhead in interpolation, grid sampling, gradient accumulation, and pairwise distance computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->