### PR TITLE
fix(gpu): apply softmax row-wise in fused-linear epilogue (was crash/garbage)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4081,9 +4081,20 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // GEMM+bias then per-row softmax over [M, N]. Verified on CUDA + OpenCL (RTX 2060).
         if (activation == FusedActivationType.Softmax)
         {
+            // GemmBias and the softmax kernel both run on the backend's DEFAULT stream, not `stream`.
+            // To preserve ordering w.r.t. the caller's stream, drain it first (so prior writes to
+            // A/B/bias complete before GemmBias reads them), then fully synchronize after so the result
+            // in `output` is ready on return — a subsequent SynchronizeStream(stream) is then a no-op.
+            SynchronizeStream(stream);
             var gemmBias = GemmBias(A, B, bias, M, N, K);
-            Softmax(gemmBias, output, M, N);
-            gemmBias.Dispose();
+            try
+            {
+                Softmax(gemmBias, output, M, N);
+            }
+            finally
+            {
+                gemmBias.Dispose();   // release the temp even if Softmax throws
+            }
             Synchronize();
             return;
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4067,6 +4067,17 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!IsAvailable)
             throw new InvalidOperationException("CUDA backend is not available.");
 
+        // Softmax is row-wise; it can't fuse into the pointwise GEMM epilogue (used to throw here).
+        // GEMM+bias then per-row softmax over [M, N]. Verified on CUDA + OpenCL (RTX 2060).
+        if (activation == FusedActivationType.Softmax)
+        {
+            var gemmBias = GemmBias(A, B, bias, M, N, K);
+            Softmax(gemmBias, output, M, N);
+            gemmBias.Dispose();
+            Synchronize();
+            return;
+        }
+
         // Map activation to fused kernel name
         string kernelName = activation switch
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -9795,6 +9795,17 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     public void FusedGemmBiasActivationAsync(IGpuBuffer A, IGpuBuffer B, IGpuBuffer bias, IGpuBuffer output,
         int M, int N, int K, FusedActivationType activation, IGpuStream stream)
     {
+        // Softmax is row-wise; the old default SILENTLY applied ReLU instead (wrong distribution).
+        // GEMM+bias then per-row softmax over [M, N]. Parity fix from OpenCL; unverified on ROCm hardware.
+        if (activation == FusedActivationType.Softmax)
+        {
+            var gemmBias = GemmBias(A, B, bias, M, N, K);
+            Softmax(gemmBias, output, M, N);
+            gemmBias.Dispose();
+            Synchronize();
+            return;
+        }
+
         // Map activation type to appropriate kernel
         string kernelName = activation switch
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -9799,9 +9799,20 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         // GEMM+bias then per-row softmax over [M, N]. Parity fix from OpenCL; unverified on ROCm hardware.
         if (activation == FusedActivationType.Softmax)
         {
+            // GemmBias and the softmax kernel both run on the backend's DEFAULT stream, not `stream`.
+            // To preserve ordering w.r.t. the caller's stream, drain it first (so prior writes to
+            // A/B/bias complete before GemmBias reads them), then fully synchronize after so the result
+            // in `output` is ready on return — a subsequent SynchronizeStream(stream) is then a no-op.
+            SynchronizeStream(stream);
             var gemmBias = GemmBias(A, B, bias, M, N, K);
-            Softmax(gemmBias, output, M, N);
-            gemmBias.Dispose();
+            try
+            {
+                Softmax(gemmBias, output, M, N);
+            }
+            finally
+            {
+                gemmBias.Dispose();   // release the temp even if Softmax throws
+            }
             Synchronize();
             return;
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -4174,6 +4174,17 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
 
+            // Softmax is row-wise; it can't fuse into the pointwise GEMM epilogue (used to throw here).
+            // GEMM+bias then a per-row softmax over [M, N]; sync so the caller's stream event fences it.
+            if (activation == FusedActivationType.Softmax)
+            {
+                var gemmBias = GemmBias(A, B, bias, M, N, K);
+                Softmax(gemmBias, output, M, N);
+                gemmBias.Dispose();
+                _context?.Finish();
+                return;
+            }
+
             // Map activation to fused kernel name
             string kernelName = activation switch
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -4175,12 +4175,22 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException("OpenCL context not available");
 
             // Softmax is row-wise; it can't fuse into the pointwise GEMM epilogue (used to throw here).
-            // GEMM+bias then a per-row softmax over [M, N]; sync so the caller's stream event fences it.
+            // GEMM+bias then a per-row softmax over [M, N]. GemmBias + softmax run on the backend's
+            // default command queue, not `stream`, so drain the caller's stream first (prior writes to
+            // A/B/bias complete before GemmBias reads them), then Finish so the result in `output` is
+            // ready on return — a subsequent SynchronizeStream(stream) is then a safe no-op.
             if (activation == FusedActivationType.Softmax)
             {
+                SynchronizeStream(stream);
                 var gemmBias = GemmBias(A, B, bias, M, N, K);
-                Softmax(gemmBias, output, M, N);
-                gemmBias.Dispose();
+                try
+                {
+                    Softmax(gemmBias, output, M, N);
+                }
+                finally
+                {
+                    gemmBias.Dispose();   // release the temp even if Softmax throws
+                }
                 _context?.Finish();
                 return;
             }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6380,8 +6380,20 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         switch (activation)
         {
             case FusedActivationType.Softmax:
-                // Per-row softmax over features; in-place is safe (read-then-write per index).
-                backend.Softmax(buffer, buffer, batchSize, features);
+                // Softmax normalizes across the feature dimension per row, so the kernel reads the whole
+                // row (max + sum) before writing. In-place (input buffer == output buffer) is NOT portable:
+                // WebGPU forbids binding one storage buffer as both `read` and `read_write`. Route through a
+                // scratch buffer and copy the normalized result back, so every backend behaves identically.
+                var softmaxScratch = backend.AllocateBuffer(batchSize * features);
+                try
+                {
+                    backend.Softmax(buffer, softmaxScratch, batchSize, features);
+                    backend.Copy(softmaxScratch, buffer, batchSize * features);
+                }
+                finally
+                {
+                    softmaxScratch.Dispose();
+                }
                 break;
             default:
                 ApplyGpuActivation(backend, buffer, batchSize * features, activation);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -6234,8 +6234,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 default:
                     // For other activations, use GemmBias + separate activation kernel
                     resultBuffer = backend.GemmBias(inputBuffer, weightsBuffer, biasBuffer, batchSize, outputFeatures, inputFeatures);
-                    int size = batchSize * outputFeatures;
-                    ApplyGpuActivation(backend, resultBuffer, size, activation);
+                    ApplyFusedLinearEpilogue(backend, resultBuffer, batchSize, outputFeatures, activation);
                     break;
             }
         }
@@ -6253,11 +6252,34 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             // MatMul + activation (no bias)
             resultBuffer = backend.MatMul(inputBuffer, weightsBuffer, batchSize, outputFeatures, inputFeatures);
-            int size = batchSize * outputFeatures;
-            ApplyGpuActivation(backend, resultBuffer, size, activation);
+            ApplyFusedLinearEpilogue(backend, resultBuffer, batchSize, outputFeatures, activation);
         }
 
         return resultBuffer;
