### PR TITLE
[codex] harden historical CI shard regressions

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/NAxisParityTests.cs
@@ -34,17 +34,14 @@ public class NAxisParityTests
     [InlineData(768, 4096, 512)]   // larger mr-aligned M, wide N
     public void NAxis_BitIdentical_ToMAxis(int m, int n, int k)
     {
-        // The N-axis private-B path requires the FP32 6x16 machine-code panel kernel and the
-        // matching PackBoth tile. AVX-512 hosts intentionally pick the 16x16 FP32 tile instead;
-        // forcing N-axis there would reinterpret packed-A with the wrong row stride.
+        // The N-axis private-B path requires the FP32 6x16 machine-code panel kernel.
+        // Exercise PackBothStrategy directly with the matching tile so this route-coverage
+        // test is independent of the host's top-level BlasManaged tile heuristic.
         Skip.IfNot(MachineKernelGemm.IsFp32PanelAvailable,
             "FP32 machine-code panel kernel unavailable — N-axis path cannot run on this platform.");
-        Skip.If(Avx512Fp32_16x16.IsSupported,
-            "AVX-512 FP32 PackBoth tile is active; the 6x16 N-axis panel path must not run on this platform.");
 
         var prior = CpuParallelSettings.MaxDegreeOfParallelism;
         var priorDisable = PB.s_disableNAxis;
-        var priorDisableGoto = BlasMgd.s_disableGotoGemm;
         var priorMachineKernel = MachineKernelGemm.Enabled;
         var priorPanelKernel = MachineKernelGemm.EnablePanelKernel;
         var priorDeterministic = BlasProvider.IsDeterministicMode;
@@ -62,23 +59,22 @@ public class NAxisParityTests
             BlasProvider.SetThreadLocalDeterministicMode(null);
             BlasProvider.SetDeterministicMode(false);
 
-            var opts = new BlasOptions<float> { PackingMode = PackingMode.ForcePackBoth, NumThreads = 4 };
+            var opts = new BlasOptions<float> { NumThreads = 4 };
+            const int kc = 256;
+            int mr = MachineKernelGemm.Fp32Mr;
+            int nr = MachineKernelGemm.Fp32Nr;
 
-            // This test verifies the PackBoth N-axis vs M-axis paths; the GotoGemm fast path would
-            // intercept these large float shapes before either runs, so disable it for the duration.
-            BlasMgd.s_disableGotoGemm = true;
             PB.s_disableNAxis = true;
-            BlasMgd.Gemm<float>(a, k, false, b, n, false, cM, n, m, n, k, opts);
+            PB.Run<float>(a, k, false, b, n, false, cM, n, m, n, k, m, n, kc, mr, nr, opts);
 
             PB.s_disableNAxis = false;
             long before = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount);
-            BlasMgd.Gemm<float>(a, k, false, b, n, false, cN, n, m, n, k, opts);
+            PB.Run<float>(a, k, false, b, n, false, cN, n, m, n, k, m, n, kc, mr, nr, opts);
             nAxisRunsForThisCase = System.Threading.Interlocked.Read(ref PB.s_nAxisRunCount) - before;
         }
         finally
         {
             PB.s_disableNAxis = priorDisable;
-            BlasMgd.s_disableGotoGemm = priorDisableGoto;
             MachineKernelGemm.Enabled = priorMachineKernel;
             MachineKernelGemm.EnablePanelKernel = priorPanelKernel;
             BlasProvider.SetDeterministicMode(priorDeterministic);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16NativeOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16NativeOpTests.cs
@@ -272,15 +272,12 @@ public class Fp16NativeOpTests
         Assert.Equal(expected.Length, actual.Length);
         for (int i = 0; i < expected.Length; i++)
         {
-#if NET6_0_OR_GREATER
-            Assert.True(float.IsFinite(actual[i]), $"{label}[{i}] not finite: {actual[i]}");
-#else
-            // float.IsFinite was added in .NET Core 2.1 / net5+; net471 lacks it.
-            Assert.True(!float.IsNaN(actual[i]) && !float.IsInfinity(actual[i]), $"{label}[{i}] not finite: {actual[i]}");
-#endif
+            Assert.True(IsFinite(actual[i]), $"{label}[{i}] not finite: {actual[i]}");
             double tol = 2e-2 + 5e-2 * Math.Abs(expected[i]); // FP16 activation rounding
             Assert.True(Math.Abs(expected[i] - actual[i]) <= tol,
                 $"{label}[{i}] reference {expected[i]} vs FP16-native {actual[i]} (tol {tol})");
         }
     }
+
+    private static bool IsFinite(float value) => !float.IsNaN(value) && !float.IsInfinity(value);
 }


### PR DESCRIPTION
## Summary

This PR addresses two historical CI shard failures found while auditing recent failed Actions runs:

- `Build (net471)` failure in PR #715 run `28483756579`: the shard failed on a `float.IsFinite` call in a net471-compiled test path. The immediate failing file is already corrected on `main`; this PR removes the remaining raw `float.IsFinite` use from the cross-target FP16 compilation test helper so that path stays net471-safe.
- `Test with Coverage` failures in PR #715 runs `28499293262` / `28517128916` and PR #707 run `28343538013`: the five `NAxisParityTests` cases failed because the test expected top-level `BlasManaged.Gemm` to route into N-axis, but the host route could legally fall back to M-axis. The parity test now exercises `PackBothStrategy` directly with the 6x16 panel tile that the N-axis path is designed for, keeping route coverage real while avoiding host heuristic mismatch.

## Validation

- `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -f net10.0 --filter "FullyQualifiedName~NAxisParityTests" --logger "console;verbosity=detailed"`
  - Passed: 5, Skipped: 1 AVX-512-only guard on this host
- `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -f net10.0 --no-build --filter "FullyQualifiedName~Fp16NativeOpTests" --logger "console;verbosity=detailed"`
  - Passed: 13, Skipped: 9 Vulkan FP16-native tests because Vulkan FP16-native ops are unavailable locally
- `dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -f net10.0 --no-restore -m:1`

## Notes

I could not locally run the net471 build because this Windows machine is missing the .NET Framework 4.7.1 targeting pack (`MSB3644`). CI should still cover that shard.