### PR TITLE
[codex] add fused schedule and bound compiled GPU memory

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -220,6 +220,11 @@ internal static class PackBothStrategy
                 && typeof(T) == typeof(float)
                 && !transA && !transB
                 && options.PackedA is null && options.PackedB is null
+                // RunNAxisParallelUnsafe dispatches the FP32 machine-code panel, whose packed-A
+                // layout is fixed at 6 rows by 16 columns. If the active PackBoth tile is wider
+                // (for example AVX-512 16x16), falling into this path would reinterpret the
+                // packed buffers with the wrong shape.
+                && nr == MachineKernelGemm.Fp32Nr
                 && (s_allowNAxisMTail || (m % mr) == 0) && m >= mr
                 // Wide-N gate (n >= k): the N-axis re-reads the shared A (m×k) once per N-block,
                 // so it pays off only when N is wide enough to amortize that — measured across 6

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1471,7 +1471,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private HashSet<object> BuildStepEvictionProtectSet()
     {
-        var protect = new HashSet<object>();
+        var protect = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
         for (int i = 0; i < _gradients.Length; i++)
             AddActivationCacheKeys(protect, _gradients[i]);
         AddActivationCacheKeys(protect, _lossGradDest);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1439,19 +1439,15 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             evictGuard?.ResumeActivationEviction();
             // Release this step's dead transient activations/grads/scratch. The optimizer has already read
-            // _gradients; protect the public parameter-gradient tensors and materialize only the returned loss.
+            // _gradients; protect the public parameter-gradient tensors and always materialize pending downloads
+            // before eviction so any externally-held step output still has a valid CPU view after Step().
             if (stepActivationEngine is not null && stepActivationSnapshot >= 0)
             {
-                // FULL-RESIDENCY: the ONLY value the caller reads from a step is the scalar loss (the returned
-                // tensor). Materialize just that (one tiny GPU→CPU copy) and DISCARD every other dead step
-                // intermediate without a download — so a training step's only host transfer is the loss readout
-                // (the activations / gradients / optimizer state never round-trip). The next step's Execute
-                // recomputes the node outputs; reading any non-loss output after Step() is not part of its contract.
                 MaterializeStepLoss();
                 stepActivationEngine.EvictActivationsCreatedAfter(
                     stepActivationSnapshot,
                     BuildStepEvictionProtectSet(),
-                    materializePending: false);
+                    materializePending: true);
             }
             // Bound cross-step VRAM growth: per-step transient activation buffers are dereferenced
             // here but their device memory is only released by the GC finalizer, which cannot keep

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1189,16 +1189,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             ? null
             : engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
         evictGuard?.SuspendActivationEviction();
-        // FP16 hetero path per-step LEAK fix (MEASURED): the Execute-replay caches fresh per-step transients
-        // (Half activations, grad contributions, scratch) keyed on NEW arrays every step, and — unlike the FP32
-        // compiled path's stable preallocated buffers — they accumulate across steps (the cortex GPU peak grew
-        // ~0.8MB/step faster than FP32). Snapshot the activation-cache timestamp before this step and
-        // deterministically release everything created during it in the finally (exactly what GradientTape does
-        // on dispose). Persistent state (params, optimizer m/v, gradMap) was allocated earlier → kept.
-        long fp16ActSnapshot = -1;
-        var fp16SnapEng = _fp16HeteroOrder is not null
-            ? engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine : null;
-        if (fp16SnapEng is not null) fp16ActSnapshot = fp16SnapEng.ActivationCacheTimestampSnapshot();
+        // Snapshot the activation-cache timestamp before this eager compiled step. Step() returns only the scalar
+        // loss and exposes parameter gradients; all other forward/backward intermediates created during the step
+        // are dead after the optimizer runs and must not accumulate across long training loops.
+        var stepActivationEngine = engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
+        long stepActivationSnapshot = stepActivationEngine?.ActivationCacheTimestampSnapshot() ?? -1;
         // FP16 mixed precision on the FUSED path (AiDotNet #1354 / #555). The fused plan
         // ignores AiDotNet's _mixedPrecisionContext, but the Tensors-level AutocastScope is
         // honored by the engine's matmul/conv/elementwise GPU ops (norms, softmax, loss and
@@ -1443,20 +1438,20 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         finally
         {
             evictGuard?.ResumeActivationEviction();
-            // FP16 hetero per-step leak fix: deterministically release THIS step's transient activations/grads/
-            // scratch (created after the snapshot). The optimizer has already read _gradients (separate stable
-            // buffers); the stable node-output tensors re-cache on the next step's Execute. This is what keeps
-            // the FP16 path's cross-step VRAM flat instead of climbing ~0.8MB/step.
-            if (fp16SnapEng is not null && fp16ActSnapshot >= 0)
+            // Release this step's dead transient activations/grads/scratch. The optimizer has already read
+            // _gradients; protect the public parameter-gradient tensors and materialize only the returned loss.
+            if (stepActivationEngine is not null && stepActivationSnapshot >= 0)
             {
                 // FULL-RESIDENCY: the ONLY value the caller reads from a step is the scalar loss (the returned
                 // tensor). Materialize just that (one tiny GPU→CPU copy) and DISCARD every other dead step
                 // intermediate without a download — so a training step's only host transfer is the loss readout
                 // (the activations / gradients / optimizer state never round-trip). The next step's Execute
                 // recomputes the node outputs; reading any non-loss output after Step() is not part of its contract.
-                var lossKey = _lossOutput.DataVector.GetBackingArrayUnsafe();
-                if (lossKey is not null) Helpers.DeferredArrayMaterializer.TryMaterialize(lossKey);
-                fp16SnapEng.EvictActivationsCreatedAfter(fp16ActSnapshot, protect: null, materializePending: false);
+                MaterializeStepLoss();
+                stepActivationEngine.EvictActivationsCreatedAfter(
+                    stepActivationSnapshot,
+                    BuildStepEvictionProtectSet(),
+                    materializePending: false);
             }
             // Bound cross-step VRAM growth: per-step transient activation buffers are dereferenced
             // here but their device memory is only released by the GC finalizer, which cannot keep
@@ -1464,6 +1459,33 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // finalizer-backed reclaim under memory pressure (cheap no-op when not pressured).
             (engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine)?.ReclaimGpuMemoryUnderPressure();
         }
+    }
+
+    private void MaterializeStepLoss()
+    {
+        var lossKey = _lossOutput.DataVector.GetBackingArrayUnsafe();
+        if (lossKey is not null)
+            Helpers.DeferredArrayMaterializer.TryMaterialize(lossKey);
+        Helpers.DeferredArrayMaterializer.TryMaterialize(_lossOutput.DataVector);
+    }
+
+    private HashSet<object> BuildStepEvictionProtectSet()
+    {
+        var protect = new HashSet<object>();
+        for (int i = 0; i < _gradients.Length; i++)
+            AddActivationCacheKeys(protect, _gradients[i]);
+        AddActivationCacheKeys(protect, _lossGradDest);
+        AddActivationCacheKeys(protect, _lossGradSeed);
+        return protect;
+    }
+
+    private static void AddActivationCacheKeys(HashSet<object> keys, Tensor<T>? tensor)
+    {
+        if (tensor is null) return;
+        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        if (backing is not null)
+            keys.Add(backing);
+        keys.Add(tensor.DataVector);
     }
 
     public unsafe void ConfigureOptimizer(

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1439,8 +1439,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             evictGuard?.ResumeActivationEviction();
             // Release this step's dead transient activations/grads/scratch. The optimizer has already read
-            // _gradients; protect the public parameter-gradient tensors and always materialize pending downloads
-            // before eviction so any externally-held step output still has a valid CPU view after Step().
+            // _gradients; protect public gradient/seed/dest tensors, materialize only the returned loss, and
+            // discard unprotected scratch materializers so cleanup does not introduce step-ending DtoH traffic.
             if (stepActivationEngine is not null && stepActivationSnapshot >= 0)
             {
                 try
@@ -1452,7 +1452,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     stepActivationEngine.EvictActivationsCreatedAfter(
                         stepActivationSnapshot,
                         BuildStepEvictionProtectSet(),
-                        materializePending: true);
+                        materializePending: false);
                 }
             }
             // Bound cross-step VRAM growth: per-step transient activation buffers are dereferenced

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1443,11 +1443,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // before eviction so any externally-held step output still has a valid CPU view after Step().
             if (stepActivationEngine is not null && stepActivationSnapshot >= 0)
             {
-                MaterializeStepLoss();
-                stepActivationEngine.EvictActivationsCreatedAfter(
-                    stepActivationSnapshot,
-                    BuildStepEvictionProtectSet(),
-                    materializePending: true);
+                try
+                {
+                    MaterializeStepLoss();
+                }
+                finally
+                {
+                    stepActivationEngine.EvictActivationsCreatedAfter(
+                        stepActivationSnapshot,
+                        BuildStepEvictionProtectSet(),
+                        materializePending: true);
+                }
             }
             // Bound cross-step VRAM growth: per-step transient activation buffers are dereferenced
             // here but their device memory is only released by the GC finalizer, which cannot keep

--- a/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
@@ -354,7 +354,8 @@ internal sealed class LinearWarmupLr : LrSchedule
         // — _currentStep is (batch - 1) and Step() floors with _minLearningRate = endLr.
         // The 1-indexed fused step maps batch n → GetLr(n); reproduce both branches so the
         // per-step LR is bit-identical to the eager replay (FusedLrScheduleMappingTests).
-        if (_warmupSteps > 0 && step <= 1) return _warmupInitLr;
+        if (step <= 1)
+            return _warmupSteps > 0 ? _warmupInitLr : _lrMax;
         double raw = ComputeRaw(step - 1);
         return raw > _endLr ? raw : _endLr;
     }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
@@ -332,13 +332,13 @@ internal sealed class LinearWarmupLr : LrSchedule
         double warmupInitLr, WarmupDecayMode decayMode, double endLr)
     {
         if (warmupSteps < 0) throw new ArgumentOutOfRangeException(nameof(warmupSteps));
-        if (decayMode != WarmupDecayMode.Constant && totalSteps < warmupSteps)
+        int normalizedTotalSteps = totalSteps > 0 ? totalSteps : warmupSteps;
+        if (decayMode != WarmupDecayMode.Constant && normalizedTotalSteps < warmupSteps)
             throw new ArgumentOutOfRangeException(nameof(totalSteps),
                 "totalSteps must be >= warmupSteps for decay modes.");
         _lrMax = lrMax;
         _warmupSteps = warmupSteps;
-        // Eager ctor: _totalSteps = totalSteps > 0 ? totalSteps : warmupSteps.
-        _totalSteps = totalSteps > 0 ? totalSteps : warmupSteps;
+        _totalSteps = normalizedTotalSteps;
         _warmupInitLr = warmupInitLr;
         _decayMode = decayMode;
         _endLr = endLr;

--- a/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
@@ -332,6 +332,8 @@ internal sealed class LinearWarmupLr : LrSchedule
         double warmupInitLr, WarmupDecayMode decayMode, double endLr)
     {
         if (warmupSteps < 0) throw new ArgumentOutOfRangeException(nameof(warmupSteps));
+        if (!Enum.IsDefined(typeof(WarmupDecayMode), decayMode))
+            throw new ArgumentOutOfRangeException(nameof(decayMode), decayMode, "Undefined warmup decay mode.");
         int normalizedTotalSteps = totalSteps > 0 ? totalSteps : warmupSteps;
         if (decayMode != WarmupDecayMode.Constant && normalizedTotalSteps < warmupSteps)
             throw new ArgumentOutOfRangeException(nameof(totalSteps),
@@ -352,7 +354,7 @@ internal sealed class LinearWarmupLr : LrSchedule
         // — _currentStep is (batch - 1) and Step() floors with _minLearningRate = endLr.
         // The 1-indexed fused step maps batch n → GetLr(n); reproduce both branches so the
         // per-step LR is bit-identical to the eager replay (FusedLrScheduleMappingTests).
-        if (step <= 1) return _warmupInitLr;
+        if (_warmupSteps > 0 && step <= 1) return _warmupInitLr;
         double raw = ComputeRaw(step - 1);
         return raw > _endLr ? raw : _endLr;
     }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LrSchedule.cs
@@ -3,6 +3,21 @@ using System.Runtime.CompilerServices;
 namespace AiDotNet.Tensors.Engines.Compilation;
 
 /// <summary>
+/// Decay shape applied AFTER the linear-warmup ramp in <see cref="LrSchedule.LinearWarmup"/>.
+/// Mirrors <c>AiDotNet.LearningRateSchedulers.LinearWarmupScheduler.DecayMode</c> so the
+/// fused mapping reproduces the eager scheduler exactly.
+/// </summary>
+public enum WarmupDecayMode
+{
+    /// <summary>Hold the peak learning rate after warmup.</summary>
+    Constant,
+    /// <summary>Linearly decay from peak to <c>endLr</c> over the post-warmup steps.</summary>
+    Linear,
+    /// <summary>Cosine-anneal from peak to <c>endLr</c> over the post-warmup steps.</summary>
+    Cosine
+}
+
+/// <summary>
 /// Per-step learning-rate schedule used by the fused-compiled training path.
 /// Implementations must be pure and allocation-free — they're called inside
 /// the tight <c>Step()</c> loop, once per optimizer step.
@@ -77,6 +92,24 @@ public abstract class LrSchedule
     public static LrSchedule LinearWarmupCosine(
         double lrMax, int warmupSteps, int totalSteps, double lrMin = 0.0)
         => new LinearWarmupCosineLr(lrMax, warmupSteps, totalSteps, lrMin);
+
+    /// <summary>
+    /// Linear warmup from <paramref name="warmupInitLr"/> to <paramref name="lrMax"/>
+    /// over <paramref name="warmupSteps"/> steps, then a Constant / Linear / Cosine
+    /// decay to <paramref name="endLr"/> per <paramref name="decayMode"/>. This is the
+    /// fused-path image of <c>AiDotNet.LearningRateSchedulers.LinearWarmupScheduler</c>:
+    /// its per-step sequence is bit-identical to that eager scheduler's per-batch LR
+    /// (batch 1 = ctor <c>warmupInitLr</c>; batch n = <c>max(endLr, ComputeLearningRate(n-1))</c>),
+    /// so the warmup recipe runs on the captured fast path instead of the eager tape.
+    /// Unlike <see cref="LinearWarmupCosine"/> (warmup→cosine only, floor 0), this honors
+    /// a non-zero warmup-init, all three decay modes, and a non-zero end LR.
+    /// </summary>
+    public static LrSchedule LinearWarmup(
+        double lrMax, int warmupSteps, int totalSteps,
+        double warmupInitLr = 0.0,
+        WarmupDecayMode decayMode = WarmupDecayMode.Constant,
+        double endLr = 0.0)
+        => new LinearWarmupLr(lrMax, warmupSteps, totalSteps, warmupInitLr, decayMode, endLr);
 
     /// <summary>
     /// Noam schedule from "Attention Is All You Need" (Vaswani et al. 2017,
@@ -283,5 +316,64 @@ internal sealed class LinearWarmupCosineLr : LrSchedule
             : (s - _warmup) / (double)System.Math.Max(_total - _warmup, 1);
         double cos = 0.5 * (1.0 + System.Math.Cos(System.Math.PI * progress));
         return _lrMin + (_lrMax - _lrMin) * cos;
+    }
+}
+
+internal sealed class LinearWarmupLr : LrSchedule
+{
+    private readonly double _lrMax;
+    private readonly int _warmupSteps;
+    private readonly int _totalSteps;
+    private readonly double _warmupInitLr;
+    private readonly WarmupDecayMode _decayMode;
+    private readonly double _endLr;
+
+    public LinearWarmupLr(double lrMax, int warmupSteps, int totalSteps,
+        double warmupInitLr, WarmupDecayMode decayMode, double endLr)
+    {
+        if (warmupSteps < 0) throw new ArgumentOutOfRangeException(nameof(warmupSteps));
+        if (decayMode != WarmupDecayMode.Constant && totalSteps < warmupSteps)
+            throw new ArgumentOutOfRangeException(nameof(totalSteps),
+                "totalSteps must be >= warmupSteps for decay modes.");
+        _lrMax = lrMax;
+        _warmupSteps = warmupSteps;
+        // Eager ctor: _totalSteps = totalSteps > 0 ? totalSteps : warmupSteps.
+        _totalSteps = totalSteps > 0 ? totalSteps : warmupSteps;
+        _warmupInitLr = warmupInitLr;
+        _decayMode = decayMode;
+        _endLr = endLr;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override double GetLr(int step)
+    {
+        // The eager LinearWarmupScheduler reports its ctor value (warmupInitLr) on
+        // batch 1 (unfloored), then on batch n>=2 reports max(endLr, ComputeLearningRate(n-1))
+        // — _currentStep is (batch - 1) and Step() floors with _minLearningRate = endLr.
+        // The 1-indexed fused step maps batch n → GetLr(n); reproduce both branches so the
+        // per-step LR is bit-identical to the eager replay (FusedLrScheduleMappingTests).
+        if (step <= 1) return _warmupInitLr;
+        double raw = ComputeRaw(step - 1);
+        return raw > _endLr ? raw : _endLr;
+    }
+
+    // Mirror of LinearWarmupScheduler.ComputeLearningRate(step) with _baseLearningRate = lrMax.
+    private double ComputeRaw(int t)
+    {
+        if (t < _warmupSteps)
+        {
+            if (_warmupSteps == 0) return _lrMax;
+            return _warmupInitLr + (_lrMax - _warmupInitLr) * ((double)t / _warmupSteps);
+        }
+        if (_decayMode == WarmupDecayMode.Constant) return _lrMax;
+
+        int decaySteps = _totalSteps - _warmupSteps;
+        int decayStep = t - _warmupSteps;
+        if (decayStep >= decaySteps) return _endLr;
+        double progress = (double)decayStep / decaySteps;
+        if (_decayMode == WarmupDecayMode.Linear)
+            return _lrMax - (_lrMax - _endLr) * progress;
+        double cos = (1.0 + System.Math.Cos(System.Math.PI * progress)) / 2.0;
+        return _endLr + (_lrMax - _endLr) * cos;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -11447,7 +11447,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     /// <summary>
     /// Proximal gradient (ISTA) step with L1 soft-threshold prox, in place on the GPU:
-    /// <c>tmp = param - lr*grad; param = sign(tmp)*max(|tmp| - l1Strength, 0)</c>.
+    /// <c>tmp = param - lr*grad; param = sign(tmp)*max(|tmp| - lr*l1Strength, 0)</c>.
     /// </summary>
     public unsafe void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
         float learningRate, float l1Strength, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaOptimizerKernels.cs
@@ -411,10 +411,8 @@ extern ""C"" __global__ __launch_bounds__(256) void ftrl_update(
 }
 
 // ---------------------------------------------------------------------------
-// Proximal gradient (ISTA) with L1 soft-threshold prox. Matches the CPU
-// ProximalGradientDescentOptimizer + L1Regularization path exactly:
-//   tmp = param - lr*grad;  param = sign(tmp) * max(|tmp| - l1Strength, 0)
-// Note the threshold is the raw L1 strength (not lr*strength), per L1Regularization.
+// Proximal gradient (ISTA) with L1 soft-threshold prox:
+//   tmp = param - lr*grad;  param = sign(tmp) * max(|tmp| - lr*l1Strength, 0)
 // ---------------------------------------------------------------------------
 extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
     float* __restrict__ param, const float* __restrict__ gradient,
@@ -424,7 +422,7 @@ extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
     if (idx >= size) return;
 
     float tmp = param[idx] - learningRate * gradient[idx];
-    float a = fabsf(tmp) - l1Strength;
+    float a = fabsf(tmp) - (learningRate * l1Strength);
     float sgn = (tmp > 0.0f) ? 1.0f : ((tmp < 0.0f) ? -1.0f : 0.0f);
     param[idx] = sgn * (a > 0.0f ? a : 0.0f);
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuMemoryTracker.cs
@@ -206,9 +206,23 @@ public static class GpuMemoryTracker
         }
         if (!Enabled) return;
         var rec = new Rec { Bytes = bytes, Site = CaptureSite(), Seq = Interlocked.Increment(ref s_seq) };
-        s_live[(long)ptr] = rec;
+        long key = (long)ptr;
+        long delta;
+        while (true)
+        {
+            if (s_live.TryAdd(key, rec))
+            {
+                delta = bytes;
+                break;
+            }
+            if (s_live.TryGetValue(key, out var prior) && s_live.TryUpdate(key, rec, prior))
+            {
+                delta = bytes - prior.Bytes;
+                break;
+            }
+        }
         Interlocked.Increment(ref s_totalAllocs);
-        long lb = Interlocked.Add(ref s_liveBytes, bytes);
+        long lb = Interlocked.Add(ref s_liveBytes, delta);
         // Best-effort peak update (CAS loop; a benign miss under contention only undercounts the peak slightly).
         long peak;
         while (lb > (peak = Interlocked.Read(ref s_peakBytes)))

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -11702,6 +11702,30 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     }
 
     /// <inheritdoc/>
+    public unsafe void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+    {
+        if (!_kernelCache.TryGetValue("proximal_l1_update", out var krnl))
+            throw new InvalidOperationException("HIP kernel not found: proximal_l1_update");
+
+            {
+            IntPtr _p0 = ((HipGpuBuffer)param).Handle;
+            IntPtr _p1 = ((HipGpuBuffer)gradient).Handle;
+            void** args = stackalloc void*[5];
+            args[0] = &_p0;
+            args[1] = &_p1;
+            args[2] = &learningRate;
+            args[3] = &l1Strength;
+            args[4] = &size;
+
+
+            uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
+            LaunchKernel(krnl, grid, DefaultBlockSize, args);
+            Synchronize();
+            }
+    }
+
+    /// <inheritdoc/>
     public unsafe void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
     {
         if (!_kernelCache.TryGetValue("convert_fp32_to_fp16", out var krnl))

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
@@ -1426,7 +1426,7 @@ extern ""C"" __global__ __launch_bounds__(256) void dropout_backward(
 // IMPORTANT: Caller MUST ensure indices[i] >= 0 and < vocabSize to avoid undefined behavior.
 // Negative indices will wrap around; out-of-bounds access causes memory corruption.
 extern ""C"" __global__ __launch_bounds__(256) void embedding_forward(
-    const float* indices, const float* embeddingTable, float* output,
+    const int* indices, const float* embeddingTable, float* output,
     int numIndices, int embeddingDim)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1434,7 +1434,7 @@ extern ""C"" __global__ __launch_bounds__(256) void embedding_forward(
 
     // Note: idx must be validated by caller to be within [0, vocabSize)
     // We clamp negative values to 0 as a defensive measure
-    int idx = (int)indices[i];
+    int idx = indices[i];
     if (idx < 0) idx = 0;  // Defensive: prevent negative index wrapping
     for (int d = 0; d < embeddingDim; d++) {
         output[i * embeddingDim + d] = embeddingTable[idx * embeddingDim + d];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipOptimizerKernels.cs
@@ -413,6 +413,26 @@ extern ""C"" __global__ __launch_bounds__(256) void ftrl_update(
         param[idx] = -zSign * (zAbs - l1Reg) / denom;
     }
 }
+
+// ---------------------------------------------------------------------------
+// Proximal gradient (ISTA) update with L1 soft-thresholding
+// ---------------------------------------------------------------------------
+extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
+    float* param, const float* gradient,
+    float learningRate, float l1Strength, int size)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= size) return;
+
+    float tmp = param[idx] - learningRate * gradient[idx];
+    float mag = fabsf(tmp) - l1Strength;
+    if (mag <= 0.0f) {
+        param[idx] = 0.0f;
+    } else {
+        float signTmp = (tmp > 0.0f) ? 1.0f : -1.0f;
+        param[idx] = signTmp * mag;
+    }
+}
 ";
     }
 
