### PR TITLE
feat(streaming): RAM-aware Auto store — bf16 → int8 → int4 to fit resident cap in inference

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
@@ -30,8 +30,10 @@ internal static class StreamingEncoding
     /// <summary>int8: PER-ROW symmetric quantisation — [int32 rows][rows × fp32
     /// scale][1 byte/element]. One scale per output channel preserves far more SNR
     /// than a single per-tensor scale on varied-magnitude rows, and the layout feeds
-    /// the int8 weight-only GEMM directly (no upcast). Lossier than bf16; explicit
-    /// opt-in only — <c>StreamingStoreDtype.Auto</c> never picks int8.</summary>
+    /// the int8 weight-only GEMM directly (no upcast). Lossier than bf16, so it is
+    /// only chosen automatically by RAM-aware <c>StreamingStoreDtype.Auto</c> in
+    /// INFERENCE when bf16 would overflow the resident cap (never in training —
+    /// quantized write-back is native-only); otherwise explicit opt-in.</summary>
     internal const byte Int8 = 2;
 
     /// <summary>Lossless: SIMD byte-plane shuffle + Deflate (variable size). Exact
@@ -42,7 +44,9 @@ internal static class StreamingEncoding
     /// <summary>int4: AWQ/GPTQ-style GROUP-symmetric quantization — [int32 count][int32
     /// groupSize][numGroups × fp32 scale][ceil(count/2) packed nibbles]. 8x compression at
     /// 4 bits/weight; one scale per contiguous group bounds the int4 RMSE. Feeds the no-upcast
-    /// int4 weight-only GEMM directly. Lossier than int8; explicit opt-in only —
-    /// <c>StreamingStoreDtype.Auto</c> never picks int4.</summary>
+    /// int4 weight-only GEMM directly. Lossier than int8, so it is only chosen
+    /// automatically by RAM-aware <c>StreamingStoreDtype.Auto</c> in INFERENCE as the
+    /// last rung when even int8 would overflow the resident cap (never in training);
+    /// otherwise explicit opt-in.</summary>
     internal const byte Int4 = 4;
 }

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightLifetime.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightLifetime.cs
@@ -61,10 +61,16 @@ public enum WeightLifetime
 public enum StreamingStoreDtype
 {
     /// <summary>Context-aware default — compresses whenever the execution mode is known:
-    /// bf16 in inference/eval (read-only weights → a one-time quantization, always safe, 2x),
-    /// and LOSSLESS (byte-shuffle + Deflate, ~1.18x, BIT-EXACT) during training so the
-    /// fp32/fp64 masters are preserved exactly. Unknown mode (no declared context) → full
-    /// precision (don't guess).</summary>
+    /// in inference/eval (read-only weights → a one-time quantization, always safe) it is
+    /// <b>RAM-aware</b> when <see cref="GpuOffloadOptions.ExpectedStreamingFootprintBytes"/>
+    /// is set: it stores the HIGHEST-fidelity precision whose resident footprint still fits
+    /// <see cref="GpuOffloadOptions.StreamingPoolMaxResidentBytes"/> — bf16 (2x) if the model
+    /// fits at bf16, else int8 (4x), else int4 (8x) so an otherwise-too-large model runs on a
+    /// constrained box; with no footprint hint it defaults to bf16. During TRAINING it stays
+    /// LOSSLESS (byte-shuffle + Deflate, ~1.18x, BIT-EXACT) so the fp32/fp64 masters are
+    /// preserved exactly (the quantized tiers can't write mutations back — write-back is
+    /// native-only — so they are never chosen while weights are mutable). Unknown mode (no
+    /// declared context) → full precision (don't guess).</summary>
     Auto = 0,
 
     /// <summary>Always store at the weight's native precision (fp32/fp64). No
@@ -81,10 +87,11 @@ public enum StreamingStoreDtype
     /// bf16 masters (large-batch pretraining). Opt-in for training.</summary>
     Bf16Stochastic = 3,
 
-    /// <summary>Always store int8 with a per-tensor symmetric scale. 4x I/O at
-    /// ~1.1% RMS error — much more lossy than bf16, so it's never the Auto default
-    /// and is intended for inference / aggressive memory-bound cases where the
-    /// accuracy tradeoff is accepted.</summary>
+    /// <summary>Always store int8 with a per-row symmetric scale. 4x I/O at ~1.1% RMS
+    /// error — more lossy than bf16, so <see cref="Auto"/> only steps down to it
+    /// automatically in INFERENCE when bf16 would overflow the resident cap (see
+    /// <see cref="GpuOffloadOptions.ExpectedStreamingFootprintBytes"/>); this explicit
+    /// value forces it unconditionally for aggressive memory-bound inference.</summary>
     Int8 = 4,
 
     /// <summary>EXACT (lossless) storage: SIMD byte-plane shuffle + Deflate. ~1.18x I/O on
@@ -97,8 +104,9 @@ public enum StreamingStoreDtype
     /// <summary>Always store int4 with AWQ/GPTQ-style GROUP-symmetric quantization (one fp32
     /// scale per 128-weight group). 8x I/O — the most aggressive rung, intended to make the
     /// very largest (&gt;~20B) models RESIDENT inside a 16 GiB budget so they skip streaming.
-    /// More lossy than int8, so it is never the Auto default and is explicit opt-in for
-    /// aggressive memory-bound inference where the accuracy tradeoff is accepted.</summary>
+    /// More lossy than int8, so <see cref="Auto"/> only steps down to it automatically in
+    /// INFERENCE as the last rung when even int8 would overflow the resident cap; this explicit
+    /// value forces it unconditionally for aggressive memory-bound inference.</summary>
     Int4 = 6,
 }
 
