### PR TITLE
fix(streaming): reclaim WeightRegistry entries for GC'd owners (#714)

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -2001,10 +2001,15 @@ public static class WeightRegistry
     /// pinned in the pool forever, so <see cref="StreamingTensorPool.RegisteredEntryCount"/> climbs
     /// across sequentially-created-then-dropped models (test shards, long training/inference loops)
     /// until a later <see cref="Configure"/> throws "existing streaming pool has N registered entries"
-    /// or the host OOMs. Long-lived hosts and test harnesses should call this periodically — typically
-    /// right after a <c>GC.Collect()</c> so disposed models' owners are actually collected first. Only
-    /// genuinely-dead owners (weak reference collected) are reclaimed; a live weight is never touched.
-    /// Returns the number of entries reclaimed.
+    /// or the host OOMs. Call this when owners are expected to have been collected — e.g. on a
+    /// memory-pressure signal, between iterations of a long sequential-model loop, or between test
+    /// cases. Reclamation is driven off the owners' weak references, so an entry is only released once
+    /// the runtime has actually collected its owner; this method does NOT force a garbage collection,
+    /// and callers generally should NOT either — forcing a full <c>GC.Collect()</c> is harmful to
+    /// latency/throughput outside controlled scenarios such as tests. Note the common paths already
+    /// self-heal without any explicit call: <see cref="RegisterWeight{T}"/> sweeps amortized and
+    /// <see cref="Configure"/> sweeps before its guard. Only genuinely-dead owners (weak reference
+    /// collected) are reclaimed; a live weight is never touched. Returns the number of entries reclaimed.
     /// </summary>
     public static int PruneDeadEntries()
     {
@@ -2018,7 +2023,18 @@ public static class WeightRegistry
     /// Sweeps <see cref="_ownerByHandle"/> for owners whose weak reference has been collected and
     /// releases each such handle's pool entry + materialized-tracking state — the exact cleanup
     /// <see cref="UnregisterWeight{T}"/> performs, but for tensors that were GC'd without calling it.
-    /// MUST be called under <see cref="_lock"/>. Returns the number of entries reclaimed.
+    /// MUST be called under <see cref="_lock"/>.
+    /// <para>
+    /// This is an O(n) scan over the owner map (n = registered-weight count), so it is invoked only on
+    /// low-frequency / already-locked paths: <see cref="Configure"/> (per-model, rare) and an amortized
+    /// 1-in-<see cref="DeadOwnerSweepInterval"/> tick inside <see cref="RegisterWeight{T}"/> (which
+    /// already holds <see cref="_lock"/> for the whole registration). The scan body is a cheap weak
+    /// <c>TryGetTarget</c>; the dead list is allocated lazily and only when dead owners exist (the
+    /// steady-state case allocates nothing). The reclamation loop stays UNDER the lock deliberately —
+    /// <see cref="Configure"/>/<see cref="Reset"/> can dispose or swap <see cref="_streamingPool"/>
+    /// while holding <see cref="_lock"/>, so dropping the lock to call <c>Unregister</c> would race a
+    /// pool swap and free handles against the wrong (or disposed) pool. Returns entries reclaimed.
+    /// </para>
     /// </summary>
     private static int PruneDeadOwnersUnlocked()
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -73,6 +73,14 @@ public static class WeightRegistry
         DrainInFlightPrefetches();
         lock (_lock)
         {
+            // #714: first reclaim entries whose owner was GC'd without UnregisterWeight. A
+            // sequentially-created-then-dropped model (test shards, long loops) leaves dead-owner
+            // entries pinned in the pool; without this sweep they would wrongly count as "live" and
+            // block the next Configure with "existing streaming pool has N registered entries" — the
+            // symptom that reddens the foundation-scale CV/diffusion model shards. Only genuinely-dead
+            // owners are reclaimed, so a real "live weights still registered" misuse still throws below.
+            PruneDeadOwnersUnlocked();
+
             // Mid-flight guard: refuse to dispose a pool that holds live
             // entries. Otherwise tensors registered against the old pool
             // would silently break on Materialize.
@@ -154,6 +162,16 @@ public static class WeightRegistry
         // reference and StreamingPool field stable for the duration.
         lock (_lock)
         {
+            // #714: amortized dead-owner sweep so a long run (many sequential streaming models)
+            // reclaims orphaned entries incrementally as new weights register, instead of letting the
+            // pool grow unbounded until an OOM or a later Configure throw. Throttled by
+            // DeadOwnerSweepInterval so the O(n) scan is paid at most once per N registrations.
+            if (++_registrationsSinceSweep >= DeadOwnerSweepInterval)
+            {
+                _registrationsSinceSweep = 0;
+                PruneDeadOwnersUnlocked();
+            }
+
             switch (weight.Lifetime)
             {
                 case WeightLifetime.Default:
@@ -1965,7 +1983,64 @@ public static class WeightRegistry
             // the policy is documented as "training or unknown → full
             // precision", so the safe-unknown state has to mean null here.
             _streamingTrainingMode = null;
+            _registrationsSinceSweep = 0;
         }
+    }
+
+    /// <summary>
+    /// #714: number of Streaming registrations between opportunistic dead-owner sweeps in
+    /// <see cref="RegisterWeight{T}"/>. Bounds orphaned-entry accumulation during a long run
+    /// (sequential model creation) without paying an O(n) sweep on every single registration.
+    /// </summary>
+    private const int DeadOwnerSweepInterval = 128;
+    private static int _registrationsSinceSweep;
+
+    /// <summary>
+    /// Reclaims streaming-pool entries whose owning tensor was garbage-collected WITHOUT an explicit
+    /// <see cref="UnregisterWeight{T}"/> (#714). A GC'd owner otherwise leaves its serialized bytes
+    /// pinned in the pool forever, so <see cref="StreamingTensorPool.RegisteredEntryCount"/> climbs
+    /// across sequentially-created-then-dropped models (test shards, long training/inference loops)
+    /// until a later <see cref="Configure"/> throws "existing streaming pool has N registered entries"
+    /// or the host OOMs. Long-lived hosts and test harnesses should call this periodically — typically
+    /// right after a <c>GC.Collect()</c> so disposed models' owners are actually collected first. Only
+    /// genuinely-dead owners (weak reference collected) are reclaimed; a live weight is never touched.
+    /// Returns the number of entries reclaimed.
+    /// </summary>
+    public static int PruneDeadEntries()
+    {
+        lock (_lock)
+        {
+            return PruneDeadOwnersUnlocked();
+        }
+    }
+
+    /// <summary>
+    /// Sweeps <see cref="_ownerByHandle"/> for owners whose weak reference has been collected and
+    /// releases each such handle's pool entry + materialized-tracking state — the exact cleanup
+    /// <see cref="UnregisterWeight{T}"/> performs, but for tensors that were GC'd without calling it.
+    /// MUST be called under <see cref="_lock"/>. Returns the number of entries reclaimed.
+    /// </summary>
+    private static int PruneDeadOwnersUnlocked()
+    {
+        if (_streamingPool is null || _ownerByHandle.Count == 0) return 0;
+
+        List<long>? dead = null;
+        foreach (var kvp in _ownerByHandle)
+        {
+            // A collected weak target means the owning tensor is gone and can never be Materialized or
+            // Unregistered again, so its pool bytes are unreachable and safe to release.
+            if (!kvp.Value.TryGetTarget(out _))
+                (dead ??= new List<long>()).Add(kvp.Key);
+        }
+        if (dead is null) return 0;
+
+        foreach (long handle in dead)
+        {
+            _streamingPool.Unregister(handle);
+            _ownerByHandle.Remove(handle);
+            UntrackMaterializedOwner(handle);
+        }
+        return dead.Count;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -96,6 +96,72 @@ public class WeightRegistryStreamingTests : IDisposable
         Assert.Equal(0, w.DataVector.Length);
     }
 
+    // Register streaming weights in a NON-INLINED helper so the locals genuinely leave scope and
+    // become collectable — a JIT could otherwise keep a live root to a same-method local across the GC.
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static void RegisterAndAbandonStreamingWeights(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            var w = new Tensor<float>(new float[] { 1f, 2f, 3f, 4f }, new[] { 4 });
+            w.Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(w);
+            // No reference kept: w is unreachable at the next iteration / method return, so once GC
+            // runs its _ownerByHandle weak reference dies and its pool entry is an orphan (#714).
+        }
+    }
+
+    [Fact]
+    public void PruneDeadEntries_ReclaimsPoolEntriesForGarbageCollectedOwners()
+    {
+        // #714: a streaming weight whose owning tensor is GC'd WITHOUT UnregisterWeight leaves its
+        // serialized bytes pinned in the pool forever. Across sequentially-created-then-dropped models
+        // (the CV/diffusion foundation-scale test shards, long training loops) RegisteredEntryCount
+        // climbs until Configure throws "existing streaming pool has N registered entries" / the host
+        // OOMs. PruneDeadEntries must reclaim those orphaned entries; a fresh Configure must then work.
+        RegisterAndAbandonStreamingWeights(20);
+        Assert.True(WeightRegistry.GetStreamingReport().RegisteredEntryCount > 0,
+            "Sanity: the 20 streaming registrations should be resident in the pool before GC.");
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        int reclaimed = WeightRegistry.PruneDeadEntries();
+
+        Assert.True(reclaimed > 0, "PruneDeadEntries should reclaim entries whose owners were GC'd.");
+        Assert.Equal(0, WeightRegistry.GetStreamingReport().RegisteredEntryCount);
+
+        // The leak used to make this throw "existing streaming pool has N registered entries";
+        // after the sweep (Configure also prunes internally) it must succeed.
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024 * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+    }
+
+    [Fact]
+    public void Configure_PrunesGarbageCollectedOwners_InsteadOfThrowing()
+    {
+        // #714 (the exact CV/diffusion shard symptom): a new streaming model's Configure must not be
+        // blocked by a PRIOR model's entries once that model has been GC'd. Configure prunes dead
+        // owners first, so only genuinely-live registrations still throw.
+        RegisterAndAbandonStreamingWeights(15);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // Should NOT throw — the 15 orphaned entries are reclaimed by Configure's internal sweep.
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024 * 1024,
+            StreamingBackingStorePath = _backingDir,
+        });
+
+        Assert.Equal(0, WeightRegistry.GetStreamingReport().RegisteredEntryCount);
+    }
+
     [Fact]
     public void TryFinalizeDeferredDrop_NoOpOnNonDeferredTensor()
     {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -1,7 +1,11 @@
 // Copyright (c) AiDotNet. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Tensors.NumericOperations;
 using Xunit;
@@ -96,19 +100,42 @@ public class WeightRegistryStreamingTests : IDisposable
         Assert.Equal(0, w.DataVector.Length);
     }
 