@@ -437,7 +457,8 @@ extern ""C"" __global__ __launch_bounds__(256) void ftrl_update(
             "adamax_update",
             "lion_update",
             "nadam_update",
-            "ftrl_update"
+            "ftrl_update",
+            "proximal_l1_update"
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipOptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipOptimizerKernels.cs
@@ -425,7 +425,7 @@ extern ""C"" __global__ __launch_bounds__(256) void proximal_l1_update(
     if (idx >= size) return;
 
     float tmp = param[idx] - learningRate * gradient[idx];
-    float mag = fabsf(tmp) - l1Strength;
+    float mag = fabsf(tmp) - (learningRate * l1Strength);
     if (mag <= 0.0f) {
         param[idx] = 0.0f;
     } else {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2320,7 +2320,7 @@ public interface IDirectGpuBackend : IDisposable
     /// <param name="param">Parameters to update (in-place).</param>
     /// <param name="gradient">Gradient values.</param>
     /// <param name="learningRate">Learning rate.</param>
-    /// <param name="l1Strength">L1 shrinkage threshold.</param>
+    /// <param name="l1Strength">L1 regularization strength; shrinkage threshold is learningRate * l1Strength.</param>
     /// <param name="size">Number of parameters.</param>
     void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
         float learningRate, float l1Strength, int size);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -2314,6 +2314,17 @@ public interface IDirectGpuBackend : IDisposable
     void FtrlUpdate(IGpuBuffer param, IGpuBuffer gradient, IGpuBuffer z, IGpuBuffer n,
         float learningRate, float l1Reg, float l2Reg, float beta, int size);
 
+    /// <summary>
+    /// Proximal gradient (ISTA) step with L1 soft-thresholding.
+    /// </summary>
+    /// <param name="param">Parameters to update (in-place).</param>
+    /// <param name="gradient">Gradient values.</param>
+    /// <param name="learningRate">Learning rate.</param>
+    /// <param name="l1Strength">L1 shrinkage threshold.</param>
+    /// <param name="size">Number of parameters.</param>
+    void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size);
+
     // --------------------------------------------------------------
     // PR #567 — Sparse counterparts of the dense optimizer steps above.
     // Each method launches a native CUDA scatter-update kernel with one

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Optimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Optimizer.cs
@@ -490,17 +490,20 @@ public sealed partial class MetalBackend
     {
         ThrowIfDisposed();
 
-        var paramData = DownloadBuffer(param);
-        var gradData = DownloadBuffer(gradient);
+        if (param is not MetalGpuBuffer paramBuffer || gradient is not MetalGpuBuffer gradientBuffer)
+            throw new ArgumentException("Buffers must be MetalGpuBuffer");
 
-        for (int i = 0; i < size; i++)
-        {
-            float tmp = paramData[i] - learningRate * gradData[i];
-            float mag = MathF.Abs(tmp) - l1Strength;
-            paramData[i] = mag > 0 ? MathF.Sign(tmp) * mag : 0f;
-        }
+        var pipeline = GetPipeline("Optimizer", _optimizerLibrary, "proximal_l1_update");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(size);
 
-        UploadToBuffer(param, paramData);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(paramBuffer, 0);
+        encoder.SetBuffer(gradientBuffer, 1);
+        encoder.SetBytes(learningRate, 2);
+        encoder.SetBytes(l1Strength, 3);
+        encoder.SetBytes((uint)size, 4);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
     }
 
     #endregion

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Optimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Optimizer.cs
@@ -482,5 +482,26 @@ public sealed partial class MetalBackend
         UploadToBuffer(n, nData);
     }
 
+    /// <summary>
+    /// Proximal gradient (ISTA) update with L1 soft-thresholding.
+    /// </summary>
+    public void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+    {
+        ThrowIfDisposed();
+
+        var paramData = DownloadBuffer(param);
+        var gradData = DownloadBuffer(gradient);
+
+        for (int i = 0; i < size; i++)
+        {
+            float tmp = paramData[i] - learningRate * gradData[i];
+            float mag = MathF.Abs(tmp) - l1Strength;
+            paramData[i] = mag > 0 ? MathF.Sign(tmp) * mag : 0f;
+        }
+
+        UploadToBuffer(param, paramData);
+    }
+
     #endregion
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -3873,6 +3873,27 @@ kernel void lion_update(
     }
 }
 
+// Proximal gradient (ISTA) update with L1 soft-thresholding.
+kernel void proximal_l1_update(
+    device float* param [[buffer(0)]],
+    device const float* grad [[buffer(1)]],
+    constant float& lr [[buffer(2)]],
+    constant float& l1_strength [[buffer(3)]],
+    constant uint& size [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid < size) {
+        float tmp = param[gid] - lr * grad[gid];
+        float mag = abs(tmp) - lr * l1_strength;
+        if (mag <= 0.0f) {
+            param[gid] = 0.0f;
+        } else {
+            float sign_tmp = (tmp > 0.0f) ? 1.0f : -1.0f;
+            param[gid] = sign_tmp * mag;
+        }
+    }
+}
+
 // Gradient clipping by norm
 kernel void clip_grad_norm(
     device float* grad [[buffer(0)]],

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/NeuralNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/NeuralNetKernels.cs
@@ -1215,20 +1215,18 @@ __kernel void dropout_backward(
 
 // Embedding lookup
 __kernel void embedding_lookup(
-    __global const float* indices,
+    __global const int* indices,
     __global const float* embeddingTable,
     __global float* output,
     const int numIndices,
     const int embeddingDim)
 {
-    const int idx = get_global_id(0);
-    if (idx >= numIndices) return;
+    const int d = get_global_id(0);
+    const int idx = get_global_id(1);
+    if (idx >= numIndices || d >= embeddingDim) return;
 
-    int index = (int)indices[idx];
-
-    for (int d = 0; d < embeddingDim; d++) {
-        output[idx * embeddingDim + d] = embeddingTable[index * embeddingDim + d];
-    }
+    int index = indices[idx];
+    output[idx * embeddingDim + d] = embeddingTable[index * embeddingDim + d];
 }
 
 // Embedding backward (scatter add gradients)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/OptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/OptimizerKernels.cs
@@ -609,7 +609,7 @@ __kernel void sgd_update(
 // ---------------------------------------------------------------------------
 // Proximal gradient (ISTA) update with L1 soft-thresholding
 // Formula: tmp = param - lr * grad
-//          param = sign(tmp) * max(abs(tmp) - l1Strength, 0)
+//          param = sign(tmp) * max(abs(tmp) - lr * l1Strength, 0)
 // ---------------------------------------------------------------------------
 __kernel void proximal_l1_update(
     __global float* param,
@@ -622,7 +622,7 @@ __kernel void proximal_l1_update(
     if (idx >= size) return;
 
     float tmp = param[idx] - learningRate * gradient[idx];
-    float mag = fabs(tmp) - l1Strength;
+    float mag = fabs(tmp) - (learningRate * l1Strength);
     if (mag <= 0.0f) {
         param[idx] = 0.0f;
     } else {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/OptimizerKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/OptimizerKernels.cs
@@ -605,6 +605,31 @@ __kernel void sgd_update(
 
     param[idx] -= learningRate * grad;
 }
+
+// ---------------------------------------------------------------------------
+// Proximal gradient (ISTA) update with L1 soft-thresholding
+// Formula: tmp = param - lr * grad
+//          param = sign(tmp) * max(abs(tmp) - l1Strength, 0)
+// ---------------------------------------------------------------------------
+__kernel void proximal_l1_update(
+    __global float* param,
+    __global const float* gradient,
+    const float learningRate,
+    const float l1Strength,
+    const int size)
+{
+    const int idx = get_global_id(0);
+    if (idx >= size) return;
+
+    float tmp = param[idx] - learningRate * gradient[idx];
+    float mag = fabs(tmp) - l1Strength;
+    if (mag <= 0.0f) {
+        param[idx] = 0.0f;
+    } else {
+        float signTmp = (tmp > 0.0f) ? 1.0f : -1.0f;
+        param[idx] = signTmp * mag;
+    }
+}
 ";
     }
 
@@ -629,7 +654,8 @@ __kernel void sgd_update(
             "adamax_update",
             "lion_update",
             "nadam_update",
-            "ftrl_update"
+            "ftrl_update",
+            "proximal_l1_update"
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -10307,6 +10307,21 @@ KERNEL VARIANTS (A/B testing):
             k.Execute1D(size, Math.Min(256, size));
         }
 
+        /// <inheritdoc/>
+        public void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+            float learningRate, float l1Strength, int size)
+        {
+            var k = _kernelCache["proximal_l1_update"];
+            uint arg = 0;
+            k.SetArg(arg++, ((DirectOpenClGpuBuffer)param).Buffer.Handle);
+            k.SetArg(arg++, ((DirectOpenClGpuBuffer)gradient).Buffer.Handle);
+            k.SetArg(arg++, learningRate);
+            k.SetArg(arg++, l1Strength);
+            k.SetArg(arg++, size);
+
+            k.Execute1D(size, Math.Min(256, size));
+        }
+
         #endregion
 
         #region FFT and Signal Processing

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -12480,6 +12480,12 @@ KERNEL VARIANTS (A/B testing):
 
         public void Release()
         {
+            if (GpuBufferReleaseDeferral.TryDefer(ReleaseCore)) return;
+            ReleaseCore();
+        }
+
+        private void ReleaseCore()
+        {
             if (Interlocked.Exchange(ref _poolState, 2) == 2)
                 return;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -264,7 +264,7 @@ public sealed unsafe partial class VulkanBackend
         for (int i = 0; i < size; i++)
         {
             float tmp = p[i] - learningRate * g[i];
-            float mag = MathF.Abs(tmp) - l1Strength;
+            float mag = MathF.Abs(tmp) - learningRate * l1Strength;
             p[i] = mag > 0 ? MathF.Sign(tmp) * mag : 0f;
         }
         UploadToBuffer(p, param);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -255,6 +255,21 @@ public sealed unsafe partial class VulkanBackend
         UploadToBuffer(p, param); UploadToBuffer(zArr, z); UploadToBuffer(nArr, n);
     }
 
+    public void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+    {
+        EnsureInitialized();
+        var p = DownloadBuffer(param);
+        var g = DownloadBuffer(gradient);
+        for (int i = 0; i < size; i++)
+        {
+            float tmp = p[i] - learningRate * g[i];
+            float mag = MathF.Abs(tmp) - l1Strength;
+            p[i] = mag > 0 ? MathF.Sign(tmp) * mag : 0f;
+        }
+        UploadToBuffer(p, param);
+    }
+
     public void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
     {
         EnsureInitialized();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -18,6 +18,15 @@ public sealed partial class WebGpuBackend
             param, gradient, dummy, dummy, uniforms, size).GetAwaiter().GetResult();
     }
 
+    public void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+    {
+        var dummy = SharedDummyBuffer;
+        var uniforms = MakeOptimizerUniforms(size, learningRate, l1Strength, 0, 0, 0, 0);
+        Dispatch4BufferAsync("Optimizer", WebGpuKernels.OptimizerSource, "proximal_l1",
+            param, gradient, dummy, dummy, uniforms, size).GetAwaiter().GetResult();
+    }
+
     public void SgdMomentumUpdate(IGpuBuffer param, IGpuBuffer gradient, IGpuBuffer velocity,
         float learningRate, float momentum, float weightDecay, int size)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -1180,6 +1180,20 @@ fn sgd_momentum(@builtin(global_invocation_id) gid: vec3<u32>) {
 }
 
 @compute @workgroup_size(256)
+fn proximal_l1(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx < opt_params.size) {
+        let tmp = params_arr[idx] - opt_params.lr * gradients[idx];
+        let mag = abs(tmp) - opt_params.beta1;
+        if (mag <= 0.0) {
+            params_arr[idx] = 0.0;
+        } else {
+            params_arr[idx] = sign(tmp) * mag;
+        }
+    }
+}
+
+@compute @workgroup_size(256)
 fn adam(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x;
     if (idx < opt_params.size) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -1184,7 +1184,7 @@ fn proximal_l1(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x;
     if (idx < opt_params.size) {
         let tmp = params_arr[idx] - opt_params.lr * gradients[idx];
-        let mag = abs(tmp) - opt_params.beta1;
+        let mag = abs(tmp) - (opt_params.lr * opt_params.beta1);
         if (mag <= 0.0) {
             params_arr[idx] = 0.0;
         } else {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2022,12 +2022,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private bool TryFreeActivationByKey(object key)
     {
+        if (!_activationCache.TryRemove(key, out var e)) return false;
         // Dead tensor: discard the lazy GPU->CPU materializer before freeing
         // the cache-owned buffer. Materializing here would be wasted work, and
         // leaving the registration behind would point a later bulk drain at a
-        // freed buffer.
+        // freed buffer. Remove only after the cache entry is actually owned.
         Helpers.DeferredArrayMaterializer.Remove(key);
-        if (!_activationCache.TryRemove(key, out var e)) return false;
         System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, -e.Buffer.SizeInBytes);
         System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -e.ManagedBytes);
         // CUDA uses STREAM-ORDERED deferred free (cuMemFreeAsync) to release the buffer at the stream's

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2202,22 +2202,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 if (entries[i].Value.Timestamp <= snapshot) continue;   // pre-existing — keep
                 if (entries[i].Value.ThreadId != callerThreadId) continue; // another thread's live buffer
                 if (protect is not null && protect.Contains(entries[i].Key)) continue; // live gradient — keep
-                if (Helpers.DeferredArrayMaterializer.IsPending(entries[i].Key))
-                {
-                    if (materializePending)
-                    {
-                        // #226 safe path: flush the pending DtoH so a later CPU read still sees correct data.
-                        try { Helpers.DeferredArrayMaterializer.TryMaterialize(entries[i].Key); }
-                        catch { Helpers.DeferredArrayMaterializer.Remove(entries[i].Key); }
-                    }
-                    else
-                    {
-                        // Dead scratch: drop the pending download (no DtoH) — keeps the step fully GPU-resident.
-                        Helpers.DeferredArrayMaterializer.Remove(entries[i].Key);
-                    }
-                }
                 if (_activationCache.TryRemove(entries[i].Key, out var entry))
                 {
+                    if (Helpers.DeferredArrayMaterializer.IsPending(entries[i].Key))
+                    {
+                        if (materializePending)
+                        {
+                            // #226 safe path: flush the pending DtoH so a later CPU read still sees correct data.
+                            try { Helpers.DeferredArrayMaterializer.TryMaterialize(entries[i].Key); }
+                            catch { Helpers.DeferredArrayMaterializer.Remove(entries[i].Key); }
+                        }
+                        else
+                        {
+                            // Dead scratch: drop the pending download (no DtoH) after owning the cache entry.
+                            Helpers.DeferredArrayMaterializer.Remove(entries[i].Key);
+                        }
+                    }
                     System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, -entry.Buffer.SizeInBytes);
                     System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -entry.ManagedBytes);
                     toDispose.Add(entry);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10047,6 +10047,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         using var gradQBuffer = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
         using var gradKBuffer = AllocateOutputBuffer(backend, batch * heads * seqK * headDim);
         using var gradVBuffer = AllocateOutputBuffer(backend, batch * heads * seqK * headDim);
+        backend.Fill(gradQBuffer.Buffer, 0f, batch * heads * seqQ * headDim);
+        backend.Fill(gradKBuffer.Buffer, 0f, batch * heads * seqK * headDim);
+        backend.Fill(gradVBuffer.Buffer, 0f, batch * heads * seqK * headDim);
 
         // Upload attention bias to GPU if provided, with shape validation
         int biasBatchStride = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2022,6 +2022,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private bool TryFreeActivationByKey(object key)
     {
+        // Dead tensor: discard the lazy GPU->CPU materializer before freeing
+        // the cache-owned buffer. Materializing here would be wasted work, and
+        // leaving the registration behind would point a later bulk drain at a
+        // freed buffer.
+        Helpers.DeferredArrayMaterializer.Remove(key);
         if (!_activationCache.TryRemove(key, out var e)) return false;
         System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, -e.Buffer.SizeInBytes);
         System.Threading.Interlocked.Add(ref _currentActivationManagedBytes, -e.ManagedBytes);

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1634,6 +1634,11 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.FtrlUpdate(param, gradient, z, n, learningRate, l1Reg, l2Reg, beta, size);
 
     /// <inheritdoc/>
+    public virtual void ProximalL1Update(IGpuBuffer param, IGpuBuffer gradient,
+        float learningRate, float l1Strength, int size)
+        => Inner.ProximalL1Update(param, gradient, learningRate, l1Strength, size);
+
+    /// <inheritdoc/>
     public virtual void SparseSgdUpdate(IGpuBuffer param, IGpuBuffer sparseIndices, IGpuBuffer sparseValues, int nnz, float learningRate, float weightDecay)
         => Inner.SparseSgdUpdate(param, sparseIndices, sparseValues, nnz, learningRate, weightDecay);
 

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -151,8 +151,7 @@ public static class GpuOptimizer
 
     /// <summary>
     /// Proximal gradient (ISTA) step with L1 soft-threshold prox, in place on the GPU.
-    /// CUDA-only (proximal_l1_update lives on CudaBackend); returns false on any
-    /// other backend or when param/grad aren't GPU-resident, so the caller falls
+    /// Returns false when param/grad aren't GPU-resident so the caller falls
     /// back to the CPU path.
     /// </summary>
     public static bool TryProximalL1Step(Tensor<float> p, Tensor<float> g, float lr, float l1Strength)
@@ -160,11 +159,12 @@ public static class GpuOptimizer
         if (p is null) throw new ArgumentNullException(nameof(p));
         if (g is null) throw new ArgumentNullException(nameof(g));
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
-        if (!(e.GetBackend() is DirectGpu.CUDA.CudaBackend cb)) return false;
+        var backend = e.GetBackend();
+        if (backend is null) return false;
         var pb = p.TryGetGpuBuffer(); var gb = g.TryGetGpuBuffer();
         if (pb is null || gb is null) return false;
-        cb.ProximalL1Update(pb, gb, lr, l1Strength, p.Length);
-        MarkGpuUpdated(cb, p);
+        backend.ProximalL1Update(pb, gb, lr, l1Strength, p.Length);
+        MarkGpuUpdated(backend, p);
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -33,32 +33,37 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// </remarks>
 public static class GpuOptimizer
 {
-    private static void MarkGpuUpdated(Tensor<float>? tensor)
+    private static GpuSyncPoint CreateWriteSyncPoint(IDirectGpuBackend backend)
+        => backend is IAsyncGpuBackend asyncBackend
+            ? asyncBackend.CreateSyncPoint()
+            : GpuSyncPoint.CreateComplete();
+
+    private static void MarkGpuUpdated(IDirectGpuBackend backend, Tensor<float>? tensor)
     {
         if (tensor is null) return;
-        tensor.MarkModified(syncPoint: null);
+        tensor.MarkModified(CreateWriteSyncPoint(backend));
         tensor._gpuBufferVersion = tensor.Version;
     }
 
-    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second)
+    private static void MarkGpuUpdated(IDirectGpuBackend backend, Tensor<float>? first, Tensor<float>? second)
     {
-        MarkGpuUpdated(first);
-        MarkGpuUpdated(second);
+        MarkGpuUpdated(backend, first);
+        MarkGpuUpdated(backend, second);
     }
 
-    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second, Tensor<float>? third)
+    private static void MarkGpuUpdated(IDirectGpuBackend backend, Tensor<float>? first, Tensor<float>? second, Tensor<float>? third)
     {
-        MarkGpuUpdated(first);
-        MarkGpuUpdated(second);
-        MarkGpuUpdated(third);
+        MarkGpuUpdated(backend, first);
+        MarkGpuUpdated(backend, second);
+        MarkGpuUpdated(backend, third);
     }
 
-    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second, Tensor<float>? third, Tensor<float>? fourth)
+    private static void MarkGpuUpdated(IDirectGpuBackend backend, Tensor<float>? first, Tensor<float>? second, Tensor<float>? third, Tensor<float>? fourth)
     {
-        MarkGpuUpdated(first);
-        MarkGpuUpdated(second);
-        MarkGpuUpdated(third);
-        MarkGpuUpdated(fourth);
+        MarkGpuUpdated(backend, first);
+        MarkGpuUpdated(backend, second);
+        MarkGpuUpdated(backend, third);
+        MarkGpuUpdated(backend, fourth);
     }
 
     /// <summary>
@@ -94,7 +99,7 @@ public static class GpuOptimizer
 
         backend.AdamUpdate(pBuf, gBuf, mBuf, vBuf,
             learningRate, beta1, beta2, epsilon, weightDecay, step, param.Length);
-        MarkGpuUpdated(param, m, v);
+        MarkGpuUpdated(backend, param, m, v);
         return true;
     }
 
@@ -140,7 +145,7 @@ public static class GpuOptimizer
         if (pBuf is null || gBuf is null) return false;
 
         backend.SgdUpdate(pBuf, gBuf, learningRate, weightDecay: 0f, param.Length);
-        MarkGpuUpdated(param);
+        MarkGpuUpdated(backend, param);
         return true;
     }
 
