### PR TITLE
feat(fused): bfloat16 moment storage for fused Adam/AdamW (CPU)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -719,6 +719,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private Action? _preForwardParamTransform;
     private int _optimizerStep;
 
+    // #1745: when set, the float Adam/AdamW fused path stores its m/v moment
+    // buffers as bfloat16 (half the fp32 footprint) instead of fp32. The
+    // consumer requests this before ConfigureOptimizer; it is honored only for
+    // CPU-resident float Adam/AdamW (the only kernels with a bf16 variant), and
+    // silently ignored otherwise so correctness never depends on it. Lets large
+    // models keep BOTH the fused fast path and a halved optimizer-state
+    // footprint instead of dropping to the eager tape for memory.
+    private bool _useBf16Moments;
+
+    /// <summary>
+    /// Requests bfloat16 storage for the Adam/AdamW moment state on the float CPU
+    /// fused path (#1745). Halves resident optimizer-state memory (m, v) while
+    /// keeping the fp32 update math; honored only for CPU float Adam/AdamW and a
+    /// no-op for every other configuration. Call before <see cref="ConfigureOptimizer(OptimizerType, float, float, float, float, float, FusedOptimizerExtras?)"/>.
+    /// </summary>
+    public void RequestBf16MomentStorage(bool enabled) => _useBf16Moments = enabled;
+
     /// <summary>
     /// Global gradient L2-norm clip threshold. When &gt; 0, applied inside
     /// <see cref="Step"/> between the backward pass and the fused optimizer
@@ -1668,6 +1685,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // the optimizer is AMSGrad, else left as an empty array.
         var vMax = new float[paramCount][];
 
+        // #1745: bfloat16 moment storage for CPU float Adam/AdamW. Honored only
+        // when requested AND the optimizer is Adam/AdamW AND no parameter is
+        // GPU-resident (the GPU Adam kernel keeps fp32 moments). Halves the m/v
+        // resident footprint while the update math stays fp32. When engaged, the
+        // fp32 m[p]/v[p] slots are left empty and these bf16 buffers carry state.
+        bool anyGpuParam = System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
+        bool useBf16 = _useBf16Moments
+            && (optimizerType is OptimizerType.Adam or OptimizerType.AdamW)
+            && !anyGpuParam;
+        var mB = new ushort[paramCount][];
+        var vB = new ushort[paramCount][];
+
         // GPU path state (parallel arrays to paramArrays etc.). For each
         // parameter that's GPU-resident, gpuParam[p] / gpuGrad[p] hold the
         // live IGpuBuffer and the per-step closure dispatches to the
@@ -1801,8 +1830,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 gradArrays[p] = Array.Empty<float>();
             }
 
-            m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
-            v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+            if (useBf16)
+            {
+                // bf16 path: m/v carried as bfloat16 (half the fp32 bytes); the
+                // fp32 slots stay empty. ushort 0x0000 == bf16 +0.0 — the correct
+                // zero seed Adam expects for both moments on step 1.
+                m[p] = Array.Empty<float>();
+                v[p] = Array.Empty<float>();
+                mB[p] = new ushort[lengths[p]];
+                vB[p] = new ushort[lengths[p]];
+            }
+            else
+            {
+                m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
+                v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+                mB[p] = Array.Empty<ushort>();
+                vB[p] = Array.Empty<ushort>();
+            }
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new float[lengths[p]] : Array.Empty<float>();
         }
 
@@ -2062,12 +2106,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             // by the dedicated AdamWUpdateSimd kernel.)
                             if (wd != 0f)
                                 for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
-                            FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, _optimizerStep);
+                            // #1745: bf16-moment variant when requested (mB/vB carry
+                            // the bfloat16 state; pM/pV are empty). Same fp32 math.
+                            if (useBf16)
+                                fixed (ushort* pMb = mB[p], pVb = vB[p])
+                                    FusedOptimizer.AdamUpdateBf16Simd(pParam, pGrad, pMb, pVb, len,
+                                        lr, b1, b2, epsVal, _optimizerStep);
+                            else
+                                FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
+                                    lr, b1, b2, epsVal, _optimizerStep);
                             break;
                         case OptimizerType.AdamW:
-                            FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, wd, _optimizerStep);
+                            if (useBf16)
+                                fixed (ushort* pMb = mB[p], pVb = vB[p])
+                                    FusedOptimizer.AdamWUpdateBf16Simd(pParam, pGrad, pMb, pVb, len,
+                                        lr, b1, b2, epsVal, wd, _optimizerStep);
+                            else
+                                FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
+                                    lr, b1, b2, epsVal, wd, _optimizerStep);
                             break;
                         case OptimizerType.AMSGrad:
                             // AMSGrad (#74): Adam with a running max of v̂ so the

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -127,6 +127,79 @@ internal static class FusedOptimizer
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // BF16 moment-storage Adam/AdamW (#1745 follow-up). The Adam moment
+    // buffers m, v are the dominant training-step memory cost — 2x the model
+    // weights at fp32. Storing them as bfloat16 halves that to 1x while keeping
+    // the FULL float32 exponent (only the mantissa shortens 23→7 bits), so
+    // Adam's trajectory changes negligibly and — unlike int8 block-quant — no
+    // per-block scales are needed. These kernels widen each stored bf16 moment
+    // to fp32, run the EXACT same update math as the fp32 kernels, and narrow
+    // the result back to bf16 with round-to-nearest-even. Compute stays fp32;
+    // only the resident moment storage is halved. This lets large models keep
+    // the fused fast path AND the halved optimizer-state footprint, instead of
+    // falling off the fused path onto the eager tape when memory matters.
+    //
+    // Parameters and gradients remain fp32 (their precision is load-bearing for
+    // the weight update); bf16 applies only to the m/v accumulators, exactly as
+    // bitsandbytes / DeepSpeed store the optimizer state at reduced precision.
+    // Scalar-only: bf16 widen/narrow has no broad AVX2 intrinsic (AVX512-BF16
+    // is not assumed), and the win here is resident bytes, not peak throughput —
+    // this path is still far faster than the eager autograd tape it replaces.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// <summary>Widen a bfloat16 (the top 16 bits of a float32) to float32.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe float Bf16ToFloat(ushort b)
+    {
+        uint u = (uint)b << 16;
+        return *(float*)&u;
+    }
+
+    /// <summary>
+    /// Narrow a float32 to bfloat16 with round-to-nearest-even. NaN is mapped to a
+    /// quiet bf16 NaN (never silently truncated into an infinity), matching the
+    /// IEEE/​PyTorch bf16 cast.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe ushort Bf16FromFloat(float f)
+    {
+        uint bits = *(uint*)&f;
+        if ((bits & 0x7FFFFFFFu) > 0x7F800000u)
+            return (ushort)((bits >> 16) | 0x0040u); // preserve sign, force quiet NaN
+        uint rounding = 0x7FFFu + ((bits >> 16) & 1u); // round-to-nearest-even bias
+        return (ushort)((bits + rounding) >> 16);
+    }
+
+    /// <summary>Adam update with bfloat16 moment storage (fp32 params/grads, fp32 math).</summary>
+    internal static unsafe void AdamUpdateBf16Simd(
+        float* param, float* grad, ushort* m, ushort* v, int length,
+        float lr, float beta1, float beta2, float eps, int step)
+    {
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        for (int i = 0; i < length; i++)
+        {
+            float mi = beta1 * Bf16ToFloat(m[i]) + (1f - beta1) * grad[i];
+            float vi = beta2 * Bf16ToFloat(v[i]) + (1f - beta2) * grad[i] * grad[i];
+            m[i] = Bf16FromFloat(mi);
+            v[i] = Bf16FromFloat(vi);
+            float mHat = mi / bc1;
+            float vHat = vi / bc2;
+            param[i] -= lr * mHat / (MathF.Sqrt(vHat) + eps);
+        }
+    }
+
+    /// <summary>AdamW (decoupled weight decay) with bfloat16 moment storage.</summary>
+    internal static unsafe void AdamWUpdateBf16Simd(
+        float* param, float* grad, ushort* m, ushort* v, int length,
+        float lr, float beta1, float beta2, float eps, float weightDecay, int step)
+    {
+        for (int i = 0; i < length; i++)
+            param[i] *= (1f - weightDecay * lr);
+        AdamUpdateBf16Simd(param, grad, m, v, length, lr, beta1, beta2, eps, step);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // Double-precision overloads — engaged for `Tensor<double>` models on
     // the fused-compiled training path. PR #319 follow-up: the
     // CompiledTrainingPlan / CompiledTapeTrainingStep fast paths used to

--- a/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
@@ -420,6 +420,16 @@ public interface ICompiledTrainingPlan<T> : IDisposable
     void SetMaxGradNorm(double maxNorm);
 
     /// <summary>
+    /// Requests bfloat16 storage for the Adam/AdamW moment state (m, v) on the
+    /// float CPU fused path (#1745). Halves resident optimizer-state memory while
+    /// keeping the fp32 update math, so large models can stay on the fused fast
+    /// path instead of dropping to the eager tape for memory. Call before
+    /// <see cref="ConfigureOptimizer(OptimizerType, float, float, float, float, float, FusedOptimizerExtras?)"/>;
+    /// honored only for CPU float Adam/AdamW and a safe no-op otherwise.
+    /// </summary>
+    void RequestBf16MomentStorage(bool enabled);
+
+    /// <summary>
     /// Configures fused optimizer updates with a per-step
     /// <see cref="LrSchedule"/>. Equivalent to
     /// <see cref="ConfigureOptimizer(OptimizerType, float, float, float, float, float)"/>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedBf16MomentAdamParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedBf16MomentAdamParityTests.cs
@@ -1,0 +1,133 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// #1745: the fused Adam/AdamW path can store its moment state (m, v) as
+/// bfloat16 instead of fp32, halving the optimizer-state footprint — the
+/// dominant training-step memory cost — while keeping the fp32 update math.
+/// This lets large models stay on the fused fast path AND keep the reduced
+/// optimizer-state memory, instead of being forced onto the eager autograd
+/// tape (≈10× slower) when memory matters.
+///
+/// These tests build two identical plans over the same seeded weights and the
+/// same deterministic graph, run N optimizer steps on each — one with fp32
+/// moments, one with bf16 moments — and assert the bf16 run (a) actually
+/// updates the parameter in place and (b) tracks the fp32 reference closely.
+/// bfloat16 keeps the FULL float32 exponent (only the mantissa shortens 23→7
+/// bits), so the trajectory deviation is bounded to a small fraction of the
+/// fp32 weight movement; a broken kernel (wrong sign, no update, exponent loss)
+/// blows past that bound.
+/// </summary>
+public class FusedBf16MomentAdamParityTests
+{
+    private const int Steps = 6;
+
+    // Builds a fresh regression graph (FusedLinear → (out-target)² → sum) over a
+    // single trainable weight, seeded identically every call so the fp32 and
+    // bf16 runs start from the same point and see the same gradients each step.
+    private static (ICompiledTrainingPlan<float> plan, Tensor<float> weight, float[] init) BuildPlan()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 4, 8 });
+        var weight = new Tensor<float>(new[] { 8, 4 });
+        var bias = new Tensor<float>(new[] { 4 });
+        var target = new Tensor<float>(new[] { 4, 4 });
+        var rng = new System.Random(12345);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < bias.Length; i++) bias[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < target.Length; i++) target[i] = (float)(rng.NextDouble() - 0.5);
+        var init = weight.GetDataArray().AsSpan().ToArray();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+            var diff = engine.TensorSubtract(output, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            engine.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { weight });
+        }
+        return (plan, weight, init);
+    }
+
+    private static void AssertBf16TracksFp32(OptimizerType opt)
+    {
+        // fp32 reference run.
+        var (planRef, wRef, init) = BuildPlan();
+        using (planRef)
+        {
+            planRef.ConfigureOptimizer(opt, learningRate: 0.01f, weightDecay: opt == OptimizerType.AdamW ? 0.01f : 0f);
+            for (int s = 0; s < Steps; s++) planRef.Step();
+        }
+        var fp32 = wRef.GetDataArray().AsSpan().ToArray();
+
+        // bf16-moment run from the identical starting point.
+        var (planBf16, wBf16, _) = BuildPlan();
+        using (planBf16)
+        {
+            planBf16.RequestBf16MomentStorage(true);
+            planBf16.ConfigureOptimizer(opt, learningRate: 0.01f, weightDecay: opt == OptimizerType.AdamW ? 0.01f : 0f);
+            for (int s = 0; s < Steps; s++) planBf16.Step();
+        }
+        var bf16 = wBf16.GetDataArray().AsSpan().ToArray();
+
+        double maxMove = 0, maxParityDiff = 0;
+        for (int i = 0; i < init.Length; i++)
+        {
+            maxMove = System.Math.Max(maxMove, System.Math.Abs(fp32[i] - init[i]));
+            maxParityDiff = System.Math.Max(maxParityDiff, System.Math.Abs(bf16[i] - fp32[i]));
+        }
+
+        // (a) the bf16 kernel actually moved the weight off its init.
+        double maxBf16Move = 0;
+        for (int i = 0; i < init.Length; i++)
+            maxBf16Move = System.Math.Max(maxBf16Move, System.Math.Abs(bf16[i] - init[i]));
+        Assert.True(maxBf16Move > 0, $"{opt}: bf16-moment Step() did not update the weight in place.");
+
+        // (b) bf16 tracks fp32 to within a small fraction of the fp32 movement
+        // (bf16's 7-bit mantissa → ~0.4%/step moment error) plus a tiny floor.
+        double tolerance = 1e-4 + 0.05 * maxMove;
+        Assert.True(maxParityDiff <= tolerance,
+            $"{opt}: bf16-moment Adam diverged from fp32 reference. " +
+            $"max|Δparity|={maxParityDiff:E4}, fp32 move={maxMove:E4}, tol={tolerance:E4}.");
+    }
+
+    [Fact]
+    public void Adam_Bf16Moments_TrackFp32Reference()
+        => AssertBf16TracksFp32(OptimizerType.Adam);
+
+    [Fact]
+    public void AdamW_Bf16Moments_TrackFp32Reference()
+        => AssertBf16TracksFp32(OptimizerType.AdamW);
+
+    /// <summary>
+    /// bf16-moment Adam must be deterministic: two identical runs produce
+    /// bit-identical weights (the rounding is round-to-nearest-even, no
+    /// nondeterministic source).
+    /// </summary>
+    [Fact]
+    public void Bf16Moments_AreDeterministic()
+    {
+        float[] Run()
+        {
+            var (plan, w, _) = BuildPlan();
+            using (plan)
+            {
+                plan.RequestBf16MomentStorage(true);
+                plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+                for (int s = 0; s < Steps; s++) plan.Step();
+            }
+            return w.GetDataArray().AsSpan().ToArray();
+        }
+
+        var a = Run();
+        var b = Run();
+        for (int i = 0; i < a.Length; i++)
+            Assert.Equal(a[i], b[i]);
+    }
+}