-    // Register streaming weights in a NON-INLINED helper so the locals genuinely leave scope and
-    // become collectable — a JIT could otherwise keep a live root to a same-method local across the GC.
-    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-    private static void RegisterAndAbandonStreamingWeights(int count)
+    // Registers streaming weights in a NON-INLINED helper so the locals genuinely leave scope and
+    // become collectable, and returns WEAK references to them so the caller can deterministically WAIT
+    // for the GC to reclaim them (rather than assuming a single GC.Collect suffices — see
+    // WaitUntilCollected). The WeakReferences do not keep the tensors alive.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static List<WeakReference> RegisterAndAbandonStreamingWeights(int count)
     {
+        var refs = new List<WeakReference>(count);
         for (int i = 0; i < count; i++)
         {
             var w = new Tensor<float>(new float[] { 1f, 2f, 3f, 4f }, new[] { 4 });
             w.Lifetime = WeightLifetime.Streaming;
             WeightRegistry.RegisterWeight(w);
-            // No reference kept: w is unreachable at the next iteration / method return, so once GC
-            // runs its _ownerByHandle weak reference dies and its pool entry is an orphan (#714).
+            refs.Add(new WeakReference(w));
         }
+        return refs;
+    }
+
+    // Deterministically drives GC until every owner is OBSERVABLY collected (or a generous timeout),
+    // so a subsequent "reclaimed > 0" / "count == 0" assertion reflects a real registry regression
+    // rather than GC-timing nondeterminism (background/concurrent GC, delayed collection, JIT liveness).
+    private static void WaitUntilCollected(List<WeakReference> refs, int timeoutMs = 15000)
+    {
+        var sw = Stopwatch.StartNew();
+        do
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            if (refs.TrueForAll(static r => !r.IsAlive)) return;
+            Thread.Sleep(15);
+        }
+        while (sw.ElapsedMilliseconds < timeoutMs);
+
+        Assert.True(refs.TrueForAll(static r => !r.IsAlive),
+            "Owning tensors were not garbage-collected within the timeout — a test-environment issue, not a registry regression.");
     }
 
     [Fact]
