### PR TITLE
perf(#1715): bound streaming-pool resident set on the GetParameters/register path (foundation-scale OOM)

### DIFF
--- a/docs/investigations/1715-streaming-register-path-oom.md
+++ b/docs/investigations/1715-streaming-register-path-oom.md
@@ -39,7 +39,12 @@ so the spill mechanism exists — the gap is that the **owner tensors' resident 
 dropped** on this path, so paging the pool's byte[] snapshots to disk doesn't help (the unfreed
 `_data` is the accumulator).
 
-## Proposed fix (Tensors)
+## Rejected hypothesis — deferred-drop finalization (DISPROVEN; see "MEASURED CORRECTION" below)
+> ⚠️ Historical context only. The deferred-drop path below was the initial hypothesis; the MEASURED
+> CORRECTION section proved the pool's snapshot eviction already works and that this path does **not**
+> make the round-trip tests green. Do not implement it — the confirmed fix is the mmap redesign
+> (`MemoryMappedWeightStore` + writable zero-copy alias). Kept for the investigation trail.
+
 Bound the resident set on the register-heavy materialization path by finalizing deferred drops as we
 go, so each layer's `_data` is freed once its snapshot is in the pool:
 1. After `RegisterWeight` defers a drop, attempt finalization opportunistically when the pool crosses
@@ -87,12 +92,14 @@ out* (~10 min for one pass; disk-bound). So the pool's snapshot eviction works; 
 hypothesis is **disproven**.
 
 **Write pass** (`chunk.Data.Span[i] = …`, exactly as `AssertParameterChunksRoundTrip`):
+
 | chunk | residentMB | evictions | diskWriteMB |
-|------|-----------|-----------|-------------|
-| 50  | 1489 | 0 | 0 |
+| --- | ---: | ---: | ---: |
+| 50 | 1489 | 0 | 0 |
 | 100 | 3361 | 0 | 0 |
 | 150 | 5090 | 0 | 0 |
-| 200 | 6746 | **0** | **0** |
+| 200 | 6746 | 0 | 0 |
+
 → **OOM ~chunk 230**, before the 8 GB snapshot-eviction trigger ever fires.
 
 ### The real mechanism

--- a/docs/investigations/1715-streaming-register-path-oom.md
+++ b/docs/investigations/1715-streaming-register-path-oom.md
@@ -1,0 +1,75 @@
+# #1715 — Streaming pool: GetParameters/register path doesn't bound resident set → foundation-scale OOM
+
+## Status
+**Investigation complete; code fix pending verification.** Root cause traced end-to-end through three
+layers. This doc is the hand-off so the fix can be implemented + verified with the (slow) two-repo loop.
+
+## Symptom (AiDotNet side)
+`UnitTests.Diffusion.Models` contract tests OOM under the 16 GB CI runner (issue #1715, shard
+`Unit - 03d`):
+- `Flux2Model_GetSetParameters_RoundTrips`
+- `FluxDoubleStreamPredictor_GetSetParameters_RoundTrips`
+- `SiTPredictor_GetSetParameters_RoundTrips`
+
+Measured (Flux2): **~6.5 billion params (~25 GB fp32)**; lazy ctor = 712 MB; enumerating
+`GetParameterChunks` OOMs. Peak working set stays ~6.9 GB (and drops to ~12 MB mid-run) yet it OOMs →
+**committed memory accumulates, not live working set**.
+
+## Root cause (Tensors side) — the three layers
+The AiDotNet `GetParameterChunks` path materializes every layer's lazy weights. Engaging weight
+streaming there (AiDotNet-side wiring, see below) moves the allocation from `RentPinned` to
+`WeightRegistry.AllocateStreaming`, and registering each materialized weight reaches
+`WeightRegistry.RegisterWeight`. The residual OOM is here:
+
+`WeightRegistry.RegisterWeight` (LinearAlgebra/WeightRegistry.cs ~228):
+```csharp
+bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
+weight.StreamingPoolHandle = handle;
+weight.StreamingDropDeferred = !dropped;          // <-- when refcount>1, _data is NOT freed
+```
+When the weight's storage refcount > 1 the resident `_data` drop is **deferred** (issue #430 path:
+lazy weights captured by the next op / a held reference). `TryFinalizeDeferredDrop` retries the drop
+later — the **forward path** runs it at end-of-step, but the **GetParameterChunks round-trip never
+triggers finalization**, so every layer's `_data` stays resident, the deferred-drop set grows to the
+full ~25 GB weight set, and the next `new byte[byteCount]` snapshot allocation in `RegisterWeight`
+OOMs even though `StreamingTensorPool` itself reports under its `ComputeResidentCapBytes` (8 GB) budget.
+
+The streaming pool DOES have a disk-backing store (`StreamingTensorPool._backingFile`, LRU page-out),
+so the spill mechanism exists — the gap is that the **owner tensors' resident `_data` is never
+dropped** on this path, so paging the pool's byte[] snapshots to disk doesn't help (the unfreed
+`_data` is the accumulator).
+
+## Proposed fix (Tensors)
+Bound the resident set on the register-heavy materialization path by finalizing deferred drops as we
+go, so each layer's `_data` is freed once its snapshot is in the pool:
+1. After `RegisterWeight` defers a drop, attempt finalization opportunistically when the pool crosses
+   budget (e.g. `EvictIfOverBudget` also runs `TryFinalizeDeferredDrop` over `_pendingDeferredDrops`),
+   OR
+2. Expose a `WeightRegistry.FinalizeDeferredDrops()` that the AiDotNet materialization path calls per
+   layer / per N layers.
+
+**Correctness gate (the round-trip is the oracle):** the test writes a ramp into each weight via
+`Tensor.Data.Span` then re-reads to verify. So a dropped+rehydrated weight must return the WRITTEN
+ramp — eviction of a dirty (mutated-since-snapshot) entry must write-back. `StreamingTensorPool` has
+clean/dirty eviction; confirm a raw `Data.Span` write marks the entry dirty (the `MarkDirty` hooks are
+on `Matrix`/`MatrixBase` mutators — a raw span write may bypass them). If it bypasses, mark the entry
+dirty on rehydrate-for-write, or the verify pass will read stale (pre-ramp) values.
+
+## AiDotNet-side wiring (already drafted, branch `fix/generated-am-modelbugs`, uncommitted)
+These are correct + necessary and move the OOM forward through the three layers; they need this Tensors
+fix to fully land:
+- `NoisePredictorBase.GetParameterChunks/SetParameterChunks` + `MMDiTNoisePredictor` overrides: call
+  `MaybeEngageWeightStreaming()` before materializing (engages streaming on the param path, not just
+  forward).
+- `LayerBase.EnsureParametersMaterialized`: call `RegisterStreamingWeightsWithPool()` after
+  `EnsureInitialized()` (the forward path does this via `EnsureInitializedFromInput`; the param path
+  skipped it, so nothing was registered for eviction).
+
+## Verify (two-repo loop)
+1. Build this Tensors branch → local nupkg.
+2. Bump the AiDotNet `fix/generated-am-modelbugs` branch to it.
+3. Run (CI repro env: `DOTNET_GCHeapHardLimit=0x400000000 DOTNET_gcServer=1`, serial):
+   `Flux2Model_GetSetParameters_RoundTrips`, `FluxDoubleStreamPredictor_…`, `SiTPredictor_…`.
+   Oracle = no OOM AND the ramp value-check passes (write-back correctness).
+4. Also re-run the `Step-Sync` (StepVideo) + `03b` (ControlNetFlux Clone) OOMs — same foundation-scale
+   full-materialization family; this fix likely helps them too.