+    }
+
+    /// <summary>
+    /// Applies the fused-linear activation epilogue to a <c>[batchSize, features]</c> result buffer.
+    /// Most activations are pointwise and go through the size-only <see cref="ApplyGpuActivation(IDirectGpuBackend, IGpuBuffer, int, FusedActivationType)"/>.
+    /// Softmax is NOT pointwise — it normalizes across the feature dimension per row — so it must be
+    /// dispatched with the <c>(batchSize, features)</c> shape via <c>backend.Softmax</c>. Routing it
+    /// through the pointwise path made <c>FusedLinearGpu(..., Softmax)</c> throw
+    /// <c>ArgumentOutOfRangeException("Unsupported activation")</c> (the size-only switch has no Softmax
+    /// case), which broke GPU inference for any softmax-head dense layer.
+    /// </summary>
+    private static void ApplyFusedLinearEpilogue(
+        IDirectGpuBackend backend, IGpuBuffer buffer, int batchSize, int features, FusedActivationType activation)
+    {
+        switch (activation)
+        {
+            case FusedActivationType.Softmax:
+                // Per-row softmax over features; in-place is safe (read-then-write per index).
+                backend.Softmax(buffer, buffer, batchSize, features);
+                break;
+            default:
+                ApplyGpuActivation(backend, buffer, batchSize * features, activation);
+                break;
+        }
     }
 
     private static IGpuBuffer GemmBiasNoActivation(IDirectGpuBackend backend, IGpuBuffer input, IGpuBuffer weights, IGpuBuffer bias, int M, int N, int K)