@@ -159,7 +164,7 @@ public static class GpuOptimizer
         var pb = p.TryGetGpuBuffer(); var gb = g.TryGetGpuBuffer();
         if (pb is null || gb is null) return false;
         cb.ProximalL1Update(pb, gb, lr, l1Strength, p.Length);
-        MarkGpuUpdated(p);
+        MarkGpuUpdated(cb, p);
         return true;
     }
 
@@ -235,7 +240,7 @@ public static class GpuOptimizer
         int nb = (p.Length + blockSize - 1) / blockSize;
         cb.Adam8BitUpdate(pb, gb, mQ, vQ, mScales, vScales,
             lr, beta1, beta2, epsilon, 1f - beta1, 1f - beta2, biasCorrection1, biasCorrection2, blockSize, p.Length, nb);
-        MarkGpuUpdated(p);
+        MarkGpuUpdated(cb, p);
         return true;
     }
 
@@ -249,7 +254,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
         b.SgdMomentumUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length);
-        MarkGpuUpdated(p, velocity);
+        MarkGpuUpdated(b, p, velocity);
         return true;
     }
 
@@ -259,7 +264,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var sb = squaredAvg?.TryGetGpuBuffer();
         if (pb is null || gb is null || sb is null) return false;
         b.RmspropUpdate(pb, gb, sb, lr, rho, epsilon, weightDecay, p!.Length);
-        MarkGpuUpdated(p, squaredAvg);
+        MarkGpuUpdated(b, p, squaredAvg);
         return true;
     }
 
@@ -269,7 +274,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ab = accum?.TryGetGpuBuffer();
         if (pb is null || gb is null || ab is null) return false;
         b.AdagradUpdate(pb, gb, ab, lr, epsilon, weightDecay, p!.Length);
-        MarkGpuUpdated(p, accum);
+        MarkGpuUpdated(b, p, accum);
         return true;
     }
 
@@ -279,7 +284,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
         b.NagUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length);
-        MarkGpuUpdated(p, velocity);
+        MarkGpuUpdated(b, p, velocity);
         return true;
     }
 
@@ -289,7 +294,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
         b.LarsUpdate(pb, gb, vb, lr, momentum, weightDecay, trustCoeff, p!.Length);
-        MarkGpuUpdated(p, velocity);
+        MarkGpuUpdated(b, p, velocity);
         return true;
     }
 
@@ -299,7 +304,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null) return false;
         b.LambUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
-        MarkGpuUpdated(p, m, v);
+        MarkGpuUpdated(b, p, m, v);
         return true;
     }
 
@@ -309,7 +314,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ag = accumGrad?.TryGetGpuBuffer(); var au = accumUpdate?.TryGetGpuBuffer();
         if (pb is null || gb is null || ag is null || au is null) return false;
         b.AdadeltaUpdate(pb, gb, ag, au, rho, epsilon, weightDecay, p!.Length);
-        MarkGpuUpdated(p, accumGrad, accumUpdate);
+        MarkGpuUpdated(b, p, accumGrad, accumUpdate);
         return true;
     }
 
@@ -319,7 +324,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer(); var xb = vMax?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null || xb is null) return false;
         b.AmsgradUpdate(pb, gb, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
-        MarkGpuUpdated(p, m, v, vMax);
+        MarkGpuUpdated(b, p, m, v, vMax);
         return true;
     }
 
@@ -329,7 +334,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var ub = u?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || ub is null) return false;
         b.AdamaxUpdate(pb, gb, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
-        MarkGpuUpdated(p, m, u);
+        MarkGpuUpdated(b, p, m, u);
         return true;
     }
 
@@ -339,7 +344,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null) return false;
         b.LionUpdate(pb, gb, mb, lr, beta1, beta2, weightDecay, p!.Length);
-        MarkGpuUpdated(p, m);
+        MarkGpuUpdated(b, p, m);
         return true;
     }
 
@@ -349,7 +354,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null) return false;
         b.NadamUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
-        MarkGpuUpdated(p, m, v);
+        MarkGpuUpdated(b, p, m, v);
         return true;
     }
 
@@ -359,7 +364,7 @@ public static class GpuOptimizer
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var zb = z?.TryGetGpuBuffer(); var nb = n?.TryGetGpuBuffer();
         if (pb is null || gb is null || zb is null || nb is null) return false;
         b.FtrlUpdate(pb, gb, zb, nb, lr, l1Reg, l2Reg, beta, p!.Length);
-        MarkGpuUpdated(p, z, n);
+        MarkGpuUpdated(b, p, z, n);
         return true;
     }
 
@@ -421,7 +426,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseAdamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
+        try { b!.SparseAdamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(b, param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -437,7 +442,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseAdamWUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
+        try { b!.SparseAdamWUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(b, param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -448,7 +453,7 @@ public static class GpuOptimizer
         float learningRate, float weightDecay = 0f)
     {
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
-        try { b!.SparseSgdUpdate(pb!, iBuf!, vBuf!, nnz, learningRate, weightDecay); MarkGpuUpdated(param); return true; }
+        try { b!.SparseSgdUpdate(pb!, iBuf!, vBuf!, nnz, learningRate, weightDecay); MarkGpuUpdated(b, param); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -462,7 +467,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var velBuf = velocity.TryGetGpuBuffer();
         if (velBuf is null) return false;
-        try { b!.SparseSgdMomentumUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, learningRate, momentum, weightDecay); MarkGpuUpdated(param, velocity); return true; }
+        try { b!.SparseSgdMomentumUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, learningRate, momentum, weightDecay); MarkGpuUpdated(b, param, velocity); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -476,7 +481,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var sb = squaredAvg.TryGetGpuBuffer();
         if (sb is null) return false;
-        try { b!.SparseRmspropUpdate(pb!, sb, iBuf!, vBuf!, nnz, lr, rho, epsilon, weightDecay); MarkGpuUpdated(param, squaredAvg); return true; }
+        try { b!.SparseRmspropUpdate(pb!, sb, iBuf!, vBuf!, nnz, lr, rho, epsilon, weightDecay); MarkGpuUpdated(b, param, squaredAvg); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -490,7 +495,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var ab = accum.TryGetGpuBuffer();
         if (ab is null) return false;
-        try { b!.SparseAdagradUpdate(pb!, ab, iBuf!, vBuf!, nnz, lr, epsilon, weightDecay); MarkGpuUpdated(param, accum); return true; }
+        try { b!.SparseAdagradUpdate(pb!, ab, iBuf!, vBuf!, nnz, lr, epsilon, weightDecay); MarkGpuUpdated(b, param, accum); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -504,7 +509,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var velBuf = velocity.TryGetGpuBuffer();
         if (velBuf is null) return false;
-        try { b!.SparseNagUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, lr, momentum, weightDecay); MarkGpuUpdated(param, velocity); return true; }
+        try { b!.SparseNagUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, lr, momentum, weightDecay); MarkGpuUpdated(b, param, velocity); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -520,7 +525,7 @@ public static class GpuOptimizer
         var agb = accumGrad.TryGetGpuBuffer();
         var aub = accumUpdate.TryGetGpuBuffer();
         if (agb is null || aub is null) return false;
-        try { b!.SparseAdadeltaUpdate(pb!, agb, aub, iBuf!, vBuf!, nnz, rho, epsilon, weightDecay); MarkGpuUpdated(param, accumGrad, accumUpdate); return true; }
+        try { b!.SparseAdadeltaUpdate(pb!, agb, aub, iBuf!, vBuf!, nnz, rho, epsilon, weightDecay); MarkGpuUpdated(b, param, accumGrad, accumUpdate); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -536,7 +541,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer(); var vmb = vMax.TryGetGpuBuffer();
         if (mb is null || vbState is null || vmb is null) return false;
-        try { b!.SparseAmsgradUpdate(pb!, mb, vbState, vmb, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v, vMax); return true; }
+        try { b!.SparseAmsgradUpdate(pb!, mb, vbState, vmb, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(b, param, m, v, vMax); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -551,7 +556,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var ub = u.TryGetGpuBuffer();
         if (mb is null || ub is null) return false;
-        try { b!.SparseAdamaxUpdate(pb!, mb, ub, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, u); return true; }
+        try { b!.SparseAdamaxUpdate(pb!, mb, ub, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(b, param, m, u); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -565,7 +570,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer();
         if (mb is null) return false;
-        try { b!.SparseLionUpdate(pb!, mb, iBuf!, vBuf!, nnz, lr, beta1, beta2, weightDecay); MarkGpuUpdated(param, m); return true; }
+        try { b!.SparseLionUpdate(pb!, mb, iBuf!, vBuf!, nnz, lr, beta1, beta2, weightDecay); MarkGpuUpdated(b, param, m); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -580,7 +585,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseNadamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
+        try { b!.SparseNadamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(b, param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -595,7 +600,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var zb = z.TryGetGpuBuffer(); var nb = n.TryGetGpuBuffer();
         if (zb is null || nb is null) return false;
-        try { b!.SparseFtrlUpdate(pb!, zb, nb, iBuf!, vBuf!, nnz, lr, l1Reg, l2Reg, beta); MarkGpuUpdated(param, z, n); return true; }
+        try { b!.SparseFtrlUpdate(pb!, zb, nb, iBuf!, vBuf!, nnz, lr, l1Reg, l2Reg, beta); MarkGpuUpdated(b, param, z, n); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -606,7 +611,7 @@ public static class GpuOptimizer
         float lr, float l1Strength)
     {
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
-        try { b!.SparseProximalL1Update(pb!, iBuf!, vBuf!, nnz, lr, l1Strength); MarkGpuUpdated(param); return true; }
+        try { b!.SparseProximalL1Update(pb!, iBuf!, vBuf!, nnz, lr, l1Strength); MarkGpuUpdated(b, param); return true; }
         catch (NotSupportedException) { return false; }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -33,6 +33,34 @@ namespace AiDotNet.Tensors.Engines.Gpu;
 /// </remarks>
 public static class GpuOptimizer
 {
+    private static void MarkGpuUpdated(Tensor<float>? tensor)
+    {
+        if (tensor is null) return;
+        tensor.MarkModified(syncPoint: null);
+        tensor._gpuBufferVersion = tensor.Version;
+    }
+
+    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second)
+    {
+        MarkGpuUpdated(first);
+        MarkGpuUpdated(second);
+    }
+
+    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second, Tensor<float>? third)
+    {
+        MarkGpuUpdated(first);
+        MarkGpuUpdated(second);
+        MarkGpuUpdated(third);
+    }
+
+    private static void MarkGpuUpdated(Tensor<float>? first, Tensor<float>? second, Tensor<float>? third, Tensor<float>? fourth)
+    {
+        MarkGpuUpdated(first);
+        MarkGpuUpdated(second);
+        MarkGpuUpdated(third);
+        MarkGpuUpdated(fourth);
+    }
+
     /// <summary>
     /// Adam optimizer step on GPU-resident tensors. All four tensors
     /// (<paramref name="param"/>, <paramref name="grad"/>,
@@ -66,6 +94,7 @@ public static class GpuOptimizer
 
         backend.AdamUpdate(pBuf, gBuf, mBuf, vBuf,
             learningRate, beta1, beta2, epsilon, weightDecay, step, param.Length);
+        MarkGpuUpdated(param, m, v);
         return true;
     }
 
@@ -111,6 +140,7 @@ public static class GpuOptimizer
         if (pBuf is null || gBuf is null) return false;
 
         backend.SgdUpdate(pBuf, gBuf, learningRate, weightDecay: 0f, param.Length);
+        MarkGpuUpdated(param);
         return true;
     }
 
@@ -129,6 +159,7 @@ public static class GpuOptimizer
         var pb = p.TryGetGpuBuffer(); var gb = g.TryGetGpuBuffer();
         if (pb is null || gb is null) return false;
         cb.ProximalL1Update(pb, gb, lr, l1Strength, p.Length);
+        MarkGpuUpdated(p);
         return true;
     }
 
@@ -204,6 +235,7 @@ public static class GpuOptimizer
         int nb = (p.Length + blockSize - 1) / blockSize;
         cb.Adam8BitUpdate(pb, gb, mQ, vQ, mScales, vScales,
             lr, beta1, beta2, epsilon, 1f - beta1, 1f - beta2, biasCorrection1, biasCorrection2, blockSize, p.Length, nb);
+        MarkGpuUpdated(p);
         return true;
     }
 
@@ -216,7 +248,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
-        b.SgdMomentumUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length); return true;
+        b.SgdMomentumUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length);
+        MarkGpuUpdated(p, velocity);
+        return true;
     }
 
     public static bool TryRmspropStep(Tensor<float> p, Tensor<float> g, Tensor<float> squaredAvg, float lr, float rho, float epsilon, float weightDecay)
@@ -224,7 +258,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var sb = squaredAvg?.TryGetGpuBuffer();
         if (pb is null || gb is null || sb is null) return false;
-        b.RmspropUpdate(pb, gb, sb, lr, rho, epsilon, weightDecay, p!.Length); return true;
+        b.RmspropUpdate(pb, gb, sb, lr, rho, epsilon, weightDecay, p!.Length);
+        MarkGpuUpdated(p, squaredAvg);
+        return true;
     }
 
     public static bool TryAdagradStep(Tensor<float> p, Tensor<float> g, Tensor<float> accum, float lr, float epsilon, float weightDecay)
@@ -232,7 +268,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ab = accum?.TryGetGpuBuffer();
         if (pb is null || gb is null || ab is null) return false;
-        b.AdagradUpdate(pb, gb, ab, lr, epsilon, weightDecay, p!.Length); return true;
+        b.AdagradUpdate(pb, gb, ab, lr, epsilon, weightDecay, p!.Length);
+        MarkGpuUpdated(p, accum);
+        return true;
     }
 
     public static bool TryNagStep(Tensor<float> p, Tensor<float> g, Tensor<float> velocity, float lr, float momentum, float weightDecay)
@@ -240,7 +278,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
-        b.NagUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length); return true;
+        b.NagUpdate(pb, gb, vb, lr, momentum, weightDecay, p!.Length);
+        MarkGpuUpdated(p, velocity);
+        return true;
     }
 
     public static bool TryLarsStep(Tensor<float> p, Tensor<float> g, Tensor<float> velocity, float lr, float momentum, float weightDecay, float trustCoeff)
@@ -248,7 +288,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var vb = velocity?.TryGetGpuBuffer();
         if (pb is null || gb is null || vb is null) return false;
-        b.LarsUpdate(pb, gb, vb, lr, momentum, weightDecay, trustCoeff, p!.Length); return true;
+        b.LarsUpdate(pb, gb, vb, lr, momentum, weightDecay, trustCoeff, p!.Length);
+        MarkGpuUpdated(p, velocity);
+        return true;
     }
 
     public static bool TryLambStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
@@ -256,7 +298,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null) return false;
-        b.LambUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+        b.LambUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
+        MarkGpuUpdated(p, m, v);
+        return true;
     }
 
     public static bool TryAdadeltaStep(Tensor<float> p, Tensor<float> g, Tensor<float> accumGrad, Tensor<float> accumUpdate, float rho, float epsilon, float weightDecay)
