### PR TITLE
diag: capture arena/pool state on large RentUninitialized failure (AiDotNet#1767)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -365,6 +365,36 @@ public static class TensorAllocator
         for (int i = 0; i < shape.Length; i++)
             totalSize = checked(totalSize * shape[i]);
 
+        // #1767 diagnostic: a foundation-scale (~661M-element), arena-state-dependent
+        // "Source array was not long enough" surfaces from this rent during BF16 Adam Step, but only
+        // on the fast CI runner — the local repro's 100-iter training times out before the failing
+        // step, so it can't be reproduced on a dev box. Scoped to >=100M-element rents (zero cost on
+        // ordinary allocations); on failure it rethrows with the requested shape/size and the live
+        // arena/pool state so the nightly HeavyTimeout run captures the true cause. See AiDotNet#1767.
+        if (totalSize >= LargeRentDiagnosticThreshold)
+        {
+            try
+            {
+                return RentUninitializedCore<T>(shape, totalSize);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"TensorAllocator.RentUninitialized failed: T={typeof(T).Name}, " +
+                    $"shape=[{string.Join(",", shape)}], totalSize={totalSize}. " +
+                    TensorArena.DescribeCurrentStateForDiagnostics(), ex);
+            }
+        }
+
+        return RentUninitializedCore<T>(shape, totalSize);
+    }
+
+    /// <summary>Element-count floor above which <see cref="RentUninitialized{T}"/> captures arena/pool
+    /// diagnostics on failure (#1767). Well above any ordinary activation/weight tensor.</summary>
+    private const int LargeRentDiagnosticThreshold = 100_000_000;
+
+    private static Tensor<T> RentUninitializedCore<T>(int[] shape, int totalSize)
+    {
         // #318: when ForceFreshAllocations is enabled the caller wants
         // backing arrays exactly logical-Length sized. Skip both the
         // arena and pool tiers — go straight to new Tensor<T>(shape).

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -177,6 +177,53 @@ public sealed class TensorArena : IDisposable
     /// </summary>
     internal static TensorArena? Current => _current;
 
+    /// <summary>
+    /// Returns a compact, never-throwing description of the calling thread's active arena and the
+    /// cross-arena persistent pool. Diagnostic-only: used to enrich a large-allocation failure so the
+    /// nightly HeavyTimeout run can capture the arena-state-dependent BF16 Adam rent failure (AiDotNet#1767).
+    /// Reports the tensor-ring sizes, dictionary-pool keys with their backing-array lengths (to expose a
+    /// size/length mismatch), and the pinned/backing/persistent counts.
+    /// </summary>
+    internal static string DescribeCurrentStateForDiagnostics()
+    {
+        try
+        {
+            var a = _current;
+            var sb = new System.Text.StringBuilder();
+            sb.Append("arenaActive=").Append(a != null);
+            if (a != null)
+            {
+                sb.Append(", tensorRingCount=").Append(a._tensorRingCount);
+                sb.Append(", tensorRingSizes=[");
+                if (a._tensorRingSizes != null)
+                    for (int i = 0; i < a._tensorRingCount && i < a._tensorRingSizes.Length; i++)
+                    { if (i > 0) sb.Append(','); sb.Append(a._tensorRingSizes[i]); }
+                sb.Append(']');
+                sb.Append(", pinnedArrays=").Append(a._pinnedArrays.Count);
+                sb.Append(", ringBackingArrays=").Append(a._ringBackingArrays.Count);
+                sb.Append(", pool={");
+                bool first = true;
+                foreach (var kv in a._pool)
+                {
+                    if (!first) sb.Append(';'); first = false;
+                    sb.Append(kv.Key.Item1?.Name).Append(':').Append(kv.Key.Item2).Append("=>");
+                    sb.Append(kv.Value?.Count ?? 0).Append('#');
+                    // backing-array lengths for this (type,size) bucket — a length != key size is the bug signature.
+                    if (kv.Value != null)
+                        for (int i = 0; i < kv.Value.Count; i++)
+                        { if (i > 0) sb.Append('/'); sb.Append(kv.Value[i]?.Length ?? -1); }
+                }
+                sb.Append('}');
+            }
+            sb.Append(", persistentPoolKeys=").Append(_persistent?.Count ?? 0);
+            return sb.ToString();
+        }
+        catch (Exception e)
+        {
+            return "arenaDiag-unavailable(" + e.GetType().Name + ")";
+        }
+    }
+
     private TensorArena(TensorArena? previous)
     {
         _previous = previous;


### PR DESCRIPTION
## What & why

Evidence-gathering for **ooples/AiDotNet#1767** — `ParaformerLarge`'s BF16 8-bit Adam `Step` throws `System.ArgumentException: Source array was not long enough` from `TensorAllocator.RentUninitialized` at ~661M-element scale, **only on the fast CI runner**. The local foundation-scale repro (100-iter training) times out before the failing step, so it can't be reproduced on a dev box.

I ruled out the obvious hypothesis: `TensorMultiplyScalar` on a **550M-element float tensor** (already >2 GB bytes, past `int.MaxValue`) with a fresh arena **works fine** — so it's not a simple int/byte overflow in the generic path. That points to an **arena-state-dependent pooled-buffer interaction** that only arises after a full training step's worth of allocations — which a dev box can't stage.

## Change (diagnostic only — no happy-path behavior change)

- `RentUninitialized` routes **≥100M-element** rents through a `try/catch` that, on failure, rethrows with the requested `T`/shape/`totalSize` plus the live arena + pool state. The body is extracted verbatim into `RentUninitializedCore`; ordinary (<100M) rents are unchanged and pay nothing (try/catch is free unless thrown).
- `TensorArena.DescribeCurrentStateForDiagnostics()` reports the tensor-ring sizes and each dictionary-pool bucket's `(type,size)` key **with its backing-array lengths** — a length ≠ key size is the suspected bug signature — plus pinned/backing/persistent counts. Never throws.

With this in place, the nightly HeavyTimeout `ParaformerLarge` run will capture the true failing location and arena state, enabling the actual fix.

## Not a fix

This **does not close #1767** — it's instrumentation to capture the real cause (cross-repo, and diagnostic-only). The fix will follow once the nightly surfaces the enriched failure.

## Verification

Builds `net10.0`; 23 allocator/arena tests pass (`TensorAllocatorOverflowTests`, `TensorArenaPersistentPoolTests`, `TensorArenaPinnedTests`, `BackwardArenaTests`, `NonArenaLargeBufferReuseTests`).

Refs ooples/AiDotNet#1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)