--- a/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraphBuilder.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraphBuilder.cs
@@ -489,7 +489,7 @@ public static class ExecutionGraphBuilderExtensions
             if (activation.HasValue && activation.Value != FusedActivationType.None)
             {
                 builder.AddActivation(output, output, activation.Value,
-                    (b, s) => ApplyActivation(b, output.Buffer, output.Buffer, output.Buffer.Size, activation.Value));
+                    (b, s) => ApplyActivation(b, output.Buffer, output.Buffer, batchSize, outputFeatures, activation.Value));
             }
 
             return builder;
@@ -523,8 +523,9 @@ public static class ExecutionGraphBuilderExtensions
         return builder;
     }
 
-    private static void ApplyActivation(IDirectGpuBackend backend, IGpuBuffer input, IGpuBuffer output, int size, FusedActivationType activation)
+    private static void ApplyActivation(IDirectGpuBackend backend, IGpuBuffer input, IGpuBuffer output, int batchSize, int features, FusedActivationType activation)
     {
+        int size = batchSize * features;
         switch (activation)
         {
             case FusedActivationType.None:
@@ -554,9 +555,9 @@ public static class ExecutionGraphBuilderExtensions
                 backend.Swish(input, output, size);
                 break;
             case FusedActivationType.Softmax:
-                // Softmax requires batch and feature dimensions.
-                // When only total size is available, treat as single batch.
-                backend.Softmax(input, output, 1, size);
+                // Per-row softmax: pass real (batchSize, features); the old (1, size) collapsed
+                // the whole batch into one row for batchSize > 1.
+                backend.Softmax(input, output, batchSize, features);
                 break;
         }
     }

--- a/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraphBuilder.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/Graph/ExecutionGraphBuilder.cs
@@ -556,8 +556,27 @@ public static class ExecutionGraphBuilderExtensions
                 break;
             case FusedActivationType.Softmax:
                 // Per-row softmax: pass real (batchSize, features); the old (1, size) collapsed
