### PR TITLE
fix(cpu): invalidate per-array derived-weight caches on InvalidatePersistentTensor

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -38520,7 +38520,29 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual void InvalidatePersistentTensor<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        // No-op on CPU
+
+        // CPU derived-weight cache invalidation (#1711). The CPU fast paths cache
+        // forms DERIVED from a weight array — the small-N conv path's transposed
+        // kernel (GetOrBuildTransposedKernel) and the GEMM pre-packed-B panels —
+        // keyed by the weight array's identity + a per-array mutation version
+        // (SimdGemm.WeightArrayVersionOf). Those caches are only correct as long as
+        // every IN-PLACE mutation of the weight array bumps that version. Callers
+        // signal an in-place weight change by calling THIS method (e.g.
+        // ConvolutionalLayer.SetParameters copies new kernel values into the existing
+        // _kernels buffer and then calls InvalidatePersistentTensor), so a CPU no-op
+        // here left the derived caches stale: after SetParameters the conv small-N
+        // path kept transposing the PRE-mutation kernel, so a model loaded/cloned via
+        // SetParameters produced different output than the source even though its
+        // GetParameters() was byte-identical (a diffusion Clone-determinism bug class).
+        // Mark the backing array dirty so the next consume rebuilds from live bytes.
+        // GetLiveBackingArrayOrNull returns the backing array only for a simple
+        // contiguous-at-offset-0 layout — exactly the array the conv/GEMM fast paths
+        // key their caches on (they consume kernel.Contiguous().GetDataArray()); it
+        // returns null for view/lazy/GPU layouts, which never own a persistent
+        // per-array cache entry, so skipping them is correct.
+        var backing = tensor.GetLiveBackingArrayOrNull();
+        if (backing is not null)
+            AiDotNet.Tensors.Engines.Simd.SimdGemm.MarkWeightDirty(backing);
     }
 
     #endregion


### PR DESCRIPTION
## Problem

`CpuEngine.InvalidatePersistentTensor<T>` was a **no-op on CPU**. The CPU fast paths cache forms *derived* from a weight array:

- the small-N conv path's **transposed kernel** (`GetOrBuildTransposedKernel`), and
- the GEMM **pre-packed-B** panels (`SgemmWithCachedB`),

both keyed by a per-array mutation version (`SimdGemm.WeightArrayVersionOf`), invalidated only by `SimdGemm.MarkWeightDirty`.

Layers signal an in-place weight change by calling `InvalidatePersistentTensor` (`ConvolutionalLayer.SetParameters` and `DenseLayer.SetParameters` already do this after copying new values into the existing weight buffer). With the CPU implementation doing nothing, a model **cloned or weight-loaded via `SetParameters`** kept using the derived form built from the *pre-mutation* weights — so its output diverged from the source even though `GetParameters()` was byte-identical.

This is the root cause of a class of diffusion `Clone_ShouldProduceIdenticalOutput` determinism failures in the AiDotNet consumer (e.g. conv-UNet diffusion models): the clone's small-N stride-2 downsample conv kept transposing the clone's *random* pre-`SetParameters` kernel.

## Fix

Make CPU `InvalidatePersistentTensor` mark the tensor's backing array dirty via `SimdGemm.MarkWeightDirty(tensor.GetLiveBackingArrayOrNull())`. `GetLiveBackingArrayOrNull` returns the backing array only for a simple contiguous-at-offset-0 layout — exactly the array the conv/GEMM fast paths key their caches on — and null for view/lazy/GPU layouts (which never own a persistent per-array cache entry), so skipping those is correct.

No call-site changes are needed: this activates the `InvalidatePersistentTensor` calls already present in the layer `SetParameters` implementations.

## Verification

Validated end-to-end against the AiDotNet diffusion model-family tests (via a local `ProjectReference`): conv-UNet diffusion `Clone_ShouldProduceIdenticalOutput` tests that previously diverged now pass exactly, with no regression on `NeuralTuringMachine`/`DifferentiableNeuralComputer` (42/42) or `ConvolutionalNeuralNetwork` (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)