### PR TITLE
fix(compile): refresh norm statistics in the fused training forward (GroupNorm + BatchNorm)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -5436,48 +5436,25 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             (step.Inputs[0]._shape.Length == 3
              || (step.Inputs[0]._shape.Length == 4 && step.Inputs[0]._shape[0] == 1));
 
+        // BatchNorm forward: the specialized channels-first BatchNormInferenceUnsafe
+        // fast path normalized with — and never refreshed — the savedState
+        // mean/variance. In a TRAINING plan the batch statistics change every step as
+        // the input drifts (activations fed by upstream weights that move), so both the
+        // forward OUTPUT and the backward (which reads the same savedState, see the
+        // BatchNormBackwardInto step) ran on stale, trace-time statistics. Deep fused
+        // BatchNorm models — e.g. FireRedASR's Conformer conv modules — trained worse
+        // every step (LossStrictlyDecreases / DifferentInputs_AfterTraining / MoreData
+        // all failed). Returning null routes BatchNorm through the generic lazy execute
+        // delegate registered by CpuEngine.BatchNorm, which RECOMPUTES the batch
+        // statistics AND copies them into the savedState tensors on every plan.Step() —
+        // exactly the fix LayerNorm got in #1331 (and the GroupNorm equivalent). A future
+        // re-specialization MUST recompute + emit mean/variance alongside the output to
+        // stay correct under training. (Rank-2 [batch,features] BatchNorm never hit this
+        // block — layoutIsChannelsFirstContiguous is false — so it was already correct.)
         if (step.OpType == OpType.BatchNorm && typeof(T) == typeof(float)
-            && step.Inputs.Length >= 3 && step.Inputs[0].IsContiguous
-            && layoutIsChannelsFirstContiguous
-            && step.SavedState is { Length: >= 2 }
-            && step.SavedState[0] is Tensor<T> meanTensor
-            && step.SavedState[1] is Tensor<T> varTensor)
+            && layoutIsChannelsFirstContiguous)
         {
-            var input = step.Inputs[0];
-            var gamma = step.Inputs[1];
-            var beta = step.Inputs[2];
-            var mean = meanTensor;
-            var variance = varTensor;
-            var output = step.OutputBuffer;
-            int channels = gamma.Length;
-            float eps = 1e-5f;
-            if (step.SavedState.Length >= 3 && step.SavedState[2] is double epsD)
-                eps = (float)epsD;
-
-            var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
-            var outH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)output), handleTracker);
-            var gammaH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)gamma), handleTracker);
-            var betaH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)beta), handleTracker);
-            var meanH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)mean), handleTracker);
-            var varH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)variance), handleTracker);
-            int length = input.Length;
-            float capturedEps = eps;
-
-            return eng =>
-            {
-                unsafe
-                {
-                    Simd.FusedKernels.BatchNormInferenceUnsafe(
-                        (float*)inH.AddrOfPinnedObject(),
-                        (float*)outH.AddrOfPinnedObject(),
-                        length, channels,
-                        (float*)gammaH.AddrOfPinnedObject(),
-                        (float*)betaH.AddrOfPinnedObject(),
-                        (float*)meanH.AddrOfPinnedObject(),
-                        (float*)varH.AddrOfPinnedObject(),
-                        capturedEps);
-                }
-            };
+            return null;
         }
 
         // LayerNorm: previously routed through FusedKernels.LayerNormUnsafe

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -5680,13 +5680,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // × 10 sampling steps per Predict — a measurable share of the residual
         // compile-mode-slower-than-eager gap that #1305 surfaced.
         //