@@ -121,6 +129,24 @@ public sealed class GpuOffloadOptions
     /// never push the box into OS-level swap (which would page on top of the
     /// pool's own paging — double I/O). Set explicitly to override.</summary>
     public long StreamingPoolMaxResidentBytes { get; set; } = DefaultResidentBudgetBytes();
+
+    /// <summary>
+    /// The caller's estimate of the model's TOTAL streaming-weight footprint, in the
+    /// weights' native precision (fp32/fp64 bytes = ParameterCount × element size).
+    /// Zero (the default) means "unknown". When known, it makes
+    /// <see cref="StreamingStoreDtype.Auto"/> <b>RAM-aware in inference</b>: instead of
+    /// always storing bf16, Auto picks the HIGHEST-fidelity store precision whose
+    /// resident footprint still fits <see cref="StreamingPoolMaxResidentBytes"/> —
+    /// bf16 (÷2) when it fits, else int8 (÷4), else int4 (÷8). So a model that fits
+    /// resident at bf16 keeps bf16's fidelity, and only a model too large for bf16
+    /// steps down to the lossier-but-smaller quantized stores needed to run at all on
+    /// a constrained box. Training is unaffected — Auto stays lossless there (exact
+    /// masters), because the quantized stores' mutations can't be written back
+    /// (write-back is native-only); inference weights are read-only, so the quantized
+    /// tiers are safe there. Ignored unless <see cref="StreamingStoreDtype"/> is
+    /// <see cref="StreamingStoreDtype.Auto"/>.
+    /// </summary>
+    public long ExpectedStreamingFootprintBytes { get; set; }
 
     // Historical ceiling, kept as the cap for large-memory boxes so their
     // behaviour is unchanged.

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -192,7 +192,7 @@ public static class WeightRegistry
                         // registered byte[] and everything downstream (resident set,
                         // eviction, disk) for free — the pool is byte-agnostic; only the
                         // restore boundary widens bf16 → T (RestoreStorageFromBytes).
-                        var (encoding, stochastic) = ResolveStoreEncoding<T>();
+                        var (encoding, stochastic) = ResolveStoreEncoding(weight);
                         byte[] bytes;
                         if (encoding == StreamingEncoding.Lossless)
                         {
@@ -753,12 +753,22 @@ public static class WeightRegistry
     }
 
     /// <summary>