@@ -264,7 +308,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var ag = accumGrad?.TryGetGpuBuffer(); var au = accumUpdate?.TryGetGpuBuffer();
         if (pb is null || gb is null || ag is null || au is null) return false;
-        b.AdadeltaUpdate(pb, gb, ag, au, rho, epsilon, weightDecay, p!.Length); return true;
+        b.AdadeltaUpdate(pb, gb, ag, au, rho, epsilon, weightDecay, p!.Length);
+        MarkGpuUpdated(p, accumGrad, accumUpdate);
+        return true;
     }
 
     public static bool TryAmsgradStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, Tensor<float> vMax, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
@@ -272,7 +318,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer(); var xb = vMax?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null || xb is null) return false;
-        b.AmsgradUpdate(pb, gb, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+        b.AmsgradUpdate(pb, gb, mb, vb, xb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
+        MarkGpuUpdated(p, m, v, vMax);
+        return true;
     }
 
     public static bool TryAdamaxStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> u, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
@@ -280,7 +328,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var ub = u?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || ub is null) return false;
-        b.AdamaxUpdate(pb, gb, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+        b.AdamaxUpdate(pb, gb, mb, ub, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
+        MarkGpuUpdated(p, m, u);
+        return true;
     }
 
     public static bool TryLionStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, float lr, float beta1, float beta2, float weightDecay)
@@ -288,7 +338,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null) return false;
-        b.LionUpdate(pb, gb, mb, lr, beta1, beta2, weightDecay, p!.Length); return true;
+        b.LionUpdate(pb, gb, mb, lr, beta1, beta2, weightDecay, p!.Length);
+        MarkGpuUpdated(p, m);
+        return true;
     }
 
     public static bool TryNadamStep(Tensor<float> p, Tensor<float> g, Tensor<float> m, Tensor<float> v, float lr, float beta1, float beta2, float epsilon, float weightDecay, int step)
@@ -296,7 +348,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var mb = m?.TryGetGpuBuffer(); var vb = v?.TryGetGpuBuffer();
         if (pb is null || gb is null || mb is null || vb is null) return false;
-        b.NadamUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length); return true;
+        b.NadamUpdate(pb, gb, mb, vb, lr, beta1, beta2, epsilon, weightDecay, step, p!.Length);
+        MarkGpuUpdated(p, m, v);
+        return true;
     }
 
     public static bool TryFtrlStep(Tensor<float> p, Tensor<float> g, Tensor<float> z, Tensor<float> n, float lr, float l1Reg, float l2Reg, float beta)
@@ -304,7 +358,9 @@ public static class GpuOptimizer
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false; var b = e.GetBackend(); if (b is null) return false;
         var pb = p?.TryGetGpuBuffer(); var gb = g?.TryGetGpuBuffer(); var zb = z?.TryGetGpuBuffer(); var nb = n?.TryGetGpuBuffer();
         if (pb is null || gb is null || zb is null || nb is null) return false;
-        b.FtrlUpdate(pb, gb, zb, nb, lr, l1Reg, l2Reg, beta, p!.Length); return true;
+        b.FtrlUpdate(pb, gb, zb, nb, lr, l1Reg, l2Reg, beta, p!.Length);
+        MarkGpuUpdated(p, z, n);
+        return true;
     }
 
     // ==================================================================