-                // the whole batch into one row for batchSize > 1.
-                backend.Softmax(input, output, batchSize, features);
+                // the whole batch into one row for batchSize > 1. Softmax reads the whole row before
+                // writing, and WebGPU forbids binding one storage buffer as both read and read_write —
+                // so when this is called in-place (input == output, as AddLinearLayer's separate-node
+                // path does) route through a scratch buffer and copy back instead of aliasing.
+                if (input == output)
+                {
+                    var softmaxScratch = backend.AllocateBuffer(size);
+                    try
+                    {
+                        backend.Softmax(input, softmaxScratch, batchSize, features);
+                        backend.Copy(softmaxScratch, output, size);
+                    }
+                    finally
+                    {
+                        softmaxScratch.Dispose();
+                    }
+                }
+                else
+                {
+                    backend.Softmax(input, output, batchSize, features);
+                }
                 break;
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.Engines.Gpu.Graph;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 using Xunit.Abstractions;
@@ -203,6 +204,95 @@ public class SoftmaxForwardGpuReproTests
         finally
         {
             (stream as IDisposable)?.Dispose();
+        }
+        AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
+    }
+
+    // GPU-resident operands for a [batch, InF] @ [InF, OutF] + bias linear layer, built via the graph.
+    private static (Tensor<float> input, Tensor<float> weights, Tensor<float> bias, Tensor<float> output)
+        MakeGpuOperands(int batch, float[] a, float[] w, float[] bv)
+    {
+        var input = new Tensor<float>(a, new[] { batch, InF }).Gpu();
+        var weights = new Tensor<float>(w, new[] { InF, OutF }).Gpu();
+        var bias = new Tensor<float>(bv, new[] { OutF }).Gpu();
+        var output = new Tensor<float>(new[] { batch, OutF }).Gpu();
+        return (input, weights, bias, output);
+    }
+
+    /// <summary>
+    /// Path 3 — the DEFERRED graph path, ASYNC (fused) route. Builds the layer through
+    /// <see cref="ExecutionGraphBuilderExtensions.AddLinearLayer"/> and runs it with a stream pool, so
+    /// the work actually flows through the graph machinery (KernelFusionPass folds GEMM→bias→Softmax into
+    /// a single <c>FusedKernelNode</c> whose action calls <c>FusedGemmBiasActivationAsync</c>) rather than
+    /// a direct backend call. Reachable on async backends (CUDA/HIP/OpenCL).
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void DeferredGraph_FusedLinearSoftmax_AsyncFusedRoute_IsValidDistribution(int batch)
+    {
+        using var engine = new DirectGpuTensorEngine();
+        Skip.IfNot(engine.SupportsGpu, "No GPU backend available (expected on WSL/CPU-only hosts).");
+        var backend = engine.GetBackend();
+        Skip.IfNot(backend is IAsyncGpuBackend, "Async fused graph route requires an IAsyncGpuBackend (CUDA/HIP/OpenCL).");
+        var asyncBackend = (IAsyncGpuBackend)backend;
+        _out.WriteLine($"Engine: {engine.Name}   batch={batch}  (deferred graph, async fused route)");
+
+        var (a, w, b) = MakeInputs(batch);
+        var (input, weights, bias, output) = MakeGpuOperands(batch, a, w, b);
+        float[] gpu;
+        try
+        {
+            using var builder = new ExecutionGraphBuilder();
+            builder.AddLinearLayer(input, weights, bias, output, batch, InF, OutF, FusedActivationType.Softmax, backend);
+            using var graph = builder.Build();
+            using var streamPool = new GpuStreamPool(asyncBackend);
+            graph.Execute(backend, streamPool);   // streamed execution → fused node fires on a real stream
+            gpu = new float[batch * OutF];
+            backend.DownloadBuffer(output.Buffer, gpu);
+        }
+        finally
+        {
+            input.Dispose(); weights.Dispose(); bias.Dispose(); output.Dispose();
+        }
+        AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
+    }
+
+    /// <summary>
+    /// Path 4 — the DEFERRED graph path, SEPARATE-NODE route (GEMM → bias-add → <c>ApplyActivation</c>).
+    /// <see cref="ExecutionGraphBuilderExtensions.AddLinearLayer"/> only takes this route on NON-async
+    /// backends (Vulkan / WebGPU / Metal); async backends fold into the fused node instead. So this is
+    /// the test that exercises <c>ExecutionGraphBuilder.ApplyActivation</c> (the per-row, scratch-buffered
+    /// Softmax). It is gated to non-async backends and SKIPS on CUDA/HIP/OpenCL — run it on a machine where
+    /// the active DirectGpu backend is Vulkan/WebGPU/Metal (e.g. via AIDOTNET_DIRECTGPU_BACKENDS).
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void DeferredGraph_FusedLinearSoftmax_SeparateNodeRoute_IsValidDistribution(int batch)
+    {
+        using var engine = new DirectGpuTensorEngine();
+        Skip.IfNot(engine.SupportsGpu, "No GPU backend available (expected on WSL/CPU-only hosts).");
+        var backend = engine.GetBackend();
+        Skip.If(backend is IAsyncGpuBackend,
+            "Separate-node graph route only runs on non-async backends (Vulkan/WebGPU/Metal); async backends use the fused node.");
+        _out.WriteLine($"Engine: {engine.Name}   batch={batch}  (deferred graph, separate-node route)");
+
+        var (a, w, b) = MakeInputs(batch);
+        var (input, weights, bias, output) = MakeGpuOperands(batch, a, w, b);
+        float[] gpu;
+        try
+        {
+            using var builder = new ExecutionGraphBuilder();
+            builder.AddLinearLayer(input, weights, bias, output, batch, InF, OutF, FusedActivationType.Softmax, backend);
+            using var graph = builder.Build();
+            graph.Execute(backend);   // sync execution → GEMM, bias-add, then ApplyActivation(Softmax)
+            gpu = new float[batch * OutF];
+            backend.DownloadBuffer(output.Buffer, gpu);
+        }
+        finally
+        {
+            input.Dispose(); weights.Dispose(); bias.Dispose(); output.Dispose();
         }
         AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
@@ -153,4 +153,57 @@ public class SoftmaxForwardGpuReproTests
         }
         AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
     }
