### PR TITLE
fix(compilation): stop topo-sort dropping in-place op chains (BatchNorm running-stat staleness)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
@@ -174,7 +174,13 @@ internal sealed class LazyNode<T> : ILazyNode
         // RecordInPlace overwrites target.LazySource (self-loop).
         if (_externalPrerequisite is { IsRealized: false } pre && !ReferenceEquals(pre, this))
             pre.Realize(engine);
-        if (Input0.LazySource is ILazyNode n0 && !n0.IsRealized && !ReferenceEquals(n0, this)) n0.Realize(engine);
+        // In-place op (Input0 IS the mutated target/output): the prior producer
+        // of the target is _externalPrerequisite (realized above). Input0.LazySource
+        // instead resolves to the LATEST in-place writer of the target — for an
+        // EARLIER op in an in-place chain that is a LATER node, so following it
+        // would recurse into a not-yet-realized successor. Skip it.
+        bool input0IsInPlaceTarget = ReferenceEquals(Input0, Output);
+        if (!input0IsInPlaceTarget && Input0.LazySource is ILazyNode n0 && !n0.IsRealized && !ReferenceEquals(n0, this)) n0.Realize(engine);
         if (Input1?.LazySource is ILazyNode n1 && !n1.IsRealized && !ReferenceEquals(n1, this)) n1.Realize(engine);
         if (Input2?.LazySource is ILazyNode n2 && !n2.IsRealized && !ReferenceEquals(n2, this)) n2.Realize(engine);
         if (InputsOverflow != null)
@@ -191,7 +197,16 @@ internal sealed class LazyNode<T> : ILazyNode
         // not see a phantom self-edge for in-place ops where Input0 == Output.
         if (_externalPrerequisite is ILazyNode pre && !ReferenceEquals(pre, this))
             nodes.Add(pre);
-        if (Input0.LazySource is ILazyNode n0 && !ReferenceEquals(n0, this)) nodes.Add(n0);
+        // In-place op (Input0 IS the mutated target/output): its prior producer is
+        // _externalPrerequisite (added above). Input0.LazySource resolves to the
+        // LATEST in-place writer of the target tensor; for the FIRST op in an
+        // in-place chain that is a LATER node — a false back-edge that turns the
+        // chain into a topo-sort cycle (e.g. M1↔A1 for runningVar *= m; += v), so
+        // Kahn's reordering pass schedules NEITHER and silently DROPS the whole
+        // in-place chain from the compiled plan. The dropped EMA never executes,
+        // leaving the persistent running-stat tensor stale (BatchNorm clone bug).
+        bool input0IsInPlaceTarget = ReferenceEquals(Input0, Output);
+        if (!input0IsInPlaceTarget && Input0.LazySource is ILazyNode n0 && !ReferenceEquals(n0, this)) nodes.Add(n0);
         if (Input1?.LazySource is ILazyNode n1 && !ReferenceEquals(n1, this)) nodes.Add(n1);
         if (Input2?.LazySource is ILazyNode n2 && !ReferenceEquals(n2, this)) nodes.Add(n2);
         if (InputsOverflow != null)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/RunningStatInPlaceMaterializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/RunningStatInPlaceMaterializationTests.cs
