### PR TITLE
perf(cpu): parallelize 3 linear-attn scans + fused fp16-weight GEMM

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
@@ -100,37 +100,46 @@ public partial class CpuEngine
     {
         var negA = new double[numHeads];
         for (int hi = 0; hi < numHeads; hi++) negA[hi] = -Math.Exp(aLog[hi]);
-        var h = new double[innerDim * sd];
+        // Each head hi owns a disjoint state block and output region (B/C are shared but only read here),
+        // so the head axis is parallelizable with no reduction in the forward. Keep b outer; head-local
+        // state. (di within a head share the head's scalar dt/aBar but distinct state rows.)
         for (int b = 0; b < batch; b++)
         {
-            Array.Clear(h, 0, h.Length);
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(numHeads, MambaDiGrain, (hStart, hCount) =>
             {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                for (int hi = 0; hi < numHeads; hi++)
+                var hHead = new double[headDim * sd];
+                int hEnd = hStart + hCount;
+                for (int hi = hStart; hi < hEnd; hi++)
                 {
-                    double dt = delta[btHead + hi];
-                    double aBar = Math.Exp(dt * negA[hi]);
+                    Array.Clear(hHead, 0, headDim * sd);
+                    double aHi = negA[hi];
                     double dv = D[hi];
                     int dimStart = hi * headDim;
-                    for (int di = 0; di < headDim; di++)
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        double xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        double y = 0.0;
-                        for (int n = 0; n < sd; n++)
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        double dt = delta[btHead + hi];
+                        double aBar = Math.Exp(dt * aHi);
+                        for (int di = 0; di < headDim; di++)
                         {
-                            double hNew = aBar * h[hsBase + n] + dt * B[btState + n] * xv;
-                            h[hsBase + n] = hNew;
-                            y += C[btState + n] * hNew;
+                            int flatD = dimStart + di;
+                            double xv = X[btInner + flatD];
+                            int hsBase = di * sd; // head-local state row
+                            double y = 0.0;
+                            for (int n = 0; n < sd; n++)
+                            {
+                                double hNew = aBar * hHead[hsBase + n] + dt * B[btState + n] * xv;
+                                hHead[hsBase + n] = hNew;
+                                y += C[btState + n] * hNew;
+                            }
+                            outp[btInner + flatD] = y + dv * xv;
                         }
-                        outp[btInner + flatD] = y + dv * xv;
                     }
                 }
-            }
+            });
         }
     }
 
@@ -139,91 +148,117 @@ public partial class CpuEngine
         double[] dX, double[] dDelta, double[] dALog, double[] dB, double[] dC, double[] dD,
         int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
     {
-        int isd = innerDim * sd;
         var negA = new double[numHeads];
         for (int hi = 0; hi < numHeads; hi++) negA[hi] = -Math.Exp(aLog[hi]);
-        var hTraj = new double[seqLen * isd];
-        var h = new double[isd];
-        var dh = new double[isd];
+        int hd = headDim * sd; // head-local state size
 
+        // Parallelize over the head axis hi. dDelta/dALog/dD are per-head and dX per-flatD (all owned by
+        // hi), so they're written lock-free; B/C are shared across heads, so dB/dC (summed over heads) use
+        // per-chunk private partials reduced under a coarse lock. Keep b outer; head-local state/trajectory.
+        var reduceLock = new object();
         for (int b = 0; b < batch; b++)
         {
-            // Forward recompute, saving the post-update state trajectory.
-            Array.Clear(h, 0, isd);
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(numHeads, MambaDiGrain, (hStart, hCount) =>
             {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                for (int hi = 0; hi < numHeads; hi++)
+                var hHead = new double[hd];
+                var hTrajHead = new double[seqLen * hd];
+                var dhHead = new double[hd];
+                var dBpart = new double[seqLen * sd];
+                var dCpart = new double[seqLen * sd];
+                int hEnd = hStart + hCount;
+                for (int hi = hStart; hi < hEnd; hi++)
                 {
-                    double dt = delta[btHead + hi];
-                    double aBar = Math.Exp(dt * negA[hi]);
+                    double aHi = negA[hi];
                     int dimStart = hi * headDim;
-                    for (int di = 0; di < headDim; di++)
+
+                    // Forward recompute for this head, saving its post-update state trajectory.
+                    Array.Clear(hHead, 0, hd);
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        double xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        for (int n = 0; n < sd; n++)
-                            h[hsBase + n] = aBar * h[hsBase + n] + dt * B[btState + n] * xv;
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        double dt = delta[btHead + hi];
+                        double aBar = Math.Exp(dt * aHi);
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            int flatD = dimStart + di;
+                            double xv = X[btInner + flatD];
+                            int hsBase = di * sd;
+                            for (int n = 0; n < sd; n++)
+                                hHead[hsBase + n] = aBar * hHead[hsBase + n] + dt * B[btState + n] * xv;
+                        }
+                        Array.Copy(hHead, 0, hTrajHead, t * hd, hd);
+                    }
+
+                    // Reverse sweep.
+                    Array.Clear(dhHead, 0, hd);
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        int stOff = t * hd, spOff = (t - 1) * hd, dbOff = t * sd;
+                        double dt = delta[btHead + hi];
+                        double a = aHi;
+                        double aBar = Math.Exp(dt * a);
+                        double dDeltaAcc = 0.0, dALogAcc = 0.0, dDAcc = 0.0;
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            int flatD = dimStart + di;
+                            double xv = X[btInner + flatD];
+                            int hsBase = di * sd;
+                            double dOutVal = dOut[btInner + flatD];
+
+                            // D skip: y += D[h]*x.
+                            dX[btInner + flatD] += D[hi] * dOutVal;
+                            dDAcc += xv * dOutVal;
+
+                            for (int n = 0; n < sd; n++)
+                            {
+                                double hCur = hTrajHead[stOff + hsBase + n];
+                                double hPrev = t > 0 ? hTrajHead[spOff + hsBase + n] : 0.0;
+                                // Output: dh += C*dOut ; dC += h_t*dOut (private partial).
+                                dhHead[hsBase + n] += C[btState + n] * dOutVal;
+                                dCpart[dbOff + n] += hCur * dOutVal;
+                                double dhVal = dhHead[hsBase + n];
+
+                                // h_t = aBar*hPrev + dt*B*x.
+                                double dAbar = dhVal * hPrev;
+                                dDeltaAcc += dAbar * aBar * a;            // A-path: dAbar*Abar*A
+                                dALogAcc += dAbar * aBar * (dt * a);      // aLog: dAbar*Abar*(dt*A)
+                                dDeltaAcc += dhVal * B[btState + n] * xv; // B*x path
+                                dBpart[dbOff + n] += dhVal * dt * xv;
+                                dX[btInner + flatD] += dhVal * dt * B[btState + n];
+
+                                // Propagate to previous step.
+                                dhHead[hsBase + n] = dhVal * aBar;
+                            }
+                        }
+                        dDelta[btHead + hi] += dDeltaAcc;
+                        dALog[hi] += dALogAcc;
+                        dD[hi] += dDAcc;
                     }
                 }
-                Array.Copy(h, 0, hTraj, t * isd, isd);
-            }
 
-            // Reverse sweep.
-            Array.Clear(dh, 0, isd);
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                int stOff = t * isd, spOff = (t - 1) * isd;
-                for (int hi = 0; hi < numHeads; hi++)
+                // Reduce this chunk's dB/dC partials into the shared gradients (cross-head sum).
+                lock (reduceLock)
                 {
-                    double dt = delta[btHead + hi];
-                    double a = negA[hi];
-                    double aBar = Math.Exp(dt * a);
-                    int dimStart = hi * headDim;
-                    double dDeltaAcc = 0.0, dALogAcc = 0.0, dDAcc = 0.0;
-                    for (int di = 0; di < headDim; di++)
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        double xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        double dOutVal = dOut[btInner + flatD];
-
-                        // D skip: y += D[h]*x.
-                        dX[btInner + flatD] += D[hi] * dOutVal;
-                        dDAcc += xv * dOutVal;
-
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int dbOff = t * sd;
                         for (int n = 0; n < sd; n++)
                         {
-                            double hCur = hTraj[stOff + hsBase + n];
-                            double hPrev = t > 0 ? hTraj[spOff + hsBase + n] : 0.0;
-                            // Output: dh += C*dOut ; dC += h_t*dOut.
-                            dh[hsBase + n] += C[btState + n] * dOutVal;
-                            dC[btState + n] += hCur * dOutVal;
-                            double dhVal = dh[hsBase + n];
-
-                            // h_t = aBar*hPrev + dt*B*x.
-                            double dAbar = dhVal * hPrev;
-                            dDeltaAcc += dAbar * aBar * a;            // A-path: dAbar*Abar*A
-                            dALogAcc += dAbar * aBar * (dt * a);      // aLog: dAbar*Abar*(dt*A)
-                            dDeltaAcc += dhVal * B[btState + n] * xv; // B*x path
-                            dB[btState + n] += dhVal * dt * xv;
-                            dX[btInner + flatD] += dhVal * dt * B[btState + n];
-
-                            // Propagate to previous step.
-                            dh[hsBase + n] = dhVal * aBar;
+                            dB[btState + n] += dBpart[dbOff + n];
+                            dC[btState + n] += dCpart[dbOff + n];
                         }
                     }
-                    dDelta[btHead + hi] += dDeltaAcc;
-                    dALog[hi] += dALogAcc;
-                    dD[hi] += dDAcc;
+                    Array.Clear(dBpart, 0, seqLen * sd);
+                    Array.Clear(dCpart, 0, seqLen * sd);
                 }
-            }
+            });
         }
     }
 
@@ -235,38 +270,46 @@ public partial class CpuEngine
         var ops = MathHelper.GetNumericOperations<T>();
         var negA = new T[numHeads];
         for (int hi = 0; hi < numHeads; hi++) negA[hi] = ops.Negate(ops.Exp(aLog[hi]));