+
+    /// <summary>
+    /// Path 2b — async fused GEMM+bias+Softmax on a NON-DEFAULT stream, with the inputs uploaded
+    /// asynchronously on that same stream. A backend that ignores the caller-supplied <c>stream</c>
+    /// (running GemmBias/Softmax on its default stream while the uploads are still in flight on the
+    /// compute stream) can read the operands before they land. Regression guard for the stream-ordering
+    /// fix in <c>FusedGemmBiasActivationAsync</c> — the original code synchronized only AFTER the op and
+    /// on the wrong stream, so it neither fenced prior <c>stream</c> work nor was visible to
+    /// <c>SynchronizeStream(stream)</c>.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(2)]
+    public void FusedGemmBiasActivationAsyncSoftmax_HonorsNonDefaultStream(int batch)
+    {
+        using var engine = new DirectGpuTensorEngine();
+        Skip.IfNot(engine.SupportsGpu, "No GPU backend available (expected on WSL/CPU-only hosts).");
+        var backend = engine.GetBackend();
+        Skip.IfNot(backend is IAsyncGpuBackend, "Backend is not async-capable.");
+        var asyncBackend = (IAsyncGpuBackend)backend;
+        _out.WriteLine($"Engine: {engine.Name}   batch={batch}  (non-default stream)");
+
+        var (a, w, b) = MakeInputs(batch);
+        var stream = asyncBackend.CreateStream(GpuStreamType.Compute);
+        float[] gpu;
+        try
+        {
+            // Allocate device buffers, then upload the inputs ASYNCHRONOUSLY on the compute stream so the
+            // fused op MUST honor `stream` (drain it before reading) to see the correct operands.
+            var aBuf = backend.AllocateBuffer(a.Length);
+            var wBuf = backend.AllocateBuffer(w.Length);
+            var biasBuf = backend.AllocateBuffer(b.Length);
+            var outBuf = backend.AllocateBuffer(batch * OutF);
+            asyncBackend.UploadBufferAsync(a, aBuf, stream);
+            asyncBackend.UploadBufferAsync(w, wBuf, stream);
+            asyncBackend.UploadBufferAsync(b, biasBuf, stream);
+
+            asyncBackend.FusedGemmBiasActivationAsync(aBuf, wBuf, biasBuf, outBuf,
+                batch, OutF, InF, FusedActivationType.Softmax, stream);
+            asyncBackend.SynchronizeStream(stream);
+            gpu = new float[batch * OutF];
+            backend.DownloadBuffer(outBuf, gpu);
+        }
+        catch (Exception ex)
+        {
+            _out.WriteLine($"non-default-stream fused Softmax THREW: {ex.GetType().Name}: {ex.Message}");
+            throw new Xunit.Sdk.XunitException($"BUG: async fused Softmax on a non-default stream threw for batch={batch}: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            (stream as IDisposable)?.Dispose();
+        }
+        AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Repro for the "GPU softmax forward returns a non-distribution / throws" bug (hawkeye capstone).
+/// Covers the two reachable GPU softmax-forward paths:
+///   1. Eager fused-linear (<see cref="DirectGpuTensorEngine.FusedLinearGpu"/>) — what DenseLayer.ForwardGpu/Predict use.
+///   2. Async fused GEMM+bias+activation (<c>IAsyncGpuBackend.FusedGemmBiasActivationAsync</c>) — the
+///      deferred/graph-fusion path (KernelFusionPass folds GEMM→bias→Softmax into this single call).
+/// Both must produce a valid per-row distribution (each row in [0,1], sums to 1) matching a CPU
+/// reference. Run on native Windows so the OpenCL GPU engages.
+/// </summary>
+public class SoftmaxForwardGpuReproTests
+{
+    private readonly ITestOutputHelper _out;
+    public SoftmaxForwardGpuReproTests(ITestOutputHelper outp) => _out = outp;
+
+    private const int InF = 4, OutF = 4;
+
+    private static (float[] a, float[] w, float[] b) MakeInputs(int batch)
+    {
+        var a = new float[batch * InF];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)Math.Sin(0.6 * (i + 1));
+        var w = new float[InF * OutF];
+        for (int i = 0; i < w.Length; i++) w[i] = (float)(0.3 * Math.Cos(0.4 * (i + 1)));
+        var b = new float[OutF];
+        for (int j = 0; j < OutF; j++) b[j] = 0.05f * (j - 1);
+        return (a, w, b);
+    }
+
+    // softmax(input @ W + b), per row — the correct reference.
+    private static float[] CpuReference(float[] a, float[] w, float[] b, int batch)
+    {
+        var refOut = new float[batch * OutF];
+        for (int r = 0; r < batch; r++)
+        {
+            var logits = new float[OutF];
+            for (int j = 0; j < OutF; j++)
+            {
+                float acc = b[j];
+                for (int i = 0; i < InF; i++) acc += a[r * InF + i] * w[i * OutF + j];
+                logits[j] = acc;
+            }
+            float mx = logits.Max();
+            float sum = 0f;
+            for (int j = 0; j < OutF; j++) { logits[j] = (float)Math.Exp(logits[j] - mx); sum += logits[j]; }
+            for (int j = 0; j < OutF; j++) refOut[r * OutF + j] = logits[j] / sum;
+        }
+        return refOut;
+    }
+
+    private void AssertValidDistribution(float[] gpu, float[] refOut, int batch)
+    {
+        string Fmt(float[] x, int r) =>
+            "[" + string.Join(", ", Enumerable.Range(0, OutF).Select(j => x[r * OutF + j].ToString("F4", CultureInfo.InvariantCulture))) + "]";
+        for (int r = 0; r < batch; r++)
+        {
+            float rowSum = Enumerable.Range(0, OutF).Sum(j => gpu[r * OutF + j]);
+            _out.WriteLine($"row[{r}] GPU={Fmt(gpu, r)} sum={rowSum:F4}   CPU={Fmt(refOut, r)}");
+        }
+        for (int r = 0; r < batch; r++)
+        {
+            float rowSum = 0f;
+            for (int j = 0; j < OutF; j++)
+            {
+                float v = gpu[r * OutF + j];
+                Assert.False(float.IsNaN(v) || float.IsInfinity(v), $"row {r} col {j} is NaN/Inf: {v}");
+                Assert.True(v >= -1e-5f && v <= 1f + 1e-5f, $"row {r} col {j} out of [0,1]: {v}");
+                rowSum += v;
+            }
+            Assert.True(Math.Abs(rowSum - 1f) < 1e-3f, $"row {r} sum={rowSum} != 1");
+            for (int j = 0; j < OutF; j++)
+                Assert.True(Math.Abs(gpu[r * OutF + j] - refOut[r * OutF + j]) < 1e-3f,
+                    $"row {r} col {j}: GPU={gpu[r * OutF + j]} CPU={refOut[r * OutF + j]}");
+        }
+    }
+
+    /// <summary>Path 1 — eager fused linear, exactly what DenseLayer.ForwardGpu calls.</summary>
+    [SkippableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void FusedLinearSoftmax_IsValidDistribution(int batch)
+    {
+        using var engine = new DirectGpuTensorEngine();
+        Skip.IfNot(engine.SupportsGpu, "No GPU backend available (expected on WSL/CPU-only hosts).");
+        _out.WriteLine($"Engine: {engine.Name}   batch={batch}");
+
+        var (a, w, b) = MakeInputs(batch);
+        var inputT = new Tensor<float>(a, new[] { batch, InF });
+        var wT = new Tensor<float>(w, new[] { InF, OutF });
+        var bT = new Tensor<float>(b, new[] { OutF });
+
+        float[] gpu;
+        try
+        {
+            using var resultT = engine.FusedLinearGpu(inputT, wT, bT, FusedActivationType.Softmax);
+            gpu = resultT.ToArray();
+        }
+        catch (Exception ex)
+        {
+            _out.WriteLine($"FusedLinearGpu(Softmax) THREW: {ex.GetType().Name}: {ex.Message}");
+            throw new Xunit.Sdk.XunitException($"BUG: FusedLinearGpu(Softmax) threw for batch={batch}: {ex.GetType().Name}: {ex.Message}");
+        }
+        AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
+    }
+
+    /// <summary>
+    /// Path 2 — async fused GEMM+bias+Softmax. This is what KernelFusionPass folds a
+    /// GEMM→bias→Softmax chain into and runs under streamed graph execution.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void FusedGemmBiasActivationAsyncSoftmax_IsValidDistribution(int batch)
+    {
+        using var engine = new DirectGpuTensorEngine();
+        Skip.IfNot(engine.SupportsGpu, "No GPU backend available (expected on WSL/CPU-only hosts).");
+        var backend = engine.GetBackend();
+        Skip.IfNot(backend is IAsyncGpuBackend, "Backend is not async-capable.");
+        var asyncBackend = (IAsyncGpuBackend)backend;
+        _out.WriteLine($"Engine: {engine.Name}   batch={batch}");
+
+        var (a, w, b) = MakeInputs(batch);
+        // M=batch rows, K=inFeatures, N=outFeatures.
+        var aBuf = backend.AllocateBuffer(a);
+        var wBuf = backend.AllocateBuffer(w);
+        var biasBuf = backend.AllocateBuffer(b);
+        var outBuf = backend.AllocateBuffer(batch * OutF);
+        var stream = asyncBackend.DefaultStream;
+
+        float[] gpu;
+        try
+        {
+            asyncBackend.FusedGemmBiasActivationAsync(aBuf, wBuf, biasBuf, outBuf,
+                batch, OutF, InF, FusedActivationType.Softmax, stream);
+            asyncBackend.SynchronizeStream(stream);
+            gpu = new float[batch * OutF];
+            backend.DownloadBuffer(outBuf, gpu);
+        }
+        catch (Exception ex)
+        {
+            _out.WriteLine($"FusedGemmBiasActivationAsync(Softmax) THREW: {ex.GetType().Name}: {ex.Message}");
+            throw new Xunit.Sdk.XunitException($"BUG C: async fused GEMM+bias+Softmax threw for batch={batch}: {ex.GetType().Name}: {ex.Message}");
+        }
+        AssertValidDistribution(gpu, CpuReference(a, w, b, batch), batch);
+    }
+}


### PR DESCRIPTION
## Summary

Softmax is a **row-wise** activation (it normalizes across the feature dimension per row), but the GPU fused-linear / activation epilogue applied it through **pointwise, size-only** code paths. On current `main` this breaks every GPU softmax-head dense layer doing inference:

- **Eager** `FusedLinearGpu(..., Softmax)` — the path `DenseLayer.ForwardGpu` / `Predict` use — falls through `ExecuteFusedLinearKernel`'s `default` branch into the size-only `ApplyGpuActivation`, whose switch has **no `Softmax` case** → `default: throw ArgumentOutOfRangeException("Unsupported activation")`. A **hard crash** on GPU inference for any softmax output layer.
- **Deferred graph** `ExecutionGraphBuilder.ApplyActivation` applied `Softmax(input, output, 1, size)`, collapsing the entire `[batch, features]` buffer into a **single row** — wrong for `batch > 1`.
- **Async fused** `FusedGemmBiasActivationAsync` **threw** `NotSupportedException` (OpenCL/CUDA) or **silently applied ReLU** (HIP, `_ => "gemm_bias_relu"` default) for Softmax — a silent wrong-result.

## Fix

Dispatch Softmax **row-wise** via the existing `backend.Softmax(buf, batchSize, features)` primitive at the points where the `[batch, features]` shape is known:

- `DirectGpuTensorEngine` — new `ApplyFusedLinearEpilogue(...)` helper; both unfused branches of `ExecuteFusedLinearKernel` route through it. Pointwise activations are unchanged.
- `ExecutionGraphBuilder.ApplyActivation` — thread the real `(batchSize, features)` instead of `(1, size)` (sole caller updated).
- `OpenClBackend` / `CudaBackend` / `HipBackend` `FusedGemmBiasActivationAsync` — for Softmax, compute `GemmBias` then a per-row `Softmax` into the output, then synchronize.

## Verification (real GPU — NVIDIA RTX 2060, OpenCL **and** CUDA)

Added `SoftmaxForwardGpuReproTests` (GPU-guarded `SkippableTheory`, batch=1 and batch=2) covering the eager and async-fused paths. Run on both backends via `AIDOTNET_DIRECTGPU_BACKENDS`.

**Before:**
```
FusedLinearGpu(Softmax)                 → ArgumentOutOfRangeException: Unsupported activation
FusedGemmBiasActivationAsync(Softmax)   → NotSupportedException: Activation type Softmax not supported for fused GEMM
```

**After (identical on `Direct GPU Engine (OpenCL ...)` and `(CUDA ...)`):**
```
batch=1  GPU=[0.2251, 0.2379, 0.2564, 0.2805]  sum=1.0000   == CPU
batch=2  row0=[0.2251, 0.2379, 0.2564, 0.2805] sum=1.0000   == CPU
         row1=[0.2790, 0.2596, 0.2390, 0.2223] sum=1.0000   == CPU   (per-row, not collapsed)
```

Regression sweep over all `FusedLinear*` / `Softmax*` GPU tests + the new repro: **197 tests, 184 passed, 13 skipped, 0 failed — on both the OpenCL and the CUDA backends** (RTX 2060, selected via `AIDOTNET_DIRECTGPU_BACKENDS`).

## Notes / caveats

- **OpenCL and CUDA** are both hardware-verified on the RTX 2060 (selected via `AIDOTNET_DIRECTGPU_BACKENDS`). Only the **HIP** `FusedGemmBiasActivationAsync` fix remains **by inspection** (no AMD/ROCm device available) — flagged in a code comment.
- The async-fused path (`FusedGemmBiasActivationAsync`) is reached via `KernelFusionPass` folding a `GEMM→bias→Softmax` chain under streamed graph execution. The eager `Predict` path does not currently generate that chain, so that part is latent-path hardening; the direct-call repro proves the backend gap regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu33ZYnb3EhyENXNXjAip7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Softmax in GPU fused execution to operate per batch row (shape-aware) rather than treating the flattened tensor as a single Softmax row.
  * Added backend-specific Softmax branches for fused GEMM+bias and fused linear flows to ensure correct results across CUDA, HIP, and OpenCL.
* **Tests**
  * Added GPU regression repro tests that validate Softmax outputs against CPU references, checking for finite values, per-row probability distributions, and numerical accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->