@@ -1,0 +1,149 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Ground-truth repro for the BatchNormalizationLayer running-stat staleness
+/// behind the #7 clone-bucket failures (WebRTCVad / TOTEM / TableTransformer /
+/// Zamba2 Clone_AfterTraining_ShouldPreserveLearnedWeights).
+///
+/// The layer updates running mean/variance with an IN-PLACE EMA on a PERSISTENT
+/// tensor (BatchNormalizationLayer.cs:694-700):
+///     runningVar *= momentum
+///     runningVar += (1-momentum) * batchVar
+/// Under GraphMode these in-place ops are recorded as deferred LazyNodes
+/// (LazyTensorScope.RecordInPlace) so CompiledTrainingPlan replay re-applies
+/// them per Step (#350). The running-stat update is a SIDE EFFECT — it is NOT
+/// reachable from the loss output — so the question these tests pin down is:
+/// after a compiled training Step (and after the scope disposes), is the
+/// persistent running-stat tensor MATERIALIZED to its post-EMA value, or does
+/// it read stale (pre-EMA) until some later lazy read forces realization?
+///
+/// If stale: the trained model's first Predict reads stale running stats while
+/// a deserialized clone (whose serialization already read/materialized them)
+/// reads fresh — producing the probe-0-only divergence the clone test reports.
+/// </summary>
+[Collection("CompilationGlobalState")]
+public class RunningStatInPlaceMaterializationTests
+{
+    /// <summary>
+    /// After a compiled training Step that records an in-place EMA on a
+    /// persistent running-variance tensor, the persistent tensor must hold the
+    /// post-EMA value. momentum=0.9, batchVar=0.5, init=1.0
+    /// => expected = 0.9*1.0 + 0.1*0.5 = 0.95.
+    /// </summary>
+    [Fact]
+    public void PersistentRunningStat_InPlaceEMA_MaterializedAfterCompiledStep()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 4;
+        const double epsilon = 1e-5;
+        const double momentum = 0.9;
+        const double batchVarConst = 0.5;
+        const double expected = momentum * 1.0 + (1.0 - momentum) * batchVarConst; // 0.95
+
+        var rng = new System.Random(42);
+        var inputData = new double[batch * features];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.NextDouble() - 0.5;
+
+        // Persistent layer state — survives across Steps, init to 1.0 (the BN default).
+        var runningVar = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) runningVar[i] = 1.0;
+
+        // A constant standing in for the per-batch variance feeding the EMA.
+        var batchVar = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) batchVar[i] = batchVarConst;
+
+        // Trainable params so CompileTraining has something to optimize.
+        var input = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < input.Length; i++) input[i] = inputData[i];
+        var gamma = new Tensor<double>(new[] { features });
+        var beta = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) { gamma[i] = 1.0; beta[i] = 0.0; }
+
+        ICompiledTrainingPlan<double> plan;
+        bool srcSetAfterCompile;
+        double rawAfterCompile;
+        using (var scope = GraphMode.Enable())
+        {
+            // Trainable forward producing a loss (gamma/beta are the params).
+            var bn = engine.BatchNorm(input, gamma, beta, epsilon, out _, out _);
+            engine.ReduceSum(bn, null);
+
+            // Side-effect running-stat EMA — exactly the layer's pattern.
+            engine.TensorMultiplyScalarInPlace(runningVar, momentum);
+            var scaled = engine.TensorMultiplyScalar(batchVar, 1.0 - momentum);
+            engine.TensorAddInPlace(runningVar, scaled);
+
+            plan = scope.CompileTraining(new[] { gamma, beta });
+        }
+        // LazySource non-null after compile => the in-place node was NOT
+        // scheduled (dropped from `optimized`), so the plan won't execute it.
+        srcSetAfterCompile = runningVar.LazySource is not null;
+        rawAfterCompile = ((double[])(object)runningVar.GetDataArray())[0];
+
+        double rawAfterStep, idxAfterStep;
+        bool srcSetAfterStep;
+        int fwdStepCount = plan.ForwardStepCount;
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+            // RAW backing FIRST (bypasses EnsureMaterialized), THEN indexer
+            // (triggers EnsureMaterialized → may realize a pending LazySource).
+            rawAfterStep = ((double[])(object)runningVar.GetDataArray())[0];
+            srcSetAfterStep = runningVar.LazySource is not null;
+            idxAfterStep = runningVar[0];
+        }
+        double afterDispose = runningVar[0];
+
+        Assert.True(
+            System.Math.Abs(rawAfterStep - expected) < 1e-9,
+            $"Persistent running-stat materialization probe:\n" +
+            $"  LazySource set after Compile = {srcSetAfterCompile}  (true => in-place node DROPPED from plan)\n" +
+            $"  raw backing  after Compile   = {rawAfterCompile:F12}\n" +
+            $"  plan ForwardStepCount        = {fwdStepCount}\n" +
+            $"  LazySource set after Step    = {srcSetAfterStep}\n" +
+            $"  RAW backing[0] after Step    = {rawAfterStep:F12}\n" +
+            $"  indexer[0]   after Step      = {idxAfterStep:F12}\n" +
+            $"  indexer[0]   after Dispose   = {afterDispose:F12}\n" +
+            $"  expected (post-EMA)          = {expected:F12}\n" +
+            $"  (raw==1.0 && idx==0.95 => in-place side-effect left DEFERRED/stale)");
+    }
+
+    /// <summary>
+    /// Eager-tape control: the SAME in-place EMA outside GraphMode (under a
+    /// plain GradientTape, which is how non-fused training runs) must update
+    /// the persistent tensor immediately. Pins that the staleness is specific
+    /// to the compiled/graph path, not the in-place ops themselves.
+    /// </summary>
+    [Fact]
+    public void PersistentRunningStat_InPlaceEMA_EagerTape_UpdatesImmediately()
+    {
+        var engine = new CpuEngine();
+        const int features = 4;
+        const double momentum = 0.9;
+        const double batchVarConst = 0.5;
+        const double expected = momentum * 1.0 + (1.0 - momentum) * batchVarConst; // 0.95
+
+        var runningVar = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) runningVar[i] = 1.0;
+        var batchVar = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) batchVar[i] = batchVarConst;
+
+        using (var tape = new GradientTape<double>())
+        {
+            engine.TensorMultiplyScalarInPlace(runningVar, momentum);
+            var scaled = engine.TensorMultiplyScalar(batchVar, 1.0 - momentum);
+            engine.TensorAddInPlace(runningVar, scaled);
+        }
+
+        Assert.True(
+            System.Math.Abs(runningVar[0] - expected) < 1e-9,
+            $"Eager-tape in-place EMA did not update immediately: runningVar[0]={runningVar[0]:F12}, expected {expected:F12}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/RunningStatInPlaceMaterializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/RunningStatInPlaceMaterializationTests.cs
@@ -113,6 +113,18 @@ public class RunningStatInPlaceMaterializationTests
             $"  indexer[0]   after Dispose   = {afterDispose:F12}\n" +
             $"  expected (post-EMA)          = {expected:F12}\n" +
             $"  (raw==1.0 && idx==0.95 => in-place side-effect left DEFERRED/stale)");