-        var h = new T[innerDim * sd];
+        int hd = headDim * sd;
+        // Head-parallel with b outer; head-local state. See Mamba2ForwardDouble.
         for (int b = 0; b < batch; b++)
         {
-            for (int i = 0; i < h.Length; i++) h[i] = ops.Zero;
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(numHeads, MambaDiGrain, (hStart, hCount) =>
             {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                for (int hi = 0; hi < numHeads; hi++)
+                var hHead = new T[hd];
+                int hEnd = hStart + hCount;
+                for (int hi = hStart; hi < hEnd; hi++)
                 {
-                    T dt = delta[btHead + hi];
-                    T aBar = ops.Exp(ops.Multiply(dt, negA[hi]));
+                    for (int i = 0; i < hd; i++) hHead[i] = ops.Zero;
+                    T aHi = negA[hi];
                     T dv = D[hi];
                     int dimStart = hi * headDim;
-                    for (int di = 0; di < headDim; di++)
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        T xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        T y = ops.Zero;
-                        for (int n = 0; n < sd; n++)
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        T dt = delta[btHead + hi];
+                        T aBar = ops.Exp(ops.Multiply(dt, aHi));
+                        for (int di = 0; di < headDim; di++)
                         {
-                            T hNew = ops.Add(ops.Multiply(aBar, h[hsBase + n]),
-                                ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
-                            h[hsBase + n] = hNew;
-                            y = ops.Add(y, ops.Multiply(C[btState + n], hNew));
+                            int flatD = dimStart + di;
+                            T xv = X[btInner + flatD];
+                            int hsBase = di * sd;
+                            T y = ops.Zero;
+                            for (int n = 0; n < sd; n++)
+                            {
+                                T hNew = ops.Add(ops.Multiply(aBar, hHead[hsBase + n]),
+                                    ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
+                                hHead[hsBase + n] = hNew;
+                                y = ops.Add(y, ops.Multiply(C[btState + n], hNew));
+                            }
+                            outp[btInner + flatD] = ops.Add(y, ops.Multiply(dv, xv));
                         }
-                        outp[btInner + flatD] = ops.Add(y, ops.Multiply(dv, xv));
                     }
                 }
-            }
+            });
         }
     }
 
@@ -276,82 +319,105 @@ public partial class CpuEngine
         int batch, int seqLen, int innerDim, int numHeads, int headDim, int sd)
     {
         var ops = MathHelper.GetNumericOperations<T>();
-        int isd = innerDim * sd;
         var negA = new T[numHeads];
         for (int hi = 0; hi < numHeads; hi++) negA[hi] = ops.Negate(ops.Exp(aLog[hi]));
-        var hTraj = new T[seqLen * isd];
-        var h = new T[isd];
-        var dh = new T[isd];
+        int hd = headDim * sd;
 
+        // Head-parallel with b outer; head-local state/trajectory; per-chunk dB/dC partials (cross-head
+        // reduction) under a coarse lock. See Mamba2BackwardDouble.
+        var reduceLock = new object();
         for (int b = 0; b < batch; b++)
         {
-            for (int i = 0; i < isd; i++) h[i] = ops.Zero;
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(numHeads, MambaDiGrain, (hStart, hCount) =>
             {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                for (int hi = 0; hi < numHeads; hi++)
+                var hHead = new T[hd];
+                var hTrajHead = new T[seqLen * hd];
+                var dhHead = new T[hd];
+                var dBpart = new T[seqLen * sd];
+                var dCpart = new T[seqLen * sd];
+                for (int i = 0; i < seqLen * sd; i++) { dBpart[i] = ops.Zero; dCpart[i] = ops.Zero; }
+                int hEnd = hStart + hCount;
+                for (int hi = hStart; hi < hEnd; hi++)
                 {
-                    T dt = delta[btHead + hi];
-                    T aBar = ops.Exp(ops.Multiply(dt, negA[hi]));
+                    T aHi = negA[hi];
                     int dimStart = hi * headDim;
-                    for (int di = 0; di < headDim; di++)
+
+                    for (int i = 0; i < hd; i++) hHead[i] = ops.Zero;
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        T xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        for (int n = 0; n < sd; n++)
-                            h[hsBase + n] = ops.Add(ops.Multiply(aBar, h[hsBase + n]),
-                                ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        T dt = delta[btHead + hi];
+                        T aBar = ops.Exp(ops.Multiply(dt, aHi));
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            int flatD = dimStart + di;
+                            T xv = X[btInner + flatD];
+                            int hsBase = di * sd;
+                            for (int n = 0; n < sd; n++)
+                                hHead[hsBase + n] = ops.Add(ops.Multiply(aBar, hHead[hsBase + n]),
+                                    ops.Multiply(dt, ops.Multiply(B[btState + n], xv)));
+                        }
+                        Array.Copy(hHead, 0, hTrajHead, t * hd, hd);
+                    }
+
+                    for (int i = 0; i < hd; i++) dhHead[i] = ops.Zero;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int btInner = (bIdx * seqLen + t) * innerDim;
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int btHead = (bIdx * seqLen + t) * numHeads;
+                        int stOff = t * hd, spOff = (t - 1) * hd, dbOff = t * sd;
+                        T dt = delta[btHead + hi];
+                        T a = aHi;
+                        T aBar = ops.Exp(ops.Multiply(dt, a));
+                        T dDeltaAcc = ops.Zero, dALogAcc = ops.Zero, dDAcc = ops.Zero;
+                        for (int di = 0; di < headDim; di++)
+                        {
+                            int flatD = dimStart + di;
+                            T xv = X[btInner + flatD];
+                            int hsBase = di * sd;
+                            T dOutVal = dOut[btInner + flatD];
+                            dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(D[hi], dOutVal));
+                            dDAcc = ops.Add(dDAcc, ops.Multiply(xv, dOutVal));
+                            for (int n = 0; n < sd; n++)
+                            {
+                                T hCur = hTrajHead[stOff + hsBase + n];
+                                T hPrev = t > 0 ? hTrajHead[spOff + hsBase + n] : ops.Zero;
+                                dhHead[hsBase + n] = ops.Add(dhHead[hsBase + n], ops.Multiply(C[btState + n], dOutVal));
+                                dCpart[dbOff + n] = ops.Add(dCpart[dbOff + n], ops.Multiply(hCur, dOutVal));
+                                T dhVal = dhHead[hsBase + n];
+                                T dAbar = ops.Multiply(dhVal, hPrev);
+                                dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(ops.Multiply(dAbar, aBar), a));
+                                dALogAcc = ops.Add(dALogAcc, ops.Multiply(ops.Multiply(dAbar, aBar), ops.Multiply(dt, a)));
+                                dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(dhVal, ops.Multiply(B[btState + n], xv)));
+                                dBpart[dbOff + n] = ops.Add(dBpart[dbOff + n], ops.Multiply(dhVal, ops.Multiply(dt, xv)));
+                                dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(dhVal, ops.Multiply(dt, B[btState + n])));
+                                dhHead[hsBase + n] = ops.Multiply(dhVal, aBar);
+                            }
+                        }
+                        dDelta[btHead + hi] = ops.Add(dDelta[btHead + hi], dDeltaAcc);
+                        dALog[hi] = ops.Add(dALog[hi], dALogAcc);
+                        dD[hi] = ops.Add(dD[hi], dDAcc);
                     }
                 }
-                Array.Copy(h, 0, hTraj, t * isd, isd);
-            }
 
-            for (int i = 0; i < isd; i++) dh[i] = ops.Zero;
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int btInner = (b * seqLen + t) * innerDim;
-                int btState = (b * seqLen + t) * sd;
-                int btHead = (b * seqLen + t) * numHeads;
-                int stOff = t * isd, spOff = (t - 1) * isd;
-                for (int hi = 0; hi < numHeads; hi++)
+                lock (reduceLock)
                 {
-                    T dt = delta[btHead + hi];
-                    T a = negA[hi];
-                    T aBar = ops.Exp(ops.Multiply(dt, a));
-                    int dimStart = hi * headDim;
-                    T dDeltaAcc = ops.Zero, dALogAcc = ops.Zero, dDAcc = ops.Zero;
-                    for (int di = 0; di < headDim; di++)
+                    for (int t = 0; t < seqLen; t++)
                     {
-                        int flatD = dimStart + di;
-                        T xv = X[btInner + flatD];
-                        int hsBase = flatD * sd;
-                        T dOutVal = dOut[btInner + flatD];
-                        dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(D[hi], dOutVal));
-                        dDAcc = ops.Add(dDAcc, ops.Multiply(xv, dOutVal));
+                        int btState = (bIdx * seqLen + t) * sd;
+                        int dbOff = t * sd;
                         for (int n = 0; n < sd; n++)
                         {
-                            T hCur = hTraj[stOff + hsBase + n];
-                            T hPrev = t > 0 ? hTraj[spOff + hsBase + n] : ops.Zero;
-                            dh[hsBase + n] = ops.Add(dh[hsBase + n], ops.Multiply(C[btState + n], dOutVal));
-                            dC[btState + n] = ops.Add(dC[btState + n], ops.Multiply(hCur, dOutVal));
-                            T dhVal = dh[hsBase + n];
-                            T dAbar = ops.Multiply(dhVal, hPrev);
-                            dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(ops.Multiply(dAbar, aBar), a));
-                            dALogAcc = ops.Add(dALogAcc, ops.Multiply(ops.Multiply(dAbar, aBar), ops.Multiply(dt, a)));
-                            dDeltaAcc = ops.Add(dDeltaAcc, ops.Multiply(dhVal, ops.Multiply(B[btState + n], xv)));
-                            dB[btState + n] = ops.Add(dB[btState + n], ops.Multiply(dhVal, ops.Multiply(dt, xv)));
-                            dX[btInner + flatD] = ops.Add(dX[btInner + flatD], ops.Multiply(dhVal, ops.Multiply(dt, B[btState + n])));
-                            dh[hsBase + n] = ops.Multiply(dhVal, aBar);
+                            dB[btState + n] = ops.Add(dB[btState + n], dBpart[dbOff + n]);
+                            dC[btState + n] = ops.Add(dC[btState + n], dCpart[dbOff + n]);
                         }
                     }
-                    dDelta[btHead + hi] = ops.Add(dDelta[btHead + hi], dDeltaAcc);
-                    dALog[hi] = ops.Add(dALog[hi], dALogAcc);
-                    dD[hi] = ops.Add(dD[hi], dDAcc);
                 }
-            }
+            });
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
@@ -84,25 +84,38 @@ public partial class CpuEngine
         var baseDecay = new double[recDim];
         for (int c = 0; c < recDim; c++) baseDecay[c] = SigD(-decay[c]);
 
-        var h = new double[recDim];
+        // Each recurrent channel c evolves an independent scalar state, so c is parallelizable; keep b
+        // outer (the per-channel gradients dBase/dDecay accumulate across batch in the backward). Local
+        // scalar state + disjoint output writes — fully lock-free.
         for (int b = 0; b < batch; b++)
         {
-            Array.Clear(h, 0, recDim);
-            for (int t = 0; t < seqLen; t++)
+            int bb = b;
+            CpuParallelSettings.ParallelForChunks(recDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    double a = R[off + c] * baseDecay[c];
-                    double oneMinus = 1.0 - a * a;
-                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
-                    double hv = a * h[c] + s * (I[off + c] * V[off + c]);
-                    h[c] = hv;
-                    outp[off + c] = hv;
+                    double hc = 0.0;
+                    double bdc = baseDecay[c];
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        double a = R[off + c] * bdc;
+                        double oneMinus = 1.0 - a * a;
+                        double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                        hc = a * hc + s * (I[off + c] * V[off + c]);
+                        outp[off + c] = hc;
+                    }
                 }