@@ -365,7 +421,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseAdamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); return true; }
+        try { b!.SparseAdamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -381,7 +437,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseAdamWUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); return true; }
+        try { b!.SparseAdamWUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, learningRate, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -392,7 +448,7 @@ public static class GpuOptimizer
         float learningRate, float weightDecay = 0f)
     {
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
-        try { b!.SparseSgdUpdate(pb!, iBuf!, vBuf!, nnz, learningRate, weightDecay); return true; }
+        try { b!.SparseSgdUpdate(pb!, iBuf!, vBuf!, nnz, learningRate, weightDecay); MarkGpuUpdated(param); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -406,7 +462,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var velBuf = velocity.TryGetGpuBuffer();
         if (velBuf is null) return false;
-        try { b!.SparseSgdMomentumUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, learningRate, momentum, weightDecay); return true; }
+        try { b!.SparseSgdMomentumUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, learningRate, momentum, weightDecay); MarkGpuUpdated(param, velocity); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -420,7 +476,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var sb = squaredAvg.TryGetGpuBuffer();
         if (sb is null) return false;
-        try { b!.SparseRmspropUpdate(pb!, sb, iBuf!, vBuf!, nnz, lr, rho, epsilon, weightDecay); return true; }
+        try { b!.SparseRmspropUpdate(pb!, sb, iBuf!, vBuf!, nnz, lr, rho, epsilon, weightDecay); MarkGpuUpdated(param, squaredAvg); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -434,7 +490,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var ab = accum.TryGetGpuBuffer();
         if (ab is null) return false;
-        try { b!.SparseAdagradUpdate(pb!, ab, iBuf!, vBuf!, nnz, lr, epsilon, weightDecay); return true; }
+        try { b!.SparseAdagradUpdate(pb!, ab, iBuf!, vBuf!, nnz, lr, epsilon, weightDecay); MarkGpuUpdated(param, accum); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -448,7 +504,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var velBuf = velocity.TryGetGpuBuffer();
         if (velBuf is null) return false;
-        try { b!.SparseNagUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, lr, momentum, weightDecay); return true; }
+        try { b!.SparseNagUpdate(pb!, velBuf, iBuf!, vBuf!, nnz, lr, momentum, weightDecay); MarkGpuUpdated(param, velocity); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -464,7 +520,7 @@ public static class GpuOptimizer
         var agb = accumGrad.TryGetGpuBuffer();
         var aub = accumUpdate.TryGetGpuBuffer();
         if (agb is null || aub is null) return false;
-        try { b!.SparseAdadeltaUpdate(pb!, agb, aub, iBuf!, vBuf!, nnz, rho, epsilon, weightDecay); return true; }
+        try { b!.SparseAdadeltaUpdate(pb!, agb, aub, iBuf!, vBuf!, nnz, rho, epsilon, weightDecay); MarkGpuUpdated(param, accumGrad, accumUpdate); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -480,7 +536,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer(); var vmb = vMax.TryGetGpuBuffer();
         if (mb is null || vbState is null || vmb is null) return false;
-        try { b!.SparseAmsgradUpdate(pb!, mb, vbState, vmb, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        try { b!.SparseAmsgradUpdate(pb!, mb, vbState, vmb, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v, vMax); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -495,7 +551,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var ub = u.TryGetGpuBuffer();
         if (mb is null || ub is null) return false;
-        try { b!.SparseAdamaxUpdate(pb!, mb, ub, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        try { b!.SparseAdamaxUpdate(pb!, mb, ub, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, u); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -509,7 +565,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer();
         if (mb is null) return false;
-        try { b!.SparseLionUpdate(pb!, mb, iBuf!, vBuf!, nnz, lr, beta1, beta2, weightDecay); return true; }
+        try { b!.SparseLionUpdate(pb!, mb, iBuf!, vBuf!, nnz, lr, beta1, beta2, weightDecay); MarkGpuUpdated(param, m); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -524,7 +580,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var mb = m.TryGetGpuBuffer(); var vbState = v.TryGetGpuBuffer();
         if (mb is null || vbState is null) return false;
-        try { b!.SparseNadamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); return true; }
+        try { b!.SparseNadamUpdate(pb!, mb, vbState, iBuf!, vBuf!, nnz, lr, beta1, beta2, epsilon, weightDecay, step); MarkGpuUpdated(param, m, v); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -539,7 +595,7 @@ public static class GpuOptimizer
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
         var zb = z.TryGetGpuBuffer(); var nb = n.TryGetGpuBuffer();
         if (zb is null || nb is null) return false;
-        try { b!.SparseFtrlUpdate(pb!, zb, nb, iBuf!, vBuf!, nnz, lr, l1Reg, l2Reg, beta); return true; }
+        try { b!.SparseFtrlUpdate(pb!, zb, nb, iBuf!, vBuf!, nnz, lr, l1Reg, l2Reg, beta); MarkGpuUpdated(param, z, n); return true; }
         catch (NotSupportedException) { return false; }
     }
 
@@ -550,7 +606,7 @@ public static class GpuOptimizer
         float lr, float l1Strength)
     {
         if (!TryPrepareSparse(param, sparseIndices, sparseValues, nnz, out var b, out var pb, out var iBuf, out var vBuf)) return false;
-        try { b!.SparseProximalL1Update(pb!, iBuf!, vBuf!, nnz, lr, l1Strength); return true; }
+        try { b!.SparseProximalL1Update(pb!, iBuf!, vBuf!, nnz, lr, l1Strength); MarkGpuUpdated(param); return true; }
         catch (NotSupportedException) { return false; }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -158,6 +158,12 @@ public static class GpuOptimizer
     {
         if (p is null) throw new ArgumentNullException(nameof(p));
         if (g is null) throw new ArgumentNullException(nameof(g));
+        if (p.Length != g.Length)
+            throw new ArgumentException("param and grad must have the same length.", nameof(g));
+        if (float.IsNaN(lr) || float.IsInfinity(lr) || lr < 0f)
+            throw new ArgumentOutOfRangeException(nameof(lr), lr, "Learning rate must be finite and non-negative.");
+        if (float.IsNaN(l1Strength) || float.IsInfinity(l1Strength) || l1Strength < 0f)
+            throw new ArgumentOutOfRangeException(nameof(l1Strength), l1Strength, "L1 strength must be finite and non-negative.");
         if (!(AiDotNetEngine.Current is DirectGpuTensorEngine e)) return false;
         var backend = e.GetBackend();
         if (backend is null) return false;

--- a/tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj
+++ b/tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj
@@ -54,6 +54,7 @@
 
   <!-- ZipArchive needs an explicit reference on net471. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
+    <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MachineCodeKernelTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MachineCodeKernelTests.cs
@@ -14,6 +14,7 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// executable-memory + call infrastructure (a trivial x+1 function), then the
 /// 12-accumulator FMA-throughput kernel that breaks RyuJIT's 8-register cap.
 /// </summary>
+[Collection("BlasManaged-Stats-Serial")]
 public class MachineCodeKernelTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MachineKernelGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/MachineKernelGemmTests.cs
@@ -15,7 +15,7 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// for qualifying FP64 shapes (Auto pack-mode), matching both the managed
 /// ForcePackBoth strategy and a naive triple-loop reference.
 /// </summary>
-[Collection("BlasManaged-Perf-Serial")]
+[Collection("BlasManaged-Stats-Serial")]
 public class MachineKernelGemmTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
@@ -34,10 +34,13 @@ public class NAxisParityTests
     [InlineData(768, 4096, 512)]   // larger mr-aligned M, wide N
     public void NAxis_BitIdentical_ToMAxis(int m, int n, int k)
     {
-        // The N-axis private-B path requires the FP32 machine-code panel kernel; without it the
-        // "N-axis" run silently falls back to M-axis and the comparison would be a vacuous M-vs-M.
+        // The N-axis private-B path requires the FP32 6x16 machine-code panel kernel and the
+        // matching PackBoth tile. AVX-512 hosts intentionally pick the 16x16 FP32 tile instead;
+        // forcing N-axis there would reinterpret packed-A with the wrong row stride.
         Skip.IfNot(MachineKernelGemm.IsFp32PanelAvailable,
             "FP32 machine-code panel kernel unavailable — N-axis path cannot run on this platform.");
+        Skip.If(Avx512Fp32_16x16.IsSupported,
+            "AVX-512 FP32 PackBoth tile is active; the 6x16 N-axis panel path must not run on this platform.");
 
         var prior = CpuParallelSettings.MaxDegreeOfParallelism;
         var priorDisable = PB.s_disableNAxis;
@@ -90,5 +93,52 @@ public class NAxisParityTests
         for (int i = 0; i < cM.Length; i++)
             if (cM[i] != cN[i])
                 Assert.Fail($"N-axis diverged at [{i / n},{i % n}] m={m} n={n} k={k}: Maxis={cM[i]:R} Naxis={cN[i]:R}");
+    }
+
+    [SkippableFact]
+    public void Avx512PackBothTile_DoesNotEnterSixBySixteenNAxisPanelPath()
+    {
+        Skip.IfNot(MachineKernelGemm.IsFp32PanelAvailable && Avx512Fp32_16x16.IsSupported,
+            "Requires an AVX-512 FP32 PackBoth host with the FP32 panel kernel available.");
+
+        var prior = CpuParallelSettings.MaxDegreeOfParallelism;
+        var priorDisable = PB.s_disableNAxis;
+        var priorDisableGoto = BlasMgd.s_disableGotoGemm;
+        var priorMachineKernel = MachineKernelGemm.Enabled;
+        var priorPanelKernel = MachineKernelGemm.EnablePanelKernel;
+        var priorDeterministic = BlasProvider.IsDeterministicMode;
+        var priorThreadDeterministic = BlasProvider.GetThreadLocalDeterministicMode();
+        CpuParallelSettings.MaxDegreeOfParallelism = 4;
+        try
+        {
+            MachineKernelGemm.Enabled = true;
+            MachineKernelGemm.EnablePanelKernel = true;
+            BlasProvider.SetThreadLocalDeterministicMode(null);
+            BlasProvider.SetDeterministicMode(false);
+            BlasMgd.s_disableGotoGemm = true;
+            PB.s_disableNAxis = false;
+
+            int m = 384, n = 4096, k = 512;
+            var a = Rand(m * k, 11);
+            var b = Rand(k * n, 12);
+            var c = new float[m * n];
+            long before = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount);
+
+            BlasMgd.Gemm<float>(a, k, false, b, n, false, c, n, m, n, k,
+                new BlasOptions<float> { PackingMode = PackingMode.ForcePackBoth, NumThreads = 4 });
+
+            long nAxisRuns = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount) - before;
+            Assert.Equal(0, nAxisRuns);
+        }
+        finally
+        {
+            PB.s_disableNAxis = priorDisable;
+            BlasMgd.s_disableGotoGemm = priorDisableGoto;
+            MachineKernelGemm.Enabled = priorMachineKernel;
+            MachineKernelGemm.EnablePanelKernel = priorPanelKernel;
+            BlasProvider.SetDeterministicMode(priorDeterministic);
+            BlasProvider.SetThreadLocalDeterministicMode(priorThreadDeterministic);
+            CpuParallelSettings.MaxDegreeOfParallelism = prior;
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
 using AiDotNet.Tensors.Helpers;
 using Xunit;
 using BlasMgd = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
@@ -41,6 +42,10 @@ public class NAxisParityTests
         var prior = CpuParallelSettings.MaxDegreeOfParallelism;
         var priorDisable = PB.s_disableNAxis;
         var priorDisableGoto = BlasMgd.s_disableGotoGemm;
+        var priorMachineKernel = MachineKernelGemm.Enabled;
+        var priorPanelKernel = MachineKernelGemm.EnablePanelKernel;
+        var priorDeterministic = BlasProvider.IsDeterministicMode;
+        var priorThreadDeterministic = BlasProvider.GetThreadLocalDeterministicMode();
         CpuParallelSettings.MaxDegreeOfParallelism = 4;
         var a = Rand(m * k, 1);
         var b = Rand(k * n, 2);
@@ -49,21 +54,32 @@ public class NAxisParityTests
         long nAxisRunsForThisCase;
         try
         {
+            MachineKernelGemm.Enabled = true;
+            MachineKernelGemm.EnablePanelKernel = true;
+            BlasProvider.SetThreadLocalDeterministicMode(null);
+            BlasProvider.SetDeterministicMode(false);
+
+            var opts = new BlasOptions<float> { PackingMode = PackingMode.ForcePackBoth, NumThreads = 4 };
+
             // This test verifies the PackBoth N-axis vs M-axis paths; the GotoGemm fast path would
             // intercept these large float shapes before either runs, so disable it for the duration.
             BlasMgd.s_disableGotoGemm = true;
             PB.s_disableNAxis = true;
-            BlasMgd.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k);
+            BlasMgd.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k, opts);
 
             PB.s_disableNAxis = false;
             long before = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount);
-            BlasMgd.Gemm<float>(a, k, false, b, n, false, cN, n, m, n, k);
+            BlasMgd.Gemm<float>(a, k, false, b, n, false, cN, n, m, n, k, opts);
             nAxisRunsForThisCase = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount) - before;
         }
         finally
         {
             PB.s_disableNAxis = priorDisable;
             BlasMgd.s_disableGotoGemm = priorDisableGoto;
+            MachineKernelGemm.Enabled = priorMachineKernel;
+            MachineKernelGemm.EnablePanelKernel = priorPanelKernel;
+            BlasProvider.SetDeterministicMode(priorDeterministic);
+            BlasProvider.SetThreadLocalDeterministicMode(priorThreadDeterministic);
             CpuParallelSettings.MaxDegreeOfParallelism = prior;
         }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -23,6 +24,7 @@ public sealed class CompiledTrainingPlanCleanupTests
 
         var protect = (HashSet<object>)Invoke(plan, "BuildStepEvictionProtectSet")!;
 
+        Assert.Same(ReferenceEqualityComparer<object>.Instance, protect.Comparer);
         AssertContainsTensorKeys(protect, grad0);
         AssertContainsTensorKeys(protect, grad1);
         AssertContainsTensorKeys(protect, seed);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class CompiledTrainingPlanCleanupTests
+{
+    [Fact]
+    public void BuildStepEvictionProtectSet_IncludesGradientSeedDestAndBackingKeys()
+    {
+        var loss = new Tensor<float>(new[] { 1 });
+        var grad0 = new Tensor<float>(new[] { 2 });
+        var grad1 = new Tensor<float>(new[] { 3 });
+        var seed = new Tensor<float>(new[] { 1 });
+        var dest = new Tensor<float>(new[] { 1 });
+        var plan = CreatePlan(loss, new[] { grad0, grad1 }, seed, dest);
+
+        var protect = (HashSet<object>)Invoke(plan, "BuildStepEvictionProtectSet")!;
+
+        AssertContainsTensorKeys(protect, grad0);
+        AssertContainsTensorKeys(protect, grad1);
+        AssertContainsTensorKeys(protect, seed);
+        AssertContainsTensorKeys(protect, dest);
+        Assert.DoesNotContain(loss.DataVector, protect);
+    }
+
+    [Fact]
+    public void MaterializeStepLoss_MaterializesBackingArrayAndVectorKeys()
+    {
+        var loss = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
+        var plan = CreatePlan(loss, Array.Empty<Tensor<float>>(), new Tensor<float>(new[] { 1 }), null);
+        var backing = loss.DataVector.GetBackingArrayUnsafe()
+            ?? throw new InvalidOperationException("Expected CPU tensor to expose a backing array.");
+        int backingCalls = 0;
+        int vectorCalls = 0;
+
+        DeferredArrayMaterializer.Register(backing, _ => backingCalls++);
+        DeferredArrayMaterializer.Register(loss.DataVector, _ => vectorCalls++);
+        try
+        {
+            Invoke(plan, "MaterializeStepLoss");
+
+            Assert.Equal(1, backingCalls);
+            Assert.Equal(1, vectorCalls);
+        }
+        finally
+        {
+            DeferredArrayMaterializer.Remove(backing);
+            DeferredArrayMaterializer.Remove(loss.DataVector);
+        }
+    }
+
+    private static void AssertContainsTensorKeys(HashSet<object> protect, Tensor<float> tensor)
+    {
+        Assert.Contains(tensor.DataVector, protect);
+        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        if (backing is not null)
+            Assert.Contains(backing, protect);
+    }
+
+    private static CompiledTrainingPlan<float> CreatePlan(
+        Tensor<float> loss,
+        Tensor<float>[] gradients,
+        Tensor<float> lossGradSeed,
+        Tensor<float>? lossGradDest)
+    {
+#pragma warning disable SYSLIB0050
+        var plan = (CompiledTrainingPlan<float>)FormatterServices.GetUninitializedObject(typeof(CompiledTrainingPlan<float>));
+#pragma warning restore SYSLIB0050
+        SetField(plan, "_lossOutput", loss);
+        SetField(plan, "_gradients", gradients);
+        SetField(plan, "_lossGradSeed", lossGradSeed);
+        SetField(plan, "_lossGradDest", lossGradDest);
+        return plan;
+    }
+
+    private static object? Invoke(CompiledTrainingPlan<float> plan, string methodName)
+    {
+        var method = typeof(CompiledTrainingPlan<float>).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Method not found: {methodName}");
+        return method.Invoke(plan, null);
+    }
+
+    private static void SetField(CompiledTrainingPlan<float> plan, string fieldName, object? value)
+    {
+        var field = typeof(CompiledTrainingPlan<float>).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field not found: {fieldName}");
+        field.SetValue(plan, value);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
@@ -62,6 +62,10 @@ public sealed class CortexTransformerMemoryReproTests
             }
 
             double pL1Before = ParamL1(parameters);
+            float[][] parameterSnapshot = SnapshotParameters(parameters);
+            long memoryBaselineBytes = GpuMemoryTracker.LiveBytes;
+            GpuMemoryTracker.ResetPeak();
+
             ICompiledTrainingPlan<float> plan;
             using (var scope = GraphMode.Enable())
             {
@@ -107,16 +111,19 @@ public sealed class CortexTransformerMemoryReproTests
                     lastLoss = loss.AsSpan()[0];
                     _output.WriteLine($"step {step + 1}/{steps}: loss={lastLoss:G9}");
                     _output.WriteLine(GpuMemoryTracker.Report(topN: 12));
-                    AssertMemoryEnvelope(maxLiveMb, maxPeakMb);
+                    AssertMemoryEnvelope(maxLiveMb, maxPeakMb, memoryBaselineBytes);
                 }
 
                 double pL1After = ParamL1(parameters);
                 double delta = Math.Abs(pL1After - pL1Before);
-                _output.WriteLine($"pL1 before={pL1Before:F6} after={pL1After:F6} delta={delta:G9}");
+                double maxElementDelta = MaxParameterDelta(parameters, parameterSnapshot);
+                _output.WriteLine(
+                    $"pL1 before={pL1Before:F6} after={pL1After:F6} delta={delta:G9}; maxElementDelta={maxElementDelta:G9}");
 
                 Assert.True(!float.IsNaN(lastLoss) && !float.IsInfinity(lastLoss),
                     $"compiled step returned non-finite loss: {lastLoss}");
-                Assert.True(delta > 1e-6, $"parameters did not move; pL1 delta={delta:G9}");
+                Assert.True(maxElementDelta > 1e-7,
+                    $"parameters did not move; max element delta={maxElementDelta:G9}, pL1 delta={delta:G9}");
             }
         }
         finally
@@ -149,20 +156,42 @@ public sealed class CortexTransformerMemoryReproTests
 
     private static Tensor<float> Zeros(int[] shape) => new(shape);
 
-    private static void AssertMemoryEnvelope(int maxLiveMb, int maxPeakMb)
+    private static void AssertMemoryEnvelope(int maxLiveMb, int maxPeakMb, long baselineLiveBytes)
     {
         const long bytesPerMiB = 1024L * 1024L;
         if (maxLiveMb > 0)
         {
-            double liveMb = GpuMemoryTracker.LiveBytes / (double)bytesPerMiB;
+            double liveMb = Math.Max(0L, GpuMemoryTracker.LiveBytes - baselineLiveBytes) / (double)bytesPerMiB;
             Assert.True(liveMb <= maxLiveMb, $"GPU live memory {liveMb:F1} MiB exceeded {maxLiveMb} MiB.");
         }
 
         if (maxPeakMb > 0)
         {
-            double peakMb = GpuMemoryTracker.PeakBytes / (double)bytesPerMiB;
+            double peakMb = Math.Max(0L, GpuMemoryTracker.PeakBytes - baselineLiveBytes) / (double)bytesPerMiB;
             Assert.True(peakMb <= maxPeakMb, $"GPU peak memory {peakMb:F1} MiB exceeded {maxPeakMb} MiB.");
         }
+    }
+
+    private static float[][] SnapshotParameters(Tensor<float>[] parameters)
+    {
+        var snapshot = new float[parameters.Length][];
+        for (int i = 0; i < parameters.Length; i++)
+            snapshot[i] = parameters[i].AsSpan().ToArray();
+        return snapshot;
+    }
+
+    private static double MaxParameterDelta(Tensor<float>[] parameters, float[][] before)
+    {
+        double maxDelta = 0;
+        for (int p = 0; p < parameters.Length; p++)
+        {
+            var after = parameters[p].AsSpan();
+            Assert.Equal(before[p].Length, after.Length);
+            for (int i = 0; i < after.Length; i++)
+                maxDelta = Math.Max(maxDelta, Math.Abs(after[i] - before[p][i]));
+        }
+
+        return maxDelta;
     }
 
     private static double ParamL1(Tensor<float>[] parameters)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
@@ -114,7 +114,8 @@ public sealed class CortexTransformerMemoryReproTests
                 double delta = Math.Abs(pL1After - pL1Before);
                 _output.WriteLine($"pL1 before={pL1Before:F6} after={pL1After:F6} delta={delta:G9}");
 
-                Assert.True(float.IsFinite(lastLoss), $"compiled step returned non-finite loss: {lastLoss}");
+                Assert.True(!float.IsNaN(lastLoss) && !float.IsInfinity(lastLoss),
+                    $"compiled step returned non-finite loss: {lastLoss}");
                 Assert.True(delta > 1e-6, $"parameters did not move; pL1 delta={delta:G9}");
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CortexTransformerMemoryReproTests.cs
@@ -1,0 +1,178 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Manual CUDA repro for the HarmonicEngine Cortex fused-training memory envelope.
+/// This is intentionally opt-in because the default target shape can use many GB
+/// of device memory and is meant for local bug isolation, not CI.
+/// </summary>
+[Collection("DirectGpuSerial")]
+public sealed class CortexTransformerMemoryReproTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CortexTransformerMemoryReproTests(ITestOutputHelper output) => _output = output;
+
+    [SkippableFact]
+    public void CortexLikeD256L4CompiledStep_MemoryEnvelopeProbe()
+    {
+        Skip.IfNot(
+            string.Equals(Environment.GetEnvironmentVariable("AIDOTNET_RUN_CORTEX_MEMORY_REPRO"), "1", StringComparison.Ordinal),
+            "Manual CUDA memory-envelope repro. Set AIDOTNET_RUN_CORTEX_MEMORY_REPRO=1 to run.");
+
+        using var gpu = new DirectGpuTensorEngine();
+        Skip.IfNot(gpu.SupportsGpu, "DirectGpu backend is not available.");
+
+        var previousEngine = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = gpu;
+        try
+        {
+            int batch = ReadInt("AIDOTNET_REPRO_BATCH", 1024);
+            int seqLen = ReadInt("AIDOTNET_REPRO_SEQLEN", 64);
+            int dModel = ReadInt("AIDOTNET_REPRO_DMODEL", 256);
+            int ffDim = ReadInt("AIDOTNET_REPRO_FFDIM", 512);
+            int layers = ReadInt("AIDOTNET_REPRO_LAYERS", 4);
+            int steps = ReadInt("AIDOTNET_REPRO_STEPS", 2);
+            int maxLiveMb = ReadInt("AIDOTNET_REPRO_MAX_LIVE_MB", 0);
+            int maxPeakMb = ReadInt("AIDOTNET_REPRO_MAX_PEAK_MB", 0);
+
+            _output.WriteLine(
+                $"Cortex-like repro shape: B={batch}, S={seqLen}, D={dModel}, FF={ffDim}, L={layers}, steps={steps}");
+
+            var input = Rand([batch, seqLen, dModel], seed: 11, scale: 0.02f);
+            var target = Rand([batch, seqLen, dModel], seed: 12, scale: 0.02f);
+
+            var parameters = new Tensor<float>[layers * 6];
+            for (int layer = 0; layer < layers; layer++)
+            {
+                int o = layer * 6;
+                parameters[o + 0] = Ones([dModel]);
+                parameters[o + 1] = Zeros([dModel]);
+                parameters[o + 2] = Rand([dModel, ffDim], seed: 1000 + layer * 10 + 2, scale: 0.01f);
+                parameters[o + 3] = Zeros([ffDim]);
+                parameters[o + 4] = Rand([ffDim, dModel], seed: 1000 + layer * 10 + 4, scale: 0.01f);
+                parameters[o + 5] = Zeros([dModel]);
+            }
+
+            double pL1Before = ParamL1(parameters);
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var x = input;
+                for (int layer = 0; layer < layers; layer++)
+                {
+                    int o = layer * 6;
+                    var gamma = parameters[o + 0];
+                    var beta = parameters[o + 1];
+                    var w1 = parameters[o + 2];
+                    var b1 = parameters[o + 3];
+                    var w2 = parameters[o + 4];
+                    var b2 = parameters[o + 5];
+
+                    var normed = gpu.LayerNorm(x, gamma, beta, 1e-5, out _, out _);
+                    var flat = gpu.Reshape(normed, [batch * seqLen, dModel]);
+                    var hidden = gpu.FusedLinear(flat, w1, b1, FusedActivationType.ReLU);
+                    var projected = gpu.FusedLinear(hidden, w2, b2, FusedActivationType.None);
+                    var projected3D = gpu.Reshape(projected, [batch, seqLen, dModel]);
+                    x = gpu.TensorAdd(x, projected3D);
+                }
+
+                var diff = gpu.TensorSubtract(x, target);
+                var sq = gpu.TensorMultiply(diff, diff);
+                var loss = gpu.ReduceSum(sq, null);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                plan.ConfigureOptimizer(
+                    OptimizerType.Adam,
+                    learningRate: 1e-4f,
+                    beta1: 0.9f,
+                    beta2: 0.999f,
+                    eps: 1e-8f,
+                    weightDecay: 0f);
+
+                float lastLoss = float.NaN;
+                for (int step = 0; step < steps; step++)
+                {
+                    var loss = plan.Step();
+                    lastLoss = loss.AsSpan()[0];
+                    _output.WriteLine($"step {step + 1}/{steps}: loss={lastLoss:G9}");
+                    _output.WriteLine(GpuMemoryTracker.Report(topN: 12));
+                    AssertMemoryEnvelope(maxLiveMb, maxPeakMb);
+                }
+
+                double pL1After = ParamL1(parameters);
+                double delta = Math.Abs(pL1After - pL1Before);
+                _output.WriteLine($"pL1 before={pL1Before:F6} after={pL1After:F6} delta={delta:G9}");
+
+                Assert.True(float.IsFinite(lastLoss), $"compiled step returned non-finite loss: {lastLoss}");
+                Assert.True(delta > 1e-6, $"parameters did not move; pL1 delta={delta:G9}");
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+        }
+    }
+
+    private static int ReadInt(string name, int fallback)
+        => int.TryParse(Environment.GetEnvironmentVariable(name), out int parsed) && parsed > 0
+            ? parsed
+            : fallback;
+
+    private static Tensor<float> Rand(int[] shape, int seed, float scale)
+    {
+        var tensor = new Tensor<float>(shape);
+        var span = tensor.AsWritableSpan();
+        var rng = new Random(seed);
+        for (int i = 0; i < span.Length; i++)
+            span[i] = (float)((rng.NextDouble() * 2.0 - 1.0) * scale);
+        return tensor;
+    }
+
+    private static Tensor<float> Ones(int[] shape)
+    {
+        var tensor = new Tensor<float>(shape);
+        tensor.AsWritableSpan().Fill(1f);
+        return tensor;
+    }
+
+    private static Tensor<float> Zeros(int[] shape) => new(shape);
+
+    private static void AssertMemoryEnvelope(int maxLiveMb, int maxPeakMb)
+    {
+        const long bytesPerMiB = 1024L * 1024L;
+        if (maxLiveMb > 0)
+        {
+            double liveMb = GpuMemoryTracker.LiveBytes / (double)bytesPerMiB;
+            Assert.True(liveMb <= maxLiveMb, $"GPU live memory {liveMb:F1} MiB exceeded {maxLiveMb} MiB.");
+        }
+
+        if (maxPeakMb > 0)
+        {
+            double peakMb = GpuMemoryTracker.PeakBytes / (double)bytesPerMiB;
+            Assert.True(peakMb <= maxPeakMb, $"GPU peak memory {peakMb:F1} MiB exceeded {maxPeakMb} MiB.");
+        }
+    }
+
+    private static double ParamL1(Tensor<float>[] parameters)
+    {
+        double sum = 0;
+        foreach (var parameter in parameters)
+        {
+            var span = parameter.AsSpan();
+            for (int i = 0; i < span.Length; i++)
+                sum += Math.Abs(span[i]);
+        }
+        return sum;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
@@ -219,6 +219,28 @@ public class LrScheduleTests
     }
 
     [Theory]
+    [InlineData(WarmupDecayMode.Linear, 0)]
+    [InlineData(WarmupDecayMode.Linear, -1)]
+    [InlineData(WarmupDecayMode.Cosine, 0)]
+    [InlineData(WarmupDecayMode.Cosine, -1)]
+    public void LinearWarmup_DecayModesDefaultNonPositiveTotalStepsToWarmup(
+        WarmupDecayMode decayMode, int totalSteps)
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.1,
+            warmupSteps: 3,
+            totalSteps: totalSteps,
+            warmupInitLr: 0.01,
+            decayMode: decayMode,
+            endLr: 0.001);
+
+        Assert.Equal(0.01, s.GetLr(1), 1e-12);
+        Assert.Equal(0.04, s.GetLr(2), 1e-12);
+        Assert.Equal(0.07, s.GetLr(3), 1e-12);
+        Assert.Equal(0.001, s.GetLr(4), 1e-12);
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(-1)]
     public void Cosine_RejectsBadTotalSteps(int total)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
@@ -203,6 +203,34 @@ public class LrScheduleTests
         Assert.Equal(0.001, s.GetLr(100), 1e-12);
     }
 
+    [Theory]
+    [InlineData(WarmupDecayMode.Constant)]
+    [InlineData(WarmupDecayMode.Linear)]
+    [InlineData(WarmupDecayMode.Cosine)]
+    public void LinearWarmup_ZeroWarmup_StartsAtLrMax(WarmupDecayMode decayMode)
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.1,
+            warmupSteps: 0,
+            totalSteps: 4,
+            warmupInitLr: 0.001,
+            decayMode: decayMode,
+            endLr: 0.01);
+
+        Assert.Equal(0.1, s.GetLr(1), 1e-12);
+    }
+
+    [Fact]
+    public void LinearWarmup_RejectsUndefinedDecayMode()
+    {
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            LrSchedule.LinearWarmup(
+                lrMax: 0.1,
+                warmupSteps: 2,
+                totalSteps: 4,
+                decayMode: (WarmupDecayMode)999));
+    }
+
     [Fact]
     public void LinearWarmup_DecayModesRejectTotalBeforeWarmup()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