-    /// Resolves the streaming-store encoding (1 = bf16, 0 = native) and rounding
-    /// (stochastic) for type T from <see cref="GpuOffloadOptions.StreamingStoreDtype"/>
-    /// and the execution-mode hint. Only float/double can be bf16-encoded; all other
-    /// types always store native. Caller holds <see cref="_lock"/>.
+    /// The minimum element count for <see cref="StreamingStoreDtype.Auto"/> to step a weight
+    /// BELOW bf16 (to int8/int4) in the RAM-aware inference path. Small weights — 1-D biases,
+    /// LayerNorm/RMSNorm gains, tiny projections — are both precision-sensitive AND a negligible
+    /// share of the footprint, so quantizing them costs accuracy for ~no memory. Mirrors
+    /// production weight-only quant (bitsandbytes/AWQ quantize the big Linear/conv weights and
+    /// keep norms + biases in higher precision). Weights below this always stay bf16 in inference.
     /// </summary>
-    private static (byte encoding, bool stochastic) ResolveStoreEncoding<T>()
+    private const int MinAutoQuantElements = 1 << 14; // 16,384 elements (64 KiB fp32)
+
+    /// <summary>
+    /// Resolves the streaming-store encoding (see <see cref="StreamingEncoding"/>) and rounding
+    /// (stochastic) for <paramref name="weight"/> from <see cref="GpuOffloadOptions.StreamingStoreDtype"/>
+    /// and the execution-mode hint. Only float/double can be narrowed; all other types always store
+    /// native. Caller holds <see cref="_lock"/>.
+    /// </summary>
+    private static (byte encoding, bool stochastic) ResolveStoreEncoding<T>(Tensor<T> weight)
     {
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return (StreamingEncoding.Native, false);
         switch (_options.StreamingStoreDtype)
@@ -766,28 +776,59 @@ public static class WeightRegistry
             case StreamingStoreDtype.FullPrecision: return (StreamingEncoding.Native, false);
             case StreamingStoreDtype.Bf16: return (StreamingEncoding.Bf16, false);
             case StreamingStoreDtype.Bf16Stochastic: return (StreamingEncoding.Bf16, true);
-            case StreamingStoreDtype.Int8: return (StreamingEncoding.Int8, false); // explicit opt-in (Auto never picks int8)
-            case StreamingStoreDtype.Int4: return (StreamingEncoding.Int4, false); // explicit opt-in (Auto never picks int4)
+            case StreamingStoreDtype.Int8: return (StreamingEncoding.Int8, false); // explicit opt-in
+            case StreamingStoreDtype.Int4: return (StreamingEncoding.Int4, false); // explicit opt-in
             case StreamingStoreDtype.Lossless: return (StreamingEncoding.Lossless, false); // exact, variable-size; explicit opt-in
             case StreamingStoreDtype.Auto:
             default:
                 // Compress by DEFAULT whenever the execution mode is known — every model that
-                // goes through SetTrainingMode is — always picking the max-safe option:
-                //   • inference → bf16: 2x (4x for fp64) at ~0.17% RMS, a safe one-time
-                //     quantization of read-only weights.
+                // goes through SetTrainingMode is:
                 //   • training → LOSSLESS (byte-shuffle + Deflate): bit-exact, so the fp32/fp64
                 //     masters are preserved EXACTLY (no convergence risk) while still reclaiming
-                //     ~1.18x of disk + resident bytes. Never silently lossy.
-                //   • unknown (no declared mode — raw registry use) → full precision: don't
-                //     guess; keep the bytes exact and the layout fixed-size.
-                // (int8 is too lossy to ever be an automatic choice — explicit opt-in only.)
+                //     ~1.18x. The quantized tiers are NEVER chosen here: their eviction write-back
+                //     is native-only (TryWriteBackResidentForStreaming), so a mutated quantized
+                //     weight would silently lose its update. Inference weights are read-only, so
+                //     the quantized tiers below are safe only in that mode.
+                //   • inference → RAM-aware (ResolveAutoInferenceEncoding): bf16 by default, but
+                //     stepping down to int8/int4 for the large weights when — and only when —
+                //     the model's footprint would otherwise exceed the resident cap.
+                //   • unknown (no declared mode — raw registry use) → full precision: don't guess.
                 return _streamingTrainingMode switch
                 {
-                    false => (StreamingEncoding.Bf16, false),     // inference → bf16
-                    true => (StreamingEncoding.Lossless, false),  // training → lossless
-                    _ => (StreamingEncoding.Native, false),       // unknown → full precision
+                    false => (ResolveAutoInferenceEncoding(weight), false), // inference → RAM-aware
+                    true => (StreamingEncoding.Lossless, false),            // training → lossless
+                    _ => (StreamingEncoding.Native, false),                 // unknown → full precision
                 };
         }
