### PR TITLE
fix(#638): CUDA-graph capture training now LEARNS (device barrier + deterministic scratch pool + LN resident-weight gate)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2024,6 +2024,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         if (gradTransient) gradBuf.Dispose();
                     }
                     if (diagAU) { try { gpuBe.Synchronize(); var w = gpuBe.DownloadBuffer(gpuP); double s = 0; for (int i = 0; i < w.Length; i++) s += System.Math.Abs((double)w[i]); System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_opt_diag.txt"), $"[AU] p=0 step6 lr={lr:E3} gradBufL1={auGrad:E4} mvAlloc={(gpuM[p] != null && gpuV[p] != null)} paramL1 before={auBefore:E6} after={s:E6} delta={(s - auBefore):E6}" + System.Environment.NewLine); } catch { } }
+                    // EVAL-LEAK ROOT FIX (#638): on-device Adam just updated _parameters[p]'s RESIDENT device
+                    // buffer IN PLACE — it now holds the authoritative current weights. Sync _gpuBufferVersion to
+                    // Version so the version-gate in GetWeightBufferPreferResident TRUSTS it during forward-only
+                    // eval. Without this, on-device Adam bumps Version but not _gpuBufferVersion, so the gate
+                    // falsely judges the (fresh) device buffer stale → re-uploads the weights via GetDataArray()
+                    // (a FRESH host array each call → persistent-cache MISS) on EVERY Predict → a per-call
+                    // ~weight-size GPU leak that OOMs the eval at d256/L4+. A later CPU SetParameters legitimately
+                    // re-bumps Version (without this device write) → mismatch returns → correct re-upload. Harmless
+                    // to capture (the gate's ResidentStepActive branch already covers it).
+                    _parameters[p]._gpuBufferVersion = _parameters[p].Version;
                     continue;
                 }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1060,6 +1060,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
     {
         var engine = _engine;
+        // PR #638 capture-determinism: tag each compiled action so its transient scratch draws from the engine's
+        // STATIC (action,local)-keyed pool → identical device addresses across the pre-residency pass, the capture
+        // pass, and every replay (XLA/TensorRT-style position-keyed buffer assignment). action=-1 disables pooling
+        // (the pre-pass's persistent EnsureResidentBuffer allocs must NOT be pooled).
+        var de = engine as Engines.DirectGpuTensorEngine;
+        de?.SetCurrentScratchAction(-1);
         _preForwardParamTransform?.Invoke();
         var fwd = _forwardActions;
         // The whole forward (INCLUDING the embedding, which gathers on-device from the externally-refreshed stable
@@ -1067,6 +1073,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool capDiag = System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1" && cb.IsStreamCapturing();
         for (int i = _graphEagerFwd; i < fwd.Length; i++)
         {
+            de?.SetCurrentScratchAction(i);   // pool this forward action's transient scratch by (i, local)
             fwd[i](engine);
             if (capDiag && cb.StreamCaptureStatusRaw() == 2)
             {
@@ -1076,6 +1083,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
         }
 
+        de?.SetCurrentScratchAction(-1);   // pre-pass (persistent EnsureResidentBuffer/seed/memset) runs UNpooled
         int esz = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();
         // PR #638 A1: bind a STABLE resident GPU buffer to every pre-allocated gradient accumulator (the generic
         // backward accumulates into gradMap[input] in place; without a resident buffer that accumulator lived on
@@ -1130,6 +1138,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var bwdNames = ProfBackwardStepNames;
         for (int i = 0; i < bwd.Length; i++)
         {
+            de?.SetCurrentScratchAction(fwd.Length + i);   // backward actions keyed in a namespace above forward
             bwd[i](engine);
             if (bwdDiag && cb.StreamCaptureStatusRaw() == 2)
             {
@@ -1139,6 +1148,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 bwdDiag = false;   // log only the FIRST invalidation
             }
         }
+        de?.SetCurrentScratchAction(-1);   // grad clip + optimizer (run after) must NOT pool
         // NOTE: _optimizerUpdate is intentionally NOT invoked here — it runs eagerly
         // in Step() after LaunchCapturedGraph so the LR schedule / Adam bias-correction
         // scalars are fresh per step rather than frozen at capture time.
@@ -1939,6 +1949,26 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 int len = lengths[p];
 
+                if (_optimizerStep <= 10 && System.Environment.GetEnvironmentVariable("AIDOTNET_OPT_DIAG") == "1")
+                {
+                    try
+                    {
+                        var gradResNow = _gradients[p]?.TryGetGpuBuffer();
+                        var paramResNow = _parameters[p].TryGetGpuBuffer();
+                        var be = gpuBackends[p];
+                        double gradL2 = -1, paramL1 = -1;
+                        if (be is not null)
+                        {
+                            if (gradResNow is not null) { var g = be.DownloadBuffer(gradResNow); double s = 0; for (int i = 0; i < g.Length; i++) s += (double)g[i] * g[i]; gradL2 = System.Math.Sqrt(s); }
+                            if (paramResNow is not null) { var w = be.DownloadBuffer(paramResNow); double s = 0; for (int i = 0; i < w.Length; i++) s += System.Math.Abs((double)w[i]); paramL1 = s; }
+                        }
+                        System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_opt_diag.txt"),
+                            $"step{_optimizerStep} p={p} len={len} paramBufMatch={ReferenceEquals(gpuParam[p], paramResNow)} " +
+                            $"gradResidentNow={(gradResNow != null)} gradL2={gradL2:E4} paramL1={paramL1:E6}" + System.Environment.NewLine);
+                    }
+                    catch (Exception dex) { System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_opt_diag.txt"), $"step{_optimizerStep} p={p} DIAG-ERR {dex.Message}" + System.Environment.NewLine); }
+                }
+
                 // GPU path: dispatch to backend-native fused optimizer kernel.
                 // Backends own Sgd/Adam/AdamW kernel implementations
                 // (CUDA / HIP / OpenCL / Metal); we just translate the
@@ -1946,7 +1976,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // (uploaded transiently) or GPU (passed through directly).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
                 {
-                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
+                    // CAPTURE-FREEZE FIX (#638): re-resolve the gradient's resident buffer EACH STEP. gpuGrad[p]
+                    // was bound ONCE at ConfigureOptimizer time — but under CUDA-graph capture the backward writes
+                    // grads into a buffer made GPU-resident by the capture pre-pass (EnsureResidentBuffer on
+                    // _preAllocatedGrads), which runs AFTER ConfigureOptimizer. So at config time the param-grad
+                    // tensor was NOT yet resident → gpuGrad[p] was null → the optimizer fell back to uploading the
+                    // stale host backing (gradArrays[p], all zeros after the captured resident backward bypassed
+                    // it) → AdamUpdate ran on ~zero grads → weights never changed → FLAT loss / frozen pL1 across
+                    // epochs (the capture-doesn't-learn bug; only visible at a learning scale, not the smoke run).
+                    // Reading the tensor's CURRENT resident buffer each step makes the optimizer consume the grads
+                    // the captured backward actually produced. Mirrors the param-side pin near the GPU fast path.
+                    // Eager paths are unaffected: a non-resident grad still yields null here → gpuGrad/host fallback.
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = (_gradients[p]?.TryGetGpuBuffer()) ?? gpuGrad[p];
                     bool gradTransient = false;
                     if (gradBuf is null)
                     {
@@ -1954,6 +1995,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         gradBuf = gpuBe.AllocateBuffer(gradArrays[p]);
                         gradTransient = true;
                     }
+                    bool diagAU = p == 0 && _optimizerStep == 6 && System.Environment.GetEnvironmentVariable("AIDOTNET_OPT_DIAG") == "1";
+                    double auBefore = -1, auGrad = -1;
+                    if (diagAU) { try { gpuBe.Synchronize(); var w = gpuBe.DownloadBuffer(gpuP); double s = 0; for (int i = 0; i < w.Length; i++) s += System.Math.Abs((double)w[i]); auBefore = s; var gg = gpuBe.DownloadBuffer(gradBuf); double s2 = 0; for (int i = 0; i < gg.Length; i++) s2 += System.Math.Abs((double)gg[i]); auGrad = s2; } catch { } }
                     try
                     {
                         switch (optType)
@@ -1979,6 +2023,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     {
                         if (gradTransient) gradBuf.Dispose();
                     }
+                    if (diagAU) { try { gpuBe.Synchronize(); var w = gpuBe.DownloadBuffer(gpuP); double s = 0; for (int i = 0; i < w.Length; i++) s += System.Math.Abs((double)w[i]); System.IO.File.AppendAllText(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aidotnet_opt_diag.txt"), $"[AU] p=0 step6 lr={lr:E3} gradBufL1={auGrad:E4} mvAlloc={(gpuM[p] != null && gpuV[p] != null)} paramL1 before={auBefore:E6} after={s:E6} delta={(s - auBefore):E6}" + System.Environment.NewLine); } catch { } }
                     continue;
                 }
 
@@ -2272,7 +2317,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // GPU path (mirrors ConfigureOptimizerFloat).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
                 {
-                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
+                    // CAPTURE-FREEZE FIX (#638): re-resolve the gradient's resident buffer EACH STEP. gpuGrad[p]
+                    // was bound ONCE at ConfigureOptimizer time — but under CUDA-graph capture the backward writes
+                    // grads into a buffer made GPU-resident by the capture pre-pass (EnsureResidentBuffer on
+                    // _preAllocatedGrads), which runs AFTER ConfigureOptimizer. So at config time the param-grad
+                    // tensor was NOT yet resident → gpuGrad[p] was null → the optimizer fell back to uploading the
+                    // stale host backing (gradArrays[p], all zeros after the captured resident backward bypassed
+                    // it) → AdamUpdate ran on ~zero grads → weights never changed → FLAT loss / frozen pL1 across
+                    // epochs (the capture-doesn't-learn bug; only visible at a learning scale, not the smoke run).
+                    // Reading the tensor's CURRENT resident buffer each step makes the optimizer consume the grads
+                    // the captured backward actually produced. Mirrors the param-side pin near the GPU fast path.
+                    // Eager paths are unaffected: a non-resident grad still yields null here → gpuGrad/host fallback.
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = (_gradients[p]?.TryGetGpuBuffer()) ?? gpuGrad[p];
                     bool gradTransient = false;
                     if (gradBuf is null)
                     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.Graph.cs
@@ -120,6 +120,14 @@ public sealed partial class CudaBackend
         using var _ = PushContext();
         CuBlasNative.CheckCudaResult(
             CudaNativeBindings.cuGraphLaunch(graphExec, _stream), "cuGraphLaunch");
+        // DEVICE-WIDE barrier so the WHOLE captured step completes before the caller's EAGER grad-clip /
+        // optimizer read the gradients. The captured backward writes some grads on BLAS LEASE streams (not
+        // _stream), so a stream-only sync — or no sync — lets the eager optimizer race the still-in-flight
+        // grad writes and read partially-written (intermittently ZERO) gradients → non-deterministic grad
+        // oscillation and a training plateau (the embedding grad flickered 0.11↔0 step-to-step). The capture
+        // win is launch-overhead collapse, NOT cross-step async overlap, and a training step must finish
+        // before the next anyway, so this per-step barrier costs ~nothing while making grads deterministic.
+        CuBlasNative.CheckCudaResult(CuBlasNative.cuCtxSynchronize(), "cuCtxSynchronize (post-capture-launch grad barrier)");
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3892,6 +3892,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return nb;
     }
 
+    /// <summary>Dispose + clear the per-action capture scratch pool. Call at the training→eval transition:
+    /// these pooled transient buffers are training-only (the captured graph does NOT replay during forward-only
+    /// eval), and on a big model (d256/L4+) they hold GBs that the async pool reserved at the training peak.
+    /// Freeing them returns that memory to the pool (then trimmable to the OS on the next alloc-OOM retry), so
+    /// the eval forward's weight uploads no longer hit cuMemAllocAsync free=0. Safe ONLY when no further training
+    /// step will run on this plan (eval is terminal); a replay after this would read freed device memory.</summary>
+    public void ClearActionScratchPool()
+    {
+        foreach (var kv in _actionScratchPool)
+            { try { kv.Value?.Dispose(); } catch { } }
+        _actionScratchPool.Clear();
+        _currentScratchAction = -1;
+        _currentScratchLocal = 0;
+    }
+
     // Set during the resident step so the STATIC AllocateOutputBuffer can route transient allocs into this
     // engine's per-action pool. Plain static (one plan captures at a time on the single GPU; resident step is
     // single-threaded in practice). Set on EnterCompiledCapturePath, cleared when its depth returns to 0.
@@ -12163,9 +12178,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 if (gR is not null && iR is not null && gamR is not null && meanR is not null && varR is not null)
                 {
                     IGpuBuffer? invVarBuf = null;
+                    bool invVarPooled = false;
                     try
                     {
-                        invVarBuf = backend.AllocateBuffer(batchSize);
+                        // CAPTURE-DETERMINISM (#638): pool the invVar scratch by (action,local) during the resident step
+                        // so it is NOT a cuMemAllocAsync graph node (the 8 small ~32KB in-capture allocs). Pooled ⇒ do
+                        // NOT dispose (the pool owns + reuses it across steps/replays); unpooled (eager/eval) ⇒ dispose.
+                        invVarPooled = ScratchPoolingActive;
+                        invVarBuf = invVarPooled ? RentActionScratch(backend, batchSize) : backend.AllocateBuffer(batchSize);
                         if (invVarBuf is not null && invVarBuf.Handle != System.IntPtr.Zero)
                         {
                             backend.AddScalar(varR, invVarBuf, (float)epsilon, batchSize); // var + eps
@@ -12191,7 +12211,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                         }
                     }
                     catch (Exception ex) { AliasDiag($"LayerNormBackward-resident FELLBACK: {ex.GetType().Name}: {ex.Message}"); }
-                    finally { invVarBuf?.Dispose(); }
+                    finally { if (!invVarPooled) invVarBuf?.Dispose(); }
                 }
             }
 
@@ -17947,8 +17967,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                             outBuf = e.Buffer;
                 if (outBuf is null)
                 {
-                    outBuf = backend.AllocateBuffer(output.Length);
-                    if (arr is not null) CacheActivation(arr, outBuf, output._shape, backend);
+                    // CAPTURE-DETERMINISM (#638): inside a compiled action during the resident step, draw the permute
+                    // output from the per-action scratch pool — a stable address by (action,local) → NO cuMemAllocAsync
+                    // graph node → no AUTO_FREE_ON_LAUNCH realloc nondeterminism. This was the DOMINANT residual: ~50 of
+                    // 58 in-capture allocs funneled here (TensorPermute←PermuteBackward/MatMulBackward, and
+                    // ReduceAxisGpu←ReduceSum←SumToShape/ReduceGradToShape), each a fresh AllocateBuffer because the
+                    // backward intermediate's backing array is null (CacheActivation skipped) → cache miss every pass.
+                    // Pooled buffers are first-rented in the pre-residency pass (outside capture); the capture pass hits
+                    // the pool (no alloc). Do NOT CacheActivation when pooled (its per-step bookkeeping perturbs the
+                    // captured graph — matches GetOrCreateResidentBuffer's resident-miss path).
+                    if (ScratchPoolingActive)
+                        outBuf = RentActionScratch(backend, output.Length);
+                    else
+                    {
+                        outBuf = backend.AllocateBuffer(output.Length);
+                        if (arr is not null) CacheActivation(arr, outBuf, output._shape, backend);
+                    }
                 }
                 backend.Permute(bufIn.Buffer, outBuf, tensor.Shape._dims, axes);
                 ResidentSyncCheck("Permute");

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -339,6 +339,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal IDisposable EnterCompiledCapturePath()
     {
         System.Threading.Interlocked.Increment(ref _capturePathDepth);
+        s_residentScratchEngine = this;   // route the static AllocateOutputBuffer's transient allocs here
         return new CapturePathScope(this);
     }
 
@@ -349,7 +350,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         public void Dispose()
         {
             var e = System.Threading.Interlocked.Exchange(ref _e, null);
-            if (e is not null) System.Threading.Interlocked.Decrement(ref e._capturePathDepth);
+            if (e is not null && System.Threading.Interlocked.Decrement(ref e._capturePathDepth) == 0)
+            {
+                e._currentScratchAction = -1;
+                if (ReferenceEquals(s_residentScratchEngine, e)) s_residentScratchEngine = null;
+            }
         }
     }
 
@@ -2070,6 +2075,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int removeCount = entries.Length / 2;
         if (removeCount == 0) return toDispose;
 
+        // #226 ROBUST FIX: drain THIS THREAD's pending deferred downloads before freeing ANY buffer. The
+        // per-entry `IsPending(entries[i].Key)` guard below only catches a materializer registered under the
+        // SAME object as the cache key — but BindResidentBuffer registers its download keyed by the tensor's
+        // BACKING ARRAY while the activation cache may key the same logical tensor by its DataVector (or vice
+        // versa). A buffer whose pending download is keyed differently than its cache entry then gets freed
+        // here, and the later materialize hits a released buffer → "GPU buffer released before its deferred
+        // download (#226)" (seen on eager d384/L4+). MaterializeAll is thread-scoped (only this thread's
+        // pending, so it never touches another tape-thread's in-flight buffer) and idempotent; after it runs
+        // no buffer we are about to free can have an outstanding download, regardless of its key. Eviction
+        // only fires under real VRAM pressure (the count cap is huge), so this broader drain is rare, not
+        // per-step. Not reached during capture (eviction is suspended while the stream is capturing).
+        Helpers.DeferredArrayMaterializer.MaterializeAll(swallowErrors: true);
+
         // Find threshold using Array.Sort on timestamps (avoids LINQ allocation)
         var timestamps = new long[entries.Length];
         for (int i = 0; i < entries.Length; i++)
@@ -2347,8 +2365,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // current weights and caches them. The offload-pointer path (GpuPinned / GpuOffload) has
             // _gpuBuffer == null and owns its own device-pointer lifetime, so it is NOT version-tracked —
             // keep trusting it unconditionally.
+            //
+            // EXCEPTION — the resident/captured training step (#638): during ResidentStepActive the DEVICE
+            // buffer is authoritative, not the host array. On-device Adam updates the resident weight buffer
+            // IN PLACE and bumps the host Version WITHOUT refreshing _gpuBufferVersion, so the version-gate
+            // would (a) falsely judge the fresh device buffer "stale" and re-upload the now-OLD host array
+            // over it (a correctness regression for on-device training) and (b) issue a cuStreamSynchronize
+            // re-upload that is illegal inside CUDA-graph capture (CUDA-900 → capture aborts → eager
+            // fallback, losing the 1.8× whole-step capture). So in the resident step trust the device buffer
+            // unconditionally; the #649 stale-weight gate still guards the eager/eval inference path.
             bool versionTracked = weights._gpuBuffer != null;
-            if (!versionTracked || weights._gpuBufferVersion == weights.Version)
+            if (ResidentStepActive || !versionTracked || weights._gpuBufferVersion == weights.Version)
                 return new OwnedBuffer(resident, ownsBuffer: false);
         }
         return GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role);
@@ -2435,6 +2462,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     private static OwnedBuffer AllocateOutputBuffer(IDirectGpuBackend backend, int size)
     {
+        // PR #638 capture-determinism: inside a compiled action during the resident step, draw from the engine's
+        // per-action static pool (stable address by (action,local) → no graph alloc node, no AUTO_FREE
+        // non-determinism). ownsBuffer:false so the caller's using/Dispose is a no-op on the pooled buffer.
+        var eng = s_residentScratchEngine;
+        if (eng is not null && eng.ScratchPoolingActive)
+            return new OwnedBuffer(eng.RentActionScratchOrAllocate(backend, size), ownsBuffer: false);
         return new OwnedBuffer(backend.AllocateBuffer(size), ownsBuffer: true);
     }
 
@@ -3813,6 +3846,57 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // Stable cached GPU buffer for a compiled-plan op OUTPUT: allocated ONCE and reused across steps (the
     // activation cache holds it alive while the step has eviction suspended), so capture/replay never cuMemAlloc
     // — a sync alloc inside a stream capture aborts it. Keyed by the destination's backing array.
+    // PR #638 capture-determinism: STATIC buffer assignment (the XLA/TensorRT/TVM industry approach — every op
+    // output gets a STABLE buffer keyed by its POSITION in the compiled graph, NOT by runtime call-order).
+    // The captured backward's intermediates are fresh tensors each step, so GetOrCreateResidentBuffer's caches
+    // MISS → it used to cuMemAllocAsync a new buffer each step → graph MEMORY NODES that AUTO_FREE_ON_LAUNCH
+    // reallocated non-deterministically each replay → grads came back zero/oscillating → frozen training. A
+    // global allocation-order index is too fragile (any variable-count alloc shifts every later buffer — it
+    // regressed when AllocateOutputBuffer was added). Key instead by (compiled-action index, local-alloc-index
+    // within that action): action i's allocs ALWAYS map to the same buffers regardless of what other actions
+    // do → robust + deterministic across the pre-residency pass, the capture pass, and every replay. The pool
+    // persists for the plan's life (the replayed graph bakes in these addresses). Pooling engages ONLY inside a
+    // compiled action (_currentScratchAction >= 0); the pre-pass (EnsureResidentBuffer) and the eager optimizer
+    // run with action = -1 → normal alloc, so the cached-once persistent buffers are never pooled.
+    private readonly System.Collections.Generic.Dictionary<long, IGpuBuffer> _actionScratchPool = new();
+    private int _currentScratchAction = -1;
+    private int _currentScratchLocal;
+
+    /// <summary>Mark the compiled action whose transient scratch allocs are pooled by (action, local) for
+    /// capture determinism. Call before each fwd/bwd action; pass -1 to disable (pre-pass / optimizer / eval).</summary>
+    internal void SetCurrentScratchAction(int action) { _currentScratchAction = action; _currentScratchLocal = 0; }
+
+    /// <summary>True while inside a compiled action whose transient scratch should draw from the static pool.</summary>
+    private bool ScratchPoolingActive => _currentScratchAction >= 0 && ResidentStepActive;
+
+    /// <summary>Pool a transient when inside a compiled action (stable buffer by (action,local)); else normal alloc.
+    /// Exposed for the static AllocateOutputBuffer routing.</summary>
+    internal IGpuBuffer RentActionScratchOrAllocate(IDirectGpuBackend backend, int length)
+        => ScratchPoolingActive ? RentActionScratch(backend, length) : backend.AllocateBuffer(length);
+
+    private IGpuBuffer RentActionScratch(IDirectGpuBackend backend, int length)
+    {
+        long key = ((long)_currentScratchAction << 32) | (uint)_currentScratchLocal++;
+        if (_actionScratchPool.TryGetValue(key, out var b) && b is not null
+            && b.Handle != System.IntPtr.Zero && b.Size >= length)
+        {
+            // Re-zero on reuse to preserve the alloc-zero invariant (accumulate / partial-write ops read it).
+            // Capturable cuMemsetD8Async on _stream (CudaBackend.MemsetBuffer); Fill/cuMemsetD32 aborts capture.
+            if (backend is DirectGpu.CUDA.CudaBackend cudaZ) cudaZ.MemsetBuffer(b, 0, (long)length * sizeof(float));
+            else backend.Fill(b, 0f, length);
+            return b;
+        }
+        if (b is not null) { try { b.Dispose(); } catch { } }
+        var nb = backend.AllocateBuffer(length);   // first pass at this (action,local): record the stable buffer
+        _actionScratchPool[key] = nb;
+        return nb;
+    }
+
+    // Set during the resident step so the STATIC AllocateOutputBuffer can route transient allocs into this
+    // engine's per-action pool. Plain static (one plan captures at a time on the single GPU; resident step is
+    // single-threaded in practice). Set on EnterCompiledCapturePath, cleared when its depth returns to 0.
+    private static DirectGpuTensorEngine? s_residentScratchEngine;
+
     private IGpuBuffer GetOrCreateResidentBuffer<T>(IDirectGpuBackend backend, Tensor<T> t, int length)
     {
         // PR #638 (CUDA-700 fix): the reused buffer MUST hold at least `length` elements. A pooled backing array
@@ -3835,6 +3919,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // re-cache (CacheActivation's TryAdd fails on an existing key and would keep the wrong-sized one).
             RemoveActivationCacheEntry(arr);
         }
+        // Resident/capture step: rent a deterministic stable scratch buffer (see RentResidentScratch). This is
+        // ONLY reached on a cache MISS (a fresh-array transient — the per-step backward intermediates), so it
+        // fires in the same order every step → the same device address each step/replay → capture-deterministic.
+        // Do NOT CacheActivation here: the cache's per-step bookkeeping during the resident step perturbs the
+        // captured graph (cuGraphLaunch fails). The caller binds the pooled buffer to `t` (BindResidentBuffer),
+        // so SAME-tensor consumers resolve it via t._gpuBuffer; the (action,local) key gives determinism.
+        if (ScratchPoolingActive)
+            return RentActionScratch(backend, length);
         var buf = backend.AllocateBuffer(length);
         if (arr is not null) CacheActivation(arr, buf, t._shape, backend);
         return buf;
@@ -19991,7 +20083,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     for (int i = 0; i < axis; i++) outerSize *= tensor.Shape._dims[i];
                     int reduceSize = tensor.Shape._dims[axis];
                     var gi = UploadTensorRaw(b, tensor);
-                    var go = b.AllocateBuffer(outerSize);
+                    var go = RentActionScratchOrAllocate(b, outerSize);
                     b.SumAxis(gi, go, outerSize, reduceSize);
                     int[] outShape;
                     if (keepDims)
@@ -20036,7 +20128,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     for (int i = 0; i < axis; i++) outerSize *= input.Shape._dims[i];
                     int reduceSize = input.Shape._dims[axis];
                     var gi = UploadTensorRaw(b, input);
-                    var go = b.AllocateBuffer(outerSize);
+                    var go = RentActionScratchOrAllocate(b, outerSize);
                     b.MeanAxis(gi, go, outerSize, reduceSize);
                     int[] outShape;
                     if (keepDims)


### PR DESCRIPTION
## What
Forward-ports the cortex CUDA-graph **whole-step capture training** correctness fixes onto current main (these fixes lived only on a stale local branch).

With `AIDOTNET_CUDA_GRAPH_STEP=1` the captured training step replayed but produced **non-deterministic / zero gradients** -> loss frozen at `ln(V)`. Three root causes, three fixes:

1. **Within-step grad race.** The captured backward writes some gradients on BLAS **lease streams** (not `_stream`); the *eager* grad-clip/optimizer then read them before they finished -> partially-written (often zero) grads -> grad oscillation + training plateau. **Fix:** device-wide `cuCtxSynchronize` after `cuGraphLaunch`. The capture win is launch-overhead collapse, not cross-step overlap, and a step must finish before the next anyway, so the per-step barrier is ~free while making grads deterministic.

2. **Transient graph-alloc nondeterminism.** Backward ops allocated `cuMemAllocAsync` scratch *during* capture -> graph MEMORY NODES that `AUTO_FREE_ON_LAUNCH` reallocated each replay -> non-deterministic reads. **Fix:** an **action-keyed deterministic scratch pool** (XLA / TensorRT-style position-keyed buffer assignment), keyed by `(compiled-action-index, local-index)`; pre-pass + optimizer run unpooled so persistent buffers never pool.

3. **LN resident-weight false-stale.** `#649`'s weight version-gate re-uploaded a weight mid-capture during the on-device-Adam resident step -> CUDA-900. **Fix:** trust the resident weight buffer when `ResidentStepActive` (keeps `#649`'s gate for eager/eval).

## Verification
HarmonicEngine cortex, `d64/L2/8000/3ep`, capture vs eager **off the packaged build**:
- capture **FULLY ENGAGED** (0 in-capture violations), `eagerFallback=False`, **0 CUDA-700**
- held-out `LAMBADA-CAND-RANK` **byte-identical to eager**: recall 70.7% / C 2.50% / M 1.07% / hybrid 2.14%

Requires `AIDOTNET_RESIDENT_INPLACE=1`. Diagnostic probes (`AIDOTNET_OPT_DIAG`) are env-gated (zero-cost off).

## Diff
3 files, +162/-6: `CudaBackend.Graph.cs` (barrier), `DirectGpuTensorEngine.cs` (scratch pool + LN gate), `CompiledTrainingPlan.cs` (scratch-action threading).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of compiled GPU training by making captured runs use consistent buffer allocation and replay behavior.
  * Fixed issues that could cause stale or zero gradients during optimizer steps and gradient clipping.
  * Added a synchronization step after captured graph launches to prevent race conditions with later operations.
  * Improved buffer cleanup so deferred downloads complete before memory is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->