### PR TITLE
test: serialize PaddedBuffer bit-match test with OpenBLAS thread-count mutators

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/ManagedVsNativeGemmAudit.cs
@@ -17,6 +17,12 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 // native OpenBLAS. Writes results to a FILE (xUnit ITestOutputHelper isn't captured for
 // passing tests). Native gets ALL cores (deterministic mode otherwise pins OpenBLAS to 1).
 // Category=Performance so CI (Category!=Performance) skips it.
+// Joined to BlasManaged-Stats-Serial because Audit_ManagedVsNative_AcrossHotShapes calls
+// BlasProvider.TrySetOpenBlasThreads (mutating the PROCESS-GLOBAL OpenBLAS thread count). Left
+// uncollected it raced the bit-match/determinism tests in that collection under xUnit's parallel
+// collections, flipping their reduction order. Serializing it here is the same remedy applied to
+// the other global-BLAS-state mutators (see the collection definition in BlasManagedCollections).
+[Collection("BlasManaged-Stats-Serial")]
 public class ManagedVsNativeGemmAudit
 {
     private static readonly (int M, int K, int N, string Note)[] Shapes =

--- a/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferConcurrencyStressTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/PaddedBufferConcurrencyStressTests.cs
@@ -18,6 +18,16 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Helpers;
 
+// Joined to the BlasManaged-Stats-Serial collection. The native-BLAS test below asserts the
+// OpenBLAS GEMM output is bit-identical to a single-thread reference — which only holds while
+// the OpenBLAS internal thread count stays constant (a changed count gives a different, equally
+// valid reduction order, i.e. a ~1-ULP difference). Tests that mutate the PROCESS-GLOBAL thread
+// count (CpuInferenceConfig.PinBlasThreadsForLatency, ManagedVsNativeGemmAudit, the FlashAttention
+// #411 guard) live in this collection; xUnit runs distinct collections in PARALLEL, so leaving
+// this class uncollected let one of those flip the count mid-test and drift the bit-match under
+// the parallel CI pool (the #519 / #513 contamination class — passes in isolation, flakes on CI).
+// Membership in the one serial collection serializes against every such mutator.
+[Collection("BlasManaged-Stats-Serial")]
 public class PaddedBufferConcurrencyStressTests
 {
     private static Tensor<float> RentWithGarbagePadding(int[] shape, float[] logical, float pad)


### PR DESCRIPTION
## Problem

`PaddedBufferConcurrencyStressTests.MatMul_NativeBlasPath_UnderHeavyConcurrency_DoesNotCrashOrDrift` is intermittently red on the `build` job (e.g. seen on #707: `Δ=1.192E-07`). It passes in isolation and on re-run — a classic parallel-CI flake.

## Root cause (not corruption — thread-count contamination)

The test computes a single-thread reference `refOut`, then runs many threads through native OpenBLAS `cblas_sgemm` (M=8, K=513, N=512) and asserts each result is **bit-identical** to `refOut`. Native multi-threaded GEMM is only bit-reproducible while the OpenBLAS **internal thread count is constant** — a different count produces a different (equally valid) reduction order, i.e. a ~1-ULP difference. `1.192E-07` is exactly one float ULP, so this is reduction-order drift, **not** a buffer race (which the test's garbage padding would surface as ~1e5-scale errors, not 1 ULP).

The class was **not** in the `BlasManaged-Stats-Serial` collection. xUnit runs distinct collections **in parallel**, so a concurrent test that mutates the *process-global* OpenBLAS thread count could flip it mid-test and shift the reduction order between the reference and the worker calls. The mutators that do this:

- `CpuInferenceConfigTests` (`PinBlasThreadsForLatency`) — in the serial collection
- `FlashAttentionDoubleHangIssue411Test` — in the serial collection
- `ManagedVsNativeGemmAudit` (`TrySetOpenBlasThreads`) — was **uncollected**

Because the determinism-sensitive PaddedBuffer test was outside the collection, it ran in parallel with all of them. This is the same `#519`/`#513` contamination class — and `#513` was fixed the same way (serialize the bit-match tests with the mutators).

## Fix

Put the determinism-sensitive class in `BlasManaged-Stats-Serial` so it serializes against every global-thread-count mutator → the thread count stays constant during the test → the bit-match holds. Also moved the previously-uncollected `ManagedVsNativeGemmAudit` into the same collection so it can no longer race the determinism tests.

**No assertion is loosened.** The corruption/crash guard (huge drift / access violation — orders of magnitude above 1 ULP) is exactly as before; only the false-positive on legitimate reduction-order non-determinism is removed, by eliminating its trigger.

## Verification

- The determinism tests + the thread-count mutators now run serialized in one collection: **235/235 green** together (`PaddedBufferConcurrencyStressTests` + `CpuInferenceConfigTests` + `PrePackSpeedupTest` + `ScalarKernelTests`).
- The native-BLAS test passes **25/25 in isolation** (the flake never reproduces single-collection — consistent with the parallel-contamination diagnosis).

The flake is CI-parallelism-specific (4-vCPU pool), so it can't be reproduced single-collection locally; this is the same serialization remedy proven on `#513`, and changes only test-collection membership (no production code, no assertion change).