-            }
+            });
         }
     }
+
+    /// <summary>
+    /// Minimum recurrent channels per parallel chunk for the channel-parallel scan kernels (RG-LRU,
+    /// RWKV-4). Each channel owns a private scalar state and writes disjoint output/gradient slots.
+    /// </summary>
+    private const int RgLruChannelGrain = 8;
 
     private static void RgLruBackwardDouble(
         double[] dOut, double[] V, double[] R, double[] I, double[] decay,
@@ -112,64 +125,66 @@ public partial class CpuEngine
         var baseDecay = new double[recDim];
         for (int c = 0; c < recDim; c++) baseDecay[c] = SigD(-decay[c]);
 
-        var hTraj = new double[seqLen * recDim];
-        var h = new double[recDim];
-        var dH = new double[recDim];
-        var dBase = new double[recDim];
+        var dBase = new double[recDim]; // [recDim], one slot per channel — disjoint across c-threads
 
+        // Parallelize over channel c (independent scalar recurrence); keep b outer so dBase accumulates
+        // across batch serially. Each c owns a private scalar state + a private seqLen trajectory.
         for (int b = 0; b < batch; b++)
         {
-            // Forward recompute, saving the post-update state trajectory.
-            Array.Clear(h, 0, recDim);
-            for (int t = 0; t < seqLen; t++)
+            int bb = b;
+            CpuParallelSettings.ParallelForChunks(recDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
-                {
-                    double a = R[off + c] * baseDecay[c];
-                    double oneMinus = 1.0 - a * a;
-                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
-                    h[c] = a * h[c] + s * (I[off + c] * V[off + c]);
-                    hTraj[t * recDim + c] = h[c];
-                }
-            }
-
-            // Reverse sweep. dH carries the adjoint of h_t from t+1 (and y_t = h_t).
-            Array.Clear(dH, 0, recDim);
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
+                var hTrajC = new double[seqLen]; // this channel's post-update state over time
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
                     double bd = baseDecay[c];
-                    double a = R[off + c] * bd;
-                    double oneMinus = 1.0 - a * a;
-                    double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
-                    double iv = I[off + c] * V[off + c];
-                    double hPrev = t > 0 ? hTraj[(t - 1) * recDim + c] : 0.0;
 
-                    // y_t = h_t.
-                    double dh = dH[c] + dOut[off + c];
+                    // Forward recompute for this channel, saving its post-update state trajectory.
+                    double hc = 0.0;
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        double a = R[off + c] * bd;
+                        double oneMinus = 1.0 - a * a;
+                        double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                        hc = a * hc + s * (I[off + c] * V[off + c]);
+                        hTrajC[t] = hc;
+                    }
 
-                    // h_t = a*hPrev + s*(i*v).
-                    // d(g=i*v) = dh*s ; d(s) = dh*iv ; d(a) = dh*hPrev + ds/da contribution.
-                    double dG = dh * s;
-                    dI[off + c] += dG * V[off + c];
-                    dV[off + c] += dG * I[off + c];
+                    // Reverse sweep. dHc carries the adjoint of h_t from t+1 (and y_t = h_t).
+                    double dHc = 0.0;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        double a = R[off + c] * bd;
+                        double oneMinus = 1.0 - a * a;
+                        double s = oneMinus > 0.0 ? Math.Sqrt(oneMinus) : 0.0;
+                        double iv = I[off + c] * V[off + c];
+                        double hPrev = t > 0 ? hTrajC[t - 1] : 0.0;
 
-                    double dS = dh * iv;
-                    // s = sqrt(1-a^2) (when positive): ds/da = -a/s.
-                    double dA = dh * hPrev;
-                    if (s > 1e-12) dA += dS * (-a / s);
+                        // y_t = h_t.
+                        double dh = dHc + dOut[off + c];
 
-                    // a = r * base.
-                    dR[off + c] += dA * bd;
-                    dBase[c] += dA * R[off + c];
+                        // h_t = a*hPrev + s*(i*v).
+                        double dG = dh * s;
+                        dI[off + c] += dG * V[off + c];
+                        dV[off + c] += dG * I[off + c];
 
-                    // Adjoint to previous step: d(h_{t-1}) = dh * a.
-                    dH[c] = dh * a;
+                        double dS = dh * iv;
+                        // s = sqrt(1-a^2) (when positive): ds/da = -a/s.
+                        double dA = dh * hPrev;
+                        if (s > 1e-12) dA += dS * (-a / s);
+
+                        // a = r * base.
+                        dR[off + c] += dA * bd;
+                        dBase[c] += dA * R[off + c];
+
+                        // Adjoint to previous step: d(h_{t-1}) = dh * a.
+                        dHc = dh * a;
+                    }
                 }
-            }
+            });
         }
 
         // base = sigmoid(-decay): d(base)/d(decay) = -base*(1-base).
@@ -186,23 +201,28 @@ public partial class CpuEngine
         var baseDecay = new T[recDim];
         for (int c = 0; c < recDim; c++) baseDecay[c] = SigGeneric(ops, ops.Negate(decay[c]));
 
-        var h = new T[recDim];
+        // Channel-parallel with b outer; per-channel local scalar state. See RgLruForwardDouble.
         for (int b = 0; b < batch; b++)
         {
-            for (int c = 0; c < recDim; c++) h[c] = zero;
-            for (int t = 0; t < seqLen; t++)
+            int bb = b;
+            CpuParallelSettings.ParallelForChunks(recDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    T a = ops.Multiply(R[off + c], baseDecay[c]);
-                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
-                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
-                    T hv = ops.Add(ops.Multiply(a, h[c]), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
-                    h[c] = hv;
-                    outp[off + c] = hv;
+                    T hc = zero;
+                    T bdc = baseDecay[c];
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        T a = ops.Multiply(R[off + c], bdc);
+                        T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                        T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                        hc = ops.Add(ops.Multiply(a, hc), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
+                        outp[off + c] = hc;
+                    }
                 }
-            }
+            });
         }
     }
 
@@ -216,57 +236,59 @@ public partial class CpuEngine
         var baseDecay = new T[recDim];
         for (int c = 0; c < recDim; c++) baseDecay[c] = SigGeneric(ops, ops.Negate(decay[c]));
 
-        var hTraj = new T[seqLen * recDim];
-        var h = new T[recDim];
-        var dH = new T[recDim];
         var dBase = new T[recDim];
         for (int c = 0; c < recDim; c++) dBase[c] = zero;
 
+        // Channel-parallel with b outer; per-channel local scalar state + private trajectory. See double.
         for (int b = 0; b < batch; b++)
         {
-            for (int c = 0; c < recDim; c++) h[c] = zero;
-            for (int t = 0; t < seqLen; t++)
+            int bb = b;
+            CpuParallelSettings.ParallelForChunks(recDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
-                {
-                    T a = ops.Multiply(R[off + c], baseDecay[c]);
-                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
-                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
-                    h[c] = ops.Add(ops.Multiply(a, h[c]), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
-                    hTraj[t * recDim + c] = h[c];
-                }
-            }
-
-            for (int c = 0; c < recDim; c++) dH[c] = zero;
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int off = (b * seqLen + t) * recDim;
-                for (int c = 0; c < recDim; c++)
+                var hTrajC = new T[seqLen];
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
                     T bd = baseDecay[c];
-                    T a = ops.Multiply(R[off + c], bd);
-                    T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
-                    T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
-                    T iv = ops.Multiply(I[off + c], V[off + c]);
-                    T hPrev = t > 0 ? hTraj[(t - 1) * recDim + c] : zero;
 
-                    T dh = ops.Add(dH[c], dOut[off + c]);
-                    T dG = ops.Multiply(dh, s);
-                    dI[off + c] = ops.Add(dI[off + c], ops.Multiply(dG, V[off + c]));
-                    dV[off + c] = ops.Add(dV[off + c], ops.Multiply(dG, I[off + c]));
+                    T hc = zero;
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        T a = ops.Multiply(R[off + c], bd);
+                        T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                        T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                        hc = ops.Add(ops.Multiply(a, hc), ops.Multiply(s, ops.Multiply(I[off + c], V[off + c])));
+                        hTrajC[t] = hc;
+                    }
 
-                    T dS = ops.Multiply(dh, iv);
-                    T dA = ops.Multiply(dh, hPrev);
-                    if (ops.GreaterThan(s, tiny))
-                        dA = ops.Add(dA, ops.Multiply(dS, ops.Divide(ops.Negate(a), s)));
+                    T dHc = zero;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int off = (bb * seqLen + t) * recDim;
+                        T a = ops.Multiply(R[off + c], bd);
+                        T oneMinus = ops.Subtract(one, ops.Multiply(a, a));
+                        T s = ops.GreaterThan(oneMinus, zero) ? ops.Sqrt(oneMinus) : zero;
+                        T iv = ops.Multiply(I[off + c], V[off + c]);
+                        T hPrev = t > 0 ? hTrajC[t - 1] : zero;
 
-                    dR[off + c] = ops.Add(dR[off + c], ops.Multiply(dA, bd));
-                    dBase[c] = ops.Add(dBase[c], ops.Multiply(dA, R[off + c]));
+                        T dh = ops.Add(dHc, dOut[off + c]);
+                        T dG = ops.Multiply(dh, s);
+                        dI[off + c] = ops.Add(dI[off + c], ops.Multiply(dG, V[off + c]));
+                        dV[off + c] = ops.Add(dV[off + c], ops.Multiply(dG, I[off + c]));
 
-                    dH[c] = ops.Multiply(dh, a);
+                        T dS = ops.Multiply(dh, iv);
+                        T dA = ops.Multiply(dh, hPrev);
+                        if (ops.GreaterThan(s, tiny))
+                            dA = ops.Add(dA, ops.Multiply(dS, ops.Divide(ops.Negate(a), s)));
+
+                        dR[off + c] = ops.Add(dR[off + c], ops.Multiply(dA, bd));
+                        dBase[c] = ops.Add(dBase[c], ops.Multiply(dA, R[off + c]));
+
+                        dHc = ops.Multiply(dh, a);
+                    }
                 }
-            }
+            });
         }
 
         for (int c = 0; c < recDim; c++)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
@@ -101,41 +101,44 @@ public partial class CpuEngine
         for (int c = 0; c < modelDim; c++) w[c] = -Math.Exp(timeDecay[c]);
         // u = timeFirst (used directly).
 