@@ -220,6 +220,25 @@ public class LrScheduleTests
         Assert.Equal(0.1, s.GetLr(1), 1e-12);
     }
 
+    [Theory]
+    [InlineData(WarmupDecayMode.Linear, 0)]
+    [InlineData(WarmupDecayMode.Linear, -1)]
+    [InlineData(WarmupDecayMode.Cosine, 0)]
+    [InlineData(WarmupDecayMode.Cosine, -1)]
+    public void LinearWarmup_ZeroWarmupAndNormalizedTotal_StartsAtLrMax(
+        WarmupDecayMode decayMode, int totalSteps)
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.1,
+            warmupSteps: 0,
+            totalSteps: totalSteps,
+            warmupInitLr: 0.001,
+            decayMode: decayMode,
+            endLr: 0.01);
+
+        Assert.Equal(0.1, s.GetLr(1), 1e-12);
+    }
+
     [Fact]
     public void LinearWarmup_RejectsUndefinedDecayMode()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LrScheduleTests.cs
@@ -146,6 +146,78 @@ public class LrScheduleTests
         }
     }
 
+    [Fact]
+    public void LinearWarmup_Constant_MatchesAiDotNetBatchSequence()
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.2,
+            warmupSteps: 4,
+            totalSteps: 4,
+            warmupInitLr: 0.01,
+            decayMode: WarmupDecayMode.Constant);
+
+        Assert.Equal(0.01, s.GetLr(1), 1e-12);
+        Assert.Equal(0.0575, s.GetLr(2), 1e-12);
+        Assert.Equal(0.105, s.GetLr(3), 1e-12);
+        Assert.Equal(0.1525, s.GetLr(4), 1e-12);
+        Assert.Equal(0.2, s.GetLr(5), 1e-12);
+        Assert.Equal(0.2, s.GetLr(50), 1e-12);
+    }
+
+    [Fact]
+    public void LinearWarmup_LinearDecay_MatchesAiDotNetBatchSequence()
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.1,
+            warmupSteps: 2,
+            totalSteps: 6,
+            warmupInitLr: 0.02,
+            decayMode: WarmupDecayMode.Linear,
+            endLr: 0.001);
+
+        Assert.Equal(0.02, s.GetLr(1), 1e-12);
+        Assert.Equal(0.06, s.GetLr(2), 1e-12);
+        Assert.Equal(0.1, s.GetLr(3), 1e-12);
+        Assert.Equal(0.07525, s.GetLr(4), 1e-12);
+        Assert.Equal(0.0505, s.GetLr(5), 1e-12);
+        Assert.Equal(0.02575, s.GetLr(6), 1e-12);
+        Assert.Equal(0.001, s.GetLr(7), 1e-12);
+    }
+
+    [Fact]
+    public void LinearWarmup_CosineDecay_ReachesEndLrAndClamps()
+    {
+        var s = LrSchedule.LinearWarmup(
+            lrMax: 0.05,
+            warmupSteps: 3,
+            totalSteps: 9,
+            warmupInitLr: 0.005,
+            decayMode: WarmupDecayMode.Cosine,
+            endLr: 0.001);
+
+        Assert.Equal(0.005, s.GetLr(1), 1e-12);
+        Assert.Equal(0.02, s.GetLr(2), 1e-12);
+        Assert.Equal(0.035, s.GetLr(3), 1e-12);
+        Assert.Equal(0.05, s.GetLr(4), 1e-12);
+        Assert.Equal(0.001, s.GetLr(10), 1e-12);
+        Assert.Equal(0.001, s.GetLr(100), 1e-12);
+    }
+
+    [Fact]
+    public void LinearWarmup_DecayModesRejectTotalBeforeWarmup()
+    {
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            LrSchedule.LinearWarmup(0.1, warmupSteps: 10, totalSteps: 9,
+                decayMode: WarmupDecayMode.Linear));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            LrSchedule.LinearWarmup(0.1, warmupSteps: 10, totalSteps: 9,
+                decayMode: WarmupDecayMode.Cosine));
+
+        var constant = LrSchedule.LinearWarmup(0.1, warmupSteps: 10, totalSteps: 9,
+            decayMode: WarmupDecayMode.Constant);
+        Assert.Equal(0.1, constant.GetLr(11), 1e-12);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EmbeddingKernelSourceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EmbeddingKernelSourceTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public sealed class EmbeddingKernelSourceTests
+{
+    [Fact]
+    public void HipEmbeddingForward_ReadsUploadedIntIndexBuffer()
+    {
+        string source = GetKernelSource("AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels.HipNeuralNetKernels");
+        string signature = ExtractFunctionSignature(source, "embedding_forward");
+
+        Assert.Contains("const int* indices", signature);
+        Assert.DoesNotContain("const float* indices", signature);
+    }
+
+    [Fact]
+    public void OpenClEmbeddingForward_ReadsUploadedIntIndexBufferAndUses2DLaunchShape()
+    {
+        string source = GetKernelSource("AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels.NeuralNetKernels");
+        string signature = ExtractFunctionSignature(source, "embedding_lookup");
+
+        Assert.Contains("__global const int* indices", signature);
+        Assert.DoesNotContain("__global const float* indices", signature);
+        Assert.Contains("const int d = get_global_id(0);", source);
+        Assert.Contains("const int idx = get_global_id(1);", source);
+    }
+
+    private static string GetKernelSource(string typeName)
+    {
+        var type = typeof(DirectGpuTensorEngine).Assembly.GetType(typeName)
+            ?? throw new InvalidOperationException($"Kernel source type not found: {typeName}");
+        var method = type.GetMethod("GetSource", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"GetSource method not found on {typeName}");
+        return (string)(method.Invoke(null, null)
+            ?? throw new InvalidOperationException($"GetSource returned null for {typeName}"));
+    }
+
+    private static string ExtractFunctionSignature(string source, string functionName)
+    {
+        int nameIndex = source.IndexOf(functionName, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            throw new InvalidOperationException($"Function not found: {functionName}");
+
+        int openParen = source.IndexOf('(', nameIndex);
+        int closeParen = source.IndexOf(')', openParen);
+        if (openParen < 0 || closeParen < 0)
+            throw new InvalidOperationException($"Function signature not found: {functionName}");
+
+        return source.Substring(nameIndex, closeParen - nameIndex + 1);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using AiDotNet.Tensors.Engines;
@@ -166,6 +167,48 @@ public class EvictActivationsCreatedAfterLifetimeTests
                 "before disposing its buffer (#226 contract on the per-step release path).");
             Assert.Equal(0, disposeCountWhenMaterialized);
             Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key));
+            Assert.Equal(1, buffer.DisposeCount);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(key);
+        }
+    }
+
+    [Fact]
+    public void EvictActivationsCreatedAfter_DiscardsPendingDownloadsWhenRequested()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var activationCacheField = engineType.GetField(
+            "_activationCache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var timestampField = engineType.GetField(
+            "_activationCacheTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var evictMethod = engineType.GetMethod(
+            "EvictActivationsCreatedAfter", BindingFlags.NonPublic | BindingFlags.Instance,
+            null, new[] { typeof(long), typeof(HashSet<object>), typeof(bool) }, null)!;
+        var activationCacheEntryType = engineType.Assembly.GetType(
+            "AiDotNet.Tensors.Engines.ActivationCacheEntry")!;
+        var entryCtor = GetActivationCacheEntryCtor(activationCacheEntryType);
+        object activationCache = activationCacheField.GetValue(engine)!;
+        var tryAdd = activationCache.GetType().GetMethod("TryAdd")!;
+
+        var key = new float[4];
+        var buffer = new TrackingGpuBuffer(size: 4);
+        object entry = entryCtor.Invoke(new object?[] { buffer, new[] { 4 }, 5L, null, 16L });
+        Assert.True((bool)tryAdd.Invoke(activationCache, new[] { (object)key, entry })!);
+        timestampField.SetValue(engine, 5L);
+
+        bool materializerRan = false;
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(key, _ => materializerRan = true);
+
+        try
+        {
+            evictMethod.Invoke(engine, new object?[] { 0L, null, false });
+
+            Assert.False(materializerRan);
+            Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key));
+            Assert.False(((System.Collections.IDictionary)activationCache).Contains(key));
             Assert.Equal(1, buffer.DisposeCount);
         }
         finally

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
@@ -119,6 +119,22 @@ public sealed class GpuOptimizerResidencyMockTests
             t => t.P);
     }
 
+    [Fact]
+    public void DenseProximalL1_RejectsInvalidInputsBeforeDispatch()
+    {
+        using var ctx = new MockGpuEngineScope();
+        var p = GpuFloat(ctx.Backend, 4);
+        var g = GpuFloat(ctx.Backend, 4);
+        var shortGrad = GpuFloat(ctx.Backend, 3);
+
+        Assert.Throws<ArgumentException>(() => GpuOptimizer.TryProximalL1Step(p, shortGrad, 0.01f, 0.1f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => GpuOptimizer.TryProximalL1Step(p, g, -0.01f, 0.1f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => GpuOptimizer.TryProximalL1Step(p, g, 0.01f, -0.1f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => GpuOptimizer.TryProximalL1Step(p, g, float.NaN, 0.1f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => GpuOptimizer.TryProximalL1Step(p, g, 0.01f, float.PositiveInfinity));
+        Assert.Empty(ctx.State.OptimizerCalls);
+    }
+
     private static void RunDenseCase(
         MockGpuEngineScope ctx,
         string expectedBackendCall,
@@ -143,34 +159,53 @@ public sealed class GpuOptimizerResidencyMockTests
         MockGpuEngineScope ctx,
         string expectedBackendCall,
         Func<bool> run,
-        IReadOnlyList<Tensor<float>> allTensors,
+        IReadOnlyList<TrackedTensor> allTensors,
         IReadOnlyList<Tensor<float>> expectedUpdated)
     {
         ctx.State.OptimizerCalls.Clear();
-        var beforeVersion = new Dictionary<Tensor<float>, int>();
-        var beforeGpuVersion = new Dictionary<Tensor<float>, int>();
-        var beforeSync = new Dictionary<Tensor<float>, object>();
-        foreach (var tensor in allTensors)
-        {
-            beforeVersion[tensor] = tensor.Version;
-            beforeGpuVersion[tensor] = tensor._gpuBufferVersion;
-            beforeSync[tensor] = tensor.LastWriteSync;
-        }
+        var before = new TensorSnapshot[allTensors.Count];
+        for (int i = 0; i < allTensors.Count; i++)
+            before[i] = allTensors[i].Snapshot();
 
         Assert.True(run(), $"GpuOptimizer wrapper for {expectedBackendCall} should run against the mock GPU backend.");
         Assert.Contains(expectedBackendCall, ctx.State.OptimizerCalls);
 
-        var updatedSet = new HashSet<Tensor<float>>(expectedUpdated);
         foreach (var tensor in expectedUpdated)
-            AssertGpuMarkedCurrent(tensor, beforeVersion[tensor], expectedBackendCall);
-
-        foreach (var tensor in allTensors)
         {
-            if (updatedSet.Contains(tensor)) continue;
-            Assert.Equal(beforeVersion[tensor], tensor.Version);
-            Assert.Equal(beforeGpuVersion[tensor], tensor._gpuBufferVersion);
-            Assert.Same(beforeSync[tensor], tensor.LastWriteSync);
+            int trackedIndex = IndexOfTracked(allTensors, tensor);
+            Assert.True(trackedIndex >= 0, $"{expectedBackendCall}: expected updated tensor was not tracked.");
+            AssertGpuMarkedCurrent(tensor, before[trackedIndex].Version, expectedBackendCall);
         }
+
+        for (int i = 0; i < allTensors.Count; i++)
+        {
+            if (ContainsReference(expectedUpdated, allTensors[i].Instance)) continue;
+            Assert.Equal(before[i].Version, allTensors[i].Version);
+            Assert.Equal(before[i].GpuBufferVersion, allTensors[i].GpuBufferVersion);
+            Assert.Same(before[i].LastWriteSync, allTensors[i].LastWriteSync);
+        }
+    }
+
+    private static int IndexOfTracked(IReadOnlyList<TrackedTensor> tensors, object expected)
+    {
+        for (int i = 0; i < tensors.Count; i++)
+        {
+            if (ReferenceEquals(tensors[i].Instance, expected))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool ContainsReference(IReadOnlyList<Tensor<float>> tensors, object expected)
+        => IndexOfTracked(Select(tensors), expected) >= 0;
+
+    private static TrackedTensor[] Select(IReadOnlyList<Tensor<float>> tensors)
+    {
+        var tracked = new TrackedTensor[tensors.Count];
+        for (int i = 0; i < tensors.Count; i++)
+            tracked[i] = Track(tensors[i]);
+        return tracked;
     }
 
     private static Tensor<float>[] Select<TState>(TState state, Func<TState, Tensor<float>>[] selectors)
@@ -187,6 +222,47 @@ public sealed class GpuOptimizerResidencyMockTests
         Assert.Equal(tensor.Version, tensor._gpuBufferVersion);
         Assert.NotNull(tensor.LastWriteSync);
         Assert.True(tensor.LastWriteSync!.IsComplete, $"{caseName}: mock backend write sync should be complete.");
+    }
+
+    private static TrackedTensor Track<T>(Tensor<T> tensor) => new TrackedTensor(
+        tensor,
+        () => tensor.Version,
+        () => tensor._gpuBufferVersion,
+        () => tensor.LastWriteSync);
+
+    private sealed class TrackedTensor
+    {
+        private readonly Func<int> _version;
+        private readonly Func<int> _gpuBufferVersion;
+        private readonly Func<object> _lastWriteSync;
+
+        public TrackedTensor(object instance, Func<int> version, Func<int> gpuBufferVersion, Func<object> lastWriteSync)
+        {
+            Instance = instance;
+            _version = version;
+            _gpuBufferVersion = gpuBufferVersion;
+            _lastWriteSync = lastWriteSync;
+        }
+
+        public object Instance { get; }
+        public int Version => _version();
+        public int GpuBufferVersion => _gpuBufferVersion();
+        public object LastWriteSync => _lastWriteSync();
+        public TensorSnapshot Snapshot() => new TensorSnapshot(Version, GpuBufferVersion, LastWriteSync);
+    }
+
+    private readonly struct TensorSnapshot
+    {
+        public TensorSnapshot(int version, int gpuBufferVersion, object lastWriteSync)
+        {
+            Version = version;
+            GpuBufferVersion = gpuBufferVersion;
+            LastWriteSync = lastWriteSync;
+        }
+
+        public int Version { get; }
+        public int GpuBufferVersion { get; }
+        public object LastWriteSync { get; }
     }
 
     private static Tensor<float> GpuFloat(IDirectGpuBackend backend, int length = 4)
@@ -210,7 +286,7 @@ public sealed class GpuOptimizerResidencyMockTests
         public Tensor<float> AccumGrad { get; }
         public Tensor<float> AccumUpdate { get; }
         public Tensor<float> VMax { get; }
-        public Tensor<float>[] All { get; }
+        public TrackedTensor[] All { get; }
 
         public DenseTensors(IDirectGpuBackend backend)
         {
@@ -227,7 +303,7 @@ public sealed class GpuOptimizerResidencyMockTests
             AccumGrad = GpuFloat(backend);
             AccumUpdate = GpuFloat(backend);
             VMax = GpuFloat(backend);
-            All = new[] { P, G, M, V, U, Z, N, Velocity, Accum, SquaredAvg, AccumGrad, AccumUpdate, VMax };
+            All = new[] { Track(P), Track(G), Track(M), Track(V), Track(U), Track(Z), Track(N), Track(Velocity), Track(Accum), Track(SquaredAvg), Track(AccumGrad), Track(AccumUpdate), Track(VMax) };
         }
     }
 
@@ -247,7 +323,7 @@ public sealed class GpuOptimizerResidencyMockTests
         public Tensor<float> VMax { get; }
         public Tensor<int> Indices { get; }
         public Tensor<float> Values { get; }
-        public Tensor<float>[] All { get; }
+        public TrackedTensor[] All { get; }
 
         public SparseTensors(IDirectGpuBackend backend)
         {
@@ -265,7 +341,7 @@ public sealed class GpuOptimizerResidencyMockTests
             VMax = GpuFloat(backend);
             Indices = GpuInt(backend);
             Values = GpuFloat(backend);
-            All = new[] { P, M, V, U, Z, N, Velocity, Accum, SquaredAvg, AccumGrad, AccumUpdate, VMax, Values };
+            All = new[] { Track(P), Track(M), Track(V), Track(U), Track(Z), Track(N), Track(Velocity), Track(Accum), Track(SquaredAvg), Track(AccumGrad), Track(AccumUpdate), Track(VMax), Track(Indices), Track(Values) };
         }
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) AiDotNet. All rights reserved.
 
-#if !NETFRAMEWORK
 #nullable disable
 
 using System;
@@ -29,6 +28,9 @@ public sealed class GpuOptimizerResidencyMockTests
             t => t.P, t => t.M, t => t.V);
         RunDenseCase(ctx, "SgdUpdate",
             t => GpuOptimizer.TrySgdStep(t.P, t.G, 0.01f),
+            t => t.P);
+        RunDenseCase(ctx, "ProximalL1Update",
+            t => GpuOptimizer.TryProximalL1Step(t.P, t.G, 0.01f, 0.1f),
             t => t.P);
         RunDenseCase(ctx, "SgdMomentumUpdate",
             t => GpuOptimizer.TrySgdMomentumStep(t.P, t.G, t.Velocity, 0.01f, 0.9f, 0f),
@@ -124,7 +126,7 @@ public sealed class GpuOptimizerResidencyMockTests
         params Func<DenseTensors, Tensor<float>>[] updatedSelectors)
     {
         var tensors = new DenseTensors(ctx.Backend);
-        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.G, tensors.All, Select(tensors, updatedSelectors));
+        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.All, Select(tensors, updatedSelectors));
     }
 
     private static void RunSparseCase(
@@ -134,31 +136,41 @@ public sealed class GpuOptimizerResidencyMockTests
         params Func<SparseTensors, Tensor<float>>[] updatedSelectors)
     {
         var tensors = new SparseTensors(ctx.Backend);
-        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.Values, tensors.All, Select(tensors, updatedSelectors));
+        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.All, Select(tensors, updatedSelectors));
     }
 
     private static void RunCase(
         MockGpuEngineScope ctx,
         string expectedBackendCall,
         Func<bool> run,
-        Tensor<float> gradientTensor,
         IReadOnlyList<Tensor<float>> allTensors,
         IReadOnlyList<Tensor<float>> expectedUpdated)
     {
         ctx.State.OptimizerCalls.Clear();
-        var before = new Dictionary<Tensor<float>, int>();
+        var beforeVersion = new Dictionary<Tensor<float>, int>();
+        var beforeGpuVersion = new Dictionary<Tensor<float>, int>();
+        var beforeSync = new Dictionary<Tensor<float>, object>();
         foreach (var tensor in allTensors)
-            before[tensor] = tensor.Version;
+        {
+            beforeVersion[tensor] = tensor.Version;
+            beforeGpuVersion[tensor] = tensor._gpuBufferVersion;
+            beforeSync[tensor] = tensor.LastWriteSync;
+        }
 
         Assert.True(run(), $"GpuOptimizer wrapper for {expectedBackendCall} should run against the mock GPU backend.");
         Assert.Contains(expectedBackendCall, ctx.State.OptimizerCalls);
 
         var updatedSet = new HashSet<Tensor<float>>(expectedUpdated);
         foreach (var tensor in expectedUpdated)
-            AssertGpuMarkedCurrent(tensor, before[tensor], expectedBackendCall);
+            AssertGpuMarkedCurrent(tensor, beforeVersion[tensor], expectedBackendCall);
 
-        Assert.DoesNotContain(gradientTensor, updatedSet);
-        Assert.Equal(before[gradientTensor], gradientTensor.Version);
+        foreach (var tensor in allTensors)
+        {
+            if (updatedSet.Contains(tensor)) continue;
+            Assert.Equal(beforeVersion[tensor], tensor.Version);
+            Assert.Equal(beforeGpuVersion[tensor], tensor._gpuBufferVersion);
+            Assert.Same(beforeSync[tensor], tensor.LastWriteSync);
+        }
     }
 
     private static Tensor<float>[] Select<TState>(TState state, Func<TState, Tensor<float>>[] selectors)