+    }
+
+    /// <summary>
+    /// RAM-aware <see cref="StreamingStoreDtype.Auto"/> encoding for a read-only inference weight:
+    /// the HIGHEST-fidelity store precision whose whole-model resident footprint still fits the
+    /// pool's resident cap. bf16 (÷2) unless the model is too large for bf16 to fit, in which case
+    /// the large weights step to int8 (÷4) or int4 (÷8) — enough to bring the resident set under
+    /// the cap so an otherwise-too-large model runs on a constrained box. Small / 1-D weights
+    /// (biases, norms) always stay bf16 (<see cref="MinAutoQuantElements"/>): they are
+    /// precision-sensitive and a negligible share of the footprint. With no footprint hint the
+    /// behaviour is unchanged (bf16).
+    /// </summary>
+    private static byte ResolveAutoInferenceEncoding<T>(Tensor<T> weight)
+    {
+        long footprint = _options.ExpectedStreamingFootprintBytes;
+        long cap = _options.StreamingPoolMaxResidentBytes;
+        // No footprint hint, or bf16 already fits, or a degenerate cap → keep bf16 (best fidelity,
+        // unchanged default). footprint/2 is the whole-model resident cost at bf16.
+        if (footprint <= 0 || cap <= 0 || footprint / 2 <= cap) return StreamingEncoding.Bf16;
+
+        // bf16 does NOT fit — the large weights must step down. Keep small / 1-D weights at bf16:
+        // they barely move the footprint and int8/int4 hurts their precision the most.
+        if (weight.Length < MinAutoQuantElements || weight.Rank < 2) return StreamingEncoding.Bf16;
+
+        // Pick the coarsest tier only as needed: int8 (÷4) if it fits, else int4 (÷8). int4 is the
+        // most aggressive rung — if even it doesn't fit, still use it (best effort; the resident cap
+        // then bounds the set by paging, which int4 minimizes the IO of).
+        if (footprint / 4 <= cap) return StreamingEncoding.Int8;
+        return StreamingEncoding.Int4;
     }
 
     /// <summary>bf16 byte count (2 per element) with the same int.MaxValue overflow

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
@@ -98,6 +98,46 @@ public class StreamingInt4NoUpcastTests
         finally { Cleanup(dir); }
     }
 
+    [Fact]
+    public void Auto_RamAware_SelectsInt4_WhenEvenInt8Overflows_KeepsInt4NoUpcast()
+    {
+        // Extreme pressure: footprint 8 MiB, cap 1 MiB → bf16 (4 MiB) and int8 (2 MiB) both overflow,
+        // so RAM-aware Auto steps to int4 (1 MiB) — the last rung — for this large inference weight,
+        // and it materializes to the SAME no-upcast int4 form as the explicit Int4 path.
+        const int inDim = 128, outDim = 256, n = inDim * outDim; // 32,768 ≥ MinAutoQuantElements, rank 2
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-autoint4-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 1L * 1024 * 1024,
+            ExpectedStreamingFootprintBytes = 8L * 1024 * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Auto,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false); // inference
+        try
+        {
+            var t = new Tensor<float>(new[] { inDim, outDim });
+            for (int i = 0; i < n; i++) t[i] = Val(i);
+            t.Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(t);
+
+            Assert.Equal(StreamingEncoding.Int4, t.StreamingStoreEncoding); // Auto chose int4
+
+            WeightRegistry.Materialize(t);
+            Assert.NotNull(t.StreamingInt4);
+            Assert.Equal(0, t.DataVector.Length);
+            Assert.Equal(outDim, t.StreamingInt4!.Rows); // [out, in] kernel layout
+            Assert.Equal(inDim, t.StreamingInt4.K);
+
+            // Lazy fp fallback lands each value at its logical index within int4's group-quant RMS.
+            var span = t.AsSpan();
+            double sum2 = 0, ref2 = 0;
+            for (int i = 0; i < n; i++) { double e = span[i] - Val(i); sum2 += e * e; ref2 += (double)Val(i) * Val(i); }
+            Assert.True(Math.Sqrt(sum2 / ref2) < 0.20, "Auto-int4 lazy dequant should be within ~12-15% RMS");
+        }
+        finally { Cleanup(dir); }
+    }
+
     private static void Cleanup(string dir)
     {
         WeightRegistry.SetStreamingExecutionTraining(null);

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt8MatMulRoutingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt8MatMulRoutingTests.cs
@@ -109,5 +109,77 @@ public class StreamingInt8MatMulRoutingTests
             if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
         }
     }