-        var aa = new double[modelDim];
-        var bb = new double[modelDim];
-        var pp = new double[modelDim];
+        // Each channel c has an independent (aa, bb, pp) running state; parallelize over c with b kept
+        // outer (per-channel dTimeDecay/dTimeFirst accumulate across batch in the backward). Local scalar
+        // state + disjoint output writes — fully lock-free.
         for (int b = 0; b < batch; b++)
         {
-            Array.Clear(aa, 0, modelDim);
-            Array.Clear(bb, 0, modelDim);
-            for (int c = 0; c < modelDim; c++) pp[c] = double.NegativeInfinity;
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(modelDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int baseOff = (b * seqLen + t) * modelDim;
-                for (int c = 0; c < modelDim; c++)
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    double k = K[baseOff + c];
-                    double v = V[baseOff + c];
-                    double u = timeFirst[c];
+                    double aac = 0.0, bbc = 0.0, ppc = double.NegativeInfinity;
+                    double wc = w[c], u = timeFirst[c];
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        double k = K[baseOff + c];
+                        double v = V[baseOff + c];
 
-                    // Output for token t (current key boosted by the time-first bonus u).
-                    double ww = u + k;
-                    double q = Math.Max(pp[c], ww);
-                    double e1 = Math.Exp(pp[c] - q);
-                    double e2 = Math.Exp(ww - q);
-                    double wkv = (e1 * aa[c] + e2 * v) / (e1 * bb[c] + e2);
-                    outp[baseOff + c] = Sig(R[baseOff + c]) * wkv;
+                        // Output for token t (current key boosted by the time-first bonus u).
+                        double ww = u + k;
+                        double q = Math.Max(ppc, ww);
+                        double e1 = Math.Exp(ppc - q);
+                        double e2 = Math.Exp(ww - q);
+                        double wkv = (e1 * aac + e2 * v) / (e1 * bbc + e2);
+                        outp[baseOff + c] = Sig(R[baseOff + c]) * wkv;
 
-                    // State update with the static decay w (no bonus on the carried state).
-                    double ww2 = pp[c] + w[c];
-                    double q2 = Math.Max(ww2, k);
-                    double e1b = Math.Exp(ww2 - q2);
-                    double e2b = Math.Exp(k - q2);
-                    aa[c] = e1b * aa[c] + e2b * v;
-                    bb[c] = e1b * bb[c] + e2b;
-                    pp[c] = q2;
+                        // State update with the static decay w (no bonus on the carried state).
+                        double ww2 = ppc + wc;
+                        double q2 = Math.Max(ww2, k);
+                        double e1b = Math.Exp(ww2 - q2);
+                        double e2b = Math.Exp(k - q2);
+                        aac = e1b * aac + e2b * v;
+                        bbc = e1b * bbc + e2b;
+                        ppc = q2;
+                    }
                 }
-            }
+            });
         }
     }
 
@@ -147,107 +150,102 @@ public partial class CpuEngine
         var w = new double[modelDim];
         for (int c = 0; c < modelDim; c++) w[c] = -Math.Exp(timeDecay[c]);
 
-        // Post-update state trajectories for every t (reused per batch).
-        var aaTraj = new double[seqLen * modelDim];
-        var bbTraj = new double[seqLen * modelDim];
-        var ppTraj = new double[seqLen * modelDim];
-        var aa = new double[modelDim];
-        var bb = new double[modelDim];
-        var pp = new double[modelDim];
-        var dAa = new double[modelDim];
-        var dBb = new double[modelDim];
         // dw accumulates the grad of w[c] = -exp(timeDecay[c]); converted to dTimeDecay at the end.
-        var dw = new double[modelDim];
+        var dw = new double[modelDim]; // one slot per channel — disjoint across c-threads
 
+        // Parallelize over channel c (independent (aa,bb,pp) recurrence); keep b outer so dw/dTimeFirst
+        // accumulate across batch serially. Each c owns private scalar state + private seqLen trajectories.
         for (int b = 0; b < batch; b++)
         {
-            // Forward recompute, saving the post-update state trajectory.
-            Array.Clear(aa, 0, modelDim);
-            Array.Clear(bb, 0, modelDim);
-            for (int c = 0; c < modelDim; c++) pp[c] = double.NegativeInfinity;
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(modelDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int baseOff = (b * seqLen + t) * modelDim;
-                int tOff = t * modelDim;
-                for (int c = 0; c < modelDim; c++)
+                var aaTrajC = new double[seqLen];
+                var bbTrajC = new double[seqLen];
+                var ppTrajC = new double[seqLen];
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    double k = K[baseOff + c];
-                    double v = V[baseOff + c];
-                    double ww2 = pp[c] + w[c];
-                    double q2 = Math.Max(ww2, k);
-                    double e1b = Math.Exp(ww2 - q2);
-                    double e2b = Math.Exp(k - q2);
-                    aa[c] = e1b * aa[c] + e2b * v;
-                    bb[c] = e1b * bb[c] + e2b;
-                    pp[c] = q2;
-                    aaTraj[tOff + c] = aa[c];
-                    bbTraj[tOff + c] = bb[c];
-                    ppTraj[tOff + c] = pp[c];
+                    double wc = w[c], u = timeFirst[c];
+
+                    // Forward recompute, saving this channel's post-update state trajectory.
+                    double aac = 0.0, bbc = 0.0, ppc = double.NegativeInfinity;
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        double k = K[baseOff + c];
+                        double v = V[baseOff + c];
+                        double ww2 = ppc + wc;
+                        double q2 = Math.Max(ww2, k);
+                        double e1b = Math.Exp(ww2 - q2);
+                        double e2b = Math.Exp(k - q2);
+                        aac = e1b * aac + e2b * v;
+                        bbc = e1b * bbc + e2b;
+                        ppc = q2;
+                        aaTrajC[t] = aac;
+                        bbTrajC[t] = bbc;
+                        ppTrajC[t] = ppc;
+                    }
+
+                    // Reverse sweep. dAac/dBbc carry the adjoint of the post-update state from t+1.
+                    double dAac = 0.0, dBbc = 0.0;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        double k = K[baseOff + c];
+                        double v = V[baseOff + c];
+
+                        // Pre-update state entering step t (post-update state of t-1).
+                        double aaPrev = t > 0 ? aaTrajC[t - 1] : 0.0;
+                        double bbPrev = t > 0 ? bbTrajC[t - 1] : 0.0;
+                        double ppPrev = t > 0 ? ppTrajC[t - 1] : double.NegativeInfinity;
+                        double ppCur = ppTrajC[t];
+
+                        // Output recompute (q, pp treated as constants).
+                        double ww = u + k;
+                        double q = Math.Max(ppPrev, ww);
+                        double e1 = Math.Exp(ppPrev - q);
+                        double e2 = Math.Exp(ww - q);
+                        double den = e1 * bbPrev + e2;
+                        double num = e1 * aaPrev + e2 * v;
+                        double wkv = num / den;
+                        double sr = Sig(R[baseOff + c]);
+
+                        // Output backward: out = sr * wkv.
+                        double dO = dOut[baseOff + c];
+                        dR[baseOff + c] += dO * wkv * sr * (1.0 - sr);
+                        double gWkv = dO * sr;
+                        double dNum = gWkv / den;
+                        double dDen = -gWkv * wkv / den;
+                        // num = e1*aaPrev + e2*v ; den = e1*bbPrev + e2 (e1 constant in pp).
+                        double dAaFromOut = dNum * e1;
+                        double dBbFromOut = dDen * e1;
+                        dV[baseOff + c] += dNum * e2;
+                        double dE2 = dNum * v + dDen;          // e2 = exp(u + k - q)
+                        dK[baseOff + c] += dE2 * e2;            // de2/dk = e2
+                        dTimeFirst[c] += dE2 * e2;              // de2/du = e2
+
+                        // State-update recompute (ww2, q2=ppCur constants).
+                        double ww2 = ppPrev + wc;
+                        double e1b = Math.Exp(ww2 - ppCur);
+                        double e2b = Math.Exp(k - ppCur);
+
+                        // State-update backward: aa_t = e1b*aaPrev + e2b*v ; bb_t = e1b*bbPrev + e2b.
+                        double dAt = dAac;
+                        double dBt = dBbc;
+                        double dE1b = dAt * aaPrev + dBt * bbPrev;   // e1b = exp(ppPrev + w - ppCur)
+                        dw[c] += dE1b * e1b;                          // de1b/dw = e1b
+                        dV[baseOff + c] += dAt * e2b;
+                        double dE2b = dAt * v + dBt;                 // e2b = exp(k - ppCur)
+                        dK[baseOff + c] += dE2b * e2b;                // de2b/dk = e2b
+
+                        // Adjoint flowing to the pre-update state (for step t-1): from the update
+                        // (e1b factor) and from this step's output (e1 factor).
+                        dAac = dAt * e1b + dAaFromOut;
+                        dBbc = dBt * e1b + dBbFromOut;
+                    }
                 }
-            }
-
-            // Reverse sweep. dAa/dBb carry the adjoint of the post-update state from t+1.
-            Array.Clear(dAa, 0, modelDim);
-            Array.Clear(dBb, 0, modelDim);
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int baseOff = (b * seqLen + t) * modelDim;
-                for (int c = 0; c < modelDim; c++)
-                {
-                    double k = K[baseOff + c];
-                    double v = V[baseOff + c];
-                    double u = timeFirst[c];
-
-                    // Pre-update state entering step t (post-update state of t-1).
-                    double aaPrev = t > 0 ? aaTraj[(t - 1) * modelDim + c] : 0.0;
-                    double bbPrev = t > 0 ? bbTraj[(t - 1) * modelDim + c] : 0.0;
-                    double ppPrev = t > 0 ? ppTraj[(t - 1) * modelDim + c] : double.NegativeInfinity;
-                    double ppCur = ppTraj[t * modelDim + c];
-
-                    // Output recompute (q, pp treated as constants).
-                    double ww = u + k;
-                    double q = Math.Max(ppPrev, ww);
-                    double e1 = Math.Exp(ppPrev - q);
-                    double e2 = Math.Exp(ww - q);
-                    double den = e1 * bbPrev + e2;
-                    double num = e1 * aaPrev + e2 * v;
-                    double wkv = num / den;
-                    double sr = Sig(R[baseOff + c]);
-
-                    // Output backward: out = sr * wkv.
-                    double dO = dOut[baseOff + c];
-                    dR[baseOff + c] += dO * wkv * sr * (1.0 - sr);
-                    double gWkv = dO * sr;
-                    double dNum = gWkv / den;
-                    double dDen = -gWkv * wkv / den;
-                    // num = e1*aaPrev + e2*v ; den = e1*bbPrev + e2 (e1 constant in pp).
-                    double dAaFromOut = dNum * e1;
-                    double dBbFromOut = dDen * e1;
-                    dV[baseOff + c] += dNum * e2;
-                    double dE2 = dNum * v + dDen;          // e2 = exp(u + k - q)
-                    dK[baseOff + c] += dE2 * e2;            // de2/dk = e2
-                    dTimeFirst[c] += dE2 * e2;              // de2/du = e2
-
-                    // State-update recompute (ww2, q2=ppCur constants).
-                    double ww2 = ppPrev + w[c];
-                    double e1b = Math.Exp(ww2 - ppCur);
-                    double e2b = Math.Exp(k - ppCur);
-
-                    // State-update backward: aa_t = e1b*aaPrev + e2b*v ; bb_t = e1b*bbPrev + e2b.
-                    double dAt = dAa[c];
-                    double dBt = dBb[c];
-                    double dE1b = dAt * aaPrev + dBt * bbPrev;   // e1b = exp(ppPrev + w - ppCur)
-                    dw[c] += dE1b * e1b;                          // de1b/dw = e1b
-                    dV[baseOff + c] += dAt * e2b;
-                    double dE2b = dAt * v + dBt;                 // e2b = exp(k - ppCur)
-                    dK[baseOff + c] += dE2b * e2b;                // de2b/dk = e2b
-
-                    // Adjoint flowing to the pre-update state (for step t-1): from the update
-                    // (e1b factor) and from this step's output (e1 factor).
-                    dAa[c] = dAt * e1b + dAaFromOut;
-                    dBb[c] = dBt * e1b + dBbFromOut;
-                }
-            }
+            });
         }
 
         // Chain w = -exp(timeDecay) -> dTimeDecay = dw * dw/dTimeDecay = dw * (-exp(timeDecay)) = dw * w.