@@ -269,7 +281,7 @@ public sealed class GpuOptimizerResidencyMockTests
         {
             _priorEngine = AiDotNetEngine.Current;
             _priorBackendEnv = Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS");
-            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", "mock-unavailable");
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", "none");
             var directGpu = new DirectGpuEngine();
             Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", _priorBackendEnv);
 
@@ -296,4 +308,3 @@ public sealed class GpuOptimizerResidencyMockTests
         }
     }
 }
-#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuOptimizerResidencyMockTests.cs
@@ -1,0 +1,299 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+#if !NETFRAMEWORK
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public sealed class GpuOptimizerResidencyMockTests
+{
+    [Fact]
+    public void DenseOptimizerWrappers_MarkEveryMutatedTensorCurrent()
+    {
+        using var ctx = new MockGpuEngineScope();
+
+        RunDenseCase(ctx, "AdamUpdate",
+            t => GpuOptimizer.TryAdamStep(t.P, t.G, t.M, t.V, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunDenseCase(ctx, "AdamUpdate",
+            t => GpuOptimizer.TryAdamWStep(t.P, t.G, t.M, t.V, 0.01f, 0.9f, 0.999f, 1e-8f, 0.01f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunDenseCase(ctx, "SgdUpdate",
+            t => GpuOptimizer.TrySgdStep(t.P, t.G, 0.01f),
+            t => t.P);
+        RunDenseCase(ctx, "SgdMomentumUpdate",
+            t => GpuOptimizer.TrySgdMomentumStep(t.P, t.G, t.Velocity, 0.01f, 0.9f, 0f),
+            t => t.P, t => t.Velocity);
+        RunDenseCase(ctx, "RmspropUpdate",
+            t => GpuOptimizer.TryRmspropStep(t.P, t.G, t.SquaredAvg, 0.01f, 0.99f, 1e-8f, 0f),
+            t => t.P, t => t.SquaredAvg);
+        RunDenseCase(ctx, "AdagradUpdate",
+            t => GpuOptimizer.TryAdagradStep(t.P, t.G, t.Accum, 0.01f, 1e-8f, 0f),
+            t => t.P, t => t.Accum);
+        RunDenseCase(ctx, "NagUpdate",
+            t => GpuOptimizer.TryNagStep(t.P, t.G, t.Velocity, 0.01f, 0.9f, 0f),
+            t => t.P, t => t.Velocity);
+        RunDenseCase(ctx, "LarsUpdate",
+            t => GpuOptimizer.TryLarsStep(t.P, t.G, t.Velocity, 0.01f, 0.9f, 0f, 0.001f),
+            t => t.P, t => t.Velocity);
+        RunDenseCase(ctx, "LambUpdate",
+            t => GpuOptimizer.TryLambStep(t.P, t.G, t.M, t.V, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunDenseCase(ctx, "AdadeltaUpdate",
+            t => GpuOptimizer.TryAdadeltaStep(t.P, t.G, t.AccumGrad, t.AccumUpdate, 0.95f, 1e-6f, 0f),
+            t => t.P, t => t.AccumGrad, t => t.AccumUpdate);
+        RunDenseCase(ctx, "AmsgradUpdate",
+            t => GpuOptimizer.TryAmsgradStep(t.P, t.G, t.M, t.V, t.VMax, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V, t => t.VMax);
+        RunDenseCase(ctx, "AdamaxUpdate",
+            t => GpuOptimizer.TryAdamaxStep(t.P, t.G, t.M, t.U, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.U);
+        RunDenseCase(ctx, "LionUpdate",
+            t => GpuOptimizer.TryLionStep(t.P, t.G, t.M, 0.01f, 0.9f, 0.99f, 0f),
+            t => t.P, t => t.M);
+        RunDenseCase(ctx, "NadamUpdate",
+            t => GpuOptimizer.TryNadamStep(t.P, t.G, t.M, t.V, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunDenseCase(ctx, "FtrlUpdate",
+            t => GpuOptimizer.TryFtrlStep(t.P, t.G, t.Z, t.N, 0.01f, 0f, 0f, 0f),
+            t => t.P, t => t.Z, t => t.N);
+    }
+
+    [Fact]
+    public void SparseOptimizerWrappers_MarkEveryMutatedTensorCurrent()
+    {
+        using var ctx = new MockGpuEngineScope();
+
+        RunSparseCase(ctx, "SparseAdamUpdate",
+            t => GpuOptimizer.TryAdamStepSparse(t.P, t.M, t.V, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunSparseCase(ctx, "SparseAdamWUpdate",
+            t => GpuOptimizer.TryAdamWStepSparse(t.P, t.M, t.V, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.999f, 1e-8f, 0.01f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunSparseCase(ctx, "SparseSgdUpdate",
+            t => GpuOptimizer.TrySgdStepSparse(t.P, t.Indices, t.Values, 2, 0.01f),
+            t => t.P);
+        RunSparseCase(ctx, "SparseSgdMomentumUpdate",
+            t => GpuOptimizer.TrySgdMomentumStepSparse(t.P, t.Velocity, t.Indices, t.Values, 2, 0.01f, 0.9f, 0f),
+            t => t.P, t => t.Velocity);
+        RunSparseCase(ctx, "SparseRmspropUpdate",
+            t => GpuOptimizer.TryRmspropStepSparse(t.P, t.SquaredAvg, t.Indices, t.Values, 2, 0.01f, 0.99f, 1e-8f, 0f),
+            t => t.P, t => t.SquaredAvg);
+        RunSparseCase(ctx, "SparseAdagradUpdate",
+            t => GpuOptimizer.TryAdagradStepSparse(t.P, t.Accum, t.Indices, t.Values, 2, 0.01f, 1e-8f, 0f),
+            t => t.P, t => t.Accum);
+        RunSparseCase(ctx, "SparseNagUpdate",
+            t => GpuOptimizer.TryNagStepSparse(t.P, t.Velocity, t.Indices, t.Values, 2, 0.01f, 0.9f, 0f),
+            t => t.P, t => t.Velocity);
+        RunSparseCase(ctx, "SparseAdadeltaUpdate",
+            t => GpuOptimizer.TryAdadeltaStepSparse(t.P, t.AccumGrad, t.AccumUpdate, t.Indices, t.Values, 2, 0.95f, 1e-6f, 0f),
+            t => t.P, t => t.AccumGrad, t => t.AccumUpdate);
+        RunSparseCase(ctx, "SparseAmsgradUpdate",
+            t => GpuOptimizer.TryAmsgradStepSparse(t.P, t.M, t.V, t.VMax, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V, t => t.VMax);
+        RunSparseCase(ctx, "SparseAdamaxUpdate",
+            t => GpuOptimizer.TryAdamaxStepSparse(t.P, t.M, t.U, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.U);
+        RunSparseCase(ctx, "SparseLionUpdate",
+            t => GpuOptimizer.TryLionStepSparse(t.P, t.M, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.99f, 0f),
+            t => t.P, t => t.M);
+        RunSparseCase(ctx, "SparseNadamUpdate",
+            t => GpuOptimizer.TryNadamStepSparse(t.P, t.M, t.V, t.Indices, t.Values, 2, 0.01f, 0.9f, 0.999f, 1e-8f, 0f, 1),
+            t => t.P, t => t.M, t => t.V);
+        RunSparseCase(ctx, "SparseFtrlUpdate",
+            t => GpuOptimizer.TryFtrlStepSparse(t.P, t.Z, t.N, t.Indices, t.Values, 2, 0.01f, 0f, 0f, 0f),
+            t => t.P, t => t.Z, t => t.N);
+        RunSparseCase(ctx, "SparseProximalL1Update",
+            t => GpuOptimizer.TryProximalL1StepSparse(t.P, t.Indices, t.Values, 2, 0.01f, 0.1f),
+            t => t.P);
+    }
+
+    private static void RunDenseCase(
+        MockGpuEngineScope ctx,
+        string expectedBackendCall,
+        Func<DenseTensors, bool> run,
+        params Func<DenseTensors, Tensor<float>>[] updatedSelectors)
+    {
+        var tensors = new DenseTensors(ctx.Backend);
+        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.G, tensors.All, Select(tensors, updatedSelectors));
+    }
+
+    private static void RunSparseCase(
+        MockGpuEngineScope ctx,
+        string expectedBackendCall,
+        Func<SparseTensors, bool> run,
+        params Func<SparseTensors, Tensor<float>>[] updatedSelectors)
+    {
+        var tensors = new SparseTensors(ctx.Backend);
+        RunCase(ctx, expectedBackendCall, () => run(tensors), tensors.Values, tensors.All, Select(tensors, updatedSelectors));
+    }
+
+    private static void RunCase(
+        MockGpuEngineScope ctx,
+        string expectedBackendCall,
+        Func<bool> run,
+        Tensor<float> gradientTensor,
+        IReadOnlyList<Tensor<float>> allTensors,
+        IReadOnlyList<Tensor<float>> expectedUpdated)
+    {
+        ctx.State.OptimizerCalls.Clear();
+        var before = new Dictionary<Tensor<float>, int>();
+        foreach (var tensor in allTensors)
+            before[tensor] = tensor.Version;
+
+        Assert.True(run(), $"GpuOptimizer wrapper for {expectedBackendCall} should run against the mock GPU backend.");
+        Assert.Contains(expectedBackendCall, ctx.State.OptimizerCalls);
+
+        var updatedSet = new HashSet<Tensor<float>>(expectedUpdated);
+        foreach (var tensor in expectedUpdated)
+            AssertGpuMarkedCurrent(tensor, before[tensor], expectedBackendCall);
+
+        Assert.DoesNotContain(gradientTensor, updatedSet);
+        Assert.Equal(before[gradientTensor], gradientTensor.Version);
+    }
+
+    private static Tensor<float>[] Select<TState>(TState state, Func<TState, Tensor<float>>[] selectors)
+    {
+        var tensors = new Tensor<float>[selectors.Length];
+        for (int i = 0; i < selectors.Length; i++)
+            tensors[i] = selectors[i](state);
+        return tensors;
+    }
+
+    private static void AssertGpuMarkedCurrent(Tensor<float> tensor, int oldVersion, string caseName)
+    {
+        Assert.True(tensor.Version > oldVersion, $"{caseName}: tensor Version should advance.");
+        Assert.Equal(tensor.Version, tensor._gpuBufferVersion);
+        Assert.NotNull(tensor.LastWriteSync);
+        Assert.True(tensor.LastWriteSync!.IsComplete, $"{caseName}: mock backend write sync should be complete.");
+    }
+
+    private static Tensor<float> GpuFloat(IDirectGpuBackend backend, int length = 4)
+        => Tensor<float>.FromGpuBuffer(backend, new MockGpuBuffer(new float[length]), new[] { length });
+
+    private static Tensor<int> GpuInt(IDirectGpuBackend backend, int length = 4)
+        => Tensor<int>.FromGpuBuffer(backend, new MockGpuBuffer(new float[length]), new[] { length });
+
+    private sealed class DenseTensors
+    {
+        public Tensor<float> P { get; }
+        public Tensor<float> G { get; }
+        public Tensor<float> M { get; }
+        public Tensor<float> V { get; }
+        public Tensor<float> U { get; }
+        public Tensor<float> Z { get; }
+        public Tensor<float> N { get; }
+        public Tensor<float> Velocity { get; }
+        public Tensor<float> Accum { get; }
+        public Tensor<float> SquaredAvg { get; }
+        public Tensor<float> AccumGrad { get; }
+        public Tensor<float> AccumUpdate { get; }
+        public Tensor<float> VMax { get; }
+        public Tensor<float>[] All { get; }
+
+        public DenseTensors(IDirectGpuBackend backend)
+        {
+            P = GpuFloat(backend);
+            G = GpuFloat(backend);
+            M = GpuFloat(backend);
+            V = GpuFloat(backend);
+            U = GpuFloat(backend);
+            Z = GpuFloat(backend);
+            N = GpuFloat(backend);
+            Velocity = GpuFloat(backend);
+            Accum = GpuFloat(backend);
+            SquaredAvg = GpuFloat(backend);
+            AccumGrad = GpuFloat(backend);
+            AccumUpdate = GpuFloat(backend);
+            VMax = GpuFloat(backend);
+            All = new[] { P, G, M, V, U, Z, N, Velocity, Accum, SquaredAvg, AccumGrad, AccumUpdate, VMax };
+        }
+    }
+
+    private sealed class SparseTensors
+    {
+        public Tensor<float> P { get; }
+        public Tensor<float> M { get; }
+        public Tensor<float> V { get; }
+        public Tensor<float> U { get; }
+        public Tensor<float> Z { get; }
+        public Tensor<float> N { get; }
+        public Tensor<float> Velocity { get; }
+        public Tensor<float> Accum { get; }
+        public Tensor<float> SquaredAvg { get; }
+        public Tensor<float> AccumGrad { get; }
+        public Tensor<float> AccumUpdate { get; }
+        public Tensor<float> VMax { get; }
+        public Tensor<int> Indices { get; }
+        public Tensor<float> Values { get; }
+        public Tensor<float>[] All { get; }
+
+        public SparseTensors(IDirectGpuBackend backend)
+        {
+            P = GpuFloat(backend);
+            M = GpuFloat(backend);
+            V = GpuFloat(backend);
+            U = GpuFloat(backend);
+            Z = GpuFloat(backend);
+            N = GpuFloat(backend);
+            Velocity = GpuFloat(backend);
+            Accum = GpuFloat(backend);
+            SquaredAvg = GpuFloat(backend);
+            AccumGrad = GpuFloat(backend);
+            AccumUpdate = GpuFloat(backend);
+            VMax = GpuFloat(backend);
+            Indices = GpuInt(backend);
+            Values = GpuFloat(backend);
+            All = new[] { P, M, V, U, Z, N, Velocity, Accum, SquaredAvg, AccumGrad, AccumUpdate, VMax, Values };
+        }
+    }
+
+    private sealed class MockGpuEngineScope : IDisposable
+    {
+        private readonly IEngine _priorEngine;
+        private readonly string? _priorBackendEnv;
+        public MockBackendState State { get; } = new();
+        public IDirectGpuBackend Backend { get; }
+        public DirectGpuTensorEngine Engine { get; }
+
+        public MockGpuEngineScope()
+        {
+            _priorEngine = AiDotNetEngine.Current;
+            _priorBackendEnv = Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS");
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", "mock-unavailable");
+            var directGpu = new DirectGpuEngine();
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", _priorBackendEnv);
+
+            Backend = MockDirectGpuBackend.Create(State);
+            SetField(directGpu, "_backend", Backend);
+            SetField(directGpu, "_isAvailable", true);
+
+            Engine = new DirectGpuTensorEngine(directGpu);
+            AiDotNetEngine.Current = Engine;
+        }
+
+        public void Dispose()
+        {
+            AiDotNetEngine.Current = _priorEngine;
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", _priorBackendEnv);
+            Engine.Dispose();
+        }
+
+        private static void SetField(object target, string name, object? value)
+        {
+            var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException($"Field not found: {name}");
+            field.SetValue(target, value);
+        }
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/InvalidateActivationCacheEntryLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/InvalidateActivationCacheEntryLifetimeTests.cs
@@ -120,4 +120,31 @@ public class InvalidateActivationCacheEntryLifetimeTests
             AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(key);
         }
     }
+
+    [Fact]
+    public void TryFreeActivationByKey_CacheMiss_DoesNotDropPendingMaterializer()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        var method = typeof(DirectGpuTensorEngine).GetMethod(
+            "TryFreeActivationByKey", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var key = new float[4];
+        bool materializerRan = false;
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(key, _ => materializerRan = true);
+        try
+        {
+            Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key));
+
+            var removed = (bool)method.Invoke(engine, new object[] { key })!;
+
+            Assert.False(removed);
+            Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(key),
+                "A miss in the activation cache must not remove an unrelated still-valid deferred materializer.");
+            Assert.False(materializerRan);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(key);
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -66,6 +66,7 @@ internal sealed class MockBackendState
     public int DownloadBufferCalls { get; set; }
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
+    public List<string> OptimizerCalls { get; } = new();
 }
 
 /// <summary>
@@ -137,6 +138,39 @@ public class MockDirectGpuBackend : DispatchProxy
                 Array.Copy(b.Data, dest, b.Size);
                 return null!;
             }
+
+            // Optimizer dispatch probes. These methods are void on IDirectGpuBackend; tests
+            // verify the wrapper reached the backend and marked only the mutated tensors current.
+            case "AdamUpdate":
+            case "SgdUpdate":
+            case "SgdMomentumUpdate":
+            case "RmspropUpdate":
+            case "AdagradUpdate":
+            case "NagUpdate":
+            case "LarsUpdate":
+            case "LambUpdate":
+            case "AdadeltaUpdate":
+            case "AmsgradUpdate":
+            case "AdamaxUpdate":
+            case "LionUpdate":
+            case "NadamUpdate":
+            case "FtrlUpdate":
+            case "SparseAdamUpdate":
+            case "SparseAdamWUpdate":
+            case "SparseSgdUpdate":
+            case "SparseSgdMomentumUpdate":
+            case "SparseRmspropUpdate":
+            case "SparseAdagradUpdate":
+            case "SparseNagUpdate":
+            case "SparseAdadeltaUpdate":
+            case "SparseAmsgradUpdate":
+            case "SparseAdamaxUpdate":
+            case "SparseLionUpdate":
+            case "SparseNadamUpdate":
+            case "SparseFtrlUpdate":
+            case "SparseProximalL1Update":
+                _state.OptimizerCalls.Add(targetMethod.Name);
+                return null!;
         }
         throw new NotImplementedException(
             $"MockDirectGpuBackend does not implement {targetMethod.Name}. " +

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -4,12 +4,9 @@
 // and throws NotImplementedException for everything else. Sidesteps the
 // 470-member interface surface that would require a hand-written stub.
 //
-// DispatchProxy lives in System.Reflection from .NET Core 5+; it is NOT
-// available on .NET Framework, so the whole mock + its tests are gated
-// to non-Framework targets. Coverage on net10.0 is the meaningful one
-// for codecov.
-
-#if !NETFRAMEWORK
+// DispatchProxy is provided to net471 by the test project's
+// System.Reflection.DispatchProxy reference so this mock compiles on every
+// target framework the test project builds.
 #nullable disable
 
 using System;
@@ -147,6 +144,7 @@ public class MockDirectGpuBackend : DispatchProxy
             case "RmspropUpdate":
             case "AdagradUpdate":
             case "NagUpdate":
+            case "ProximalL1Update":
             case "LarsUpdate":
             case "LambUpdate":
             case "AdadeltaUpdate":
@@ -177,4 +175,3 @@ public class MockDirectGpuBackend : DispatchProxy
             "Add a case in MockDirectGpuBackend.Invoke if your test exercises this op.");
     }
 }
-#endif

--- a/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
@@ -266,6 +266,16 @@ public class GpuPinnedLifetimeTests
                 Assert.Equal(p.Version, p._gpuBufferVersion);
                 Assert.Equal(m.Version, m._gpuBufferVersion);
                 Assert.Equal(v.Version, v._gpuBufferVersion);
+
+                Assert.NotNull(p.LastWriteSync);
+                Assert.NotNull(m.LastWriteSync);
+                Assert.NotNull(v.LastWriteSync);
+                p.Synchronize();
+                m.Synchronize();
+                v.Synchronize();
+                Assert.True(p.LastWriteSync!.IsComplete, "Parameter GPU write sync should complete after Synchronize().");
+                Assert.True(m.LastWriteSync!.IsComplete, "Adam m-state GPU write sync should complete after Synchronize().");
+                Assert.True(v.LastWriteSync!.IsComplete, "Adam v-state GPU write sync should complete after Synchronize().");
             }
             finally
             {

--- a/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
@@ -73,16 +73,16 @@ public class GpuPinnedLifetimeTests
         Assert.Equal(32, tensor.Length);
     }
 
-    [Fact]
+    [SkippableFact]
     public void RentPinnedOnGpu_GpuOffloadCapableHost_TagsTensorGpuPinned()
     {
         // When the offload allocator IS registered (GPU host), the tensor
         // comes back tagged GpuPinned (not GpuOffload — issue #336 uses
         // the new lifetime tag to distinguish "lives on GPU for the train
         // loop" from "may swap to host for large-model memory pressure").
-        if (WeightRegistry.OffloadAllocator is null
-            || !WeightRegistry.OffloadAllocator.IsAvailable)
-            return; // CPU-only host — skip; covered by the fallback test.
+        Skip.If(WeightRegistry.OffloadAllocator is null
+            || !WeightRegistry.OffloadAllocator.IsAvailable,
+            "CPU-only host; fallback path is covered by RentPinnedOnGpu_CpuOnlyHost_FallsBackToCpuPinned_NotThrowing.");
 
         // PR #345 review: tighten assertion to require GpuPinned exactly.
         // Permitting `Default` masked regressions in the new tagging
@@ -130,7 +130,7 @@ public class GpuPinnedLifetimeTests
         Assert.Null(t.TryGetGpuBuffer());
     }
 
-    [Fact]
+    [SkippableFact]
     public void GpuOptimizer_TryAdamStep_MatchesHandComputedReference_OnGpuHost()
     {
         // Issue #336 correctness gate. Runs a single Adam step on a tiny
@@ -148,7 +148,7 @@ public class GpuPinnedLifetimeTests
         AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpu;
         try
         {
-            if (gpu.GetBackend() is null) return;
+            Skip.If(gpu.GetBackend() is null, "DirectGpu backend is not available.");
 
             // RentPinnedOnGpu falls back to CPU-pinned on CPU-only hosts.
             // TryAdamStep then returns false (no GPU buffer), and the test
@@ -163,12 +163,17 @@ public class GpuPinnedLifetimeTests
                 // Need device-resident buffers to actually run the kernel; if
                 // the tensors didn't bind to GPU buffers, TryAdamStep returns
                 // false and we treat that as skip.
-                if (p.TryGetGpuBuffer() is null) return;
+                Skip.If(p.TryGetGpuBuffer() is null
+                    || g.TryGetGpuBuffer() is null
+                    || m.TryGetGpuBuffer() is null
+                    || v.TryGetGpuBuffer() is null,
+                    "Pinned tensors did not bind to GPU buffers on this host.");
                 // Some backends (current OpenCL allocator) return a GPU buffer but
                 // do NOT provide zero-copy host↔device mapping — the optimizer kernel
                 // runs against a separate buffer the host never sees written. Skip
                 // in that case; this gate is independent of the no-GPU skip above.
-                if (!HasZeroCopyPinnedMapping()) return;
+                Skip.If(!HasZeroCopyPinnedMapping(),
+                    "GPU pinned allocator does not expose a zero-copy host mapping on this backend.");
 
                 // Initialize values via flat-data span.
                 var pData = p.GetDataArray();
@@ -219,7 +224,7 @@ public class GpuPinnedLifetimeTests
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public void GpuOptimizer_TryAdamStep_MarksGpuUpdatedTensorsCurrent_OnGpuHost()
     {
         // Regression for post-training eval on GPU-resident model weights:
@@ -232,7 +237,7 @@ public class GpuPinnedLifetimeTests
         AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpu;
         try
         {
-            if (gpu.GetBackend() is null) return;
+            Skip.If(gpu.GetBackend() is null, "DirectGpu backend is not available.");
 
             var p = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             var g = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
@@ -244,7 +249,7 @@ public class GpuPinnedLifetimeTests
                     || g.TryGetGpuBuffer() is null
                     || m.TryGetGpuBuffer() is null
                     || v.TryGetGpuBuffer() is null)
-                    return;
+                    Skip.If(true, "Pinned tensors did not bind to GPU buffers on this host.");
 
                 int pVersion = p.Version;
                 int mVersion = m.Version;
@@ -292,7 +297,7 @@ public class GpuPinnedLifetimeTests
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public void GpuOptimizer_TrySgdStep_MatchesHandComputedReference_OnGpuHost()
     {
         // Single-step SGD: p1 = p0 - lr * g
@@ -301,17 +306,19 @@ public class GpuPinnedLifetimeTests
         AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpu;
         try
         {
-            if (gpu.GetBackend() is null) return;
+            Skip.If(gpu.GetBackend() is null, "DirectGpu backend is not available.");
             var p = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             var g = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             try
             {
-                if (p.TryGetGpuBuffer() is null) return;
+                Skip.If(p.TryGetGpuBuffer() is null || g.TryGetGpuBuffer() is null,
+                    "Pinned tensors did not bind to GPU buffers on this host.");
                 // Some backends (current OpenCL allocator) return a GPU buffer but
                 // do NOT provide zero-copy host↔device mapping — the optimizer kernel
                 // runs against a separate buffer the host never sees written. Skip
                 // in that case; this gate is independent of the no-GPU skip above.
-                if (!HasZeroCopyPinnedMapping()) return;
+                Skip.If(!HasZeroCopyPinnedMapping(),
+                    "GPU pinned allocator does not expose a zero-copy host mapping on this backend.");
 
                 var pData = p.GetDataArray();
                 var gData = g.GetDataArray();
@@ -342,7 +349,7 @@ public class GpuPinnedLifetimeTests
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public void GpuOptimizer_TryAdamWStep_AppliesDecoupledWeightDecay_OnGpuHost()
     {
         // AdamW = Adam + decoupled weight decay. With weightDecay=0.01 and
@@ -353,19 +360,24 @@ public class GpuPinnedLifetimeTests
         AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpu;
         try
         {
-            if (gpu.GetBackend() is null) return;
+            Skip.If(gpu.GetBackend() is null, "DirectGpu backend is not available.");
             var p = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             var g = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             var m = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             var v = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
             try
             {
-                if (p.TryGetGpuBuffer() is null) return;
+                Skip.If(p.TryGetGpuBuffer() is null
+                    || g.TryGetGpuBuffer() is null
+                    || m.TryGetGpuBuffer() is null
+                    || v.TryGetGpuBuffer() is null,
+                    "Pinned tensors did not bind to GPU buffers on this host.");
                 // Some backends (current OpenCL allocator) return a GPU buffer but
                 // do NOT provide zero-copy host↔device mapping — the optimizer kernel
                 // runs against a separate buffer the host never sees written. Skip
                 // in that case; this gate is independent of the no-GPU skip above.
-                if (!HasZeroCopyPinnedMapping()) return;
+                Skip.If(!HasZeroCopyPinnedMapping(),
+                    "GPU pinned allocator does not expose a zero-copy host mapping on this backend.");
 
                 var pData = p.GetDataArray();
                 var initial = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };

--- a/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/GpuPinnedLifetimeTests.cs
@@ -220,6 +220,69 @@ public class GpuPinnedLifetimeTests
     }
 
     [Fact]
+    public void GpuOptimizer_TryAdamStep_MarksGpuUpdatedTensorsCurrent_OnGpuHost()
+    {
+        // Regression for post-training eval on GPU-resident model weights:
+        // a successful on-device optimizer step mutates param/m/v in place.
+        // Their resident GPU buffer version must be synced to the bumped
+        // tensor Version so later inference reuses the live device buffers
+        // instead of re-uploading fresh host arrays on every forward pass.
+        var priorEngine = AiDotNet.Tensors.Engines.AiDotNetEngine.Current;
+        var gpu = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine();
+        AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpu;
+        try
+        {
+            if (gpu.GetBackend() is null) return;
+
+            var p = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
+            var g = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
+            var m = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
+            var v = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinnedOnGpu<float>(new[] { 4 });
+            try
+            {
+                if (p.TryGetGpuBuffer() is null
+                    || g.TryGetGpuBuffer() is null
+                    || m.TryGetGpuBuffer() is null
+                    || v.TryGetGpuBuffer() is null)
+                    return;
+
+                int pVersion = p.Version;
+                int mVersion = m.Version;
+                int vVersion = v.Version;
+                int gVersion = g.Version;
+
+                bool ran = AiDotNet.Tensors.Engines.Gpu.GpuOptimizer.TryAdamStep(
+                    p, g, m, v,
+                    learningRate: 0.01f, beta1: 0.9f, beta2: 0.999f,
+                    epsilon: 1e-8f, weightDecay: 0f, step: 1);
+                Assert.True(ran,
+                    "GpuOptimizer.TryAdamStep returned false after GPU buffers were bound.");
+
+                Assert.True(p.Version > pVersion, "Parameter Version should advance after an in-place GPU Adam step.");
+                Assert.True(m.Version > mVersion, "Adam m-state Version should advance after an in-place GPU Adam step.");
+                Assert.True(v.Version > vVersion, "Adam v-state Version should advance after an in-place GPU Adam step.");
+                Assert.Equal(gVersion, g.Version);
+
+                Assert.Equal(p.Version, p._gpuBufferVersion);
+                Assert.Equal(m.Version, m._gpuBufferVersion);
+                Assert.Equal(v.Version, v._gpuBufferVersion);
+            }
+            finally
+            {
+                WeightRegistry.UnregisterWeight(p);
+                WeightRegistry.UnregisterWeight(g);
+                WeightRegistry.UnregisterWeight(m);
+                WeightRegistry.UnregisterWeight(v);
+            }
+        }
+        finally
+        {
+            AiDotNet.Tensors.Engines.AiDotNetEngine.Current = priorEngine;
+            gpu.Dispose();
+        }
+    }
+
+    [Fact]
     public void GpuOptimizer_TrySgdStep_MatchesHandComputedReference_OnGpuHost()
     {
         // Single-step SGD: p1 = p0 - lr * g


### PR DESCRIPTION
## Summary
- Add a public `WarmupDecayMode` plus `LrSchedule.LinearWarmup(...)` for compiled/fused optimizer schedules.
- Match the AiDotNet `LinearWarmupScheduler` batch sequence for constant, linear-decay, and cosine-decay post-warmup behavior.
- Reject invalid schedules where total steps are less than warmup steps.

## Verification
- `dotnet test tests\AiDotNet.Tensors.Tests\AiDotNet.Tensors.Tests.csproj --framework net10.0 --filter FullyQualifiedName~AiDotNet.Tensors.Tests.Engines.Compilation.LrScheduleTests` passed 24/24.
- Consumed via local package in HarmonicEngine with AiDotNet mapping changes: fused package canary passed and showed training movement (`avg_loss 9.4550 -> 7.4261`, `pL1 40621.47 -> 46411.97`, no eager fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `LrSchedule.LinearWarmup(...)` with `WarmupDecayMode` (Constant, Linear, Cosine).
  * Added `ProximalL1Update` optimizer support across GPU backends (proximal-gradient / ISTA with L1 soft-thresholding).

* **Bug Fixes**
  * Improved activation-cache cleanup and eviction behavior during compiled training steps.
  * Fixed GPU allocation tracking to avoid overcounting duplicate allocations.
  * Corrected embedding lookup index handling (int indices) and improved related kernel execution.
  * Hardened BLAS packed-operation routing and attention-gradient buffer initialization.

* **Tests**
  * Expanded learning-rate, GPU residency, and cleanup regression coverage; added optional memory repro test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->