### PR DESCRIPTION
## Problem
The fused compiled-training optimizer keeps its Adam moment buffers (`m`, `v`) as **fp32** — 2× the model weights, the dominant training-step memory cost. Large models therefore face a forced choice:
- **fused fast path** → fp32 moments → full optimizer-state memory, or
- a **memory-efficient optimizer** (8-bit / bf16 Adam) → **not fused** → falls back to the eager autodiff tape (~10× slower).

The consumer (AiDotNet) was papering over this by gating BF16-Adam off under memory pressure so models stayed fused — trading the memory saving away. This PR removes that tradeoff at the source.

## Fix
A **bfloat16 moment-storage variant** of the fused Adam/AdamW CPU kernel: models get **both** the fused fast path **and** half the optimizer-state footprint. bf16 keeps the full float32 exponent (only the mantissa shortens 23→7 bits), so Adam's trajectory changes negligibly and — unlike int8 block-quant — **no per-block scales** are needed.

- **`FusedOptimizer.AdamUpdateBf16Simd` / `AdamWUpdateBf16Simd`** — widen each stored bf16 moment to fp32, run the **exact same** update math as the fp32 kernels, narrow back to bf16 with round-to-nearest-even (NaN-safe). Params/grads stay fp32; only the resident moment storage is halved. net471-safe (pointer reinterpret; no `BitConverter.Int32BitsToSingle`).
- **`CompiledTrainingPlan.RequestBf16MomentStorage(bool)`** — opt-in; when set, the float CPU Adam/AdamW path allocates `ushort[]` `m`/`v` (leaving the fp32 slots empty) and dispatches the bf16 kernel. Honored only for **CPU float Adam/AdamW** (no GPU params); a safe no-op otherwise so correctness never depends on it.
- Exposed on `ICompiledTrainingPlan<T>`.

## Verification
- **New parity tests** (`FusedBf16MomentAdamParityTests`, 3/3): bf16-moment Adam **and** AdamW track an fp32 reference run within a tight bound (a fraction of the fp32 weight movement) over 6 steps; bf16 runs are bit-deterministic.
- **No regression**: 58 existing fused-optimizer tests (`ConfigureOptimizerParamUpdate`, `AMSGrad`, `FusedDispatch`, `MultiMatMulFusedAdam`) stay green.
- Builds clean across **net471 / net8.0 / net10.0**.

## Scope / follow-ups
- CPU float Adam/AdamW only (the path the memory-pressured large models hit). GPU keeps fp32 moments; bf16 requests there fall back to fp32.
- **int8 block-quant** moments and a **GPU** bf16 kernel can reuse the same `RequestBf16MomentStorage`/storage-precision seam in follow-ups.
- Consumer wiring (AiDotNet `Adam8BitOptimizer` BF16 mode → `IFusedOptimizerSpec` + `RequestBf16MomentStorage`, replacing the memory gate) lands after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)