+
+    /// <summary>
+    /// The RAM-aware <see cref="StreamingStoreDtype.Auto"/> path (not the explicit Int8 opt-in):
+    /// a large inference weight, under a footprint+cap where bf16 would overflow the resident cap
+    /// but int8 fits, is AUTO-selected to int8 AND routed through the same no-upcast int8 kernel —
+    /// producing correct output. This proves the new Auto escalation doesn't just tag the encoding
+    /// byte but actually computes through the int8 GEMM (the behavioural end-to-end, not just policy).
+    /// </summary>
+    [Fact]
+    public void Auto_RamAware_SelectsInt8_ForLargeInferenceWeight_AndRoutesToInt8Kernel()
+    {
+        const int inDim = 256, outDim = 128, batch = 8; // 32,768 weights ≥ MinAutoQuantElements, rank 2
+        var engine = new CpuEngine();
+        var rng = new Rng(7777);
+
+        var wData = new float[inDim * outDim];
+        for (int i = 0; i < wData.Length; i++) wData[i] = rng.Next(0.1);
+        var xData = new float[batch * inDim];
+        for (int i = 0; i < xData.Length; i++) xData[i] = rng.Next(1.0);
+        var biasData = new float[outDim];
+        for (int i = 0; i < biasData.Length; i++) biasData[i] = rng.Next(0.3);
+
+        var x = new Tensor<float>(xData, new[] { batch, inDim });
+        var bias = new Tensor<float>(biasData, new[] { outDim });
+
+        var deq = DequantizePerOutput(wData, inDim, outDim);
+        var wRef = new Tensor<float>(deq, new[] { inDim, outDim });
+        var cRef = engine.FusedLinear(x, wRef, bias, FusedActivationType.None);
+
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-autoint8fl-{Guid.NewGuid():N}");
+        // Footprint 4 MiB, cap 1 MiB: bf16 (÷2 = 2 MiB) overflows the cap, int8 (÷4 = 1 MiB) fits →
+        // Auto picks int8 for this large weight. The cap comfortably holds the single 33 KB weight
+        // (no thrash); it only drives the PRECISION choice.
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 1L * 1024 * 1024,
+            ExpectedStreamingFootprintBytes = 4L * 1024 * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Auto,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false); // inference (read-only)
+        try
+        {
+            var wStream = new Tensor<float>(new[] { inDim, outDim });
+            for (int i = 0; i < wData.Length; i++) wStream[i] = wData[i];
+            wStream.Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(wStream);
+
+            // (0) Auto CHOSE int8 (not bf16) for this large weight under memory pressure.
+            Assert.Equal(StreamingEncoding.Int8, wStream.StreamingStoreEncoding);
+
+            var cInt8 = engine.FusedLinear(x, wStream, bias, FusedActivationType.None);
+
+            // (1) Routed to int8, no upcast: int8 form present, fp32 _data empty.
+            Assert.NotNull(wStream.StreamingInt8);
+            Assert.Equal(0, wStream.DataVector.Length);
+
+            // (2) Correct: matches fp32 FusedLinear on the per-output-dequantized weight.
+            var rEng = cInt8.AsSpan();
+            var rRef = cRef.AsSpan();
+            double sum2 = 0, ref2 = 0;
+            for (int i = 0; i < batch * outDim; i++) { double e = rEng[i] - rRef[i]; sum2 += e * e; ref2 += (double)rRef[i] * rRef[i]; }
+            double rel = Math.Sqrt(sum2 / Math.Max(1e-30, ref2));
+            Assert.True(rel < 0.01, $"Auto-int8-routed FusedLinear should match fp32-on-dequantized (rel {rel:E3}).");
+        }
+        finally
+        {
+            WeightRegistry.SetStreamingExecutionTraining(null);
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
 }
 #endif

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryBf16StoreTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryBf16StoreTests.cs
@@ -196,6 +196,100 @@ public class WeightRegistryBf16StoreTests
         finally { Cleanup(dir); }
     }
 
