### PR TITLE
fix(build): cold builds fail — split LicenseValidator Restore/Build into distinct-property MSBuild calls

### DIFF
--- a/build/AiDotNet.Tensors.Enterprise.targets
+++ b/build/AiDotNet.Tensors.Enterprise.targets
@@ -107,18 +107,40 @@
     <Message Importance="high"
              Text="AiDotNet enterprise gate: building the license-validator task assembly because the precompiled DLL is missing at $(_AiDotNetLicenseValidatorDll)." />
     <!--
+      Restore and Build MUST be SEPARATE <MSBuild> invocations, not a single
+      Targets="Restore;Build". A combined call evaluates the project only ONCE —
+      before Restore writes obj/project.assets.json — so on a cold tree the Build
+      target compiles with an incomplete reference set (the NETStandard.Library
+      facade is missing) and fails with CS0012 "netstandard 2.0.0.0 not
+      referenced" / CS0234 on System.Security.Cryptography. Two calls force Build
+      to re-evaluate with the freshly generated assets present. (The combined
+      form only appeared to work when a prior build had already produced assets,
+      e.g. a warm tree or a second consecutive build.)
+
       RemoveProperties="TargetFramework": the parent build sets TargetFramework
       as a global property while multi-targeting (net10.0 / net471). Without
       stripping it, that value propagates into this inner build and the
       netstandard2.0 validator project is asked to build for net471 — which
       fails with MSB3644 (no net471 ref assemblies for a netstandard2.0
       project) and was the reason the net471 build path silently skipped the
-      gate. Restore is included so the validator's BouncyCastle / System.Text.Json
-      references resolve on a fresh source tree (otherwise NETSDK1004).
+      gate. The dedicated Restore invocation also resolves the validator's
+      BouncyCastle / System.Text.Json references on a fresh source tree.
+
+      The two calls carry a DIFFERENT extra global property
+      (_LicenseValidatorPhase). MSBuild caches an evaluated project instance
+      keyed by (path + global properties), NOT by the requested target, so if
+      both calls used the same properties the Build call would reuse the
+      instance evaluated during Restore — i.e. evaluated before assets.json
+      existed, defeating the split. The distinct property forces Build to
+      evaluate a fresh instance that sees the freshly-restored assets.
     -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
-             Targets="Restore;Build"
-             Properties="Configuration=Release"
+             Targets="Restore"
+             Properties="Configuration=Release;_LicenseValidatorPhase=Restore"
+             RemoveProperties="TargetFramework;NoBuild" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
+             Targets="Build"
+             Properties="Configuration=Release;_LicenseValidatorPhase=Build"
              RemoveProperties="TargetFramework;NoBuild" />
   </Target>
 
@@ -225,9 +247,23 @@
           Condition="('$(GeneratePackageOnBuild)' == 'true' Or '$(_IsPacking)' == 'true' Or '$(IsPackable)' != 'false')
                      And '$(MSBuildProjectName)' == 'AiDotNet.Tensors'
                      And Exists('$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj')">