@@ -119,13 +146,11 @@ public class WeightRegistryStreamingTests : IDisposable
         // (the CV/diffusion foundation-scale test shards, long training loops) RegisteredEntryCount
         // climbs until Configure throws "existing streaming pool has N registered entries" / the host
         // OOMs. PruneDeadEntries must reclaim those orphaned entries; a fresh Configure must then work.
-        RegisterAndAbandonStreamingWeights(20);
+        var refs = RegisterAndAbandonStreamingWeights(20);
         Assert.True(WeightRegistry.GetStreamingReport().RegisteredEntryCount > 0,
             "Sanity: the 20 streaming registrations should be resident in the pool before GC.");
 
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        WaitUntilCollected(refs); // deterministic: all owners are provably collected past this point
 
         int reclaimed = WeightRegistry.PruneDeadEntries();
 
@@ -147,10 +172,8 @@ public class WeightRegistryStreamingTests : IDisposable
         // #714 (the exact CV/diffusion shard symptom): a new streaming model's Configure must not be
         // blocked by a PRIOR model's entries once that model has been GC'd. Configure prunes dead
         // owners first, so only genuinely-live registrations still throw.
-        RegisterAndAbandonStreamingWeights(15);
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        var refs = RegisterAndAbandonStreamingWeights(15);
+        WaitUntilCollected(refs); // deterministic: all owners are provably collected past this point
 
         // Should NOT throw — the 15 orphaned entries are reclaimed by Configure's internal sweep.
         WeightRegistry.Configure(new GpuOffloadOptions


### PR DESCRIPTION
## Problem
A streaming weight whose owning tensor is garbage-collected **without** an explicit `UnregisterWeight` left its serialized bytes pinned in the `StreamingTensorPool` **forever**. The only dead-owner pruning (`DrainOwnerDropsAfterEviction`) ran solely for handles the pool had *already evicted under budget pressure* — entries the pool still held leaked. So `RegisteredEntryCount` climbed across **sequentially-created-then-dropped models** (the foundation-scale CV/diffusion ModelFamily test shards, long training/inference loops) until either:
- a later `Configure` threw `"existing streaming pool has N registered entries"`, or
- the host **OOM'd** (~18–20 GB testhost hangs on the CV shard).

This is the root cause behind AiDotNet #1754 / #1706 and the diffusion-shard cancellations.

## Fix
A **dead-owner sweep** (`PruneDeadOwnersUnlocked`) that releases the pool entry + materialized-tracking state for any handle whose **weak owner reference has been collected** — the exact cleanup `UnregisterWeight` performs. Wired in three places:
- **`Configure`** — prune before the "pool still in use" guard, so a prior model's GC'd entries no longer wrongly block the next model's `Configure`. A genuine "live weights still registered" misuse still throws.
- **`RegisterWeight`** — amortized sweep every `DeadOwnerSweepInterval` (128) registrations, so a long run reclaims orphans incrementally instead of growing unbounded.
- **`PruneDeadEntries()`** — public API for long-lived hosts / test harnesses to call after a `GC`. `Reset()` clears the sweep counter.

Only genuinely-dead owners are reclaimed (weak reference collected) — a live weight is never touched.

## Verification
- 2 new regression tests: prune reclaims orphaned entries → `RegisteredEntryCount == 0`; `Configure` prunes instead of throwing.
- **142** existing WeightRegistry / streaming / lifetime tests green — no regression.
- Builds clean.

Closes #714. Unblocks the AiDotNet foundation-scale ModelFamily/CV shards (consumer side tracked by #1754).

🤖 Generated with [Claude Code](https://claude.com/claude-code)