-        // SavedState layout for GroupNorm (set at CpuEngine.GroupNorm record-site,
-        // see line ~20597): [int numGroups, Tensor<T> mean, Tensor<T> variance,
-        // double epsilon]. Forward-only inference ignores mean/variance — they
-        // are required for backward only — so we discard them via `out _`.
+        // SavedState layout for GroupNorm (set at CpuEngine.GroupNorm record-site):
+        // [int numGroups, Tensor<T> mean, Tensor<T> variance, double epsilon]. The
+        // GroupNorm BACKWARD (BackwardFunctions<T>.GroupNormBackward) reads mean and
+        // variance from this savedState. In a compiled TRAINING plan the parameters
+        // change every step, so mean/variance MUST be recomputed from the CURRENT
+        // input on each forward replay and written back into the saved tensors —
+        // otherwise the backward runs on stale, trace-time statistics. That mis-directs
+        // the GroupNorm gradient, and (amplified by Adam's per-parameter normalization
+        // over many consecutive steps) makes deep GroupNorm models — e.g. ODISE's
+        // SD-UNet — DIVERGE instead of train: fused ODISE loss went 9231.58 -> 9244.10
+        // (worse) while eager reached 9188.04 (#1750). The eager record-site delegate
+        // already refreshes them the same way (#1331); this keeps the specialized
+        // replay consistent. GroupNormInto computes mean/variance internally regardless
+        // (they were previously discarded via `out _`), so capturing them adds no
+        // allocation — only a small write-back copy. Inference plans have no backward
+        // reader, so the refresh is harmless (and negligible) there.
         if (step.OpType == OpType.GroupNorm && step.Inputs.Length == 3 && step.Inputs[0].IsContiguous
             && step.SavedState is { Length: >= 4 }
             && step.SavedState[0] is int numGroupsGN
+            && step.SavedState[1] is Tensor<T> savedMeanGN
+            && step.SavedState[2] is Tensor<T> savedVarGN
             && step.SavedState[3] is double epsilonGN)
         {
             var inp = step.Inputs[0];
@@ -5695,13 +5709,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var o = step.OutputBuffer;
             return eng =>
             {
+                Tensor<T> freshMean, freshVar;
                 if (eng is CpuEngine cpuEng)
-                    cpuEng.GroupNormInto(o, inp, numGroupsGN, gamma, beta, epsilonGN, out _, out _);
+                    cpuEng.GroupNormInto(o, inp, numGroupsGN, gamma, beta, epsilonGN, out freshMean, out freshVar);
                 else
                 {
-                    var result = eng.GroupNorm(inp, numGroupsGN, gamma, beta, epsilonGN, out _, out _);
+                    var result = eng.GroupNorm(inp, numGroupsGN, gamma, beta, epsilonGN, out freshMean, out freshVar);
                     result.AsSpan().CopyTo(o.AsWritableSpan());
                 }
+                // Refresh the saved statistics the backward reads (see note above).
+                if (freshMean.Length == savedMeanGN.Length)
+                    freshMean.AsSpan().CopyTo(savedMeanGN.AsWritableSpan());
+                if (freshVar.Length == savedVarGN.Length)
+                    freshVar.AsSpan().CopyTo(savedVarGN.AsWritableSpan());
             };
         }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -5695,10 +5695,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     result.AsSpan().CopyTo(o.AsWritableSpan());
                 }
                 // Refresh the saved statistics the backward reads (see note above).
-                if (freshMean.Length == savedMeanGN.Length)
-                    freshMean.AsSpan().CopyTo(savedMeanGN.AsWritableSpan());
-                if (freshVar.Length == savedVarGN.Length)
-                    freshVar.AsSpan().CopyTo(savedVarGN.AsWritableSpan());
+                // In a compiled plan the trace-time and replay-time shapes are fixed, so
+                // mean/variance lengths must never legitimately diverge — a mismatch signals
+                // a real bug. Fail loud rather than silently skipping the refresh, which would
+                // resurrect the exact stale-statistics corruption this path exists to fix.
+                if (freshMean.Length != savedMeanGN.Length || freshVar.Length != savedVarGN.Length)
+                    throw new InvalidOperationException(
+                        $"GroupNorm forward produced mean/variance of length ({freshMean.Length}, {freshVar.Length}) " +
+                        $"but the compiled savedState buffers are ({savedMeanGN.Length}, {savedVarGN.Length}); " +
+                        "refusing to silently skip the statistics refresh (this is the same stale-statistics class of bug being fixed here).");
+                freshMean.AsSpan().CopyTo(savedMeanGN.AsWritableSpan());
+                freshVar.AsSpan().CopyTo(savedVarGN.AsWritableSpan());
+
+                // Return the freshly-rented stat temporaries to the pool. Both GroupNormInto
+                // and GroupNorm Rent freshMean/freshVar from TensorAllocator; this replay path
+                // only needs their values copied into savedMeanGN/savedVarGN above. Without the
+                // Return, every training Step() would leak two pooled tensors.
+                TensorAllocator.Return(freshMean);
+                TensorAllocator.Return(freshVar);
             };
         }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormCompiledTrainingStalenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/BatchNormCompiledTrainingStalenessTests.cs