@@ -265,37 +263,41 @@ public partial class CpuEngine
         for (int c = 0; c < modelDim; c++) w[c] = ops.Negate(ops.Exp(timeDecay[c]));
         T negInf = ops.FromDouble(-1e38);
 
-        var aa = new T[modelDim];
-        var bb = new T[modelDim];
-        var pp = new T[modelDim];
+        // Channel-parallel with b outer; per-channel local scalar state. See Rwkv4ForwardDouble.
         for (int b = 0; b < batch; b++)
         {
-            for (int c = 0; c < modelDim; c++) { aa[c] = ops.Zero; bb[c] = ops.Zero; pp[c] = negInf; }
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(modelDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int baseOff = (b * seqLen + t) * modelDim;
-                for (int c = 0; c < modelDim; c++)
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    T k = K[baseOff + c];
-                    T v = V[baseOff + c];
-                    T ww = ops.Add(timeFirst[c], k);
-                    T q = MaxT(ops, pp[c], ww);
-                    T e1 = ops.Exp(ops.Subtract(pp[c], q));
-                    T e2 = ops.Exp(ops.Subtract(ww, q));
-                    T wkv = ops.Divide(
-                        ops.Add(ops.Multiply(e1, aa[c]), ops.Multiply(e2, v)),
-                        ops.Add(ops.Multiply(e1, bb[c]), e2));
-                    outp[baseOff + c] = ops.Multiply(SigGeneric(ops, R[baseOff + c]), wkv);
+                    T wc = w[c], u = timeFirst[c];
+                    T aac = ops.Zero, bbc = ops.Zero, ppc = negInf;
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        T k = K[baseOff + c];
+                        T v = V[baseOff + c];
+                        T ww = ops.Add(u, k);
+                        T q = MaxT(ops, ppc, ww);
+                        T e1 = ops.Exp(ops.Subtract(ppc, q));
+                        T e2 = ops.Exp(ops.Subtract(ww, q));
+                        T wkv = ops.Divide(
+                            ops.Add(ops.Multiply(e1, aac), ops.Multiply(e2, v)),
+                            ops.Add(ops.Multiply(e1, bbc), e2));
+                        outp[baseOff + c] = ops.Multiply(SigGeneric(ops, R[baseOff + c]), wkv);
 
-                    T ww2 = ops.Add(pp[c], w[c]);
-                    T q2 = MaxT(ops, ww2, k);
-                    T e1b = ops.Exp(ops.Subtract(ww2, q2));
-                    T e2b = ops.Exp(ops.Subtract(k, q2));
-                    aa[c] = ops.Add(ops.Multiply(e1b, aa[c]), ops.Multiply(e2b, v));
-                    bb[c] = ops.Add(ops.Multiply(e1b, bb[c]), e2b);
-                    pp[c] = q2;
+                        T ww2 = ops.Add(ppc, wc);
+                        T q2 = MaxT(ops, ww2, k);
+                        T e1b = ops.Exp(ops.Subtract(ww2, q2));
+                        T e2b = ops.Exp(ops.Subtract(k, q2));
+                        aac = ops.Add(ops.Multiply(e1b, aac), ops.Multiply(e2b, v));
+                        bbc = ops.Add(ops.Multiply(e1b, bbc), e2b);
+                        ppc = q2;
+                    }
                 }
-            }
+            });
         }
     }
 
@@ -310,91 +312,90 @@ public partial class CpuEngine
         for (int c = 0; c < modelDim; c++) w[c] = ops.Negate(ops.Exp(timeDecay[c]));
         T negInf = ops.FromDouble(-1e38);
 
-        var aaTraj = new T[seqLen * modelDim];
-        var bbTraj = new T[seqLen * modelDim];
-        var ppTraj = new T[seqLen * modelDim];
-        var aa = new T[modelDim];
-        var bb = new T[modelDim];
-        var pp = new T[modelDim];
-        var dAa = new T[modelDim];
-        var dBb = new T[modelDim];
         var dw = new T[modelDim];
         for (int c = 0; c < modelDim; c++) dw[c] = ops.Zero;
 
+        // Channel-parallel with b outer; per-channel local state + private trajectories. See double path.
         for (int b = 0; b < batch; b++)
         {
-            for (int c = 0; c < modelDim; c++) { aa[c] = ops.Zero; bb[c] = ops.Zero; pp[c] = negInf; }
-            for (int t = 0; t < seqLen; t++)
+            int bIdx = b;
+            CpuParallelSettings.ParallelForChunks(modelDim, RgLruChannelGrain, (cStart, cCount) =>
             {
-                int baseOff = (b * seqLen + t) * modelDim;
-                int tOff = t * modelDim;
-                for (int c = 0; c < modelDim; c++)
+                var aaTrajC = new T[seqLen];
+                var bbTrajC = new T[seqLen];
+                var ppTrajC = new T[seqLen];
+                int cEnd = cStart + cCount;
+                for (int c = cStart; c < cEnd; c++)
                 {
-                    T k = K[baseOff + c];
-                    T v = V[baseOff + c];
-                    T ww2 = ops.Add(pp[c], w[c]);
-                    T q2 = MaxT(ops, ww2, k);
-                    T e1b = ops.Exp(ops.Subtract(ww2, q2));
-                    T e2b = ops.Exp(ops.Subtract(k, q2));
-                    aa[c] = ops.Add(ops.Multiply(e1b, aa[c]), ops.Multiply(e2b, v));
-                    bb[c] = ops.Add(ops.Multiply(e1b, bb[c]), e2b);
-                    pp[c] = q2;
-                    aaTraj[tOff + c] = aa[c];
-                    bbTraj[tOff + c] = bb[c];
-                    ppTraj[tOff + c] = pp[c];
+                    T wc = w[c], u = timeFirst[c];
+
+                    T aac = ops.Zero, bbc = ops.Zero, ppc = negInf;
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        T k = K[baseOff + c];
+                        T v = V[baseOff + c];
+                        T ww2 = ops.Add(ppc, wc);
+                        T q2 = MaxT(ops, ww2, k);
+                        T e1b = ops.Exp(ops.Subtract(ww2, q2));
+                        T e2b = ops.Exp(ops.Subtract(k, q2));
+                        aac = ops.Add(ops.Multiply(e1b, aac), ops.Multiply(e2b, v));
+                        bbc = ops.Add(ops.Multiply(e1b, bbc), e2b);
+                        ppc = q2;
+                        aaTrajC[t] = aac;
+                        bbTrajC[t] = bbc;
+                        ppTrajC[t] = ppc;
+                    }
+
+                    T dAac = ops.Zero, dBbc = ops.Zero;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int baseOff = (bIdx * seqLen + t) * modelDim;
+                        T k = K[baseOff + c];
+                        T v = V[baseOff + c];
+                        T aaPrev = t > 0 ? aaTrajC[t - 1] : ops.Zero;
+                        T bbPrev = t > 0 ? bbTrajC[t - 1] : ops.Zero;
+                        T ppPrev = t > 0 ? ppTrajC[t - 1] : negInf;
+                        T ppCur = ppTrajC[t];
+
+                        T ww = ops.Add(u, k);
+                        T q = MaxT(ops, ppPrev, ww);
+                        T e1 = ops.Exp(ops.Subtract(ppPrev, q));
+                        T e2 = ops.Exp(ops.Subtract(ww, q));
+                        T den = ops.Add(ops.Multiply(e1, bbPrev), e2);
+                        T num = ops.Add(ops.Multiply(e1, aaPrev), ops.Multiply(e2, v));
+                        T wkv = ops.Divide(num, den);
+                        T sr = SigGeneric(ops, R[baseOff + c]);
+
+                        T dO = dOut[baseOff + c];
+                        dR[baseOff + c] = ops.Add(dR[baseOff + c],
+                            ops.Multiply(ops.Multiply(dO, wkv), ops.Multiply(sr, ops.Subtract(one, sr))));
+                        T gWkv = ops.Multiply(dO, sr);
+                        T dNum = ops.Divide(gWkv, den);
+                        T dDen = ops.Divide(ops.Negate(ops.Multiply(gWkv, wkv)), den);
+                        T dAaFromOut = ops.Multiply(dNum, e1);
+                        T dBbFromOut = ops.Multiply(dDen, e1);
+                        dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dNum, e2));
+                        T dE2 = ops.Add(ops.Multiply(dNum, v), dDen);
+                        dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2, e2));
+                        dTimeFirst[c] = ops.Add(dTimeFirst[c], ops.Multiply(dE2, e2));
+
+                        T ww2 = ops.Add(ppPrev, wc);
+                        T e1b = ops.Exp(ops.Subtract(ww2, ppCur));
+                        T e2b = ops.Exp(ops.Subtract(k, ppCur));
+                        T dAt = dAac;
+                        T dBt = dBbc;
+                        T dE1b = ops.Add(ops.Multiply(dAt, aaPrev), ops.Multiply(dBt, bbPrev));
+                        dw[c] = ops.Add(dw[c], ops.Multiply(dE1b, e1b));
+                        dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dAt, e2b));
+                        T dE2b = ops.Add(ops.Multiply(dAt, v), dBt);
+                        dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2b, e2b));
+
+                        dAac = ops.Add(ops.Multiply(dAt, e1b), dAaFromOut);
+                        dBbc = ops.Add(ops.Multiply(dBt, e1b), dBbFromOut);
+                    }
                 }