+    // ── RAM-aware Auto (inference): step bf16 → int8 → int4 to fit the resident cap ──────────
+    // Registers ONE rank-2 weight of `shape` under Auto+inference with the given whole-model
+    // footprint + resident cap, and returns its chosen store encoding. Auto compares the
+    // footprint at each precision (÷2 bf16, ÷4 int8, ÷8 int4) to the cap and picks the
+    // highest-fidelity tier that fits.
+    private static byte AutoInferenceEncoding(int[] shape, long footprintBytes, long capBytes)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-autoram-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = capBytes,
+            ExpectedStreamingFootprintBytes = footprintBytes,
+            StreamingStoreDtype = StreamingStoreDtype.Auto,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false); // inference (read-only weights)
+        try
+        {
+            long n = 1L;
+            foreach (var d in shape) n *= d;
+            var t = new Tensor<float>(shape);
+            for (int i = 0; i < n; i++) t[i] = (float)Math.Sin(i * 0.001) * 0.05f;
+            t.Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(t);
+            return t.StreamingStoreEncoding;
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Auto_Inference_RamAware_KeepsBf16_WhenModelFitsAtBf16()
+    {
+        // footprint/2 (bf16) = 5,000 <= cap 8,000 → bf16 keeps its higher fidelity. A large weight
+        // is NOT stepped down just because it's large — only when bf16 would overflow the cap.
+        Assert.Equal(StreamingEncoding.Bf16, AutoInferenceEncoding(new[] { 256, 128 }, footprintBytes: 10_000, capBytes: 8_000));
+    }
+
+    [Fact]
+    public void Auto_Inference_RamAware_StepsToInt8_WhenBf16Overflows_ButInt8Fits()
+    {
+        // bf16 (÷2 = 4,000) > cap 2,500, but int8 (÷4 = 2,000) <= 2,500 → int8 for the large weight.
+        Assert.Equal(StreamingEncoding.Int8, AutoInferenceEncoding(new[] { 256, 128 }, footprintBytes: 8_000, capBytes: 2_500));
+    }
+
+    [Fact]
+    public void Auto_Inference_RamAware_StepsToInt4_WhenInt8AlsoOverflows()
+    {
+        // bf16 (4,000) and int8 (2,000) both > cap 1,000 → int4 (÷8 = 1,000, the most aggressive rung).
+        Assert.Equal(StreamingEncoding.Int4, AutoInferenceEncoding(new[] { 256, 128 }, footprintBytes: 8_000, capBytes: 1_000));
+    }
+
+    [Fact]
+    public void Auto_Inference_RamAware_KeepsSmallAnd1DWeightsBf16_EvenUnderPressure()
+    {
+        // Same overflow regime as the int4 case, but SMALL / 1-D weights are precision-sensitive
+        // and a negligible share of the footprint, so they stay bf16 (mirrors bitsandbytes/AWQ
+        // keeping norms + biases in higher precision).
+        Assert.Equal(StreamingEncoding.Bf16, AutoInferenceEncoding(new[] { 64, 64 }, footprintBytes: 8_000, capBytes: 1_000));   // 4,096 < 16,384 elems
+        Assert.Equal(StreamingEncoding.Bf16, AutoInferenceEncoding(new[] { 65_536 }, footprintBytes: 8_000, capBytes: 1_000));  // rank 1 (bias/norm)
+    }
+
+    [Fact]
+    public void Auto_Inference_NoFootprintHint_StaysBf16()
+    {
+        // No ExpectedStreamingFootprintBytes (0) → behaviour unchanged: bf16 regardless of cap.
+        Assert.Equal(StreamingEncoding.Bf16, AutoInferenceEncoding(new[] { 256, 128 }, footprintBytes: 0, capBytes: 1_000));
+    }
+
+    [Fact]
+    public void Auto_Training_StaysLossless_EvenWhenFootprintOverflowsCap()
+    {
+        // Even under the exact memory pressure that drives inference to int4, TRAINING must stay
+        // LOSSLESS: the quantized tiers' eviction write-back is native-only, so a mutated quantized
+        // master would silently lose its update. Correctness beats the extra compression here.
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-autotrain-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 1_000,
+            ExpectedStreamingFootprintBytes = 8_000,
+            StreamingStoreDtype = StreamingStoreDtype.Auto,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(true); // training
+        try
+        {
+            var t = new Tensor<float>(new[] { 256, 128 });
+            for (int i = 0; i < 256 * 128; i++) t[i] = (float)Math.Sin(i * 0.001) * 0.05f;
+            t.Lifetime = WeightLifetime.Streaming;
+            WeightRegistry.RegisterWeight(t);
+            Assert.Equal(StreamingEncoding.Lossless, t.StreamingStoreEncoding);
+        }
+        finally { Cleanup(dir); }
+    }
+
     private static void Cleanup(string dir)
     {
         WeightRegistry.SetStreamingExecutionTraining(null);


### PR DESCRIPTION
## Summary

Makes the `Auto` streaming store **RAM-aware** so a foundation-scale model that is too large to fit the resident cap at bf16 can still run — by stepping the large weights down to int8 / int4 (feeding the existing no-upcast weight-only GEMM), instead of overflowing the cap at bf16.

Previously `Auto` in inference stored bf16 unconditionally. Now, given the model's total footprint (`GpuOffloadOptions.ExpectedStreamingFootprintBytes`) and `StreamingPoolMaxResidentBytes`, it picks the **highest-fidelity** store precision that fits:

| footprint vs cap | store |
|---|---|
| fits at bf16 (÷2) | **bf16** (unchanged, best fidelity) |
| bf16 overflows, int8 (÷4) fits | **int8** |
| int8 also overflows | **int4** (÷8, last rung) |
| no footprint hint | **bf16** (unchanged) |

### Why this exceeds the usual approach
- The quantized tiers feed the **no-upcast int8/int4 weight-only GEMM** directly (fast compute), not a dequant-to-fp32 fallback.
- Fidelity is only reduced *when it must be* — a model that fits at bf16 keeps bf16.
- Small / 1-D weights (`< 16,384` elems or rank `< 2` — biases, norms) always stay bf16, mirroring bitsandbytes/AWQ keeping norms + biases higher-precision.

### Safety
Training stays **Lossless** unconditionally. The quantized tiers' eviction write-back is native-only (`TryWriteBackResidentForStreaming` returns `false` for non-Native), so a mutated quantized master would silently drop its update — therefore the quantized tiers are only ever chosen for **read-only inference** weights, where write-back never occurs.

## Tests
- **Selection** (`WeightRegistryBf16StoreTests`): bf16/int8/int4 chosen by cap; small + 1-D stay bf16; no-hint → bf16; training stays lossless even under the pressure that drives inference to int4.
- **End-to-end behavioural** (`StreamingInt8MatMulRoutingTests`): `Auto`→int8 actually **routes through the real no-upcast int8 GEMM** (`StreamingInt8` attached, fp32 `_data` empty) and matches the fp32-on-dequantized reference. `Auto`→int4 no-upcast parity (`StreamingInt4NoUpcastTests`).
- **226** streaming/registry tests green on **net10.0** and **net471** (net471 has no AVX int8 GEMM → the dequant fallback path is exercised and correct).

## Consumer note
Adoption is opt-in and non-breaking: callers set `ExpectedStreamingFootprintBytes` and keep `StreamingStoreDtype.Auto`. Existing behaviour (no footprint hint) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)