--- a/docs/investigations/1715-streaming-register-path-oom.md
+++ b/docs/investigations/1715-streaming-register-path-oom.md
@@ -120,3 +120,31 @@ longer timeout / `HeavyTimeout` (matches #1709) — the #1715 footprint concern 
 
 This is the streaming path used by every >500M-param model's inference+training, so the accounting +
 write-back change must be made carefully and validated with the two-repo loop before merge.
+
+---
+
+## DEFINITIVE CONCLUSION — streaming round-trip is the wrong tool for these tests
+
+Pursuing the memory fix to the end surfaced three independent blockers that together mean
+`{Flux2,SiT,FluxDoubleStream}_GetSetParameters_RoundTrips` **cannot be made green by streaming** at
+their default foundation scale (Flux2 = 6.5 B params / ~31 GB):
+
+1. **Precision vs exact-equality.** The round-trip asserts `span[i] == expected` exactly. The
+   streaming store often uses **bf16** (`ResolveStoreEncoding` / `StreamingStoreDtype` policy), which
+   is lossy — a bf16 page-out → rehydrate returns a rounded value, so the exact assert fails *even
+   with perfect memory bounding + write-back*. Lossless-only streaming would avoid this but is not the
+   default and doesn't help the runtime blocker.
+2. **Runtime.** Even fully memory-bounded, the round-trip streams ~70 GB across 3 passes to/from disk
+   ≈ 30 min — far over the per-test timeout.
+3. **Invariant friction.** Write-back of a mutated entry re-writes a backing-file slice, which the
+   pool's append-only + zero-copy-mmap design assumes never happens — so a correct write-back needs to
+   coordinate with (or disable) those for the mutated-resident case.
+
+**Recommended resolution (matches the #1709 precedent):** treat these as foundation-scale contract
+tests that don't fit the 16 GB default gate — keep the AiDotNet read-path memory wiring (so
+construction/read don't OOM-crash) and exclude them from the default gate via `HeavyTimeout` (or have
+the test exercise the get/set *framing* without a full 31 GB exact-value round-trip). The general
+streaming improvement (owner-resident accounting + owner-side write-back, built on the
+`ReplaceEntryData` primitive added here) remains worthwhile for real training/inference on
+foundation-scale models, but it is a separate, multi-day, design-reviewed feature — NOT a fix that
+makes these exact-equality round-trip tests pass.

--- a/docs/investigations/1715-streaming-register-path-oom.md
+++ b/docs/investigations/1715-streaming-register-path-oom.md
@@ -73,3 +73,50 @@ fix to fully land:
    Oracle = no OOM AND the ramp value-check passes (write-back correctness).
 4. Also re-run the `Step-Sync` (StepVideo) + `03b` (ControlNetFlux Clone) OOMs — same foundation-scale
    full-materialization family; this fix likely helps them too.
+
+---
+
+## MEASURED CORRECTION (supersedes the deferred-drop hypothesis above)
+
+Instrumented `WeightRegistry.GetStreamingReport()` during enumeration (AiDotNet side, no Tensors
+rebuild — the engage+register wiring was enough to engage streaming on 0.104.6). Two probes:
+
+**Read pass** (enumerate + read `chunk.Length` only): resident pinned at the **8 GB cap**,
+evictions climb 0→519, 23.6 GB written to disk, reaches ~chunk 900 / ~31 GB. **No OOM** — it *times
+out* (~10 min for one pass; disk-bound). So the pool's snapshot eviction works; the deferred-drop
+hypothesis is **disproven**.
+
+**Write pass** (`chunk.Data.Span[i] = …`, exactly as `AssertParameterChunksRoundTrip`):
+| chunk | residentMB | evictions | diskWriteMB |
+|------|-----------|-----------|-------------|
+| 50  | 1489 | 0 | 0 |
+| 100 | 3361 | 0 | 0 |
+| 150 | 5090 | 0 | 0 |
+| 200 | 6746 | **0** | **0** |
+→ **OOM ~chunk 230**, before the 8 GB snapshot-eviction trigger ever fires.
+
+### The real mechanism
+`chunk.Data.Span` triggers `WeightRegistry.Materialize` → `RehydrateInto` returns a **caller-owned
+copy** that `RestoreStorageFromBytes` installs as the tensor's `_data`. That owner `_data` copy is
+**not counted in the pool's `_residentBytes`** (only the pool's own `entry.Data` snapshot is). The
+eviction trigger (`EvictIfOverBudget`, gated on `_residentBytes` ≥ cap) therefore never sees the
+owner copies — they accumulate one-per-written-chunk (held live by each layer's `_weights`) until the
+process OOMs, well before the snapshot budget is reached (evictions=0 at 6.7 GB resident).
+
+### The fix (real, load-bearing — streaming core)
+1. **Account owner-resident bytes.** When `Materialize` restores an owner's `_data`, the pool must
+   include that in the resident budget (or page out its own redundant `entry.Data` AND track the
+   owner copy) so `EvictIfOverBudget` fires and `_pendingOwnerDrops` / `DrainOwnerDropsAfterEviction`
+   sheds cold owners' `_data` under pressure — exactly the bounding the read path already gets.
+2. **Dirty write-back on owner-drop.** A test-written (mutated) owner copy is dirty vs the pool
+   snapshot; owner-drop must re-snapshot (write-back) before freeing `_data`, or the round-trip's
+   verify pass reads stale (pre-write) values. (`Span` writes likely bypass the `MarkDirty` hooks on
+   `Matrix`/`MatrixBase`, so dirty-tracking on the rehydrated-then-mutated path needs wiring.)
+
+### Plus: inherent speed
+Even fully memory-bounded, a 31 GB model round-trip streams ~70 GB across 3 passes ≈ 30 min →
+exceeds the per-test timeout. Once memory-safe, these foundation-scale contract tests warrant a
+longer timeout / `HeavyTimeout` (matches #1709) — the #1715 footprint concern is then satisfied.
+
+This is the streaming path used by every >500M-param model's inference+training, so the accounting +
+write-back change must be made carefully and validated with the two-repo loop before merge.

--- a/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
@@ -26,6 +26,13 @@ namespace AiDotNet.Tensors.LinearAlgebra;
 /// </remarks>
 internal sealed class MemoryMappedWeightStore : IDisposable
 {
+    // Slices are 64-byte aligned (cache-line) so adjacent writable aliases never share a cache line;
+    // the file capacity is page-aligned (4 KiB) so the OS maps whole pages; the default initial capacity
+    // is 64 MiB (sparse — costs no disk until written).
+    private const long SliceAlignmentBytes = 64;
+    private const long PageAlignmentBytes = 4096;
+    private const long DefaultInitialCapacityBytes = 64L * 1024 * 1024;
+
     private readonly object _lock = new();
     private readonly string _path;
     private FileStream _file;
@@ -49,32 +56,62 @@ internal sealed class MemoryMappedWeightStore : IDisposable
     /// stays valid across a store grow (the file only ever grows, never moves existing bytes).</summary>
     public string Path => _path;
 
-    public MemoryMappedWeightStore(string path, long initialCapacity = 64L * 1024 * 1024)
+    public MemoryMappedWeightStore(string path, long initialCapacity = DefaultInitialCapacityBytes)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
         if (initialCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(initialCapacity));
-        _capacity = AlignUp(Math.Max(initialCapacity, 4096), 4096);
+        _capacity = AlignUp(Math.Max(initialCapacity, PageAlignmentBytes), PageAlignmentBytes);
         // FileShare.ReadWrite so a slice can be writably aliased through an independent MAP_SHARED view
         // (the #1715 param-IO round-trip) concurrently with the store's own mapping. The two mappings
         // touch the same page-cache pages, so writes to disjoint byte ranges stay coherent.
-        _file = new FileStream(_path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
-        _file.SetLength(_capacity);
-        TryMarkSparse(_file);     // unwritten capacity costs no disk where supported (Linux: always; Windows: NTFS)
-        Map();
+        // Clean up the file + handle if any step after CreateNew throws (CreateViewAccessor /
+        // AcquirePointer on a recoverable failure) — the ctor never reaches Dispose() on throw, so a
+        // partially-created mapping + the backing temp file would otherwise leak.
+        try
+        {
+            _file = new FileStream(_path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
+            _file.SetLength(_capacity);
+            TryMarkSparse(_file); // unwritten capacity costs no disk where supported (Linux: always; Windows: NTFS)
+            Map();
+        }
+        catch
+        {
+            try { _file?.Dispose(); } catch { /* best-effort */ }
+            try { if (File.Exists(_path)) File.Delete(_path); } catch { /* best-effort */ }
+            throw;
+        }
     }
 
     private unsafe void Map()
     {
         // leaveOpen: true — we own _file and dispose it explicitly; the MMF must not close it
-        // so a later Grow can SetLength the same handle.
-        _mmf = MemoryMappedFile.CreateFromFile(
-            _file, mapName: null, _capacity, MemoryMappedFileAccess.ReadWrite,
-            HandleInheritability.None, leaveOpen: true);
-        _view = _mmf.CreateViewAccessor(0, _capacity, MemoryMappedFileAccess.ReadWrite);
+        // so a later Grow can SetLength the same handle. Build into locals and publish only after the
+        // pointer is acquired, so a throw from CreateViewAccessor / AcquirePointer disposes the partial
+        // MMF/view instead of leaking it (the ctor's catch deletes the file).
+        MemoryMappedFile? mmf = null;
+        MemoryMappedViewAccessor? view = null;
+        bool acquired = false;
         byte* p = null;
-        _view.SafeMemoryMappedViewHandle.AcquirePointer(ref p);
-        _base = p;
-        _pointerAcquired = true;
+        try
+        {
+            mmf = MemoryMappedFile.CreateFromFile(
+                _file, mapName: null, _capacity, MemoryMappedFileAccess.ReadWrite,
+                HandleInheritability.None, leaveOpen: true);
+            view = mmf.CreateViewAccessor(0, _capacity, MemoryMappedFileAccess.ReadWrite);
+            view.SafeMemoryMappedViewHandle.AcquirePointer(ref p);
+            acquired = true;
+            _mmf = mmf;
+            _view = view;
+            _base = p;
+            _pointerAcquired = true;
+        }
+        catch
+        {
+            if (acquired && view is not null) { try { view.SafeMemoryMappedViewHandle.ReleasePointer(); } catch { /* best-effort */ } }
+            view?.Dispose();
+            mmf?.Dispose();
+            throw;
+        }
     }
 
     private unsafe void Unmap()
@@ -98,7 +135,7 @@ internal sealed class MemoryMappedWeightStore : IDisposable
         lock (_lock)
         {
             ThrowIfDisposed();
-            long offset = AlignUp(_used, 64);
+            long offset = AlignUp(_used, SliceAlignmentBytes);
             long need = offset + data.Length;
             if (need > _capacity) Grow(need);
             data.CopyTo(new Span<byte>(_base + offset, data.Length));
@@ -115,9 +152,16 @@ internal sealed class MemoryMappedWeightStore : IDisposable
         lock (_lock)
         {
             ThrowIfDisposed();
-            if (offset < 0 || length < 0 || offset + length > _used)
+            // Validate offset first, then length against the remaining span — `offset + length` could
+            // overflow before the comparison and then `_base + offset` would form a span from a bad address.
+            if (offset < 0 || length < 0 || offset > _used || length > _used - offset)
+            {
+                long end = offset >= 0 && length >= 0 && offset <= long.MaxValue - length
+                    ? offset + length
+                    : long.MaxValue;
                 throw new ArgumentOutOfRangeException(nameof(offset),
-                    $"slice [{offset},{offset + length}) is outside the allocated region [0,{_used}).");
+                    $"slice [{offset},{end}) is outside the allocated region [0,{_used}).");
+            }
             return new Span<byte>(_base + offset, length);
         }
     }
@@ -126,7 +170,7 @@ internal sealed class MemoryMappedWeightStore : IDisposable
     {
         long newCap = _capacity;
         while (newCap < minCapacity) newCap = checked(newCap * 2);
-        newCap = AlignUp(newCap, 4096);
+        newCap = AlignUp(newCap, PageAlignmentBytes);
 
         // Tear the mapping down (flushing dirty pages to the file), grow the file, re-map. The
         // file bytes already written persist across SetLength, so offsets stay valid.

--- a/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
@@ -44,12 +44,20 @@ internal sealed class MemoryMappedWeightStore : IDisposable
     /// <summary>Current mapped file capacity in bytes (grows by doubling).</summary>
     public long Capacity { get { lock (_lock) { return _capacity; } } }
 
+    /// <summary>Backing file path — callers that writably-alias a slice (the #1715 param-IO path) open
+    /// their own independent MAP_SHARED view of this file at the slice's offset; an alias's mapping
+    /// stays valid across a store grow (the file only ever grows, never moves existing bytes).</summary>
+    public string Path => _path;
+
     public MemoryMappedWeightStore(string path, long initialCapacity = 64L * 1024 * 1024)
     {
         _path = path ?? throw new ArgumentNullException(nameof(path));
         if (initialCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(initialCapacity));
         _capacity = AlignUp(Math.Max(initialCapacity, 4096), 4096);
-        _file = new FileStream(_path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+        // FileShare.ReadWrite so a slice can be writably aliased through an independent MAP_SHARED view
+        // (the #1715 param-IO round-trip) concurrently with the store's own mapping. The two mappings
+        // touch the same page-cache pages, so writes to disjoint byte ranges stay coherent.
+        _file = new FileStream(_path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
         _file.SetLength(_capacity);
         TryMarkSparse(_file);     // unwritten capacity costs no disk where supported (Linux: always; Windows: NTFS)
         Map();

--- a/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MemoryMappedWeightStore.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.LinearAlgebra;
+
+/// <summary>
+/// Memory-mapped backing store for streamed weights (#1715 redesign). A single growable
+/// file is memory-mapped with a writable view; each weight is a 64-byte-aligned
+/// <c>(offset, length)</c> slice. The OS page cache provides residency, eviction, AND
+/// write-back FOR FREE — so unlike the hand-rolled streaming pool there is no resident-byte
+/// accounting, no LRU, no explicit page-out/rehydrate IO, and no write-back-before-drop
+/// (the bug class the bespoke pool needed). Under host memory pressure the OS flushes dirty
+/// slices to the file and reclaims their pages; the next access faults them back in with the
+/// mutations intact. This is exactly the model <c>torch.load(mmap=True)</c> / safetensors use
+/// for loading and offloading models that exceed RAM.
+/// </summary>
+/// <remarks>
+/// SPAN LIFETIME CONTRACT: <see cref="GetSpan"/> returns a span aliasing the live mapped
+/// region. A grow (triggered only by <see cref="Allocate"/> when capacity is exceeded)
+/// re-maps the file and moves the base pointer, invalidating any span obtained earlier. The
+/// streaming round-trip registers all weights (Allocate) before reading any back (GetSpan),
+/// so a grow never races a held span; callers that interleave must re-fetch the span after an
+/// Allocate. All public methods are serialized under an internal lock.
+/// </remarks>
+internal sealed class MemoryMappedWeightStore : IDisposable
+{
+    private readonly object _lock = new();
+    private readonly string _path;
+    private FileStream _file;
+    private MemoryMappedFile _mmf = null!;
+    private MemoryMappedViewAccessor _view = null!;
+    private unsafe byte* _base;
+    private bool _pointerAcquired;
+    private long _capacity;
+    private long _used;          // bump-allocation high-water mark
+    private bool _disposed;
+
+    /// <summary>Total bytes handed out by <see cref="Allocate"/> (the logical size; the file
+    /// capacity may be larger and is sparse where the OS supports it).</summary>
+    public long UsedBytes { get { lock (_lock) { return _used; } } }
+
+    /// <summary>Current mapped file capacity in bytes (grows by doubling).</summary>
+    public long Capacity { get { lock (_lock) { return _capacity; } } }
+
+    public MemoryMappedWeightStore(string path, long initialCapacity = 64L * 1024 * 1024)
+    {
+        _path = path ?? throw new ArgumentNullException(nameof(path));
+        if (initialCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+        _capacity = AlignUp(Math.Max(initialCapacity, 4096), 4096);
+        _file = new FileStream(_path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+        _file.SetLength(_capacity);
+        TryMarkSparse(_file);     // unwritten capacity costs no disk where supported (Linux: always; Windows: NTFS)
+        Map();
+    }
+
+    private unsafe void Map()
+    {
+        // leaveOpen: true — we own _file and dispose it explicitly; the MMF must not close it
+        // so a later Grow can SetLength the same handle.
+        _mmf = MemoryMappedFile.CreateFromFile(
+            _file, mapName: null, _capacity, MemoryMappedFileAccess.ReadWrite,
+            HandleInheritability.None, leaveOpen: true);
+        _view = _mmf.CreateViewAccessor(0, _capacity, MemoryMappedFileAccess.ReadWrite);
+        byte* p = null;
+        _view.SafeMemoryMappedViewHandle.AcquirePointer(ref p);
+        _base = p;
+        _pointerAcquired = true;
+    }
+
+    private unsafe void Unmap()
+    {
+        if (_pointerAcquired)
+        {
+            _view.SafeMemoryMappedViewHandle.ReleasePointer();
+            _pointerAcquired = false;
+        }
+        _view?.Flush();           // push dirty pages to the file before tearing the mapping down
+        _view?.Dispose();
+        _mmf?.Dispose();
+        _base = null;
+    }
+
+    /// <summary>Bump-allocate a 64-byte-aligned slice, copy <paramref name="data"/> into the
+    /// mapped region, and return the byte offset (the handle for <see cref="GetSpan"/>). Grows
+    /// the file (doubling) when the current capacity is exceeded.</summary>
+    public unsafe long Allocate(ReadOnlySpan<byte> data)
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            long offset = AlignUp(_used, 64);
+            long need = offset + data.Length;
+            if (need > _capacity) Grow(need);
+            data.CopyTo(new Span<byte>(_base + offset, data.Length));
+            _used = offset + data.Length;
+            return offset;
+        }
+    }
+
+    /// <summary>Returns a writable span over the slice at <paramref name="offset"/>. Reading
+    /// faults the pages in; writing through the span is preserved on the next read and flushed
+    /// to disk under memory pressure (MAP_SHARED semantics). See the span-lifetime contract.</summary>
+    public unsafe Span<byte> GetSpan(long offset, int length)
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (offset < 0 || length < 0 || offset + length > _used)
+                throw new ArgumentOutOfRangeException(nameof(offset),
+                    $"slice [{offset},{offset + length}) is outside the allocated region [0,{_used}).");
+            return new Span<byte>(_base + offset, length);
+        }
+    }
+
+    private unsafe void Grow(long minCapacity)
+    {
+        long newCap = _capacity;
+        while (newCap < minCapacity) newCap = checked(newCap * 2);
+        newCap = AlignUp(newCap, 4096);
+
+        // Tear the mapping down (flushing dirty pages to the file), grow the file, re-map. The
+        // file bytes already written persist across SetLength, so offsets stay valid.
+        Unmap();
+        _file.SetLength(newCap);
+        _capacity = newCap;
+        Map();
+    }
+
+    private static long AlignUp(long value, long alignment) => (value + (alignment - 1)) & ~(alignment - 1);
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(MemoryMappedWeightStore));
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try { Unmap(); } catch { /* best-effort teardown */ }
+            try { _file?.Dispose(); } catch { /* best-effort */ }
+            // Delete the backing file so a killed/long-running process doesn't leak tens of GB
+            // (the orphaned-backing-file failure mode observed with the bespoke pool).
+            try { if (File.Exists(_path)) File.Delete(_path); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>Best-effort sparse-file marking so unwritten capacity costs no disk. Linux/macOS
+    /// make truncated files sparse automatically; on Windows (NTFS) we must request it via
+    /// FSCTL_SET_SPARSE. Failure is non-fatal — the file is simply fully allocated.</summary>
+    private static void TryMarkSparse(FileStream file)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return; // POSIX truncate is already sparse
+        try
+        {
+            const uint FSCTL_SET_SPARSE = 0x000900C4;
+            DeviceIoControl(file.SafeFileHandle.DangerousGetHandle(), FSCTL_SET_SPARSE,
+                IntPtr.Zero, 0, IntPtr.Zero, 0, out _, IntPtr.Zero);
+        }
+        catch { /* sparse is an optimization, not a correctness requirement */ }
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeviceIoControl(
+        IntPtr hDevice, uint dwIoControlCode, IntPtr lpInBuffer, uint nInBufferSize,
+        IntPtr lpOutBuffer, uint nOutBufferSize, out uint lpBytesReturned, IntPtr lpOverlapped);
+}

--- a/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
@@ -68,7 +68,7 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
             // Hold the stream in a local: if CreateFromFile throws BEFORE it takes ownership (leaveOpen:
             // false transfers ownership only on success), the catch must dispose the stream itself —
             // otherwise the file handle leaks on a recoverable mapping failure.
-            stream = new System.IO.FileStream(path, System.IO.FileMode.Open, fileAccess, System.IO.FileShare.ReadWrite);
+            stream = new System.IO.FileStream(path, System.IO.FileMode.Open, fileAccess, System.IO.FileShare.ReadWrite | System.IO.FileShare.Delete);
             _mmf = MemoryMappedFile.CreateFromFile(
                 stream, mapName: null, capacity: 0,
                 mapAccess, HandleInheritability.None, leaveOpen: false);

--- a/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
@@ -58,16 +58,21 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
         // fallback a transient mapping failure would silently leak file
         // descriptors / view handles. Dispose what we've already opened
         // before rethrowing.
+        System.IO.FileStream? stream = null;
         try
         {
             // Read-only or read-write per `_writable`. The FileStream access must match the
             // mapping access (ReadWrite needs write permission on the file handle too).
             var fileAccess = _writable ? System.IO.FileAccess.ReadWrite : System.IO.FileAccess.Read;
             var mapAccess = _writable ? MemoryMappedFileAccess.ReadWrite : MemoryMappedFileAccess.Read;
+            // Hold the stream in a local: if CreateFromFile throws BEFORE it takes ownership (leaveOpen:
+            // false transfers ownership only on success), the catch must dispose the stream itself —
+            // otherwise the file handle leaks on a recoverable mapping failure.
+            stream = new System.IO.FileStream(path, System.IO.FileMode.Open, fileAccess, System.IO.FileShare.ReadWrite);
             _mmf = MemoryMappedFile.CreateFromFile(
-                new System.IO.FileStream(path, System.IO.FileMode.Open, fileAccess, System.IO.FileShare.ReadWrite),
-                mapName: null, capacity: 0,
+                stream, mapName: null, capacity: 0,
                 mapAccess, HandleInheritability.None, leaveOpen: false);
+            stream = null; // ownership transferred to _mmf (leaveOpen: false) — don't double-dispose
             _view = _mmf.CreateViewAccessor(byteOffset, byteLength, mapAccess);
             byte* p = null;
             _view.SafeMemoryMappedViewHandle.AcquirePointer(ref p);
@@ -78,6 +83,7 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
         }
         catch
         {
+            try { stream?.Dispose(); } catch { /* best-effort: CreateFromFile didn't take ownership */ }
             _view?.Dispose();
             _view = null;
             _mmf?.Dispose();

--- a/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/MmapTensorMemoryManager.cs
@@ -20,8 +20,12 @@ namespace AiDotNet.Tensors.LinearAlgebra;
 /// disposes it when it drops/replaces its storage, so the mapping lives exactly as long as
 /// the tensor aliases it.</para>
 ///
-/// <para>READ-ONLY: the view is mapped read-only, so this must only back weights that are
-/// not written while aliased (inference / forward-read). A write would fault.</para>
+/// <para>Read-only by default (inference / forward-read — a write would fault). Pass
+/// <c>writable: true</c> (#1715 param-IO round-trip) to map the slice <c>MemoryMappedFileAccess.ReadWrite</c>
+/// so writes through <see cref="GetSpan"/> hit the mapped pages and persist to the backing file
+/// (MAP_SHARED) — the OS flushes dirty pages under memory pressure and faults them back on the next
+/// read, with the mutation intact. A writable alias must back an all-mmap store (no concurrent
+/// FileStream writer on the same file) to stay page-cache-coherent.</para>
 /// </summary>
 internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
 {
@@ -30,15 +34,21 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
     private byte* _basePtr;            // start of the acquired view mapping (page-aligned)
     private readonly long _sliceByteOffset; // PointerOffset + the requested intra-view offset
     private readonly int _count;       // element count of T
+    private readonly bool _writable;
     private bool _disposed;
+
+    /// <summary>Whether this mapping is writable (writes persist) vs read-only (writes fault).</summary>
+    public bool IsWritable => _writable;
 
     /// <summary>
     /// Maps <paramref name="elementCount"/> elements of <typeparamref name="T"/> starting at
-    /// <paramref name="byteOffset"/> in the file at <paramref name="path"/>, read-only.
+    /// <paramref name="byteOffset"/> in the file at <paramref name="path"/>. Read-only unless
+    /// <paramref name="writable"/> is set, in which case writes persist to the file (MAP_SHARED).
     /// </summary>
-    public MmapTensorMemoryManager(string path, long byteOffset, int byteLength, int elementCount)
+    public MmapTensorMemoryManager(string path, long byteOffset, int byteLength, int elementCount, bool writable = false)
     {
         _count = elementCount;
+        _writable = writable;
         // Each step opens an additional handle on top of any prior one; if a
         // later step throws (e.g. CreateViewAccessor on a corrupt file,
         // AcquirePointer on an out-of-memory address space), the earlier
@@ -50,12 +60,15 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
         // before rethrowing.
         try
         {
-            // Open a read-only mapping. The owning FileStream must share read access.
+            // Read-only or read-write per `_writable`. The FileStream access must match the
+            // mapping access (ReadWrite needs write permission on the file handle too).
+            var fileAccess = _writable ? System.IO.FileAccess.ReadWrite : System.IO.FileAccess.Read;
+            var mapAccess = _writable ? MemoryMappedFileAccess.ReadWrite : MemoryMappedFileAccess.Read;
             _mmf = MemoryMappedFile.CreateFromFile(
-                new System.IO.FileStream(path, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite),
+                new System.IO.FileStream(path, System.IO.FileMode.Open, fileAccess, System.IO.FileShare.ReadWrite),
                 mapName: null, capacity: 0,
-                MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
-            _view = _mmf.CreateViewAccessor(byteOffset, byteLength, MemoryMappedFileAccess.Read);
+                mapAccess, HandleInheritability.None, leaveOpen: false);
+            _view = _mmf.CreateViewAccessor(byteOffset, byteLength, mapAccess);
             byte* p = null;
             _view.SafeMemoryMappedViewHandle.AcquirePointer(ref p);
             _basePtr = p;
@@ -99,6 +112,9 @@ internal sealed unsafe class MmapTensorMemoryManager<T> : MemoryManager<T>
         _disposed = true;
         if (_view is not null)
         {
+            // Push dirty pages to the file before tearing the mapping down so a writable
+            // alias's mutations are durable even if the OS hasn't flushed them yet.
+            if (_writable) { try { _view.Flush(); } catch { /* best-effort */ } }
             try { _view.SafeMemoryMappedViewHandle.ReleasePointer(); } catch { /* best-effort */ }
             _view.Dispose();
             _view = null;

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -144,6 +144,12 @@ public sealed class StreamingTensorPool : IDisposable
     /// triggering eviction.</summary>
     public long ResidentBytes => Interlocked.Read(ref _residentBytes);
 
+    /// <summary>The configured resident-byte budget (<see cref="GpuOffloadOptions.StreamingPoolMaxResidentBytes"/>).
+    /// Exposed so callers that hold their OWN resident copies of pool-registered weights (e.g. a
+    /// parameter round-trip that materializes many weights at once, #1715) can bound their concurrent
+    /// resident set against the same budget the pool uses for its byte[] snapshots.</summary>
+    public long MaxResidentBytes => _maxResidentBytes;
+
     /// <summary>Number of entries currently resident in the working set.
     /// Excludes entries that have been paged out to the backing store.</summary>
     public int ResidentEntryCount

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -282,6 +282,67 @@ public sealed class StreamingTensorPool : IDisposable
     }
 
     /// <summary>
+    /// Replaces an existing entry's bytes IN PLACE under the same handle and marks it
+    /// dirty so the next eviction re-writes the new bytes to the backing file. Used by
+    /// the write-back-on-owner-drop path (#1715): when a streaming weight's resident
+    /// owner copy was MUTATED (e.g. a GetParameters round-trip or an optimizer step
+    /// writes into the rehydrated tensor), the pool's snapshot + disk slice are stale.
+    /// Calling this with the owner's current bytes makes the entry resident again with
+    /// the fresh content, so dropping the owner's copy can't lose the mutation — a later
+    /// <see cref="Rehydrate(long)"/> reads the written value back. Re-accounts resident
+    /// bytes (the new buffer may differ in size from the old, e.g. variable-size lossless)
+    /// and re-runs the budget check so the freshly-resident bytes get paged back to disk
+    /// under pressure. No-op for an unknown handle.
+    /// </summary>
+    public void ReplaceEntryData(long handleId, byte[] newData)
+    {
+        if (newData is null) throw new ArgumentNullException(nameof(newData));
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (!_entries.TryGetValue(handleId, out var entry)) return;
+
+            long oldResident = entry.Data?.Length ?? 0;
+            entry.Data = newData;
+            entry.ResidentBytes = newData.Length;
+            // The new bytes have NOT been written to the backing file, so force the
+            // next eviction to (re-)write them rather than dropping the resident copy
+            // as if the file already held it. Also reset the compressed/uncompressed
+            // metadata: the caller supplies the canonical (native-encoded) bytes, so a
+            // prior compressed page-out's sizes no longer describe this content.
+            entry.BackingFileCurrent = false;
+            entry.IsCompressed = false;
+            entry.UncompressedBytes = newData.Length;
+
+            // Net resident delta: the new buffer replaces whatever was resident before
+            // (which is 0 when the entry was paged out). Keep _residentBytes exact so
+            // the budget check below — and every future one — stays correct.
+            long delta = newData.Length - oldResident;
+            if (delta != 0)
+            {
+                Interlocked.Add(ref _residentBytes, delta);
+                long peak = Interlocked.Read(ref _residentBytesPeak);
+                long current = Interlocked.Read(ref _residentBytes);
+                if (current > peak) Interlocked.Exchange(ref _residentBytesPeak, current);
+            }
+
+            // The entry is resident again — make sure it's in the LRU so eviction can
+            // page it back to disk (carrying the new bytes) under budget pressure.
+            if (!_lruIndex.TryGetValue(handleId, out var node))
+            {
+                node = _lruOrder.AddFirst(handleId);
+                _lruIndex[handleId] = node;
+            }
+            else
+            {
+                _lruOrder.Remove(node);
+                _lruOrder.AddFirst(node);
+            }
+            EvictIfOverBudget();
+        }
+    }
+
+    /// <summary>
     /// Supplies the repeating per-step handle access order so eviction can use
     /// Belady-optimal selection (evict the entry whose next use is furthest) instead
     /// of LRU. For a transformer this is forward layers 0..N then backward N..0 — a

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -328,6 +328,11 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         oldStorage.Release();
     }
 
+    /// <summary>True when this tensor's storage aliases a WRITABLE memory-mapped slice (#1715 param-IO):
+    /// the mapped file is the canonical storage (mutations persist), so WeightRegistry must not
+    /// re-materialize it from the pool nor drop it on ReleaseToPool.</summary>
+    internal bool IsWritableMmapAliased => _storage.IsWritableMmapped;
+
     /// <summary>
     /// Physical memory layout of this tensor's data. Default
     /// <see cref="TensorLayout.Nchw"/> (standard row-major). The

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -1617,7 +1617,9 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             ThrowIfSparse();
             ValidateIndices(indices);
             EnsureOwnedForWrite();
-            _data[GetFlatIndex(indices)] = value;
+            // Route through _storage so a read-only mmap alias throws rather than faulting on write
+            // (transparent for normal tensors — _storage wraps the same Vector as _data).
+            _storage.AsWritableSpan()[GetFlatIndex(indices)] = value;
             // Element-level CPU mutation: bump the version counter so cached
             // GPU buffers (DirectGpuTensorEngine activation cache,
             // _gpuBufferVersion) detect the change and re-upload. Public
@@ -1683,17 +1685,19 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             throw new ArgumentException($"Source array length ({source.Length}) must match tensor length ({Length}).");
         if (Length == 0) return;
         EnsureOwnedForWrite();
+        // Route through _storage so a read-only mmap alias throws (ThrowIfReadOnlyMapped) rather than
+        // faulting the mapped pages; transparent for normal tensors (_storage wraps the same Vector).
         if (IsContiguous && _storageOffset == 0 && _storage.Length == Length)
         {
-            source.AsSpan().CopyTo(_data.AsWritableSpan());
+            source.AsSpan().CopyTo(_storage.AsWritableSpan());
         }
         else if (IsContiguous)
         {
-            source.AsSpan().CopyTo(_data.AsWritableSpan().Slice(_storageOffset, Length));
+            source.AsSpan().CopyTo(_storage.AsWritableSpan().Slice(_storageOffset, Length));
         }
         else
         {
-            var dstData = _data.AsWritableSpan();
+            var dstData = _storage.AsWritableSpan();
             for (int i = 0; i < Length; i++)
                 dstData[FlatIndexToStorageIndex(i)] = source[i];
         }
@@ -1729,10 +1733,13 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         if (flatIndex < 0 || flatIndex >= Length)
             throw new ArgumentOutOfRangeException(nameof(flatIndex), "Flat index is out of range.");
         EnsureOwnedForWrite();
+        // Route through _storage so a read-only mmap alias throws rather than faulting on write
+        // (transparent for normal tensors — _storage wraps the same Vector as _data).
+        var writable = _storage.AsWritableSpan();
         if (IsContiguous)
-            _data[flatIndex + _storageOffset] = value;
+            writable[flatIndex + _storageOffset] = value;
         else
-            _data[FlatIndexToStorageIndex(flatIndex)] = value;
+            writable[FlatIndexToStorageIndex(flatIndex)] = value;
         // Element-level CPU mutation: bump the version counter so cached GPU
         // buffers (DirectGpuTensorEngine activation cache, _gpuBufferVersion)
         // detect the change and re-upload. Without this, the GPU snapshot is
@@ -1863,9 +1870,12 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         if (!IsContiguous)
             throw new InvalidOperationException(
                 "Cannot get a contiguous writable span from a non-contiguous tensor view. Call Contiguous() first.");
+        // Route through _storage (not _data) so a read-only mmap alias fails loud via
+        // ThrowIfReadOnlyMapped instead of faulting the mapped pages on write. _storage wraps the same
+        // Vector as _data, so this is transparent for normal tensors; a writable mmap alias is allowed.
         if (_storageOffset == 0 && _storage.Length == Length)
-            return _data.AsWritableSpan();
-        return _data.AsWritableSpan().Slice(_storageOffset, Length);
+            return _storage.AsWritableSpan();
+        return _storage.AsWritableSpan().Slice(_storageOffset, Length);
     }
 
     /// <summary>
@@ -2534,7 +2544,9 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         get
         {
             EnsureOwnedForWrite();
-            return _data.AsWritableSpan();
+            // Route through _storage so a read-only mmap alias throws rather than faulting on write
+            // (transparent for normal tensors — _storage wraps the same Vector as _data).
+            return _storage.AsWritableSpan();
         }
     }
 

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -28,6 +28,13 @@ internal interface IStreamingDroppable
     /// when the storage is still shared (refcount &gt; 1) — e.g. an autodiff
     /// tape capture during training — leaving the data resident for the peer.</summary>
     bool TryDropStorageForStreaming(bool throwOnSharedRefcount);
+
+    /// <summary>Re-serializes this tensor's CURRENT resident data into its streaming-pool entry
+    /// under the same handle, so a later drop + rehydrate returns the current (possibly mutated)
+    /// values rather than the stale snapshot taken at register time (#1715). Returns <c>false</c>
+    /// (no-op) when the weight isn't a resident, full-precision streaming weight. Call BEFORE
+    /// dropping a mutated streaming weight so the mutation is not lost.</summary>
+    bool TryWriteBackResidentForStreaming();
 }
 
 /// <summary>
@@ -535,6 +542,26 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         => TryDropStorageForStreaming(throwOnSharedRefcount);
 
     long IStreamingDroppable.StreamingPoolHandle => StreamingPoolHandle;
+
+    bool IStreamingDroppable.TryWriteBackResidentForStreaming() => TryWriteBackResidentForStreaming();
+
+    /// <summary>
+    /// Re-serializes this tensor's current resident data into its streaming-pool entry (#1715).
+    /// Native (full-precision) streaming weights only: a lossy store (bf16/int8/int4) is taken by
+    /// read-only inference and its owner is never mutated, so skip it; a non-resident / view / quant
+    /// tensor has nothing to write back. The new bytes overwrite the pool entry under the same handle
+    /// (marked dirty), so the next eviction persists them to disk and a later <c>Materialize</c>
+    /// rehydrates the mutation instead of the stale register-time snapshot.
+    /// </summary>
+    internal bool TryWriteBackResidentForStreaming()
+    {
+        if (StreamingPoolHandle < 0) return false;
+        if (StreamingStoreEncoding != StreamingEncoding.Native) return false;
+        if (DataVector.Length != Length) return false;            // already dropped / no-upcast quant
+        if (!IsContiguous || _storageOffset != 0 || IsView) return false;
+        // Streaming weights are concrete Tensor<T>; serialization needs the concrete type.
+        return this is Tensor<T> concrete && WeightRegistry.WriteBackResidentNative(concrete);
+    }
 
     /// <summary>
     /// Restores this tensor's data from a serialized byte buffer (produced

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -303,7 +303,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// <para>READ-ONLY: the mapping is read-only; the caller guarantees nothing writes to
     /// this tensor while aliased (inference / forward-read only). A write would fault.</para>
     /// </summary>
-    internal void AliasStorageFromMmap(Vector<T> aliased, IDisposable owner)
+    internal void AliasStorageFromMmap(Vector<T> aliased, IDisposable owner, bool writable = false)
     {
         if (aliased is null) throw new ArgumentNullException(nameof(aliased));
         if (owner is null) throw new ArgumentNullException(nameof(owner));
@@ -323,7 +323,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         var oldStorage = _storage;
         _data = aliased;
         var newStorage = new TensorStorage<T>(_data);
-        newStorage.AttachMmapOwner(owner); // attach BEFORE making the storage visible to anyone else
+        newStorage.AttachMmapOwner(owner, writable); // attach BEFORE making the storage visible to anyone else
         _storage = newStorage;
         oldStorage.Release();
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -31,7 +31,12 @@ internal sealed class TensorStorage<T>
     // write paths (AsWritableSpan / AsWritableMemory / GetDataArray) can
     // throw a clear error instead of faulting in the mapped pages.
     private IDisposable? _mmapOwner;
-    internal bool IsReadOnlyMapped => Volatile.Read(ref _mmapOwner) != null;
+    // Writable mmap aliases (#1715 param-IO round-trip) back a tensor whose mutations must persist
+    // to the mapped file (MAP_SHARED). Only READ-ONLY aliases gate the write paths — a writable
+    // alias's whole purpose is to be written. Set before _mmapOwner is published (the CAS below is
+    // the release barrier), so a reader that sees a non-null owner also sees the correct writability.
+    private bool _mmapWritable;
+    internal bool IsReadOnlyMapped => Volatile.Read(ref _mmapOwner) != null && !_mmapWritable;
 
     /// <summary>
     /// Attaches an IDisposable that will be disposed when this storage's
@@ -39,11 +44,15 @@ internal sealed class TensorStorage<T>
     /// alias to tie the lifetime of the underlying memory-mapped file to
     /// the lifetime of the shared storage (not the lifetime of any single
     /// tensor that holds a ref). Must be called BEFORE the alias is exposed
-    /// to other tensors.
+    /// to other tensors. <paramref name="writable"/> (#1715) marks a
+    /// read-WRITE mapping whose mutations persist — such aliases do NOT gate
+    /// the write paths (read-only aliases do, so writes fail loud rather than
+    /// faulting the mapped pages).
     /// </summary>
-    internal void AttachMmapOwner(IDisposable owner)
+    internal void AttachMmapOwner(IDisposable owner, bool writable = false)
     {
         if (owner is null) throw new ArgumentNullException(nameof(owner));
+        _mmapWritable = writable;
         if (Interlocked.CompareExchange(ref _mmapOwner, owner, null) != null)
             throw new InvalidOperationException(
                 "TensorStorage already has an attached mmap owner; replacing it would leak the prior mapping.");

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -30,18 +30,26 @@ internal sealed class TensorStorage<T>
     // TryClaimExclusive succeeds). Also exposes IsReadOnlyMapped so the
     // write paths (AsWritableSpan / AsWritableMemory / GetDataArray) can
     // throw a clear error instead of faulting in the mapped pages.
-    private IDisposable? _mmapOwner;
-    // Writable mmap aliases (#1715 param-IO round-trip) back a tensor whose mutations must persist
-    // to the mapped file (MAP_SHARED). Only READ-ONLY aliases gate the write paths — a writable
-    // alias's whole purpose is to be written. Set before _mmapOwner is published (the CAS below is
-    // the release barrier), so a reader that sees a non-null owner also sees the correct writability.
-    private bool _mmapWritable;
-    internal bool IsReadOnlyMapped => Volatile.Read(ref _mmapOwner) != null && !_mmapWritable;
+    // Owner + writability are published together as one immutable object so a reader that observes a
+    // non-null owner always sees the matching writability — and a failed AttachMmapOwner CAS can never
+    // leave the existing mapping reporting a new writability (#1715 param-IO writable aliases).
+    private sealed class MmapOwnerState : IDisposable
+    {
+        public MmapOwnerState(IDisposable owner, bool writable) { Owner = owner; Writable = writable; }
+        public IDisposable Owner { get; }
+        public bool Writable { get; }
+        public void Dispose() => Owner.Dispose();
+    }
+
+    private MmapOwnerState? _mmapOwner;
+    // Only READ-ONLY aliases gate the write paths (AsWritableSpan / AsWritableMemory / GetDataArray) —
+    // a writable alias (#1715) exists to be written, its mutations persist via MAP_SHARED.
+    internal bool IsReadOnlyMapped => Volatile.Read(ref _mmapOwner) is { Writable: false };
 
     /// <summary>True when this storage aliases a WRITABLE memory-mapped slice (#1715 param-IO): the
     /// mapped file is the weight's canonical storage (mutations persist via MAP_SHARED), so the registry
     /// must not re-materialize it from the pool (stale bytes) nor drop it on ReleaseToPool.</summary>
-    internal bool IsWritableMmapped => Volatile.Read(ref _mmapOwner) != null && _mmapWritable;
+    internal bool IsWritableMmapped => Volatile.Read(ref _mmapOwner) is { Writable: true };
 
     /// <summary>
     /// Attaches an IDisposable that will be disposed when this storage's
@@ -57,8 +65,9 @@ internal sealed class TensorStorage<T>
     internal void AttachMmapOwner(IDisposable owner, bool writable = false)
     {
         if (owner is null) throw new ArgumentNullException(nameof(owner));
-        _mmapWritable = writable;
-        if (Interlocked.CompareExchange(ref _mmapOwner, owner, null) != null)
+        // Publish owner + writability atomically: the new state object is fully constructed before the
+        // CAS, so a failed CAS (owner already present) leaves the existing state untouched.
+        if (Interlocked.CompareExchange(ref _mmapOwner, new MmapOwnerState(owner, writable), null) != null)
             throw new InvalidOperationException(
                 "TensorStorage already has an attached mmap owner; replacing it would leak the prior mapping.");
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -38,6 +38,11 @@ internal sealed class TensorStorage<T>
     private bool _mmapWritable;
     internal bool IsReadOnlyMapped => Volatile.Read(ref _mmapOwner) != null && !_mmapWritable;
 
+    /// <summary>True when this storage aliases a WRITABLE memory-mapped slice (#1715 param-IO): the
+    /// mapped file is the weight's canonical storage (mutations persist via MAP_SHARED), so the registry
+    /// must not re-materialize it from the pool (stale bytes) nor drop it on ReleaseToPool.</summary>
+    internal bool IsWritableMmapped => Volatile.Read(ref _mmapOwner) != null && _mmapWritable;
+
     /// <summary>
     /// Attaches an IDisposable that will be disposed when this storage's
     /// refcount finally reaches 0. Used by the streaming-pool zero-copy

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -67,9 +67,13 @@ internal sealed class TensorStorage<T>
         if (owner is null) throw new ArgumentNullException(nameof(owner));
         // Publish owner + writability atomically: the new state object is fully constructed before the
         // CAS, so a failed CAS (owner already present) leaves the existing state untouched.
-        if (Interlocked.CompareExchange(ref _mmapOwner, new MmapOwnerState(owner, writable), null) != null)
+        var newState = new MmapOwnerState(owner, writable);
+        if (Interlocked.CompareExchange(ref _mmapOwner, newState, null) != null)
+        {
+            newState.Dispose();
             throw new InvalidOperationException(
                 "TensorStorage already has an attached mmap owner; replacing it would leak the prior mapping.");
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -667,6 +667,54 @@ public static class WeightRegistry
         }
     }
 
+    // #1715 param-IO writable mmap store: one growable memory-mapped file holding the writable slices
+    // that training/param-IO weights alias instead of materializing resident copies. Lazily created;
+    // disposed (file deleted) on Reset. Process-global like the streaming pool.
+    private static MemoryMappedWeightStore? _paramIoStore;
+
+    private static MemoryMappedWeightStore ParamIoStore()
+        => _paramIoStore ??= new MemoryMappedWeightStore(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "aidotnet-paramio-" + System.Guid.NewGuid().ToString("N") + ".bin"));
+
+    /// <summary>
+    /// #1715 writable zero-copy: copy <paramref name="weight"/>'s current bytes once into the param-IO
+    /// mmap store and alias its storage to that writable slice (MAP_SHARED) so mutations persist with no
+    /// resident copy and the OS pages the slice. Returns false (caller falls back to the copy path) when
+    /// the bytes aren't the tensor's native element layout or the mapping can't be opened. The store slice
+    /// becomes the weight's canonical storage — <see cref="Materialize{T}"/> / <see cref="ReleaseToPool{T}"/>
+    /// then no-op on it via <c>IsWritableMmapAliased</c>.
+    /// </summary>
+    private static bool TryAliasZeroCopyWritable<T>(Tensor<T> weight, StreamingTensorPool pool)
+    {
+        int elemSize = NativeStreamingElementSize<T>();
+        if (elemSize <= 0) return false;
+        long byteLen = (long)weight.Length * elemSize;
+        if (byteLen <= 0 || byteLen > int.MaxValue) return false;
+
+        MmapTensorMemoryManager<T>? manager = null;
+        try
+        {
+            // Current bytes from the pool (native, uncompressed). A scale prefix / compression makes the
+            // length mismatch — not aliasable, fall back to the copy path.
+            byte[] bytes = pool.RehydrateInto(weight.StreamingPoolHandle);
+            if (bytes.Length != (int)byteLen) return false;
+
+            var store = ParamIoStore();
+            long offset = store.Allocate(bytes); // Allocate is internally locked (+ grows the single file)
+            manager = new MmapTensorMemoryManager<T>(store.Path, offset, (int)byteLen, weight.Length, writable: true);
+            var aliased = Vector<T>.WrapMemory(manager.Memory);
+            weight.AliasStorageFromMmap(aliased, manager, writable: true); // tensor's storage owns the mapping
+            return true;
+        }
+        catch
+        {
+            // Any failure (length mismatch handled above; mapping open / address-space failure here) →
+            // dispose the half-built mapping and fall back to the proven copy path.
+            ((IDisposable?)manager)?.Dispose();
+            return false;
+        }
+    }
+
     /// <summary>Byte size of one native element of <typeparamref name="T"/> for the
     /// zero-copy path, or 0 for unsupported types. Matches the native (encoding 0)
     /// branch of <c>SerializeToBytes</c>/<c>RestoreStorageFromBytes</c>.</summary>
@@ -1006,6 +1054,10 @@ public static class WeightRegistry
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (weight.Lifetime != WeightLifetime.Streaming) return;
         if (weight.StreamingPoolHandle < 0) return;
+        // #1715: a writable mmap alias is the weight's canonical storage (mutations persist through the
+        // mapping). Re-materializing from the pool would read stale bytes, and the shed path would drop
+        // the alias and lose the mutation — so the weight is already materialized. Nothing to do.
+        if (weight.IsWritableMmapAliased) return;
         // A no-upcast int8/int4 weight is already materialized (as quantized + scales), even though
         // its fp _data is empty — treat it as resident so we don't re-fetch + re-attach each call.
         if (weight.DataVector.Length == weight.Length || weight.StreamingInt8 is not null || weight.StreamingInt4 is not null)
@@ -1081,6 +1133,21 @@ public static class WeightRegistry
         {
             // The pool entry stays "paged out" (the OS page cache holds the bytes now), so
             // there are no new owner-drops to drain from this path.
+            return;
+        }
+
+        // #1715 WRITABLE zero-copy fast path: in TRAINING / param-IO mode the read-only alias above can't
+        // be used (a weight update would fault), so foundation models fall to the copy path below and
+        // materialize the whole weight set as resident arrays → the GetParameters round-trip OOMs. Instead,
+        // copy the weight's bytes once into the param-IO mmap store and alias its storage to that slice
+        // WRITABLY: mutations persist (MAP_SHARED) and the OS pages the slice, so no resident copy is held.
+        // Gated to native encoding (bf16/int8/lossless need a decode = copy). The store slice becomes the
+        // weight's canonical storage, so the early IsWritableMmapAliased guard makes re-materialize a no-op
+        // and ReleaseToPool leaves it intact.
+        if (zeroCopyEnabled && !inferenceMode && weight.StreamingStoreEncoding == StreamingEncoding.Native
+            && NativeStreamingElementSize<T>() > 0
+            && TryAliasZeroCopyWritable(weight, pool))
+        {
             return;
         }
 
@@ -1225,6 +1292,10 @@ public static class WeightRegistry
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (weight.Lifetime != WeightLifetime.Streaming) return;
         if (weight.StreamingPoolHandle < 0) return;
+        // #1715: a writable mmap alias IS the offloaded form — its bytes live in the param-IO store
+        // (OS-paged), not on the GC heap. Dropping the storage would discard the mapping (and the
+        // mutated bytes) and a re-materialize would read stale pool bytes. Nothing to release.
+        if (weight.IsWritableMmapAliased) return;
         if (weight.DataVector.Length == 0) return; // already released
         // Soft-defer drop — mirrors the RegisterWeight #430 fix. A streaming
         // weight's storage can be SHARED (refcount > 1) at release time when a
@@ -1847,6 +1918,11 @@ public static class WeightRegistry
         {
             _streamingPool?.Dispose();
             _streamingPool = null;
+            // #1715: dispose the param-IO mmap store (deletes its backing file). Weights still aliasing
+            // its slices keep their own MAP_SHARED view alive (the alias owns an independent mapping), so
+            // disposing the store here only releases the registry's handle, not the live aliases' mappings.
+            _paramIoStore?.Dispose();
+            _paramIoStore = null;
             _offloadAllocator?.Dispose();
             _offloadAllocator = null;
             _ownerByHandle.Clear();

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -36,6 +36,18 @@ public static class WeightRegistry
     // drain. Written/read under _lock.
     private static readonly Dictionary<long, WeakReference<IStreamingDroppable>> _ownerByHandle = new();
 
+    // #1715: bound the set of streaming weights whose OWNER tensors hold resident _data at once.
+    // Materialize hands each weight a private resident copy; the pool only accounts ITS OWN byte[]
+    // snapshots, so without this a caller that materializes many weights and holds them (a
+    // GetParameters round-trip / Clone over a foundation-scale model) accumulates unbounded owner
+    // copies → OOM before the pool's snapshot-budget eviction ever fires. We track materialized
+    // owners in an LRU and, once their bytes exceed the budget, shed the coldest: write its current
+    // (possibly mutated) data back to the pool, then drop its resident copy. All under _lock.
+    private static readonly LinkedList<long> _materializedLru = new();           // MRU at front
+    private static readonly Dictionary<long, LinkedListNode<long>> _materializedNode = new();
+    private static readonly Dictionary<long, long> _materializedBytes = new();   // handle → owner-resident bytes
+    private static long _materializedResidentBytes;
+
     /// <summary>Replaces the active options; must be called before any
     /// <see cref="WeightLifetime.Streaming"/> / GpuOffload registration.
     /// Throws <see cref="InvalidOperationException"/> when the existing pool
@@ -552,6 +564,7 @@ public static class WeightRegistry
             {
                 _streamingPool?.Unregister(weight.StreamingPoolHandle);
                 _ownerByHandle.Remove(weight.StreamingPoolHandle);
+                UntrackMaterializedOwner(weight.StreamingPoolHandle); // #1715
                 weight.StreamingPoolHandle = -1;
             }
             if (weight.OffloadDevicePointer != IntPtr.Zero || weight.OffloadHostPointer != IntPtr.Zero)
@@ -1017,6 +1030,11 @@ public static class WeightRegistry
             // (a late RegisterWeight, or a background prefetch) since the last
             // drain, so their owners' resident _data doesn't linger.
             DrainOwnerDropsAfterEviction();
+            // #1715: a still-resident owner re-accessed here is hot — refresh its position in the
+            // materialized-owner LRU (and register it if a non-Materialize path made it resident) so
+            // it isn't shed while in use. Skip no-upcast quant (its fp _data is empty, not a copy).
+            if (weight.DataVector.Length == weight.Length)
+                NoteMaterializedAndShed(weight.StreamingPoolHandle, CheckedStreamingByteCount<T>(weight.Length));
             return;
         }
 
@@ -1094,6 +1112,105 @@ public static class WeightRegistry
         // resident set stays bounded (the just-materialized weight is protected
         // from eviction by RehydrateInto, so it's never in the drained set).
         DrainOwnerDropsAfterEviction();
+
+        // #1715: this weight now holds a resident owner copy. Track it and shed the coldest
+        // materialized owners if the concurrently-held owner set exceeds the budget — bounding the
+        // resident set for a caller (parameter round-trip / Clone) that materializes many weights and
+        // holds them all, which would otherwise OOM (the pool only accounts its own snapshots).
+        NoteMaterializedAndShed(weight.StreamingPoolHandle, CheckedStreamingByteCount<T>(weight.Length));
+    }
+
+    /// <summary>
+    /// Re-serializes a resident, native-encoded streaming weight's CURRENT data into its pool entry
+    /// under the same handle (#1715). Called by <see cref="Tensor{T}.TryWriteBackResidentForStreaming"/>
+    /// before a mutated weight is dropped, so the mutation reaches disk and a later
+    /// <see cref="Materialize{T}"/> rehydrates it rather than the stale register-time snapshot.
+    /// </summary>
+    internal static bool WriteBackResidentNative<T>(Tensor<T> weight)
+    {
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        if (weight.StreamingPoolHandle < 0) return false;
+        if (weight.DataVector.Length != weight.Length) return false;
+        int byteCount = CheckedStreamingByteCount<T>(weight.Length);
+        var bytes = new byte[byteCount];
+        SerializeToBytes(weight, bytes, StreamingEncoding.Native, stochastic: false);
+        StreamingTensorPool pool;
+        lock (_lock) { pool = StreamingPoolUnlocked(); }
+        pool.ReplaceEntryData(weight.StreamingPoolHandle, bytes);
+        return true;
+    }
+
+    // #1715: budget for concurrently-materialized owner copies. Half the pool's resident cap so the
+    // owner copies + the pool's own snapshot working set stay comfortably under the total budget the
+    // streaming model was sized against. Zero/absent cap → no bounding (degrades to prior behavior).
+    private static long MaterializedOwnerBudget()
+    {
+        long cap;
+        lock (_lock) { cap = StreamingPoolUnlocked().MaxResidentBytes; }
+        return cap > 0 ? cap / 2 : long.MaxValue;
+    }
+
+    private static void NoteMaterializedAndShed(long handle, long ownerBytes)
+    {
+        if (handle < 0 || ownerBytes <= 0) return;
+        long budget = MaterializedOwnerBudget();
+
+        lock (_lock)
+        {
+            // Add or move-to-front (MRU).
+            if (_materializedNode.TryGetValue(handle, out var existing))
+            {
+                _materializedLru.Remove(existing);
+                _materializedLru.AddFirst(existing);
+            }
+            else
+            {
+                var node = _materializedLru.AddFirst(handle);
+                _materializedNode[handle] = node;
+                _materializedBytes[handle] = ownerBytes;
+                _materializedResidentBytes += ownerBytes;
+            }
+
+            // Shed the coldest materialized owners until back under budget. Keep at least the
+            // just-added MRU entry resident (the caller is using it right now).
+            while (_materializedResidentBytes > budget && _materializedLru.Count > 1)
+            {
+                var tail = _materializedLru.Last;
+                if (tail is null) break;
+                long victim = tail.Value;
+                _materializedLru.RemoveLast();
+                _materializedNode.Remove(victim);
+                _materializedBytes.TryGetValue(victim, out long victimBytes);
+                _materializedBytes.Remove(victim);
+                _materializedResidentBytes -= victimBytes;
+
+                // Resolve the owner OUTSIDE the eventual drop's heavy work but still under _lock —
+                // the owner-drop + write-back only touch the tensor + pool, not the registry maps.
+                if (_ownerByHandle.TryGetValue(victim, out var weak) && weak.TryGetTarget(out var owner))
+                {
+                    // Persist the (possibly mutated) data, then drop the resident copy. Order matters:
+                    // write-back FIRST so the dropped bytes are recoverable from the pool/disk.
+                    try { owner.TryWriteBackResidentForStreaming(); }
+                    catch { /* best-effort: a non-native/aliased owner just stays resident */ }
+                    try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
+                    catch { /* shared refcount → leave resident; bounding is best-effort, never corrupting */ }
+                }
+            }
+        }
+    }
+
+    // #1715: stop tracking a handle as a materialized owner (it was released / unregistered).
+    private static void UntrackMaterializedOwner(long handle)
+    {
+        if (handle < 0) return;
+        if (_materializedNode.TryGetValue(handle, out var node))
+        {
+            _materializedLru.Remove(node);
+            _materializedNode.Remove(handle);
+            _materializedBytes.TryGetValue(handle, out long bytes);
+            _materializedBytes.Remove(handle);
+            _materializedResidentBytes -= bytes;
+        }
     }
 
     /// <summary>
@@ -1127,6 +1244,9 @@ public static class WeightRegistry
         // residency, never correctness.
         bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
         weight.StreamingDropDeferred = !dropped;
+        // #1715: the owner copy is gone — stop counting it against the materialized-owner budget.
+        if (dropped)
+            lock (_lock) { UntrackMaterializedOwner(weight.StreamingPoolHandle); }
     }
 
     /// <summary>
@@ -1730,6 +1850,11 @@ public static class WeightRegistry
             _offloadAllocator?.Dispose();
             _offloadAllocator = null;
             _ownerByHandle.Clear();
+            // #1715: reset the materialized-owner tracker with the pool.
+            _materializedLru.Clear();
+            _materializedNode.Clear();
+            _materializedBytes.Clear();
+            _materializedResidentBytes = 0;
             // Drop any straggler in-flight markers (a worker that timed out the
             // drain above). Leaving them would suppress the NEXT pool's prefetch
             // of a reused handle id (dedup sees it as "already in-flight").
@@ -1795,6 +1920,13 @@ public static class WeightRegistry
             // storage, which a registered weight never is — guarded anyway.
             if (owner is not null && owner.StreamingPoolHandle == handle)
             {
+                // #1715: the pool just paged out this handle's snapshot taken at register time. If the
+                // owner MUTATED its resident copy since (a GetParameters round-trip / optimizer step),
+                // that snapshot is stale — write the owner's CURRENT bytes back BEFORE dropping so a
+                // later Materialize rehydrates the mutation, not the stale value. Native-gated inside
+                // TryWriteBackResidentForStreaming, so read-only inference (bf16/quant store) is a no-op.
+                try { owner.TryWriteBackResidentForStreaming(); }
+                catch { /* best-effort write-back; never block the drop */ }
                 try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
                 catch (InvalidOperationException) { /* not droppable (view/non-contiguous) — leave resident */ }
             }

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -695,15 +695,22 @@ public static class WeightRegistry
         try
         {
             // Current bytes from the pool (native, uncompressed). A scale prefix / compression makes the
-            // length mismatch — not aliasable, fall back to the copy path.
+            // length mismatch — not aliasable, fall back to the copy path. RehydrateInto takes the pool's
+            // own lock; keep it OUTSIDE _lock to preserve the pool-lock-then-registry-lock-free ordering.
             byte[] bytes = pool.RehydrateInto(weight.StreamingPoolHandle);
             if (bytes.Length != (int)byteLen) return false;
 
-            var store = ParamIoStore();
-            long offset = store.Allocate(bytes); // Allocate is internally locked (+ grows the single file)
-            manager = new MmapTensorMemoryManager<T>(store.Path, offset, (int)byteLen, weight.Length, writable: true);
-            var aliased = Vector<T>.WrapMemory(manager.Memory);
-            weight.AliasStorageFromMmap(aliased, manager, writable: true); // tensor's storage owns the mapping
+            // Create/allocate the param-IO store and install the alias under the registry lock so a
+            // concurrent Reset (which disposes _paramIoStore under _lock) can't race store creation or
+            // open a writable view of a just-disposed mapping. store.Allocate is itself internally locked.
+            lock (_lock)
+            {
+                var store = ParamIoStore();
+                long offset = store.Allocate(bytes);
+                manager = new MmapTensorMemoryManager<T>(store.Path, offset, (int)byteLen, weight.Length, writable: true);
+                var aliased = Vector<T>.WrapMemory(manager.Memory);
+                weight.AliasStorageFromMmap(aliased, manager, writable: true); // tensor's storage owns the mapping
+            }
             return true;
         }
         catch
@@ -1245,23 +1252,38 @@ public static class WeightRegistry
                 var tail = _materializedLru.Last;
                 if (tail is null) break;
                 long victim = tail.Value;
-                _materializedLru.RemoveLast();
-                _materializedNode.Remove(victim);
                 _materializedBytes.TryGetValue(victim, out long victimBytes);
-                _materializedBytes.Remove(victim);
-                _materializedResidentBytes -= victimBytes;
 
-                // Resolve the owner OUTSIDE the eventual drop's heavy work but still under _lock —
-                // the owner-drop + write-back only touch the tensor + pool, not the registry maps.
+                // Persist + drop the coldest owner, but only UNTRACK it after both succeed. If write-back
+                // returns false (non-native/aliased — nothing to persist) or the drop returns false
+                // (shared refcount), the owner must stay resident AND accounted; untracking it first
+                // would leak its bytes from the budget (the resident copy still exists). Order: write-back
+                // FIRST so the dropped bytes are recoverable from the pool/disk.
+                bool shed;
                 if (_ownerByHandle.TryGetValue(victim, out var weak) && weak.TryGetTarget(out var owner))
                 {
-                    // Persist the (possibly mutated) data, then drop the resident copy. Order matters:
-                    // write-back FIRST so the dropped bytes are recoverable from the pool/disk.
-                    try { owner.TryWriteBackResidentForStreaming(); }
-                    catch { /* best-effort: a non-native/aliased owner just stays resident */ }
-                    try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
-                    catch { /* shared refcount → leave resident; bounding is best-effort, never corrupting */ }
+                    bool wroteBack = false;
+                    try { wroteBack = owner.TryWriteBackResidentForStreaming(); }
+                    catch { /* best-effort */ }
+                    shed = false;
+                    if (wroteBack)
+                    {
+                        try { shed = owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
+                        catch { /* shared refcount → leave resident + accounted */ }
+                    }
                 }
+                else
+                {
+                    shed = true; // dead owner: no resident copy remains to account
+                }
+
+                // Coldest owner can't be shed yet (non-native, or shared ref) — stop. Bounding is
+                // best-effort; never untrack/forget a still-resident owner.
+                if (!shed) break;
+                _materializedLru.RemoveLast();
+                _materializedNode.Remove(victim);
+                _materializedBytes.Remove(victim);
+                _materializedResidentBytes -= victimBytes;
             }
         }
     }
@@ -2001,6 +2023,12 @@ public static class WeightRegistry
                 // that snapshot is stale — write the owner's CURRENT bytes back BEFORE dropping so a
                 // later Materialize rehydrates the mutation, not the stale value. Native-gated inside
                 // TryWriteBackResidentForStreaming, so read-only inference (bf16/quant store) is a no-op.
+                // Unlike the materialized-owner SHED loop (NoteMaterializedAndShed), the drop here is safe
+                // regardless of the write-back RESULT: a native owner's write-back persists the mutation
+                // before the drop, and a non-native owner's resident copy is a re-derivable dequant of the
+                // pool's quantized snapshot (re-materialize re-derives it) — so the snapshot stays
+                // authoritative either way. (Training uses the FullPrecision/native store, so a mutated
+                // owner is always native and always writes back.)
                 try { owner.TryWriteBackResidentForStreaming(); }
                 catch { /* best-effort write-back; never block the drop */ }
                 try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MemoryMappedWeightStoreTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MemoryMappedWeightStoreTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// #1715 mmap redesign — proves the memory-mapped slice store's core contract: slices
+/// round-trip exactly, mutations through the writable span survive read-back WITH NO
+/// write-back code (the property the bespoke streaming pool needed ReplaceEntryData +
+/// write-back-before-drop for), the single file grows without corrupting earlier slices,
+/// and Dispose deletes the backing file (no orphaned multi-GB temp files).
+/// </summary>
+public class MemoryMappedWeightStoreTests
+{
+    private static string TempPath() =>
+        Path.Combine(Path.GetTempPath(), "mmws-test-" + Guid.NewGuid().ToString("N") + ".bin");
+
+    private static byte[] MakeBytes(int len, int seed)
+    {
+        var r = new Random(seed);
+        var b = new byte[len];
+        r.NextBytes(b);
+        return b;
+    }
+
+    [Fact]
+    public void Allocate_GetSpan_RoundTripsExactly_AndDisposeDeletesFile()
+    {
+        var path = TempPath();
+        using (var store = new MemoryMappedWeightStore(path, initialCapacity: 64 * 1024))
+        {
+            var a = MakeBytes(1000, seed: 1);
+            var b = MakeBytes(2000, seed: 2);
+            long oa = store.Allocate(a);
+            long ob = store.Allocate(b);
+            Assert.True(store.GetSpan(oa, a.Length).SequenceEqual(a));
+            Assert.True(store.GetSpan(ob, b.Length).SequenceEqual(b));
+            Assert.Equal(0, oa);              // first slice at offset 0
+            Assert.True(ob >= 1000 && (ob % 64) == 0); // 64-byte aligned after the first slice
+        }
+        Assert.False(File.Exists(path), "Dispose must delete the backing file");
+    }
+
+    [Fact]
+    public void Mutate_ThroughSpan_SurvivesReadBack_WithNoWriteBackCode()
+    {
+        // The exact round-trip the bespoke #707 pool needed manual write-back-before-drop for:
+        // mutate a resident slice, read it back, observe the mutation. Free here — the span and
+        // the read-back alias the same mapped pages.
+        var path = TempPath();
+        using var store = new MemoryMappedWeightStore(path, initialCapacity: 64 * 1024);
+        var data = MakeBytes(4096, seed: 7);
+        long off = store.Allocate(data);
+
+        var span = store.GetSpan(off, data.Length);
+        for (int i = 0; i < span.Length; i++) span[i] = (byte)(span[i] ^ 0xA5);
+
+        var read = store.GetSpan(off, data.Length);
+        for (int i = 0; i < data.Length; i++)
+            Assert.Equal((byte)(data[i] ^ 0xA5), read[i]);
+    }
+
+    [Fact]
+    public void Grow_PreservesEarlierSlices()
+    {
+        var path = TempPath();
+        // Tiny initial capacity forces several doubling grows across the allocations.
+        using var store = new MemoryMappedWeightStore(path, initialCapacity: 4096);
+        const int n = 8, sz = 2000;
+        var datas = new byte[n][];
+        var offs = new long[n];
+        for (int i = 0; i < n; i++)
+        {
+            datas[i] = MakeBytes(sz, seed: i + 10);
+            offs[i] = store.Allocate(datas[i]);
+        }
+        Assert.True(store.Capacity >= store.UsedBytes);
+        Assert.True(store.Capacity > 4096, "the allocations must have forced a grow");
+        // Re-fetch each span AFTER all grows (per the span-lifetime contract) — all still exact.
+        for (int i = 0; i < n; i++)
+            Assert.True(store.GetSpan(offs[i], datas[i].Length).SequenceEqual(datas[i]),
+                $"slice {i} corrupted by a grow");
+    }
+
+    [Fact]
+    public void ManySlices_AcrossMmap_AllReadBackCorrectly()
+    {
+        // 256 × 1 MB = 256 MB of slices across the single mapped file; all correct. (Bounding the
+        // RESIDENT set under host pressure is the OS page cache's job for a file-backed mapping —
+        // inherent, not asserted here; this proves correctness at scale.)
+        var path = TempPath();
+        using var store = new MemoryMappedWeightStore(path, initialCapacity: 1024 * 1024);
+        const int n = 256, sz = 1024 * 1024;
+        var offs = new long[n];
+        for (int i = 0; i < n; i++)
+        {
+            var d = new byte[sz];
+            d[0] = (byte)i;
+            d[sz - 1] = (byte)(i * 7 + 1);
+            offs[i] = store.Allocate(d);
+        }
+        for (int i = 0; i < n; i++)
+        {
+            var s = store.GetSpan(offs[i], sz);
+            Assert.Equal((byte)i, s[0]);
+            Assert.Equal((byte)(i * 7 + 1), s[sz - 1]);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapParamIoAliasTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapParamIoAliasTests.cs
@@ -1,0 +1,62 @@
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// #1715 stage 3 — the WRITABLE param-IO zero-copy path through WeightRegistry. In training mode a
+/// foundation streaming weight materializes by aliasing its bytes to a writable slice of the param-IO
+/// mmap store (no resident GC copy), mutations persist through the mapping, and that slice is the
+/// weight's canonical storage (Materialize / ReleaseToPool no-op on it). This is what stops the
+/// GetParameters → mutate → SetParameters round-trip from materializing the whole model resident → OOM.
+///
+/// [Collection("WeightRegistry")] serializes against the other tests that mutate the process-global
+/// registry via Configure/Reset.
+/// </summary>
+[Collection("WeightRegistry")]
+public class MmapParamIoAliasTests : IDisposable
+{
+    public void Dispose() => WeightRegistry.Reset();
+
+    [Fact]
+    public void TrainingMaterialize_WritablyAliasesStore_RoundTripsMutation_NoResidentCopy()
+    {
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            EnableZeroCopyMmapResidency = true,
+            StreamingStoreDtype = StreamingStoreDtype.FullPrecision, // native encoding ⇒ aliasable
+            StreamingPoolMaxResidentBytes = 64,                       // tiny ⇒ the weight is paged out
+        });
+        WeightRegistry.SetStreamingExecutionTraining(true);           // !inferenceMode ⇒ writable path
+
+        var original = new float[256];
+        for (int i = 0; i < original.Length; i++) original[i] = i * 0.25f - 7f;
+        var w = new Tensor<float>((float[])original.Clone(), new[] { original.Length });
+        w.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(w);
+        Assert.True(w.StreamingPoolHandle >= 0);
+
+        WeightRegistry.ReleaseToPool(w);   // drop resident _data → bytes live only in the pool
+        WeightRegistry.Materialize(w);     // training-mode materialize → writable mmap alias
+
+        Assert.True(w.IsWritableMmapAliased, "training materialize must writably-alias the store slice");
+        for (int i = 0; i < original.Length; i++) Assert.Equal(original[i], w[i]); // reads the slice, correct
+
+        // Mutate through the weight's storage; the change lands in the mmap slice (its canonical storage).
+        var span = w.DataVector.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++) span[i] = original[i] * 3f + 2f;
+
+        // Re-materialize must be a NO-OP (already the canonical alias) — never read stale pool bytes.
+        WeightRegistry.Materialize(w);
+        Assert.True(w.IsWritableMmapAliased);
+        for (int i = 0; i < original.Length; i++) Assert.Equal(original[i] * 3f + 2f, w[i]);
+
+        // ReleaseToPool must be a NO-OP on a writable alias — the storage stays the canonical mmap slice
+        // (dropping it would discard the mutation and a re-materialize would read stale bytes).
+        WeightRegistry.ReleaseToPool(w);
+        Assert.True(w.IsWritableMmapAliased);
+        Assert.Equal(original.Length, w.DataVector.Length);
+        for (int i = 0; i < original.Length; i++) Assert.Equal(original[i] * 3f + 2f, w[i]);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapWritableAliasTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapWritableAliasTests.cs
@@ -31,7 +31,12 @@ public class MmapWritableAliasTests
         using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         var bytes = new byte[count * sizeof(float)];
         int read = 0;
-        while (read < bytes.Length) read += fs.Read(bytes, read, bytes.Length - read);
+        while (read < bytes.Length)
+        {
+            int n = fs.Read(bytes, read, bytes.Length - read);
+            if (n == 0) throw new EndOfStreamException($"Expected {bytes.Length} bytes, read {read}.");
+            read += n;
+        }
         var values = new float[count];
         Buffer.BlockCopy(bytes, 0, values, 0, bytes.Length);
         return values;
@@ -108,9 +113,10 @@ public class MmapWritableAliasTests
         // resident array materialized (an mmap-backed Vector is not array-backed).
         for (int i = 0; i < n; i++) Assert.Equal(initial[i], tensor[i]);
 
-        // Mutate through the tensor's (writable) storage span; the change is the mmap, shared with
-        // the file. This is the GetParameters→mutate→SetParameters round-trip in miniature.
-        var span = aliased.AsWritableSpan();
+        // Mutate through the TENSOR API (not the raw alias) so this exercises the tensor-level write
+        // gate (TensorBase.AsWritableSpan → TensorStorage, which allows writable mmaps and would throw
+        // for a read-only one). The change lands in the mmap slice, shared with the file.
+        var span = tensor.AsWritableSpan();
         for (int i = 0; i < n; i++) span[i] = initial[i] * 2f + 1f;
         for (int i = 0; i < n; i++) Assert.Equal(initial[i] * 2f + 1f, tensor[i]); // tensor sees it (shared storage)
 

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapWritableAliasTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/MmapWritableAliasTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// #1715 mmap redesign, stage 2 — a streamed weight tensor's storage can VIEW a writable
+/// memory-mapped slice directly (no resident GC copy), and mutations through that storage
+/// persist to the file (MAP_SHARED). This is what kills the OOM: the param-IO round-trip
+/// (GetParameters → mutate → SetParameters → read back) no longer materializes the whole
+/// model as resident arrays — each weight aliases its mapped slice and the OS pages it.
+/// Read-only aliases (inference) still gate writes (fail loud rather than fault).
+/// </summary>
+public class MmapWritableAliasTests
+{
+    private static string TempPath() =>
+        Path.Combine(Path.GetTempPath(), "mmwa-test-" + Guid.NewGuid().ToString("N") + ".bin");
+
+    private static void WriteFloats(string path, float[] values)
+    {
+        using var fs = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        var bytes = new byte[values.Length * sizeof(float)];
+        Buffer.BlockCopy(values, 0, bytes, 0, bytes.Length);
+        fs.Write(bytes, 0, bytes.Length);
+    }
+
+    private static float[] ReadFloats(string path, int count)
+    {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        var bytes = new byte[count * sizeof(float)];
+        int read = 0;
+        while (read < bytes.Length) read += fs.Read(bytes, read, bytes.Length - read);
+        var values = new float[count];
+        Buffer.BlockCopy(bytes, 0, values, 0, bytes.Length);
+        return values;
+    }
+
+    [Fact]
+    public void WritableManager_MutationPersistsToFile()
+    {
+        const int n = 1024;
+        var path = TempPath();
+        var initial = new float[n];
+        for (int i = 0; i < n; i++) initial[i] = i * 0.5f;
+        WriteFloats(path, initial);
+
+        using (var mgr = new MmapTensorMemoryManager<float>(path, 0, n * sizeof(float), n, writable: true))
+        {
+            Assert.True(mgr.IsWritable);
+            var span = mgr.GetSpan();
+            for (int i = 0; i < n; i++) Assert.Equal(initial[i], span[i]);  // reads the file zero-copy
+            for (int i = 0; i < n; i++) span[i] = span[i] + 1000f;          // mutate through the mapping
+        } // Dispose flushes dirty pages to the file
+
+        var roundTripped = ReadFloats(path, n);
+        for (int i = 0; i < n; i++) Assert.Equal(initial[i] + 1000f, roundTripped[i]);
+        File.Delete(path);
+    }
+
+    [Fact]
+    public void ReadOnlyAlias_GatesWrites_WritableAlias_AllowsThem()
+    {
+        const int n = 64;
+        var roPath = TempPath();
+        var rwPath = TempPath();
+        var vals = new float[n];
+        for (int i = 0; i < n; i++) vals[i] = i;
+        WriteFloats(roPath, vals);
+        WriteFloats(rwPath, vals);
+
+        var roMgr = new MmapTensorMemoryManager<float>(roPath, 0, n * sizeof(float), n, writable: false);
+        var roStorage = new TensorStorage<float>(Vector<float>.WrapMemory(roMgr.Memory));
+        roStorage.AttachMmapOwner(roMgr, writable: false);
+        Assert.True(roStorage.IsReadOnlyMapped);
+        Assert.Throws<InvalidOperationException>(() => roStorage.AsWritableSpan());
+        roStorage.Release(); // disposes roMgr
+
+        var rwMgr = new MmapTensorMemoryManager<float>(rwPath, 0, n * sizeof(float), n, writable: true);
+        var rwStorage = new TensorStorage<float>(Vector<float>.WrapMemory(rwMgr.Memory));
+        rwStorage.AttachMmapOwner(rwMgr, writable: true);
+        Assert.False(rwStorage.IsReadOnlyMapped);
+        var w = rwStorage.AsWritableSpan();   // must NOT throw
+        w[0] = 42f;
+        Assert.Equal(42f, rwStorage.AsSpan()[0]);
+        rwStorage.Release(); // disposes rwMgr
+
+        File.Delete(roPath);
+        File.Delete(rwPath);
+    }
+
+    [Fact]
+    public void TensorAliasedToWritableMmap_HasNoResidentArray_AndRoundTripsMutation()
+    {
+        const int n = 512;
+        var path = TempPath();
+        var initial = new float[n];
+        for (int i = 0; i < n; i++) initial[i] = (i % 13) - 6f;
+        WriteFloats(path, initial);
+
+        var mgr = new MmapTensorMemoryManager<float>(path, 0, n * sizeof(float), n, writable: true);
+        var aliased = Vector<float>.WrapMemory(mgr.Memory);
+        var tensor = new Tensor<float>(new[] { n });
+        tensor.AliasStorageFromMmap(aliased, mgr, writable: true);
+
+        // The tensor now VIEWS the mapped slice — reading it returns the file's values with no
+        // resident array materialized (an mmap-backed Vector is not array-backed).
+        for (int i = 0; i < n; i++) Assert.Equal(initial[i], tensor[i]);
+
+        // Mutate through the tensor's (writable) storage span; the change is the mmap, shared with
+        // the file. This is the GetParameters→mutate→SetParameters round-trip in miniature.
+        var span = aliased.AsWritableSpan();
+        for (int i = 0; i < n; i++) span[i] = initial[i] * 2f + 1f;
+        for (int i = 0; i < n; i++) Assert.Equal(initial[i] * 2f + 1f, tensor[i]); // tensor sees it (shared storage)
+
+        tensor.Dispose(); // last ref → disposes mgr → flushes the mapping to the file
+
+        var roundTripped = ReadFloats(path, n);
+        for (int i = 0; i < n; i++) Assert.Equal(initial[i] * 2f + 1f, roundTripped[i]); // persisted
+        File.Delete(path);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
@@ -68,8 +68,11 @@ public class StreamingMaterializedOwnerBoundTests
             int residentNow = weights.Count(w => w.DataVector.Length == L);
             Assert.True(residentNow < N,
                 $"Expected the materialized-owner budget to shed cold owners, but all {N} are still resident.");
-            Assert.True(residentNow * (long)L * sizeof(float) <= Cap,
-                $"Resident owner set ({residentNow} weights) exceeds the pool cap ({Cap} bytes).");
+            // Assert against the OWNER budget (Cap/2), not the full pool cap — the implementation
+            // budgets materialized owners at Cap/2, so checking Cap would still pass if the owner set
+            // regressed to twice the intended limit.
+            Assert.True(residentNow * (long)L * sizeof(float) <= Cap / 2,
+                $"Resident owner set ({residentNow} weights) exceeds the owner budget ({Cap / 2} bytes).");
 
             // EXACT WRITE-BACK: re-materialize each weight and confirm the mutation survived the shed
             // (shed wrote the dirty bytes back to the pool/disk before dropping), and the untouched

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.IO;
+using System.Linq;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// #1715: when a caller materializes MANY streaming weights and holds them all resident at once — a
+/// foundation-scale GetParameters round-trip / Clone — the pool only accounts its own byte[] snapshots,
+/// so without owner-resident bounding the per-weight resident copies accumulate unbounded and OOM
+/// before the snapshot-budget eviction fires. WeightRegistry now tracks materialized owners in an LRU
+/// and sheds the coldest (write-back the current bytes, then drop the resident copy) once their bytes
+/// exceed the budget. These tests pin BOTH halves of correctness: the held set stays bounded, AND a
+/// MUTATION made to a since-shed weight survives the shed (write-back) so re-materializing reads it back.
+/// </summary>
+public class StreamingMaterializedOwnerBoundTests
+{
+    private const int L = 4096;                 // 16 KB per fp32 weight
+    private const int N = 16;                   // 256 KB total — 2x the pool cap
+    private const long Cap = 8L * L * sizeof(float); // resident cap = 8 weights; owner budget = cap/2 = 4
+
+    private static float Base(int i, int j) => (i * 31 + j) % 251 * 0.5f - 60f;
+
+    [Fact]
+    public void ManyMaterializedOwners_StayBounded_AndMutationsSurviveShed()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "aidotnet-1715-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            WeightRegistry.Configure(new GpuOffloadOptions
+            {
+                StreamingBackingStorePath = dir,
+                StreamingPoolMaxResidentBytes = Cap,
+                TransparentAutoEviction = true,
+                // Full precision so the write-back round-trip is exact (the round-trip contract test
+                // asserts exact equality; bf16/lossy stores would lose the mutation's low bits).
+                StreamingStoreDtype = StreamingStoreDtype.FullPrecision,
+            });
+
+            // Register N streaming weights. RegisterWeight snapshots each into the pool and drops its
+            // resident copy, so nothing is resident yet.
+            var weights = new Tensor<float>[N];
+            for (int i = 0; i < N; i++)
+            {
+                var t = new Tensor<float>(new[] { L });
+                for (int j = 0; j < L; j++) t[j] = Base(i, j);
+                t.Lifetime = WeightLifetime.Streaming;
+                WeightRegistry.RegisterWeight(t);
+                Assert.True(t.StreamingPoolHandle >= 0);
+                weights[i] = t;
+            }
+
+            // Materialize each and MUTATE element 0 — holding every reference, exactly as a parameter
+            // round-trip's write pass does. The owner-resident bounding must shed the cold ones.
+            for (int i = 0; i < N; i++)
+            {
+                WeightRegistry.Materialize(weights[i]);
+                Assert.Equal(L, weights[i].DataVector.Length); // resident right after materialize
+                weights[i][0] = 1000f + i;                     // dirty the resident copy
+            }
+
+            // BOUNDED: not all N owner copies are still resident — the budget (cap/2 = 4 weights)
+            // forced the coldest to shed. (Without the fix all N stay resident → the OOM mode.)
+            int residentNow = weights.Count(w => w.DataVector.Length == L);
+            Assert.True(residentNow < N,
+                $"Expected the materialized-owner budget to shed cold owners, but all {N} are still resident.");
+            Assert.True(residentNow * (long)L * sizeof(float) <= Cap,
+                $"Resident owner set ({residentNow} weights) exceeds the pool cap ({Cap} bytes).");
+
+            // EXACT WRITE-BACK: re-materialize each weight and confirm the mutation survived the shed
+            // (shed wrote the dirty bytes back to the pool/disk before dropping), and the untouched
+            // elements are intact.
+            for (int i = 0; i < N; i++)
+            {
+                WeightRegistry.Materialize(weights[i]);
+                Assert.Equal(L, weights[i].DataVector.Length);
+                Assert.Equal(1000f + i, weights[i][0]);     // the mutation
+                Assert.Equal(Base(i, 1), weights[i][1]);    // an untouched element
+                Assert.Equal(Base(i, L - 1), weights[i][L - 1]);
+            }
+        }
+        finally
+        {
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Draft — MEASURED root cause (corrects the initial deferred-drop hypothesis)

Foundation-scale diffusion predictors (Flux2 ≈ **6.5 B params / ~31 GB fp32**) fail the `GetSetParameters_RoundTrips` contract tests under the 16 GB CI runner (AiDotNet #1715, shard `Unit-03d`: Flux2 / FluxDoubleStream / SiT).

### What I measured (the initial hypothesis was wrong)
With the AiDotNet-side wiring active (engage streaming on the param path + register materialized weights — branch `fix/generated-am-modelbugs`), I instrumented `WeightRegistry.GetStreamingReport()` during `GetParameterChunks` enumeration:

| chunk | residentMB | evictions | diskWriteMB | ws MB | cumElemsMB |
|------|-----------|-----------|-------------|-------|-----------|
| 250 | 8102 | 19 | 552 | 1623 | 8655 |
| 500 | 8066 | 215 | 9627 | 5850 | 17694 |
| 900 | 8174 | 519 | 23599 | 7180 | 31775 |

**The streaming pool already bounds the resident set at the 8 GB cap — eviction works.** The read enumeration does **not** OOM; it **times out** (~10 min for one full ~31 GB pass, disk-bound). So the deferred-drop / "pool doesn't evict" hypothesis is **disproven**.

### The actual residual
1. **Write pass**: the round-trip writes a ramp via `Tensor.Data.Span`, which rehydrates each chunk (`EnsureMaterialized` → resident) and marks it dirty. The real test OOM'd here — rehydrated/dirty `_data` isn't re-tracked/re-evicted by the pool the way the freshly-materialized read path is. **This is the Tensors fix**: the `Rehydrate`/`EnsureMaterialized` path must keep rehydrated weights under the pool's resident accounting so they can be re-evicted (with dirty write-back).
2. **Inherent speed**: even perfectly memory-bounded, a 31 GB model round-tripped to disk is ~10 min/pass × 3 passes ≈ 30 min → times out regardless. Once memory-safe, these foundation-scale contract tests warrant a longer timeout / `HeavyTimeout` (matches #1709) — the #1715 "must-fix footprint" is satisfied by streaming; the residual is inherent foundation-scale slowness.

### AiDotNet-side wiring (keep — bounds the read path)
- `NoisePredictorBase`/`MMDiTNoisePredictor` `GetParameterChunks`/`SetParameterChunks` → `MaybeEngageWeightStreaming()`.
- `LayerBase.EnsureParametersMaterialized` → `RegisterStreamingWeightsWithPool()` after `EnsureInitialized()`.

Full analysis in `docs/investigations/1715-streaming-register-path-oom.md` (updated). Tensors code change (rehydrate re-tracking) + the two-repo verify loop is the remaining work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new investigation write-up detailing a streaming tensor OOM scenario, key findings, and recommended follow-up for resident-byte accounting and write-back behavior.
* **New Features**
  * Added writable, growable memory-mapped storage for streamed weights and enabled writable mmap aliasing for training/param-IO mode.
  * Exposed the resident-byte budget and added in-place entry data replacement with automatic eviction re-evaluation.
* **Bug Fixes**
  * Improved resident-owner bounding and write-back so mutated data remains correct across eviction/materialization, and writable aliases persist changes.
* **Tests**
  * Added coverage for writable vs read-only mmap behavior, mutation persistence, and bounded streaming materialization under pressure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->