+        Assert.True(
+            System.Math.Abs(idxAfterStep - expected) < 1e-9,
+            $"Indexer probe after Step diverged from expected:\n" +
+            $"  indexer[0]   after Step      = {idxAfterStep:F12}\n" +
+            $"  expected (post-EMA)          = {expected:F12}\n" +
+            $"  (divergence => clone-divergence path: indexer triggers materialization but raw backing is stale)");
+        Assert.True(
+            System.Math.Abs(afterDispose - expected) < 1e-9,
+            $"Indexer probe after Dispose diverged from expected:\n" +
+            $"  indexer[0]   after Dispose   = {afterDispose:F12}\n" +
+            $"  expected (post-EMA)          = {expected:F12}\n" +
+            $"  (divergence => post-disposal value changed unexpectedly)");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes a compiled-plan topology-sort bug that **silently drops in-place op chains**, leaving BatchNorm running mean/variance stale after a compiled training step — the root cause behind the `Clone_AfterTraining_ShouldPreserveLearnedWeights` divergences (the #7 clone bucket: WebRTCVad / TOTEM / TableTransformer / Zamba2).

## Root cause

An in-place op records itself with `Input0 == Output == target`. `RealizeInputs`/`GetInputNodes` resolve `Input0.LazySource` at query time, which returns the **latest** in-place writer of the target. For the **first** op in a multi-op in-place chain (e.g. the running-stat EMA `runningVar *= momentum; runningVar += (1-momentum)*batchVar`) that latest writer is a **later** node, creating a false back-edge. Combined with the `_externalPrerequisite` forward edge this forms a 2-cycle (`M1 ↔ A1`); Kahn's `OperationReorderingPass` can never reach in-degree 0 for either, so **both are silently dropped from the compiled plan**.

The dropped EMA chain never executes during `CompiledTrainingPlan.Step()`, so the persistent running-variance/mean tensor keeps a dangling `LazySource` over a stale (pre-EMA) backing. A later lazy read materializes it once via the float-precision `RecordingEngine`, so the trained model's first inference reads stale running stats while a deserialized clone reads fresh — the probe-0-only divergence the clone tests report.

## Fix

In `LazyNode.RealizeInputs` and `GetInputNodes`, skip `Input0.LazySource` when `Input0 IS Output` (the in-place target): the prior producer is already `_externalPrerequisite` (handled), and following `Input0.LazySource` is exactly the false back-edge. This removes the phantom cycle so the in-place chain schedules and executes in order.

## Validation

- New `RunningStatInPlaceMaterializationTests` — ground-truth repro: a compiled training step with an in-place EMA on a persistent running-variance tensor must leave it at the post-EMA value (`0.9*1.0 + 0.1*0.5 = 0.95`).
- Full `Compilation` suite green (572 passed); net10 + net471 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected graph input realization for in-place tensor operations to avoid incorrect traversal and potential stale edges/values in compiled execution.
  * Ensured persistent running variance (BatchNorm-style EMA) is properly materialized after a compiled training step, including correct values after scope disposal.

* **Tests**
  * Added new tests covering in-place EMA updates for persistent running variance in both compiled GraphMode and eager execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->