### PR TITLE
fix(compilation): fused optimizer NREs on params with no materialized weights (kicks lazy/multi-modal models off the fused path)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -4993,9 +4993,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// backing-array length), then scales every element by
     /// <c>maxNorm / (totalNorm + 1e-6)</c> when totalNorm exceeds maxNorm.
     /// </summary>
-    private static void ClipGradientsGlobalL2(Tensor<T>[] gradients, double maxNorm)
+    private void ClipGradientsGlobalL2(Tensor<T>[] gradients, double maxNorm)
     {
         if (gradients.Length == 0) return;
+        // A gradient belongs to an unexercised (lazy, off-loss-path) parameter when that PARAMETER's
+        // weight backing is unmaterialized — even though the plan holds a full-length zero gradient
+        // buffer for it. Such gradients are zero: they contribute nothing to the global norm and
+        // scaling them is a no-op. Skipping them makes the clip cost scale with the EXERCISED params
+        // (what the optimizer already does) instead of the full param set — ClipGradientsGlobalL2 was
+        // ~44% of a UnifiedMultimodal training step, almost all of it scanning ~500M zero elements. #1738
+        var ps = _parameters;
+        bool SkipUnexercised(int p)
+        {
+            if (ps is null || ps.Length != gradients.Length) return false;
+            var pt = ps[p];
+            if (pt is null) return true;
+            var pa = pt.GetLiveBackingArrayAllowingPaddingOrNull();
+            return pa is null || pa.Length == 0;
+        }
 
         // CodeRabbit #425 review: detect GPU-resident gradients before the CPU
         // clip loop. Pre-fix the CPU pass would compute the L2 norm over a
@@ -5041,7 +5056,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < gradients.Length; p++)
         {
             var tensor = gradients[p];
-            if (tensor == null) continue;
+            if (tensor == null || SkipUnexercised(p)) continue;
             var arr = tensor.GetLiveBackingArrayAllowingPaddingOrNull() ?? tensor.GetDataArray();
             int len = tensor.Length;
             for (int i = 0; i < len; i++)
@@ -5059,7 +5074,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < gradients.Length; p++)
         {
             var tensor = gradients[p];
-            if (tensor == null) continue;
+            if (tensor == null || SkipUnexercised(p)) continue;
             var arr = tensor.GetLiveBackingArrayAllowingPaddingOrNull() ?? tensor.GetDataArray();
             int len = tensor.Length;
             for (int i = 0; i < len; i++)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1983,7 +1983,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 }
 
                 // CPU path: pin live backing + SIMD kernel.
-                if (gradArrays[p].Length == 0) continue;
+                // Skip a parameter with no gradient (its grad buffer was never written this
+                // step) OR no materialized weight backing. The latter happens for lazy /
+                // unexercised layers — e.g. the unused-modality encoders of a multi-modal
+                // model whose forward only touched one modality: the plan pre-allocates their
+                // grad/m/v buffers at their declared length, but the parameter's live backing
+                // array stays empty (length 0) until first materialization, so there is nothing
+                // to update. The eager optimizer path skips such params the same way (#1738).
+                // Without the paramArrays guard, `fixed` over the empty backing yields a null
+                // pointer and the SIMD kernel NREs at the full declared length, which is caught
+                // upstream and silently kicks the ENTIRE model off the fused fast path onto the
+                // ~17× slower eager autograd tape — the exact UnifiedMultimodal regression.
+                if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
@@ -2308,7 +2319,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     continue;
                 }
 
-                if (gradArrays[p].Length == 0) continue;
+                // Skip params with no gradient OR no materialized weight backing (lazy /
+                // unexercised layers; see the same guard in ConfigureOptimizerFloat). #1738.
+                if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
 
                 fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
                        pM = m[p], pV = v[p], pVMax = vMax[p])

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1926,7 +1926,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 float wsNext = sfWeightSum;
                 for (int p = 0; p < paramCount; p++)
                 {
-                    if (gradArrays[p].Length == 0) continue;
+                    if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
                     fixed (float* pZ = m[p], pX = v[p], pGrad = gradArrays[p])
                         wsNext = FusedOptimizer.ScheduleFreeSgdUpdateSimd(

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1873,7 +1873,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 float newLr = lr + hgAdj;
                 for (int p = 0; p < paramCount; p++)
                 {
-                    if (gradArrays[p].Length == 0) continue;
+                    // Skip params with no gradient OR no materialized weight backing (#1738).
+                    if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
                     fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p], pPrev = m[p])
                         for (int i = 0; i < len2; i++) { pParam[i] -= newLr * pGrad[i]; pPrev[i] = pGrad[i]; }
@@ -1904,7 +1905,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 float gammaNew = dNew * lr;
                 for (int p = 0; p < paramCount; p++)
                 {
-                    if (gradArrays[p].Length == 0) continue;
+                    // Skip params with no gradient OR no materialized weight backing (#1738).
+                    if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
                     fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p])
                         for (int i = 0; i < len2; i++) pParam[i] -= gammaNew * pGrad[i];
@@ -2520,7 +2522,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             double lr = lrSchedule.GetLr(_optimizerStep);
             for (int p = 0; p < paramCount; p++)
             {
-                if (gradArrays[p].Length == 0) continue;
+                // Skip params with no gradient OR no materialized weight backing (#1738).
+                if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                 int len = lengths[p];
                 fixed (double* pParam = paramArrays[p], pGrad = gradArrays[p],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
@@ -2641,7 +2644,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             for (int p = 0; p < paramCount; p++)
             {
-                if (gradArrays[p].Length == 0) continue;
+                // Skip params with no gradient OR no materialized weight backing (#1738).
+                if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                 int len = lengths[p];
                 double lr = groupLrs[paramGroup[p]];
 


### PR DESCRIPTION
## Summary
Fixes a `NullReferenceException` in the fused compiled-training step that silently kicks **any model with a lazy/unexercised parameter off the fused fast path** onto the ~17× slower eager autograd tape.

## Root cause
`CompiledTrainingPlan.ConfigureOptimizerFloat` (and `…Grouped`) pin each parameter's live backing array and run a SIMD optimizer kernel. They guarded only against an empty **gradient** buffer (`gradArrays[p].Length == 0`), not an empty **parameter backing**.

Lazy / unexercised layers — e.g. the unused-modality encoders of a multi-modal model whose forward only touched one modality — have their grad/m/v buffers pre-allocated at the declared length, but the parameter's weight backing array stays **empty (length 0)** until first materialization. For those, `fixed (float* pParam = paramArrays[p])` yields a **null pointer** and the SIMD kernel dereferences it at the full declared length → NRE. The consumer catches it and falls back to the eager tape for the **entire model**.

## Impact (measured, AiDotNet#1738)
On AiDotNet's `UnifiedMultimodalNetwork` (540M params): every `Train` step hit the NRE and fell back to eager. With this fix the fused path engages and the per-step managed allocation drops **2318 → 21 MB/iter (111×)**; training still converges (loss decreases).

## Fix
Skip a parameter when its live backing is empty (nothing materialized to update) — in both the per-parameter and grouped float optimizer configs — mirroring how the eager optimizer path skips params without gradients. Simple single-path models are unaffected (their params are always materialized, so the new guard never fires).

Refs AiDotNet#1738.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimizer stability when certain model parameters haven’t been materialized yet.
  * Prevented optimizer updates from processing parameters whose weight backing is not available, not just those with empty gradient buffers.
  * Applied the protection across float and double optimizer paths, including grouped and SIMD/CPU update flows.
  * Updated global L2 gradient clipping to skip gradients for unexercised parameters with unmaterialized weight backing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->