-            }
-
-            for (int c = 0; c < modelDim; c++) { dAa[c] = ops.Zero; dBb[c] = ops.Zero; }
-            for (int t = seqLen - 1; t >= 0; t--)
-            {
-                int baseOff = (b * seqLen + t) * modelDim;
-                for (int c = 0; c < modelDim; c++)
-                {
-                    T k = K[baseOff + c];
-                    T v = V[baseOff + c];
-                    T aaPrev = t > 0 ? aaTraj[(t - 1) * modelDim + c] : ops.Zero;
-                    T bbPrev = t > 0 ? bbTraj[(t - 1) * modelDim + c] : ops.Zero;
-                    T ppPrev = t > 0 ? ppTraj[(t - 1) * modelDim + c] : negInf;
-                    T ppCur = ppTraj[t * modelDim + c];
-
-                    T ww = ops.Add(timeFirst[c], k);
-                    T q = MaxT(ops, ppPrev, ww);
-                    T e1 = ops.Exp(ops.Subtract(ppPrev, q));
-                    T e2 = ops.Exp(ops.Subtract(ww, q));
-                    T den = ops.Add(ops.Multiply(e1, bbPrev), e2);
-                    T num = ops.Add(ops.Multiply(e1, aaPrev), ops.Multiply(e2, v));
-                    T wkv = ops.Divide(num, den);
-                    T sr = SigGeneric(ops, R[baseOff + c]);
-
-                    T dO = dOut[baseOff + c];
-                    dR[baseOff + c] = ops.Add(dR[baseOff + c],
-                        ops.Multiply(ops.Multiply(dO, wkv), ops.Multiply(sr, ops.Subtract(one, sr))));
-                    T gWkv = ops.Multiply(dO, sr);
-                    T dNum = ops.Divide(gWkv, den);
-                    T dDen = ops.Divide(ops.Negate(ops.Multiply(gWkv, wkv)), den);
-                    T dAaFromOut = ops.Multiply(dNum, e1);
-                    T dBbFromOut = ops.Multiply(dDen, e1);
-                    dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dNum, e2));
-                    T dE2 = ops.Add(ops.Multiply(dNum, v), dDen);
-                    dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2, e2));
-                    dTimeFirst[c] = ops.Add(dTimeFirst[c], ops.Multiply(dE2, e2));
-
-                    T ww2 = ops.Add(ppPrev, w[c]);
-                    T e1b = ops.Exp(ops.Subtract(ww2, ppCur));
-                    T e2b = ops.Exp(ops.Subtract(k, ppCur));
-                    T dAt = dAa[c];
-                    T dBt = dBb[c];
-                    T dE1b = ops.Add(ops.Multiply(dAt, aaPrev), ops.Multiply(dBt, bbPrev));
-                    dw[c] = ops.Add(dw[c], ops.Multiply(dE1b, e1b));
-                    dV[baseOff + c] = ops.Add(dV[baseOff + c], ops.Multiply(dAt, e2b));
-                    T dE2b = ops.Add(ops.Multiply(dAt, v), dBt);
-                    dK[baseOff + c] = ops.Add(dK[baseOff + c], ops.Multiply(dE2b, e2b));
-
-                    dAa[c] = ops.Add(ops.Multiply(dAt, e1b), dAaFromOut);
-                    dBb[c] = ops.Add(ops.Multiply(dBt, e1b), dBbFromOut);
-                }
-            }
+            });
         }
 
         for (int c = 0; c < modelDim; c++)

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -10144,6 +10144,76 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <summary>
+    /// Inference-only fused linear with an fp16-resident weight: <c>Activation(input · Wfp16 + bias)</c>.
+    /// The weight stays <see cref="Half"/> and is converted fp16→fp32 inside the GEMM's pack step
+    /// (<see cref="Simd.SimdGemm.SgemmFp16WeightB"/>) — no whole-tensor upcast — then bias broadcast-add and
+    /// the fused activation run in the epilogue. Does NOT record on the autodiff tape; the caller uses it
+    /// only when <c>LowPrecisionResident</c> is active, T is float, and no tape/graph is recording.
+    /// </summary>
+    public Tensor<float> FusedLinearFp16WeightB(
+        Tensor<float> input, Tensor<Half> weightHalf, Tensor<float>? bias,
+        FusedActivationType activation, FusedActivationParams? activationParams = null)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (weightHalf is null) throw new ArgumentNullException(nameof(weightHalf));
+        if (input.Rank == 1)
+        {
+            var promoted = FusedLinearFp16WeightB(
+                Reshape(input, new[] { 1, input._shape[0] }), weightHalf, bias, activation, activationParams);
+            return Reshape(promoted, new[] { promoted._shape[promoted.Rank - 1] });
+        }
+
+        var result = TensorMatMulFp16WeightB(input, weightHalf); // [m, n], convert-in-pack matmul
+        if (bias is not null)
+        {
+            int n = result.Shape[result.Rank - 1];
+            if (bias.Length != n)
+                throw new ArgumentException($"bias length ({bias.Length}) must equal output features ({n}).");
+            var rData = result.GetCpuData();
+            var bData = bias.GetCpuData();
+            int rows = result.Length / n;
+            for (int i = 0; i < rows; i++)
+            {
+                int baseIdx = i * n;
+                for (int j = 0; j < n; j++) rData[baseIdx + j] += bData[j];
+            }
+        }
+        if (activation != FusedActivationType.None)
+            ApplyFusedActivationInPlace(result, activation, activationParams);
+        return result;
+    }
+
+    /// <summary>
+    /// Fused fp16-weight matmul for fp16-resident inference: <c>C[m,n] = A[m,k] · B[k,n]</c> where B is
+    /// a 2D <see cref="Half"/> weight in <c>[k, n]</c> row-major. Converts the weight one cache-resident
+    /// column panel at a time inside the GEMM (no full fp32 materialization), eliminating the cold-RAM
+    /// write+reread that a whole-tensor upcast pays. Inference-only (does not record on the autodiff tape);
+    /// callers use it when <c>LowPrecisionResident</c> is active and no tape is recording.
+    /// </summary>
+    public Tensor<float> TensorMatMulFp16WeightB(Tensor<float> a, Tensor<Half> b)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        if (a.Rank != 2 || b.Rank != 2)
+            throw new ArgumentException("TensorMatMulFp16WeightB requires 2D tensors.");
+        int m = a.Shape[0], k = a.Shape[1];
+        if (b.Shape[0] != k)
+            throw new ArgumentException($"Inner dimensions must match: a[.,{k}] vs b[{b.Shape[0]},.].");
+        int n = b.Shape[1];
+
+        var aData = a.GetCpuData();
+        var bData = b.GetCpuData();
+        var result = new Tensor<float>(new[] { m, n });
+        var cData = result.GetCpuData();
+        Simd.SimdGemm.SgemmFp16WeightB(
+            new ReadOnlySpan<float>(aData, 0, m * k),
+            new ReadOnlySpan<Half>(bData, 0, k * n),
+            new Span<float>(cData, 0, m * n),
+            m, k, n);
+        return result;
+    }
+
+    /// <summary>
     /// Naive Conv2D implementation for non-float types.
     /// </summary>
     private static void Conv2DNaive<T>(

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Fp16Weight.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Fp16Weight.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Helpers;
+
+namespace AiDotNet.Tensors.Engines.Simd;
+
+internal static partial class SimdGemm
+{
+    /// <summary>
+    /// Fused weight-only GEMM for fp16-resident inference: <c>C[m,n] = A[m,k] · B[k,n]</c> where B is a
+    /// <see cref="Half"/> weight in <c>[k, n]</c> row-major. On net5.0+ the fp16→fp32 conversion happens
+    /// INSIDE the GEMM's own B-packing step (<see cref="PackBFromHalf"/>), one cache-resident Kc×Nc panel
+    /// at a time — so the full fp32 weight is never materialized (eliminates the cold-RAM upcast that
+    /// dominated the fp16-resident forward and halves the weight bytes read). Structure mirrors the tuned
+    /// fp32 <see cref="SgemmTiled"/>/<see cref="SgemmTiledParallelN"/>: A is packed once per tile and shared;
+    /// each worker converts+packs only its disjoint B column-slice (so the conversion is parallel too) and
+    /// runs the existing fp32 <see cref="MacroKernel"/>. Bit-equivalent (up to fp32 non-associativity) to
+    /// upcast-then-Sgemm. Inference-only; no autodiff. (net471 has no intrinsic tiled kernel — falls back
+    /// to a whole-weight upcast + Sgemm, correct but not memory-optimal; net471 is not the perf target.)
+    /// </summary>
+    public static void SgemmFp16WeightB(
+        ReadOnlySpan<float> a,
+        ReadOnlySpan<Half> b,
+        Span<float> c,
+        int m, int k, int n)
+    {
+        if (m <= 0 || n <= 0 || k <= 0) { c.Clear(); return; }
+        if ((long)b.Length < (long)k * n)
+            throw new ArgumentException($"b.Length ({b.Length}) must be >= k*n ({(long)k * n}).", nameof(b));
+        if (a.Length < (long)m * k)
+            throw new ArgumentException($"a.Length ({a.Length}) must be >= m*k ({(long)m * k}).", nameof(a));
+        if (c.Length < (long)m * n)
+            throw new ArgumentException($"c.Length ({c.Length}) must be >= m*n ({(long)m * n}).", nameof(c));
+
+#if NET5_0_OR_GREATER
+        // MacroKernel accumulates (C += panel) across the K-panel (pc) loop, so C starts cleared.
+        c.Clear();
+
+        int Mc = ChooseAdaptiveMc(m, k, n);
+        int mcRounded = ((Mc + Mr - 1) / Mr) * Mr;
+        int ncRounded = ((Nc + Nr - 1) / Nr) * Nr;
+        int maxThreads = CpuParallelSettings.MaxDegreeOfParallelism;
+        bool parallel = UseParallelGemm && maxThreads > 1 && (long)m * k * n >= ParallelWorkThreshold;
+
+        float[] packedABuf = ArrayPool<float>.Shared.Rent(mcRounded * Kc);
+        float[]? seqPackedB = parallel ? null : ArrayPool<float>.Shared.Rent(Kc * ncRounded);
+        try
+        {
+            for (int jc = 0; jc < n; jc += Nc)
+            {
+                int nc = Math.Min(Nc, n - jc);
+                for (int pc = 0; pc < k; pc += Kc)
+                {
+                    int kc = Math.Min(Kc, k - pc);
+                    int numNrBlocks = (nc + Nr - 1) / Nr;
+
+                    if (parallel && numNrBlocks >= 2)
+                    {
+                        Fp16TileParallelN(a, b, c, m, k, n, jc, nc, pc, kc, numNrBlocks, maxThreads, Mc, packedABuf);
+                    }
+                    else
+                    {
+                        var pb = seqPackedB ?? throw new InvalidOperationException("sequential B buffer not allocated");
+                        PackBFromHalf(b, pb, n, pc, kc, jc, nc);
+                        for (int ic = 0; ic < m; ic += Mc)
+                        {
+                            int mc = Math.Min(Mc, m - ic);
+                            PackA(a, packedABuf, k, ic, mc, pc, kc);
+                            MacroKernel(packedABuf, pb, c, mc, nc, kc, n, ic, jc);
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(packedABuf);
+            if (seqPackedB is not null) ArrayPool<float>.Shared.Return(seqPackedB);
+        }
+#else
+        // net471 fallback: no intrinsic tiled kernel — upcast the whole weight then Sgemm.
+        float[] bf = ArrayPool<float>.Shared.Rent(k * n);
+        try
+        {
+            for (int i = 0; i < k * n; i++) bf[i] = (float)b[i];
+            Sgemm(a, new ReadOnlySpan<float>(bf, 0, k * n), c, m, k, n, 0f);
+        }
+        finally { ArrayPool<float>.Shared.Return(bf); }
+#endif
+    }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// N-parallel fused fp16 tile: packs A once (shared) for this (jc,pc) tile, then each worker
+    /// converts+packs its own disjoint B column-slice from Half (<see cref="PackBFromHalf"/>) and runs
+    /// <see cref="MacroKernel"/> over its columns. Mirrors <see cref="SgemmTiledParallelN"/> but moves the
+    /// (now conversion-bearing) B-pack INSIDE the worker so the fp16→fp32 decode is parallelized.
+    /// </summary>
+    private static unsafe void Fp16TileParallelN(
+        ReadOnlySpan<float> a, ReadOnlySpan<Half> b, Span<float> c,
+        int m, int k, int n,
+        int jc, int nc, int pc, int kc,
+        int numNrBlocks, int maxThreads, int Mc, float[] packedABuf)
+    {
+        int numWorkers = Math.Min(maxThreads, numNrBlocks);
+        int nrPerWorker = (numNrBlocks + numWorkers - 1) / numWorkers;
+
+        int firstMc = Math.Min(Mc, m);
+        PackA(a, packedABuf, k, 0, firstMc, pc, kc);   // shared A (first Mc block) — fp32 copy, cheap
+
+        var packedBSlices = new float[numWorkers][];
+        var sliceNcs = new int[numWorkers];
+        var sliceJStarts = new int[numWorkers];
+        int actualWorkers = numWorkers;
+        for (int w = 0; w < numWorkers; w++)
+        {
+            int nrStart = w * nrPerWorker;
+            if (nrStart >= numNrBlocks) { actualWorkers = w; break; }
+            int nrEnd = Math.Min(nrStart + nrPerWorker, numNrBlocks);
+            int jStart = nrStart * Nr;
+            int jEnd = Math.Min(nrEnd * Nr, nc);
+            int localNc = jEnd - jStart;
+            sliceNcs[w] = localNc;
+            sliceJStarts[w] = jStart;
+            int packedNc = ((localNc + Nr - 1) / Nr) * Nr;
+            packedBSlices[w] = ArrayPool<float>.Shared.Rent(kc * packedNc);
+        }
+
+        // Pin A only when extra Mc blocks need per-worker packing (m > Mc).
+        float[]? aArr = null;
+        GCHandle aHandle = default;
+        float* aPtr = null;
+        if (m > Mc)
+        {
+            aArr = ArrayPool<float>.Shared.Rent(a.Length);
+            a.CopyTo(aArr);
+            aHandle = GCHandle.Alloc(aArr, GCHandleType.Pinned);
+            aPtr = (float*)aHandle.AddrOfPinnedObject();
+        }
+
+        try
+        {
+            var localPackedABuf = packedABuf;
+            var localPackedBSlices = packedBSlices;
+            var localSliceNcs = sliceNcs;
+            var localSliceJStarts = sliceJStarts;
+            float* localAPtr = aPtr;
+            int localALen = a.Length;
+            int localM = m, localK = k, localN = n;
+            int localJc = jc, localPc = pc, localKc = kc, localFirstMc = firstMc;
+
+            fixed (Half* bPtr = b)
+            fixed (float* cPtr = c)
+            {
+                IntPtr ipB = (IntPtr)bPtr, ipC = (IntPtr)cPtr;
+                int bLen = b.Length, cLen = c.Length;
+
+                CpuParallelSettings.LightweightParallel(actualWorkers, workerId =>
+                {
+                    int workerNc = localSliceNcs[workerId];
+                    int jStart = localSliceJStarts[workerId];
+                    var bSpan = new ReadOnlySpan<Half>((Half*)ipB, bLen);
+                    var cSpan = new Span<float>((float*)ipC, cLen);
+                    float[] myB = localPackedBSlices[workerId];
+
+                    // Convert+pack THIS worker's B column-slice from Half (parallel conversion).
+                    PackBFromHalf(bSpan, myB, localN, localPc, localKc, localJc + jStart, workerNc);
+
+                    // First Mc block uses the shared pre-packed A.
+                    MacroKernel(localPackedABuf, myB, cSpan, localFirstMc, workerNc, localKc, localN, 0, localJc + jStart);
+
+                    // Additional Mc blocks (m > Mc): each worker packs its own A panel.
+                    for (int ic = Mc; ic < localM; ic += Mc)
+                    {
+                        int mc = Math.Min(Mc, localM - ic);
+                        int packedMc = ((mc + Mr - 1) / Mr) * Mr;
+                        float[] workerPackedA = ArrayPool<float>.Shared.Rent(packedMc * localKc);
+                        try
+                        {
+                            var aSpan = new ReadOnlySpan<float>(localAPtr, localALen);
+                            PackA(aSpan, workerPackedA, localK, ic, mc, localPc, localKc);
+                            MacroKernel(workerPackedA, myB, cSpan, mc, workerNc, localKc, localN, ic, localJc + jStart);
+                        }
+                        finally
+                        {
+                            ArrayPool<float>.Shared.Return(workerPackedA);
+                        }
+                    }
+                });
+            }
+        }
+        finally
+        {
+            if (aHandle.IsAllocated) aHandle.Free();
+            if (aArr is not null) ArrayPool<float>.Shared.Return(aArr);
+            for (int w = 0; w < actualWorkers; w++)
+                ArrayPool<float>.Shared.Return(packedBSlices[w]);
+        }
+    }
+
+    /// <summary>
+    /// Packs the panel <c>B[pc:pc+kc, jc:jc+nc]</c> of a <c>[k, n]</c> row-major <see cref="Half"/> weight
+    /// into the fp32 tile layout <see cref="MacroKernel"/> expects — converting fp16→fp32 during the copy.
+    /// Mirrors <see cref="PackB"/>'s no-transpose layout exactly; the only change is the Half source and
+    /// the inline SIMD decode (<see cref="SimdKernels.Fp16To32Vec8"/>) for the full Nr-column rows.
+    /// </summary>
+    private static unsafe void PackBFromHalf(ReadOnlySpan<Half> b, float[] packed, int ldb, int pc, int kc, int jc, int nc)
+    {
+        int pos = 0;
+        int j = 0;
+
+#if NET8_0_OR_GREATER
+        if (SimdKernels.Fp16Vec8Supported)
+        {
+            fixed (Half* pBBase = b)
+            fixed (float* pPackedBase = packed)
+            {
+                ushort* usBase = (ushort*)pBBase;
+                for (; j + Nr <= nc; j += Nr)
+                {
+                    float* pPacked = pPackedBase + pos;
+                    ushort* pBCol = usBase + (long)pc * ldb + (jc + j);
+                    for (int p = 0; p < kc; p++)
+                    {
+                        SimdKernels.Fp16To32Vec8(pBCol, pPacked);          // columns 0..7
+                        SimdKernels.Fp16To32Vec8(pBCol + 8, pPacked + 8);  // columns 8..15 (Nr == 16)
+                        pBCol += ldb;
+                        pPacked += Nr;
+                    }
+                    pos += kc * Nr;
+                }
+            }
+        }
+#endif
+
+        // Remaining full Nr-column panels (no AVX2) — scalar convert.
+        for (; j + Nr <= nc; j += Nr)
+        {
+            for (int p = 0; p < kc; p++)
+            {
+                int row = pc + p;
+                for (int jj = 0; jj < Nr; jj++)
+                    packed[pos++] = (float)b[row * ldb + (jc + j + jj)];
+            }
+        }
+
+        // Trailing columns (< Nr): convert present ones, zero-pad the rest (matches PackB).
+        int remaining = nc - j;
+        if (remaining > 0)
+        {
+            for (int p = 0; p < kc; p++)
+            {
+                int row = pc + p;
+                for (int jj = 0; jj < remaining; jj++)
+                    packed[pos++] = (float)b[row * ldb + (jc + j + jj)];
+                for (int jj = remaining; jj < Nr; jj++)
+                    packed[pos++] = 0f;
+            }
+        }
+    }
+#endif
+}

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdKernels.cs
@@ -6784,6 +6784,41 @@ namespace AiDotNet.Tensors.Engines.Simd
         for (; j < end; j++) dst[j] = (float)src[j];
     }
 
+#if NET8_0_OR_GREATER
+    /// <summary>True when <see cref="Fp16To32Vec8"/>'s AVX2 path is available.</summary>
+    internal static bool Fp16Vec8Supported => Avx2.IsSupported;
+
+    /// <summary>
+    /// Bit-exact AVX2 IEEE-754 decode of 8 contiguous Half bit-patterns (<paramref name="us"/> as ushort*)
+    /// into 8 floats at <paramref name="dst"/>. Same algorithm as <see cref="HalfToSingleRange"/> (validated
+    /// identical to <c>(float)Half</c> for all 65536 patterns incl. NaN-quieting); factored out so the
+    /// fused fp16-weight GEMM packer (SgemmFp16WeightB) converts during packing without a scalar pass.
+    /// Caller must ensure AVX2 (<see cref="Fp16Vec8Supported"/>) and 8 readable/writable lanes.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe void Fp16To32Vec8(ushort* us, float* dst)
+    {
+        var h = Avx2.ConvertToVector256Int32(Sse2.LoadVector128(us)).AsUInt32();
+        var sign = Avx2.ShiftLeftLogical(Avx2.And(h, Vector256.Create(0x8000u)), 16);
+        var exp5 = Avx2.And(Avx2.ShiftRightLogical(h, 10), Vector256.Create(0x1Fu));
+        var mant = Avx2.And(h, Vector256.Create(0x3FFu));
+        var mantShift = Avx2.ShiftLeftLogical(mant, 13);
+        var normal = Avx2.Or(Avx2.ShiftLeftLogical(Avx2.Add(exp5, Vector256.Create(112u)), 23), mantShift);
+        var isInfNan = Avx2.CompareEqual(exp5, Vector256.Create(0x1Fu));
+        var mantIsZero = Avx2.CompareEqual(mant, Vector256<uint>.Zero);
+        var isNan = Avx2.AndNot(mantIsZero, isInfNan);
+        var quietBit = Avx2.And(isNan, Vector256.Create(0x400000u));
+        var infnan = Avx2.Or(Avx2.Or(Vector256.Create(0x7F800000u), mantShift), quietBit);
+        var denorm = Avx.Multiply(Avx.ConvertToVector256Single(mant.AsInt32()),
+                                  Vector256.Create(5.9604644775390625e-08f)).AsUInt32();
+        var isZeroDen = Avx2.CompareEqual(exp5, Vector256<uint>.Zero);
+        var notSpecial = Avx2.Xor(Avx2.Or(isInfNan, isZeroDen), Vector256<uint>.AllBitsSet);
+        var body = Avx2.Or(Avx2.Or(Avx2.And(normal, notSpecial), Avx2.And(infnan, isInfNan)),
+                           Avx2.And(denorm, isZeroDen));
+        Avx.Store(dst, Avx2.Or(sign, body).AsSingle());
+    }
+#endif
+
     /// <summary>
     /// Converts double span to float span using AVX narrowing conversion.
     /// </summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Fp16WeightGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Fp16WeightGemmTests.cs
@@ -1,0 +1,121 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused fp16-weight GEMM used by fp16-resident inference
+/// (<see cref="CpuEngine.TensorMatMulFp16WeightB"/> / <see cref="CpuEngine.FusedLinearFp16WeightB"/>,
+/// backed by <c>SimdGemm.SgemmFp16WeightB</c>). The convert-in-pack path must match the reference
+/// "upcast the whole weight to fp32, then matmul" to within fp32 GEMM association differences — both
+/// paths decode the SAME <see cref="Half"/> bit patterns, so only summation order differs.
+/// Shapes exercise the parallel N path, trailing (&lt; Nr) columns, and the small sequential path.
+/// </summary>
+public class Fp16WeightGemmTests
+{
+    private static Tensor<float> RandomFloat(int rows, int cols, Random rng)
+    {
+        var t = new Tensor<float>(new[] { rows, cols });
+        var d = t.GetCpuData();
+        for (int i = 0; i < d.Length; i++) d[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return t;
+    }
+
+    // Half weight [k,n] plus its exact fp32 upcast (same bit patterns), so the reference matmul
+    // and the fused path start from identical fp32 values — any diff is pure GEMM association.
+    private static (Tensor<Half> half, Tensor<float> upcast) RandomHalfWeight(int k, int n, Random rng)
+    {
+        var half = new Tensor<Half>(new[] { k, n });
+        var upcast = new Tensor<float>(new[] { k, n });
+        var hd = half.GetCpuData();
+        var ud = upcast.GetCpuData();
+        for (int i = 0; i < hd.Length; i++)
+        {
+            var h = (Half)(float)(rng.NextDouble() * 2.0 - 1.0);
+            hd[i] = h;
+            ud[i] = (float)h;
+        }
+        return (half, upcast);
+    }
+
+    private static void AssertClose(Tensor<float> expected, Tensor<float> got)
+    {
+        var e = expected.GetCpuData();
+        var g = got.GetCpuData();
+        Assert.Equal(e.Length, g.Length);
+        for (int i = 0; i < e.Length; i++)
+        {
+            double tol = 1e-3 + 1e-4 * Math.Abs(e[i]);
+            Assert.True(Math.Abs(e[i] - g[i]) < tol,
+                $"element {i}: fused={g[i]} vs upcast-reference={e[i]} (tol {tol})");
+        }
+    }
+
+    [Theory]
+    [InlineData(64, 128, 100)]  // parallel N path (n > Nr) + trailing columns (100 = 6*16 + 4)
+    [InlineData(48, 96, 96)]    // parallel N path, n a multiple of Nr (no trailing)
+    [InlineData(3, 5, 7)]       // small: sequential path, trailing-only columns
+    [InlineData(1, 320, 1280)]  // single-row (m == 1), wide weight — MLP-like inference shape
+    public void TensorMatMulFp16WeightB_MatchesUpcastThenMatMul(int m, int k, int n)
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(1234 + m * 31 + k * 7 + n);
+        var a = RandomFloat(m, k, rng);
+        var (wHalf, wUpcast) = RandomHalfWeight(k, n, rng);
+
+        var reference = engine.TensorMatMul(a, wUpcast);
+        var fused = engine.TensorMatMulFp16WeightB(a, wHalf);
+
+        Assert.Equal(new[] { m, n }, fused.Shape);
+        AssertClose(reference, fused);
+    }
+
+    [Fact]
+    public void FusedLinearFp16WeightB_WithBias_NoActivation_MatchesUpcastLinear()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(99);
+        int m = 32, k = 64, n = 48;
+        var a = RandomFloat(m, k, rng);
+        var (wHalf, wUpcast) = RandomHalfWeight(k, n, rng);
+        var bias = new Tensor<float>(new[] { n });
+        var bd = bias.GetCpuData();
+        for (int j = 0; j < n; j++) bd[j] = (float)(rng.NextDouble() - 0.5);
+
+        // Reference: upcast matmul + broadcast bias.
+        var reference = engine.TensorMatMul(a, wUpcast);
+        var rd = reference.GetCpuData();
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++) rd[i * n + j] += bd[j];
+
+        var fused = engine.FusedLinearFp16WeightB(a, wHalf, bias, FusedActivationType.None);
+
+        Assert.Equal(new[] { m, n }, fused.Shape);
+        AssertClose(reference, fused);
+    }
+
+    [Fact]
+    public void FusedLinearFp16WeightB_RankOneInput_ReturnsRankOneVector()
+    {
+        var engine = new CpuEngine();
+        var rng = new Random(7);
+        int k = 40, n = 24;
+        var a = RandomFloat(1, k, rng);
+        var a1d = a.Reshape(new[] { k });   // rank-1 input path
+        var (wHalf, wUpcast) = RandomHalfWeight(k, n, rng);
+
+        var reference2d = engine.TensorMatMul(a, wUpcast);   // [1, n]
+        var fused1d = engine.FusedLinearFp16WeightB(a1d, wHalf, null, FusedActivationType.None);
+
+        Assert.Equal(new[] { n }, fused1d.Shape);
+        var e = reference2d.GetCpuData();
+        var g = fused1d.GetCpuData();
+        for (int j = 0; j < n; j++)
+        {
+            double tol = 1e-3 + 1e-4 * Math.Abs(e[j]);
+            Assert.True(Math.Abs(e[j] - g[j]) < tol, $"element {j}: {g[j]} vs {e[j]}");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Fp16WeightGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Fp16WeightGemmTests.cs
@@ -68,7 +68,7 @@ public class Fp16WeightGemmTests
         var reference = engine.TensorMatMul(a, wUpcast);
         var fused = engine.TensorMatMulFp16WeightB(a, wHalf);
 
-        Assert.Equal(new[] { m, n }, fused.Shape);
+        Assert.Equal(new[] { m, n }, fused.Shape.ToArray());
         AssertClose(reference, fused);
     }
 
@@ -92,7 +92,7 @@ public class Fp16WeightGemmTests
 
         var fused = engine.FusedLinearFp16WeightB(a, wHalf, bias, FusedActivationType.None);
 
-        Assert.Equal(new[] { m, n }, fused.Shape);
+        Assert.Equal(new[] { m, n }, fused.Shape.ToArray());
         AssertClose(reference, fused);
     }
 
@@ -109,7 +109,7 @@ public class Fp16WeightGemmTests
         var reference2d = engine.TensorMatMul(a, wUpcast);   // [1, n]
         var fused1d = engine.FusedLinearFp16WeightB(a1d, wHalf, null, FusedActivationType.None);
 
-        Assert.Equal(new[] { n }, fused1d.Shape);
+        Assert.Equal(new[] { n }, fused1d.Shape.ToArray());
         var e = reference2d.GetCpuData();
         var g = fused1d.GetCpuData();
         for (int j = 0; j < n; j++)


### PR DESCRIPTION
## Summary

Two independent, correctness-preserving CPU-inference perf changes (extracted from a stale WIP branch and rebased cleanly onto current `main`):

### 1. Scan-kernel parallelization — Mamba2 SSD, RG-LRU, RWKV4 WKV
Every `(batch, head)` pair in these linear-attention/SSM scans is fully independent: private recurrent state, disjoint output/gradient regions, no cross-channel reduction. The serial outer loops are rewritten to lock-free `CpuParallelSettings.ParallelForChunks` over the combined `(batch*numHeads)` axis with per-chunk private scratch buffers. This mirrors the already-merged `MambaScan`/`GLA` parallelization (#703) and is **bit-identical to the serial path**.

### 2. Fused fp16-weight GEMM for fp16-resident inference
New `SimdGemm.SgemmFp16WeightB` + `CpuEngine.TensorMatMulFp16WeightB` / `FusedLinearFp16WeightB`. The `Half` weight is converted fp16→fp32 **one cache-resident `Kc×Nc` panel at a time inside the GEMM's B-pack step** (`PackBFromHalf`, using an AVX2 `SimdKernels.Fp16To32Vec8` decode), so the full fp32 weight is never materialized — eliminating the cold-RAM upcast that dominated the fp16-resident forward (#1672) and halving the weight bytes read. Structure mirrors the tuned fp32 `SgemmTiledParallelN` (A packed once & shared; each worker converts+packs its own disjoint B column-slice, so the fp16 decode is parallel too). Inference-only (does not record on the autodiff tape). net471 falls back to a whole-weight upcast + `Sgemm`.

The diagnostic op-profiler from the WIP branch was intentionally **left out** of this PR.

## Verification
- **Builds**: `net10.0`, `net8.0`, `net471` all compile (net471 exercises the `HalfCompat` polyfill fallback path).
- **Scan correctness**: existing `RgLruScanTests`, `Rwkv4WkvTests`, `Mamba2SsdScanTests` (forward-vs-reference + finite-difference backward) pass 6/6.
- **fp16 GEMM correctness**: new `Fp16WeightGemmTests` (6/6) check the fused path against upcast-then-matmul across the parallel-N, trailing-column (`< Nr`), single-row (`m==1`), and small sequential shapes, plus the bias/no-activation and rank-1-input `FusedLinearFp16WeightB` paths.

> Note: correctness is verified here; end-to-end perf numbers were not re-benchmarked on this box — the design rationale/prior wins are referenced from #703 and #1672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)