@@ -1,0 +1,114 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Probe: does the compiled-TRAINING BatchNorm forward have the SAME stale-statistics
+/// bug GroupNorm had (and LayerNorm had, fixed in #1331)? The specialized BatchNorm
+/// forward routes through BatchNormInferenceUnsafe with the savedState mean/variance
+/// and does not recompute/refresh them, so once the BatchNorm input drifts across
+/// training steps the backward runs on stale trace-time stats. FireRedASR (Conformer
+/// conv modules use BatchNorm) trains on the fused path and its training invariants
+/// (LossStrictlyDecreases / DifferentInputs_AfterTraining / MoreData) fail on 0.106.1.
+/// This test drifts the input after the trace and compares the compiled gradient to a
+/// fresh eager-tape gradient on the drifted input (lr=0, no compounding).
+/// </summary>
+[Collection("CompilationGlobalState")]
+public class BatchNormCompiledTrainingStalenessTests
+{
+    [Fact]
+    public void BatchNorm_CompiledBackward_UsesFreshStats_AfterInputDrifts()
+    {
+        // Rank-3 [C,H,W] float hits the specialized channels-first BatchNorm forward
+        // (BatchNormInferenceUnsafe, CompiledTrainingPlan ~5439) — the path FireRedASR's
+        // Conformer conv-module BatchNorm takes. A rank-2 [batch,features] input misses
+        // it (routes to the generic refreshing path) and would not expose the bug.
+        const int C = 6, H = 4, W = 4;
+        const double epsilon = 1e-5;
+        int batch = C, features = C; // gamma/beta length == channels
+
+        var rng = new System.Random(1750);
+        int len = C * H * W;
+        var traceInput = new float[len];
+        var driftInput = new float[len];
+        var tgtData = new float[len];
+        var gData = new float[features];
+        var bData = new float[features];
+        for (int i = 0; i < len; i++)
+        {
+            traceInput[i] = (float)(rng.NextDouble() - 0.5);
+            driftInput[i] = (float)(rng.NextDouble() * 2.0 - 1.0); // clearly different distribution
+            tgtData[i] = (float)(rng.NextDouble() - 0.5);
+        }
+        for (int i = 0; i < features; i++) { gData[i] = (float)(0.8 + 0.4 * rng.NextDouble()); bData[i] = (float)(rng.NextDouble() - 0.5); }
+
+        // ---- COMPILED: trace with traceInput, drift the input, Step (lr=0) ----
+        var engineF = new CpuEngine();
+        var inputF = new Tensor<float>(new[] { C, H, W });
+        var targetF = new Tensor<float>(new[] { C, H, W });
+        var gammaF = new Tensor<float>(new[] { features });
+        var betaF = new Tensor<float>(new[] { features });
+        for (int i = 0; i < len; i++) { inputF[i] = traceInput[i]; targetF[i] = tgtData[i]; }
+        for (int i = 0; i < features; i++) { gammaF[i] = gData[i]; betaF[i] = bData[i]; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var bn = engineF.BatchNorm(inputF, gammaF, betaF, epsilon, out _, out _);
+            var diff = engineF.TensorSubtract(bn, targetF);
+            var sq = engineF.TensorMultiply(diff, diff);
+            engineF.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        for (int i = 0; i < len; i++) inputF[i] = driftInput[i];
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad");
+
+        // ---- EAGER reference on the DRIFTED input ----
+        var engineE = new CpuEngine();
+        var inputE = new Tensor<float>(new[] { C, H, W });
+        var targetE = new Tensor<float>(new[] { C, H, W });
+        var gammaE = new Tensor<float>(new[] { features });
+        var betaE = new Tensor<float>(new[] { features });
+        for (int i = 0; i < len; i++) { inputE[i] = driftInput[i]; targetE[i] = tgtData[i]; }
+        for (int i = 0; i < features; i++) { gammaE[i] = gData[i]; betaE[i] = bData[i]; }
+
+        Tensor<float> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<float>())
+        {
+            var bn = engineE.BatchNorm(inputE, gammaE, betaE, epsilon, out _, out _);
+            var diff = engineE.TensorSubtract(bn, targetE);
+            var sq = engineE.TensorMultiply(diff, diff);
+            var loss = engineE.ReduceSum(sq, null);
+            var g = tape.ComputeGradients(loss, sources: new[] { gammaE, betaE });
+            eagerGradGamma = g[gammaE];
+            eagerGradBeta = g[betaE];
+        }
+
+        const float tol = 1e-4f;
+        var lines = new System.Collections.Generic.List<string>();
+        float maxG = 0, maxB = 0;
+        for (int p = 0; p < features; p++)
+        {
+            float dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            float dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            maxG = System.Math.Max(maxG, dG);
+            maxB = System.Math.Max(maxB, dB);
+            lines.Add($"  ch[{p}]  γ eager={eagerGradGamma[p]:F6} fused={fusedGradGamma[p]:F6} |Δ|={dG:E3}   β eager={eagerGradBeta[p]:F6} fused={fusedGradBeta[p]:F6} |Δ|={dB:E3}");
+        }
+        Assert.True(maxG < tol && maxB < tol,
+            $"Compiled BatchNorm backward ran on STALE trace-time mean/variance after the input drifted " +
+            $"(max|Δγ|={maxG:E3}, max|Δβ|={maxB:E3}, tol {tol:E0}):\n" + string.Join("\n", lines));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GroupNormCompiledTrainingStalenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GroupNormCompiledTrainingStalenessTests.cs
@@ -1,0 +1,123 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression for the fused compiled-TRAINING GroupNorm stale-statistics bug
+/// (surfaced by ooples/AiDotNet #1750: ODISE's SD-UNet trained on the fused path
+/// and DIVERGED — CrossEntropy loss 9231.58 -> 9244.10 over 30 Adam steps — while
+/// the eager tape reached 9188.04; the fix makes the fused path reach 9188.02).
+///
+/// Root cause: the specialized GroupNorm forward in <c>CompiledTrainingPlan</c>
+/// replayed <c>GroupNormInto(o, inp, …, out _, out _)</c>, DISCARDING the freshly
+/// computed mean/variance. The GroupNorm BACKWARD reads mean/variance from the
+/// captured <c>savedState</c>; because the forward never wrote the current step's
+/// statistics back, the backward ran on stale, trace-time stats. Once the GroupNorm
+/// input drifts (its upstream weights update every step), the saved mean/var no
+/// longer match the input, so gradGamma/gradBeta/dL-dInput are mis-computed — the
+/// same class of bug LayerNorm hit and had fixed in #1331.
+///
+/// The test traces the plan with one input, then DRIFTS the GroupNorm input before
+/// stepping (mirroring an activation fed by an upstream weight that moved since the
+/// trace). With lr=0 there is no multi-step compounding, so the compiled gradient
+/// must equal a fresh eager-tape gradient computed on the drifted input — it only
+/// does when the forward refreshes the saved statistics each replay.
+/// </summary>
+[Collection("CompilationGlobalState")]
+public class GroupNormCompiledTrainingStalenessTests
+{
+    [Fact]
+    public void GroupNorm_CompiledBackward_UsesFreshStats_AfterInputDrifts()
+    {
+        const int N = 1, C = 4, H = 4, W = 4, numGroups = 2;
+        const double epsilon = 1e-5;
+
+        var rng = new System.Random(1750);
+        int len = N * C * H * W;
+        var traceInput = new float[len]; // input present at trace time
+        var driftInput = new float[len]; // a DIFFERENT input the step actually sees
+        var tgtData = new float[len];
+        var gData = new float[C];
+        var bData = new float[C];
+        for (int i = 0; i < len; i++)
+        {
+            traceInput[i] = (float)(rng.NextDouble() - 0.5);
+            driftInput[i] = (float)(rng.NextDouble() - 0.5);
+            tgtData[i] = (float)(rng.NextDouble() - 0.5);
+        }
+        for (int i = 0; i < C; i++) { gData[i] = (float)(0.8 + 0.4 * rng.NextDouble()); bData[i] = (float)(rng.NextDouble() - 0.5); }
+
+        // ---- COMPILED: trace with traceInput, then drift the input in place, Step (lr=0) ----
+        var engineF = new CpuEngine();
+        var inputF = new Tensor<float>(new[] { N, C, H, W });
+        var targetF = new Tensor<float>(new[] { N, C, H, W });
+        var gammaF = new Tensor<float>(new[] { C });
+        var betaF = new Tensor<float>(new[] { C });
+        for (int i = 0; i < len; i++) { inputF[i] = traceInput[i]; targetF[i] = tgtData[i]; }
+        for (int i = 0; i < C; i++) { gammaF[i] = gData[i]; betaF[i] = bData[i]; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var gn = engineF.GroupNorm(inputF, numGroups, gammaF, betaF, epsilon, out _, out _);
+            var diff = engineF.TensorSubtract(gn, targetF);
+            var sq = engineF.TensorMultiply(diff, diff);
+            engineF.ReduceSum(sq, null);
+            plan = scope.CompileTraining(new[] { gammaF, betaF });
+        }
+
+        // Drift the GroupNorm input between the trace and the step. The forward replay
+        // re-reads this buffer; the saved mean/variance MUST be recomputed from it.
+        for (int i = 0; i < len; i++) inputF[i] = driftInput[i];
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.Step();
+        }
+        var fusedGradGamma = gammaF.Grad ?? throw new System.InvalidOperationException("gammaF.Grad");
+        var fusedGradBeta = betaF.Grad ?? throw new System.InvalidOperationException("betaF.Grad");
+
+        // ---- EAGER reference: gradient on the DRIFTED input (the correct answer) ----
+        var engineE = new CpuEngine();
+        var inputE = new Tensor<float>(new[] { N, C, H, W });
+        var targetE = new Tensor<float>(new[] { N, C, H, W });
+        var gammaE = new Tensor<float>(new[] { C });
+        var betaE = new Tensor<float>(new[] { C });
+        for (int i = 0; i < len; i++) { inputE[i] = driftInput[i]; targetE[i] = tgtData[i]; }
+        for (int i = 0; i < C; i++) { gammaE[i] = gData[i]; betaE[i] = bData[i]; }
+
+        Tensor<float> eagerGradGamma, eagerGradBeta;
+        using (var tape = new GradientTape<float>())
+        {
+            var gn = engineE.GroupNorm(inputE, numGroups, gammaE, betaE, epsilon, out _, out _);
+            var diff = engineE.TensorSubtract(gn, targetE);
+            var sq = engineE.TensorMultiply(diff, diff);
+            var loss = engineE.ReduceSum(sq, null);
+            var g = tape.ComputeGradients(loss, sources: new[] { gammaE, betaE });
+            eagerGradGamma = g[gammaE];
+            eagerGradBeta = g[betaE];
+        }
+
+        // Stale trace-time statistics make the compiled gradient diverge sharply from
+        // the drifted-input eager gradient; fresh statistics match to FP tolerance.
+        const float tol = 1e-4f;
+        var lines = new System.Collections.Generic.List<string>();
+        float maxG = 0, maxB = 0;
+        for (int p = 0; p < C; p++)
+        {
+            float dG = System.Math.Abs(eagerGradGamma[p] - fusedGradGamma[p]);
+            float dB = System.Math.Abs(eagerGradBeta[p] - fusedGradBeta[p]);
+            maxG = System.Math.Max(maxG, dG);
+            maxB = System.Math.Max(maxB, dB);
+            lines.Add($"  ch[{p}]  γ eager={eagerGradGamma[p]:F6} fused={fusedGradGamma[p]:F6} |Δ|={dG:E3}   β eager={eagerGradBeta[p]:F6} fused={fusedGradBeta[p]:F6} |Δ|={dB:E3}");
+        }
+        Assert.True(maxG < tol && maxB < tol,
+            $"Compiled GroupNorm backward ran on STALE trace-time mean/variance after the input drifted " +
+            $"(max|Δγ|={maxG:E3}, max|Δβ|={maxB:E3}, tol {tol:E0}):\n" + string.Join("\n", lines));
+    }
+}


### PR DESCRIPTION
## Summary
The fused compiled-training path left **norm-layer statistics stale**. Specialized forward delegates for **GroupNorm** and channels-first **BatchNorm** normalized with — and never refreshed — the `savedState` mean/variance that the backward reads. Once the norm's input drifts across training steps (its upstream weights update every step), the saved statistics no longer match the input, so the gradients are mis-computed. Amplified by Adam's per-parameter normalization over many consecutive steps, this makes deep fused norm models **diverge instead of train**.

This is the same class of bug **LayerNorm** hit and had fixed in #1331 — GroupNorm and channels-first BatchNorm were missed. LayerNorm's own code comment documents the mechanism:

> the specialized fast path only wrote the forward output and didn't refresh the savedState mean/variance tensors the backward reads from. The backward then used compile-time stale mean/variance, producing gradGamma = 0 and dL/dInput = 0 — every γ stuck plus every parameter upstream of the norm stuck.

## GroupNorm — impact (ooples/AiDotNet#1750)
ODISE (Stable-Diffusion U-Net encoder, GroupNorm-heavy) trained on the fused path **diverged**. Identical seed/input/target/network, only the Tensors DLL differs:

| Tensors | `ODISETests.Training_ShouldReduceLoss` (30 Adam steps) |
|---|---|
| **before** | CrossEntropy 9231.58 → **9244.10** (worse) ❌ |
| **after** | CrossEntropy 9231.58 → **9188.02** (matches eager tape's 9188.04) ✅ |

The consumer change that routed ODISE onto the fused path was ooples/AiDotNet#1750 (it mapped `LinearWarmupScheduler` to the fused `LrSchedule`); the defect is here. The divergence only reproduces under **consecutive** `Train()` calls (an intervening `Predict()` rebuilds plan state and masks it) and only with a per-parameter optimizer (Adam); plain SGD tolerates the stale-direction error.

**Fix:** capture `out freshMean, out freshVar` and copy them into the `savedState` tensors on every replay. `GroupNormInto` computes them internally regardless (previously discarded via `out _`), so this adds **no allocation**, and keeps the zero-alloc specialized forward.

## BatchNorm — same class of bug (channels-first)
The specialized channels-first BatchNorm forward (`BatchNormInferenceUnsafe`, rank-3 `[C,H,W]` / rank-4 `[1,C,H,W]`, float) *used* the stale savedState mean/variance to normalize **and** never refreshed them, so both the forward output and the backward ran on trace-time stats. Fused BatchNorm models on channels-first tensors (e.g. Conformer conv modules) trained worse every step. Rank-2 `[batch,features]` BatchNorm already routed through the generic refreshing path and was correct.

**Fix:** return `null` for channels-first float BatchNorm so it routes through the generic `CpuEngine.BatchNorm` lazy delegate, which recomputes the batch statistics and refreshes `savedState` every `Step()` — exactly LayerNorm's #1331 approach. (`BatchNormInferenceUnsafe` uses provided stats rather than computing batch stats, so GroupNorm-style refresh-in-place isn't applicable; a future re-specialization must recompute + emit mean/variance.)

## Tests
Two regression tests, each traces a plan, drifts the norm input, runs one `lr = 0` `Step()`, and asserts the compiled gradient equals a fresh eager-tape gradient on the drifted input:

| Test | without fix | with fix |
|---|---|---|
| `GroupNormCompiledTrainingStalenessTests` | `max|Δγ| = 35.3` ❌ | `< 1e-4` ✅ |
| `BatchNormCompiledTrainingStalenessTests` (rank-3) | `max|Δγ| = 112` ❌ | `< 1e-4` ✅ |

All existing `BatchNormGradSlotResidualTests` still pass (no regression). Builds clean on net10.0 / net8.0 / net4.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compiled training for BatchNorm so it uses current statistics when inputs change between trace and step time.
  * Fixed compiled training for GroupNorm so backward passes use refreshed mean and variance values.
  * Improved gradient correctness in training runs with changing input distributions.

* **Tests**
  * Added regression tests covering stale-statistics scenarios for BatchNorm and GroupNorm compiled training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->