### PR TITLE
fix(gpu): clamp box w/h in IoU-family loss kernels so degenerate boxes match CPU

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaIoUKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaIoUKernels.cs
@@ -138,9 +138,12 @@ extern ""C"" __global__ void ciou_loss(
     float encX2 = max_f(px2,tx2), encY2 = max_f(py2,ty2);
     float encDx = encX2-encX1, encDy = encY2-encY1;
     float diagSq = encDx*encDx + encDy*encDy + 1e-7f;
-    // Aspect ratio
-    float predW = px2-px1+1e-7f, predH = py2-py1+1e-7f;
-    float targW = tx2-tx1+1e-7f, targH = ty2-ty1+1e-7f;
+    // Aspect ratio. Clamp width/height to be positive so degenerate boxes
+    // (x2<x1 or y2<y1) cannot produce a negative ratio whose atan spans a far
+    // wider range than the [0,pi/2) of a valid box — that inflated v far past
+    // its [0,1] bound and diverged from the CPU reference (which uses ReLU).
+    float predW = max_f(px2-px1, 1e-7f), predH = max_f(py2-py1, 1e-7f);
+    float targW = max_f(tx2-tx1, 1e-7f), targH = max_f(ty2-ty1, 1e-7f);
     float rDiff = atanf(targW/targH) - atanf(predW/predH);
     float v = (4.0f / (3.14159265f * 3.14159265f)) * rDiff * rDiff;
     float alpha = v / (1.0f - iou + v + 1e-7f);
@@ -380,8 +383,9 @@ extern ""C"" __global__ void ciou_loss_backward(
     dCSq[3] = 2.0f*encDy*(py2>ty2?1.0f:0.0f);
 
     // Aspect ratio: v = (4/π²) * (atan(tw/th) - atan(pw/ph))²
-    float pw=px2-px1+1e-7f, ph=py2-py1+1e-7f;
-    float tw=tx2-tx1+1e-7f, th=ty2-ty1+1e-7f;
+    // Clamp width/height positive (matches the forward kernel and the CPU ReLU).
+    float pw=max_f(px2-px1, 1e-7f), ph=max_f(py2-py1, 1e-7f);
+    float tw=max_f(tx2-tx1, 1e-7f), th=max_f(ty2-ty1, 1e-7f);
     float atanDiff = atanf(tw/th) - atanf(pw/ph);
     float fourOverPiSq = 4.0f / (3.14159265f * 3.14159265f);
     float v = fourOverPiSq * atanDiff * atanDiff;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipIoUKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipIoUKernels.cs
@@ -140,9 +140,11 @@ extern ""C"" __global__ void ciou_loss(
     float encX2 = max_f(px2,tx2), encY2 = max_f(py2,ty2);
     float encDx = encX2-encX1, encDy = encY2-encY1;
     float diagSq = encDx*encDx + encDy*encDy + 1e-7f;
-    // Aspect ratio
-    float predW = px2-px1+1e-7f, predH = py2-py1+1e-7f;
-    float targW = tx2-tx1+1e-7f, targH = ty2-ty1+1e-7f;
+    // Aspect ratio. Clamp width/height positive so degenerate boxes (x2<x1 or
+    // y2<y1) cannot yield a negative ratio whose atan spans far past [0,pi/2),
+    // inflating v beyond its [0,1] bound and diverging from the CPU ReLU clamp.
+    float predW = max_f(px2-px1, 1e-7f), predH = max_f(py2-py1, 1e-7f);
+    float targW = max_f(tx2-tx1, 1e-7f), targH = max_f(ty2-ty1, 1e-7f);
     float rDiff = atanf(targW/targH) - atanf(predW/predH);
     float v = (4.0f / (3.14159265f * 3.14159265f)) * rDiff * rDiff;
     float alpha = v / (1.0f - iou + v + 1e-7f);
@@ -391,7 +393,7 @@ extern ""C"" __global__ void ciou_loss_backward(
 
     // Aspect ratio: v = (4/π²) * (atan(tw/th) - atan(pw/ph))²
     float pw=max_f(px2-px1, 1e-7f), ph=max_f(py2-py1, 1e-7f);
-    float tw=tx2-tx1+1e-7f, th=ty2-ty1+1e-7f;
+    float tw=max_f(tx2-tx1, 1e-7f), th=max_f(ty2-ty1, 1e-7f);
     float atanDiff = atanf(tw/th) - atanf(pw/ph);
     float fourOverPiSq = 4.0f / (3.14159265f * 3.14159265f);
     float v = fourOverPiSq * atanDiff * atanDiff;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -5260,7 +5260,7 @@ kernel void ciou_loss(device const float* pred [[buffer(0)]], device const float
     float cds=dx*dx+dy*dy;
     float eDx=max(px2,tx2)-min(px1,tx1), eDy=max(py2,ty2)-min(py1,ty1);
     float ds=eDx*eDx+eDy*eDy+EPSILON;
-    float pw=px2-px1+EPSILON,ph=py2-py1+EPSILON,tw=tx2-tx1+EPSILON,th=ty2-ty1+EPSILON;
+    float pw=max(px2-px1,EPSILON),ph=max(py2-py1,EPSILON),tw=max(tx2-tx1,EPSILON),th=max(ty2-ty1,EPSILON);
     float rd=atan(tw/th)-atan(pw/ph);
     float v=(4.0f/(PI*PI))*rd*rd;
     float alpha=v/(1.0f-iou+v+EPSILON);
@@ -5345,7 +5345,7 @@ kernel void ciou_loss_backward(device const float* goB [[buffer(0)]], device con
     float encDx=max(px2,tx2)-min(px1,tx1),encDy=max(py2,ty2)-min(py1,ty1);
     float cSq=encDx*encDx+encDy*encDy+EPSILON,cSqSq=cSq*cSq;
     float dCSq[4]={2.0f*encDx*(-(px1<tx1?1.0f:0.0f)),2.0f*encDy*(-(py1<ty1?1.0f:0.0f)),2.0f*encDx*(px2>tx2?1.0f:0.0f),2.0f*encDy*(py2>ty2?1.0f:0.0f)};
-    float pw=px2-px1+EPSILON,ph=py2-py1+EPSILON,tw=tx2-tx1+EPSILON,th=ty2-ty1+EPSILON;
+    float pw=max(px2-px1,EPSILON),ph=max(py2-py1,EPSILON),tw=max(tx2-tx1,EPSILON),th=max(ty2-ty1,EPSILON);
     float atanDiff=atan(tw/th)-atan(pw/ph), fourOverPiSq=4.0f/(PI*PI);
     float v=fourOverPiSq*atanDiff*atanDiff;
     float ix1=max(px1,tx1),iy1=max(py1,ty1),ix2=min(px2,tx2),iy2=min(py2,ty2);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/IoUKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/IoUKernels.cs
@@ -199,7 +199,7 @@ __kernel void ciou_loss_backward(
     float encDx=max(px2,tx2)-min(px1,tx1),encDy=max(py2,ty2)-min(py1,ty1);
     float cSq=encDx*encDx+encDy*encDy+1e-7f,cSqSq=cSq*cSq;
     float dCSq[4]={2.0f*encDx*(-(px1<tx1?1.0f:0.0f)), 2.0f*encDy*(-(py1<ty1?1.0f:0.0f)), 2.0f*encDx*(px2>tx2?1.0f:0.0f), 2.0f*encDy*(py2>ty2?1.0f:0.0f)};
-    float pw=px2-px1+1e-7f,ph=py2-py1+1e-7f,tw=tx2-tx1+1e-7f,th=ty2-ty1+1e-7f;
+    float pw=max(px2-px1,1e-7f),ph=max(py2-py1,1e-7f),tw=max(tx2-tx1,1e-7f),th=max(ty2-ty1,1e-7f);
     float atanDiff=atan(tw/th)-atan(pw/ph);
     float fourOverPiSq=4.0f/(3.14159265f*3.14159265f);
     float v=fourOverPiSq*atanDiff*atanDiff;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -9211,7 +9211,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iw*ih; let pw=px2-px1; let ph=py2-py1; let pA=pw*ph; let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
+    let iA=iw*ih; let pw=px2-px1; let ph=py2-py1; let pA=pw*ph; let tA=(tx2-tx1)*(ty2-ty1);
     let uA=pA+tA-iA+1e-7;
     let hi=select(0.0, 1.0, iw>0.0 && ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
@@ -9240,7 +9240,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
     let iA=iw*ih; let pw=px2-px1; let ph=py2-py1;
-    let uA=pw*ph+max(0.0,tx2-tx1)*max(0.0,ty2-ty1)-iA+1e-7;
+    let uA=pw*ph+(tx2-tx1)*(ty2-ty1)-iA+1e-7;
     let hi=select(0.0,1.0,iw>0.0&&ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
     let dI2=hi*select(0.0,1.0,px2<tx2)*ih; let dI3=hi*select(0.0,1.0,py2<ty2)*iw;
@@ -9274,7 +9274,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
     let iA=iw*ih; let pw=px2-px1; let ph=py2-py1;
-    let uA=pw*ph+max(0.0,tx2-tx1)*max(0.0,ty2-ty1)-iA+1e-7;
+    let uA=pw*ph+(tx2-tx1)*(ty2-ty1)-iA+1e-7;
     let hi=select(0.0,1.0,iw>0.0&&ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
     let dI2=hi*select(0.0,1.0,px2<tx2)*ih; let dI3=hi*select(0.0,1.0,py2<ty2)*iw;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -9211,7 +9211,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iw*ih; let pw=px2-px1; let ph=py2-py1; let pA=pw*ph; let tA=(tx2-tx1)*(ty2-ty1);
+    let iA=iw*ih; let pw=px2-px1; let ph=py2-py1; let pA=pw*ph; let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
     let uA=pA+tA-iA+1e-7;
     let hi=select(0.0, 1.0, iw>0.0 && ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
@@ -9240,7 +9240,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
     let iA=iw*ih; let pw=px2-px1; let ph=py2-py1;
-    let uA=pw*ph+(tx2-tx1)*(ty2-ty1)-iA+1e-7;
+    let uA=pw*ph+max(0.0,tx2-tx1)*max(0.0,ty2-ty1)-iA+1e-7;
     let hi=select(0.0,1.0,iw>0.0&&ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
     let dI2=hi*select(0.0,1.0,px2<tx2)*ih; let dI3=hi*select(0.0,1.0,py2<ty2)*iw;
@@ -9274,7 +9274,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
     let iA=iw*ih; let pw=px2-px1; let ph=py2-py1;
-    let uA=pw*ph+(tx2-tx1)*(ty2-ty1)-iA+1e-7;
+    let uA=pw*ph+max(0.0,tx2-tx1)*max(0.0,ty2-ty1)-iA+1e-7;
     let hi=select(0.0,1.0,iw>0.0&&ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
     let dI2=hi*select(0.0,1.0,px2<tx2)*ih; let dI3=hi*select(0.0,1.0,py2<ty2)*iw;
@@ -9309,8 +9309,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iw=max(0.0,min(px2,tx2)-max(px1,tx1)); let ih=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iw*ih; let pw=px2-px1+1e-7; let ph=py2-py1+1e-7;
-    let uA=pw*ph+(tx2-tx1)*(ty2-ty1)-iA+1e-7;
+    let iA=iw*ih; let pw=max(px2-px1,1e-7); let ph=max(py2-py1,1e-7);
+    let uA=pw*ph+max(0.0,tx2-tx1)*max(0.0,ty2-ty1)-iA+1e-7;
     let hi=select(0.0,1.0,iw>0.0&&ih>0.0);
     let dI0=hi*select(0.0,-1.0,px1>tx1)*ih; let dI1=hi*select(0.0,-1.0,py1>ty1)*iw;
     let dI2=hi*select(0.0,1.0,px2<tx2)*ih; let dI3=hi*select(0.0,1.0,py2<ty2)*iw;
@@ -9324,7 +9324,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let cSq=encDx*encDx+encDy*encDy+1e-7; let cSqSq=cSq*cSq;
     let dCSq0=2.0*encDx*select(0.0,-1.0,px1<tx1); let dCSq1=2.0*encDy*select(0.0,-1.0,py1<ty1);
     let dCSq2=2.0*encDx*select(0.0,1.0,px2>tx2); let dCSq3=2.0*encDy*select(0.0,1.0,py2>ty2);
-    let tw=tx2-tx1+1e-7; let th=ty2-ty1+1e-7;
+    let tw=max(tx2-tx1,1e-7); let th=max(ty2-ty1,1e-7);
     let atanDiff=atan(tw/th)-atan(pw/ph); let fourOverPiSq=4.0/(3.14159265*3.14159265);
     let v=fourOverPiSq*atanDiff*atanDiff;
     let iou=iA/uA;
@@ -9353,7 +9353,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iW=max(0.0,min(px2,tx2)-max(px1,tx1)); let iH=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iW*iH; let pA=(px2-px1)*(py2-py1); let tA=(tx2-tx1)*(ty2-ty1);
+    let iA=iW*iH; let pA=max(0.0,px2-px1)*max(0.0,py2-py1); let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
     let uA=pA+tA-iA+1e-7; let iou=iA/uA;
     let eA=(max(px2,tx2)-min(px1,tx1))*(max(py2,ty2)-min(py1,ty1))+1e-7;
     loss[i] = 1.0 - (iou - (eA - uA) / eA);
@@ -9373,7 +9373,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iW=max(0.0,min(px2,tx2)-max(px1,tx1)); let iH=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iW*iH; let pA=(px2-px1)*(py2-py1); let tA=(tx2-tx1)*(ty2-ty1);
+    let iA=iW*iH; let pA=max(0.0,px2-px1)*max(0.0,py2-py1); let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
     let uA=pA+tA-iA+1e-7; let iou=iA/uA;
     let dx=0.5*(px1+px2)-0.5*(tx1+tx2); let dy=0.5*(py1+py2)-0.5*(ty1+ty2);
     let cds=dx*dx+dy*dy;
@@ -9396,13 +9396,13 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let px1=pred[o]; let py1=pred[o+1u]; let px2=pred[o+2u]; let py2=pred[o+3u];
     let tx1=targ[o]; let ty1=targ[o+1u]; let tx2=targ[o+2u]; let ty2=targ[o+3u];
     let iW=max(0.0,min(px2,tx2)-max(px1,tx1)); let iH=max(0.0,min(py2,ty2)-max(py1,ty1));
-    let iA=iW*iH; let pA=(px2-px1)*(py2-py1); let tA=(tx2-tx1)*(ty2-ty1);
+    let iA=iW*iH; let pA=max(0.0,px2-px1)*max(0.0,py2-py1); let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
     let uA=pA+tA-iA+1e-7; let iou=iA/uA;
     let dx=0.5*(px1+px2)-0.5*(tx1+tx2); let dy=0.5*(py1+py2)-0.5*(ty1+ty2);
     let cds=dx*dx+dy*dy;
     let eDx=max(px2,tx2)-min(px1,tx1); let eDy=max(py2,ty2)-min(py1,ty1);
     let ds=eDx*eDx+eDy*eDy+1e-7;
-    let pw=px2-px1+1e-7; let ph=py2-py1+1e-7; let tw=tx2-tx1+1e-7; let th=ty2-ty1+1e-7;
+    let pw=max(px2-px1,1e-7); let ph=max(py2-py1,1e-7); let tw=max(tx2-tx1,1e-7); let th=max(ty2-ty1,1e-7);
     let rd=atan(tw/th)-atan(pw/ph);
     let v=(4.0/(3.14159265*3.14159265))*rd*rd;
     let alpha=v/(1.0-iou+v+1e-7);
@@ -9426,8 +9426,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let iW=max(0.0, min(px2,tx2)-max(px1,tx1));
     let iH=max(0.0, min(py2,ty2)-max(py1,ty1));
     let iA=iW*iH;
-    let pA=(px2-px1)*(py2-py1);
-    let tA=(tx2-tx1)*(ty2-ty1);
+    let pA=max(0.0,px2-px1)*max(0.0,py2-py1);
+    let tA=max(0.0,tx2-tx1)*max(0.0,ty2-ty1);
     let uA=pA+tA-iA+1e-7;
     loss[i] = 1.0 - iA/uA;
 }";


### PR DESCRIPTION
## Problem

`GpuCpuAutoDifferentialTests.GpuKernel_Matches_Cpu(opKey: "TensorCIoULoss(Tensor<T>,Tensor<T>)")` failed **deterministically** with:

```
TensorCIoULoss(Tensor<T>,Tensor<T>) on shape [16,4]: GPU vs CPU max_abs_err 2.604E+000 exceeded tolerance 1.000E-002
```

(Local-GPU-only — the CI runner has no GPU/OpenCL, so the GPU-vs-CPU parity tests are skipped there. Reproduced and fixed on a CUDA box.)

## Root cause

The CIoU aspect-ratio term

```
v = (4/pi^2) * (atan(w_target/h_target) - atan(w_pred/h_pred))^2
```

was computed from **raw** box width/height (`px2-px1+eps`) rather than a positive-clamped width. The parity harness feeds random boxes whose coordinates are independently sampled, so many are *degenerate* (`x2 < x1` or `y2 < y1`). For such a box the raw width is **negative** → the ratio `w/h` is negative → `atan(w/h)` lands in the negative range, and `atan(tw/th) - atan(pw/ph)` can span nearly `pi` instead of the `(-pi/2, pi/2)` a valid box produces. That inflates `v` far past its intended `[0,1]` range (and the `alpha*v` penalty with it), producing the 2.6 divergence.

The CPU reference (`CpuEngine.TensorCIoULoss`) clamps with `ReLU(w)+eps`, so its `v` stays bounded — hence the mismatch. Worked example (the worst box in the failing case): `pred=(1.515,0.713,0.573,0.897)`, `target=(1.426,0.583,0.531,0.548)` → both widths negative → unclamped GPU `v≈3.43`, `alpha*v≈2.65`, loss `3.73` vs CPU `1.12` (diff `2.60`, an exact match for the observed error).

## Fix

Clamp box width/height to `max(., 1e-7)` in the aspect-ratio term, matching the CPU reference and the OpenCL/Vulkan forward kernels that were **already** correct. **For a valid box `max(w,1e-7)==w`, so this is a no-op on real (non-degenerate) boxes — only degenerate-box outputs change, and they now match the CPU reference.**

Per-backend status (forward + backward `ciou_loss`):

| backend | forward | backward |
|---|---|---|
| OpenCL | already clamped | **fixed** |
| Vulkan | already clamped | already clamped |
| CUDA | **fixed** | **fixed** |
| HIP | **fixed** | **fixed** (`tw/th`; a prior partial fix had clamped `pw/ph` only) |
| Metal | **fixed** | **fixed** |
| WebGPU | **fixed** | **fixed** |

WebGPU additionally never clamped the box **areas** (`(px2-px1)*(py2-py1)`) in any of its IoU/GIoU/DIoU/CIoU kernels — the other five backends clamp areas inside their `compute_iou` helper. Clamped those to `max(0,.)` so WebGPU's whole IoU family matches the CPU/other-backend behaviour on degenerate boxes too.

## Validation (CUDA — the active local backend)

- `GpuKernel_Matches_Cpu` IoU-family forward parity (IoU/GIoU/DIoU/CIoU): **4/4 green** (CIoU was the 2.604 failure).
- `BoxIouBackwardTests`: **7/7 green**; `IoULossTests`: **23/23 green** — the backward clamp is a no-op on the valid boxes they exercise, so no regression.

The other backends received the identical mechanical clamp (matching the validated CUDA pattern and the already-correct OpenCL/Vulkan convention) but can't be exercised on this hardware or on CI; the change is purely "clamp width/height positive", a no-op for valid boxes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in IoU-family loss calculations across GPU backends.
  * Clamped box widths, heights, and overlap areas to valid non-negative values, reducing invalid results from very small or negative dimensions.
  * Made CIoU forward and backward calculations more robust, helping prevent incorrect gradients and `atan`-related issues during training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->