+    <!--
+      Separate Restore + Build invocations (see EnsureAiDotNetLicenseValidatorBuilt
+      above): a combined Targets="Restore;Build" evaluates the project before the
+      assets file exists, so a cold pack build compiles the netstandard2.0 validator
+      without the NETStandard.Library facade (CS0012 "netstandard 2.0.0.0 not
+      referenced"). The distinct _LicenseValidatorPhase property on each call
+      forces Build to evaluate a fresh project instance after Restore rather
+      than reuse the pre-restore instance from the MSBuild config cache (see
+      EnsureAiDotNetLicenseValidatorBuilt above).
+    -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
-             Targets="Restore;Build"
-             Properties="Configuration=Release"
+             Targets="Restore"
+             Properties="Configuration=Release;_LicenseValidatorPhase=Restore"
+             RemoveProperties="TargetFramework;NoBuild" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
+             Targets="Build"
+             Properties="Configuration=Release;_LicenseValidatorPhase=Build"
              RemoveProperties="TargetFramework;NoBuild" />
     <ItemGroup>
       <!-- ONLY the validator DLL closure is added dynamically — those files

--- a/build/AiDotNet.Tensors.Enterprise.targets
+++ b/build/AiDotNet.Tensors.Enterprise.targets
@@ -93,19 +93,7 @@
     <_AiDotNetLicenseValidatorDll>$(MSBuildThisFileDirectory)LicenseValidator\bin\AiDotNet.Tensors.LicenseValidator.dll</_AiDotNetLicenseValidatorDll>
   </PropertyGroup>
 
-  <!--
-    Bootstrap-build the validator if the DLL isn't on disk yet. This
-    runs ahead of every consuming target and is conditional so the
-    overhead only fires when somebody actually requested a DISABLE_*
-    flag (the only path that needs the validator). Source-builds where
-    the validator project hasn't been built yet hit this; NuGet
-    installs ship a pre-built copy and skip the bootstrap.
-  -->
-  <Target Name="EnsureAiDotNetLicenseValidatorBuilt"
-          BeforeTargets="ValidateEnterpriseDisableFlags"
-          Condition="'$(_AiDotNetAnyDisableFlagRequested)' == 'true' And !Exists('$(_AiDotNetLicenseValidatorDll)')">
-    <Message Importance="high"
-             Text="AiDotNet enterprise gate: building the license-validator task assembly because the precompiled DLL is missing at $(_AiDotNetLicenseValidatorDll)." />
+  <Target Name="BuildAiDotNetLicenseValidatorAssembly">
     <!--
       Restore and Build MUST be SEPARATE <MSBuild> invocations, not a single
       Targets="Restore;Build". A combined call evaluates the project only ONCE —
@@ -142,6 +130,22 @@
              Targets="Build"
              Properties="Configuration=Release;_LicenseValidatorPhase=Build"
              RemoveProperties="TargetFramework;NoBuild" />
+  </Target>
+
+  <!--
+    Bootstrap-build the validator if the DLL isn't on disk yet. This
+    runs ahead of every consuming target and is conditional so the
+    overhead only fires when somebody actually requested a DISABLE_*
+    flag (the only path that needs the validator). Source-builds where
+    the validator project hasn't been built yet hit this; NuGet
+    installs ship a pre-built copy and skip the bootstrap.
+  -->
+  <Target Name="EnsureAiDotNetLicenseValidatorBuilt"
+          BeforeTargets="ValidateEnterpriseDisableFlags"
+          Condition="'$(_AiDotNetAnyDisableFlagRequested)' == 'true' And !Exists('$(_AiDotNetLicenseValidatorDll)')">
+    <Message Importance="high"
+             Text="AiDotNet enterprise gate: building the license-validator task assembly because the precompiled DLL is missing at $(_AiDotNetLicenseValidatorDll)." />
+    <CallTarget Targets="BuildAiDotNetLicenseValidatorAssembly" />
   </Target>
 
   <!--
@@ -247,24 +251,7 @@
           Condition="('$(GeneratePackageOnBuild)' == 'true' Or '$(_IsPacking)' == 'true' Or '$(IsPackable)' != 'false')
                      And '$(MSBuildProjectName)' == 'AiDotNet.Tensors'
                      And Exists('$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj')">
-    <!--
-      Separate Restore + Build invocations (see EnsureAiDotNetLicenseValidatorBuilt
-      above): a combined Targets="Restore;Build" evaluates the project before the
-      assets file exists, so a cold pack build compiles the netstandard2.0 validator
-      without the NETStandard.Library facade (CS0012 "netstandard 2.0.0.0 not
-      referenced"). The distinct _LicenseValidatorPhase property on each call
-      forces Build to evaluate a fresh project instance after Restore rather
-      than reuse the pre-restore instance from the MSBuild config cache (see
-      EnsureAiDotNetLicenseValidatorBuilt above).
-    -->
-    <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
-             Targets="Restore"
-             Properties="Configuration=Release;_LicenseValidatorPhase=Restore"
-             RemoveProperties="TargetFramework;NoBuild" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)LicenseValidator\AiDotNet.Tensors.LicenseValidator.csproj"
-             Targets="Build"
-             Properties="Configuration=Release;_LicenseValidatorPhase=Build"
-             RemoveProperties="TargetFramework;NoBuild" />
+    <CallTarget Targets="BuildAiDotNetLicenseValidatorAssembly" />
     <ItemGroup>
       <!-- ONLY the validator DLL closure is added dynamically — those files
            don't exist until the validator is built above, and the


### PR DESCRIPTION
## Problem

A **cold/clean build** of `AiDotNet.Tensors` (fresh checkout, or CI where `build/LicenseValidator/{obj,bin}` don't yet exist) fails with ~28 errors:

```
error CS0012: The type 'Object'/'Attribute'/'ValueType' is defined in an assembly that is not referenced.
             You must add a reference to assembly 'netstandard, Version=2.0.0.0, ...'
error CS0234: The type or namespace name 'Cryptography' does not exist in the namespace 'System.Security'
error CS0246: The type or namespace name 'RSA' could not be found
```

…all from the netstandard2.0 `AiDotNet.Tensors.LicenseValidator` task project. Curiously, a **second consecutive build succeeds**, and building the validator project *directly* (`dotnet build build/LicenseValidator/...csproj`) always works — which is what masked this.

## Root cause

The two enterprise-gate targets (`EnsureAiDotNetLicenseValidatorBuilt`, `PackLicenseValidatorAssets`) built the validator with a **single** `Targets="Restore;Build"` `<MSBuild>` call.

MSBuild caches an evaluated project instance keyed by **(project path + global properties)** — *not* by the requested target. With one combined call the project is evaluated **once, before Restore writes `obj/project.assets.json`**, so the `Build` phase reuses that pre-restore instance and compiles with an incomplete reference set (the `NETStandard.Library` facade is absent). It only "worked" on a warm tree where a previous build had already produced the assets file.

This is the documented reason restore and build shouldn't share an MSBuild invocation; the `dotnet build` CLI avoids it by restoring in a separate evaluation.

## Fix

Split each gate into **two** `<MSBuild>` calls (`Restore`, then `Build`) that carry a **different** extra global property (`_LicenseValidatorPhase=Restore` / `=Build`). The distinct property gives the `Build` call its own config-cache key, forcing a fresh evaluation that sees the freshly-restored assets.

> Note: splitting into two calls with *identical* properties is **not** sufficient — they still share the cached pre-restore instance (verified: that intermediate attempt still failed cold). The differing property is the operative part.

## Verification

```
rm -rf build/LicenseValidator/{obj,bin}
dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
```
Before: **28 errors**, `Build FAILED` (cold). After: **0 errors**, `Build succeeded`, cold, deterministically (confirmed across repeated clean runs). Warm builds continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and packaging reliability so the app’s validator component now restores and builds more consistently, reducing failures in clean environments.
  * Helped prevent issues caused by reusing build state across separate steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->