### PR TITLE
feat(cuda): wire BatchNorm to cuDNN + fix cuDNN context binding (AiDotNet#1159)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CuDnnNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuDnnNative.cs
@@ -1036,6 +1036,41 @@ public sealed class CuDnnContext : IDisposable
         }
     }
 
+    // Discriminator ctor for ForCurrentContext (see below). The bool is only
+    // there to distinguish this from the public parameterless ctor.
+    private CuDnnContext(bool bindToCurrentContext)
+    {
+        if (!IsAvailable)
+            throw new InvalidOperationException("cuDNN is not available on this system.");
+
+        // Bind the handle to the CUDA context ALREADY current on this thread
+        // instead of spinning up our own CudaBlasContext. cudnnCreate binds to
+        // whatever context is current; if we created a CudaBlasContext first it
+        // would switch the current context and the handle would bind to the
+        // wrong one — which then fails cudnnSetStream with
+        // CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH when the caller hands us its
+        // own stream, and would leave cuDNN unable to address the caller's
+        // device pointers (device memory is per-context). _blasContext stays
+        // null: only the GPU-pointer op variants (Conv2DForwardGpu /
+        // ForwardTrainingGpu / ForwardInferenceGpu / BackwardGpu) are valid on
+        // such an instance — the host-array helpers that need _blasContext are
+        // not.
+        _blasContext = null;
+        var status = CuDnnNative.cudnnCreate(out _cudnnHandle);
+        if (status != CuDnnNative.CudnnStatus.Success)
+            throw new InvalidOperationException($"Failed to create cuDNN handle: {status}");
+    }
+
+    /// <summary>
+    /// Creates a cuDNN context whose handle binds to the CUDA context already
+    /// current on the calling thread (e.g. a <c>CudaBackend</c> context pushed
+    /// via <c>cuCtxPushCurrent</c>). The handle, the caller's stream, and the
+    /// caller's device buffers then share one context — required for
+    /// <c>cudnnSetStream</c> and for cuDNN to operate on the caller's device
+    /// pointers. Only the GPU-pointer op variants are valid on the result.
+    /// </summary>
+    public static CuDnnContext ForCurrentContext() => new CuDnnContext(bindToCurrentContext: true);
+
     /// <summary>Allocates device memory.</summary>
     public CudaDeviceMemory<T> Allocate<T>(long count) where T : unmanaged
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -65,6 +65,10 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     // repeated kernel invocations (workspace reuse + descriptor cache).
     private CuDnnContext? _cudnnContext;
     private CuDnnConvolution? _cudnnConv;
+    // cuDNN batch-norm helper — lazily initialized on the first BatchNorm
+    // call that routes through the cuDNN dispatch path (UseCudnnForBatchNorm).
+    // Shares the same CuDnnContext as _cudnnConv (guarded by _cudnnInitLock).
+    private CuDnnBatchNorm? _cudnnBn;
     // Guards EnsureCudnnConv lazy-init against concurrent first callers.
     // Without this, two threads entering EnsureCudnnConv simultaneously
     // can both observe _cudnnConv == null and construct separate
@@ -5152,8 +5156,30 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             // Re-check inside the lock — another thread may have won the
             // race to construct and we'd otherwise leak its instance.
             if (_cudnnConv is not null) return;
-            _cudnnContext ??= new CuDnnContext();
+            // Bind the cuDNN handle to THIS backend's CUDA context (current on
+            // the calling thread via PushContext), not a fresh CudaBlasContext —
+            // otherwise cudnnSetStream(handle, _stream) fails with
+            // CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH and cuDNN can't address our
+            // device buffers. Callers MUST hold PushContext when they call this.
+            _cudnnContext ??= CuDnnContext.ForCurrentContext();
             _cudnnConv = new CuDnnConvolution(_cudnnContext);
+        }
+    }
+
+    // Lazily constructs the cuDNN batch-norm helper, sharing the backend's
+    // CuDnnContext (created here if Conv2D hasn't already). Mirrors
+    // EnsureCudnnConv's double-checked locking so concurrent first BatchNorm
+    // callers don't construct/leak duplicate helpers.
+    private void EnsureCudnnBatchNorm()
+    {
+        if (_cudnnBn is not null) return;
+        lock (_cudnnInitLock)
+        {
+            if (_cudnnBn is not null) return;
+            // Same context-binding requirement as EnsureCudnnConv — bind to the
+            // backend's current CUDA context (PushContext must be held).
+            _cudnnContext ??= CuDnnContext.ForCurrentContext();
+            _cudnnBn = new CuDnnBatchNorm(_cudnnContext);
         }
     }
 
@@ -6636,6 +6662,49 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         IGpuBuffer runningMean, IGpuBuffer runningVar, IGpuBuffer saveMean, IGpuBuffer saveInvVar,
         int batch, int channels, int spatialSize, float epsilon, float momentum, bool training)
     {
+        // cuDNN fast path (issue #1159). Gated on the UseCudnnForBatchNorm
+        // policy. Dispatches the GPU-pointer variant directly — caller-owned
+        // input / output / stat buffers, no host round-trip. The op's
+        // [batch, channels, spatialSize] layout maps to cuDNN's NCHW as
+        // n=batch, c=channels, h=spatialSize, w=1; Spatial mode then
+        // normalizes per-channel over (n, h·w), matching the hand-written
+        // kernel's reduction axis. Scope is opened here so PerformanceProfiler
+        // stats distinguish "BatchNorm.cuDNN" vs "BatchNorm.generic".
+        if (CudaDispatchPolicy.UseCudnnForBatchNorm)
+        {
+            using var _profileCudnn = CudaDispatchPolicy.Scope("BatchNorm", useVendor: true);
+            using var _ctxCudnn = PushContext();
+            EnsureCudnnBatchNorm();
+            // Stream affinity: bind cuDNN to this backend's stream so its
+            // kernels order correctly against surrounding Cuda ops. A silent
+            // bind failure would give nondeterministic results.
+            CuDnnContext.CheckStatus(
+                CuDnnNative.cudnnSetStream(_cudnnContext!.Handle, _stream),
+                "cudnnSetStream");
+            // cuDNN requires epsilon >= CUDNN_BN_MIN_EPSILON (1e-5).
+            double eps = epsilon < 1e-5 ? 1e-5 : epsilon;
+            if (training)
+            {
+                _cudnnBn!.ForwardTrainingGpu(
+                    inputDevPtr: input.Handle, outputDevPtr: output.Handle,
+                    scaleDevPtr: gamma.Handle, biasDevPtr: beta.Handle,
+                    runningMeanDevPtr: runningMean.Handle, runningVarDevPtr: runningVar.Handle,
+                    saveMeanDevPtr: saveMean.Handle, saveInvVarDevPtr: saveInvVar.Handle,
+                    n: batch, c: channels, h: spatialSize, w: 1,
+                    epsilon: eps, momentum: momentum);
+            }
+            else
+            {
+                _cudnnBn!.ForwardInferenceGpu(
+                    inputDevPtr: input.Handle, outputDevPtr: output.Handle,
+                    scaleDevPtr: gamma.Handle, biasDevPtr: beta.Handle,
+                    runningMeanDevPtr: runningMean.Handle, runningVarDevPtr: runningVar.Handle,
+                    n: batch, c: channels, h: spatialSize, w: 1,
+                    epsilon: eps);
+            }
+            return;
+        }
+
         if (!_kernelCache.TryGetValue("batchnorm_forward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: batchnorm_forward");
 
@@ -15025,6 +15094,13 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             _cudnnConv.Dispose();
             _cudnnConv = null;
+        }
+        if (_cudnnBn is not null)
+        {
+            // Shares _cudnnContext (does not own it), so this only releases
+            // the helper's own descriptors — the context is disposed below.
+            _cudnnBn.Dispose();
+            _cudnnBn = null;
         }
         if (_cudnnContext is not null)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
@@ -29,11 +29,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 /// <c>...ForwardInference</c> in eval, on GPU buffers via
 /// <c>CuDnnBatchNorm.ForwardTrainingGpu</c>/<c>ForwardInferenceGpu</c>) when
 /// <see cref="UseCudnnForBatchNorm"/>; otherwise the hand-written
-/// <c>batchnorm_forward</c> kernel. NOTE: cuDNN accumulates the UNBIASED
+/// <c>batchnorm_forward</c> kernel. Both paths accumulate the UNBIASED
 /// (Bessel-corrected) running variance — the paper-faithful estimator
-/// (Ioffe &amp; Szegedy 2015 §3.1) — whereas the hand-written kernel stores the
-/// biased batch variance; the current-batch normalization (and thus the
-/// forward output, saved mean and saved inv-var) is identical on both paths.</item>
+/// (Ioffe &amp; Szegedy 2015 §3.1) — while normalizing the current batch with the
+/// biased variance; the CUDA/HIP/OpenCL hand-written kernels were aligned to
+/// cuDNN so the two dispatch paths agree.</item>
 /// </list></para>
 /// </summary>
 internal static class CudaDispatchPolicy

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
@@ -15,7 +15,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 /// <c>PerformanceProfiler.Instance.GetStats("Conv2D.cuDNN")</c> that the
 /// vendor path actually ran.</para>
 ///
-/// <para>Dispatch status (verified against CudaBackend, AiDotNet#1159):
+/// <para>Dispatch status (verified against CudaBackend on an NVIDIA + cuDNN
+/// host, AiDotNet#1159):
 /// <list type="bullet">
 /// <item><b>Conv2D</b> — routes to cuDNN (<c>cudnnConvolutionForward</c> on GPU
 /// buffers via <c>CuDnnConvolution.Conv2DForwardGpu</c>) when
@@ -23,12 +24,16 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 /// kernel.</item>
 /// <item><b>MatMul / GEMM</b> — always routes to cuBLAS (<c>cublasSgemm</c>);
 /// the scope is labelled <c>"MatMul.cuBLAS"</c> unconditionally.</item>
-/// <item><b>BatchNorm</b> — still runs the hand-written CUDA kernel on every
-/// path. The <see cref="UseCudnnForBatchNorm"/> helper and dispatch-label
-/// scope exist, but the cuDNN BatchNorm call is NOT yet wired; it can be
-/// plugged into <c>CudaBackend.BatchNorm</c> with a single
-/// <c>if (UseCudnnForBatchNorm) ... else ...</c> check mirroring Conv2D
-/// (remaining work tracked by AiDotNet#1159).</item>
+/// <item><b>BatchNorm</b> — routes to cuDNN
+/// (<c>cudnnBatchNormalizationForwardTraining</c> in training,
+/// <c>...ForwardInference</c> in eval, on GPU buffers via
+/// <c>CuDnnBatchNorm.ForwardTrainingGpu</c>/<c>ForwardInferenceGpu</c>) when
+/// <see cref="UseCudnnForBatchNorm"/>; otherwise the hand-written
+/// <c>batchnorm_forward</c> kernel. NOTE: cuDNN accumulates the UNBIASED
+/// (Bessel-corrected) running variance — the paper-faithful estimator
+/// (Ioffe &amp; Szegedy 2015 §3.1) — whereas the hand-written kernel stores the
+/// biased batch variance; the current-batch normalization (and thus the
+/// forward output, saved mean and saved inv-var) is identical on both paths.</item>
 /// </list></para>
 /// </summary>
 internal static class CudaDispatchPolicy

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaDispatchPolicy.cs
@@ -15,12 +15,21 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 /// <c>PerformanceProfiler.Instance.GetStats("Conv2D.cuDNN")</c> that the
 /// vendor path actually ran.</para>
 ///
-/// <para>The actual vendor dispatch (calling cudnnConvolutionForward on
-/// GPU buffers) is tracked in a follow-up; today the CudaBackend Conv2D
-/// / BatchNorm methods still run their hand-written kernels. The
-/// dispatch-label scope + availability helpers are here so that path can
-/// be plugged in later with a single <c>if (UseCudnn) ... else ...</c>
-/// check without further wiring.</para>
+/// <para>Dispatch status (verified against CudaBackend, AiDotNet#1159):
+/// <list type="bullet">
+/// <item><b>Conv2D</b> — routes to cuDNN (<c>cudnnConvolutionForward</c> on GPU
+/// buffers via <c>CuDnnConvolution.Conv2DForwardGpu</c>) when
+/// <see cref="UseCudnnForConv"/>; otherwise the generic Winograd/tiled/im2col
+/// kernel.</item>
+/// <item><b>MatMul / GEMM</b> — always routes to cuBLAS (<c>cublasSgemm</c>);
+/// the scope is labelled <c>"MatMul.cuBLAS"</c> unconditionally.</item>
+/// <item><b>BatchNorm</b> — still runs the hand-written CUDA kernel on every
+/// path. The <see cref="UseCudnnForBatchNorm"/> helper and dispatch-label
+/// scope exist, but the cuDNN BatchNorm call is NOT yet wired; it can be
+/// plugged into <c>CudaBackend.BatchNorm</c> with a single
+/// <c>if (UseCudnnForBatchNorm) ... else ...</c> check mirroring Conv2D
+/// (remaining work tracked by AiDotNet#1159).</item>
+/// </list></para>
 /// </summary>
 internal static class CudaDispatchPolicy
 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaNormalizationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaNormalizationKernels.cs
@@ -90,7 +90,14 @@ extern ""C"" __global__ __launch_bounds__(256) void batchnorm_forward(
             saveMean[c] = mean;
             saveInvVar[c] = invVar;
             runningMean[c] = (1.0f - momentum) * runningMean[c] + momentum * mean;
-            runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * var;
+            // Running variance uses the UNBIASED (Bessel-corrected) estimate —
+            // paper-faithful (Ioffe & Szegedy 2015 §3.1) and identical to cuDNN's
+            // ForwardTraining. The current-batch normalization above still uses
+            // the biased var. Guard batchSpatial==1 (unbiased is undefined).
+            float runVarUnbiased = batchSpatial > 1
+                ? var * (float)batchSpatial / (float)(batchSpatial - 1)
+                : var;
+            runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * runVarUnbiased;
         }
     } else {
         // Inference: use running statistics

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNormalizationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNormalizationKernels.cs
@@ -50,7 +50,13 @@ extern ""C"" __global__ __launch_bounds__(256) void batchnorm_forward(
 
     if (training) {
         runningMean[c] = (1.0f - momentum) * runningMean[c] + momentum * mean;
-        runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * var;
+        // Unbiased (Bessel-corrected) running variance — paper-faithful
+        // (Ioffe & Szegedy 2015 §3.1), matches cuDNN. Normalization uses the
+        // biased var; guard batchSpatial==1 (unbiased is undefined).
+        float runVarUnbiased = batchSpatial > 1
+            ? var * (float)batchSpatial / (float)(batchSpatial - 1)
+            : var;
+        runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * runVarUnbiased;
     }
 
     float g = gamma[c];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/NormalizationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/NormalizationKernels.cs
@@ -83,7 +83,13 @@ __kernel void batchnorm_forward(
             saveMean[c] = mean;
             saveInvVar[c] = invVar;
             runningMean[c] = (1.0f - momentum) * runningMean[c] + momentum * mean;
-            runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * var;
+            // Unbiased (Bessel-corrected) running variance — paper-faithful
+            // (Ioffe & Szegedy 2015 §3.1), matches cuDNN. Normalization uses the
+            // biased var; guard batchSpatial==1 (unbiased is undefined).
+            float runVarUnbiased = batchSpatial > 1
+                ? var * (float)batchSpatial / (float)(batchSpatial - 1)
+                : var;
+            runningVar[c] = (1.0f - momentum) * runningVar[c] + momentum * runVarUnbiased;
         }
         barrier(CLK_LOCAL_MEM_FENCE);
     } else {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaBatchNormCudnnParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaBatchNormCudnnParityTests.cs
@@ -1,0 +1,299 @@
+// Parity tests for the cuDNN BatchNorm dispatch (issue #1159 / PR #726). CudaBackend.BatchNorm now
+// routes to cudnnBatchNormalizationForwardTraining|Inference when UseCudnnForBatchNorm is on
+// (default), and falls through to the hand-written batchnorm_forward kernel otherwise. These tests
+// run BOTH paths on the live CUDA backend from identical inputs and check each against a CPU
+// double-precision reference — so the cuDNN wiring is verified correct, not merely equal to the
+// hand-written kernel.
+//
+// One documented convention difference: cuDNN applies Bessel's correction (unbiased, /(N-1)) to the
+// RUNNING variance it accumulates, while the hand-written kernel stores the biased (/N) batch
+// variance. cuDNN's unbiased running-var is the paper-faithful choice (Ioffe & Szegedy 2015 §3.1 use
+// the unbiased estimate for inference). The current-batch NORMALIZATION uses the biased variance in
+// both paths, so the forward OUTPUT, saveMean, saveInvVar and runningMean are identical; only the
+// accumulated runningVar differs by the N/(N-1) factor. Each path is asserted against its own
+// convention. Runs only when a CUDA GPU is present.
+
+#if !NETFRAMEWORK
+#nullable disable
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.Optimization;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class CudaBatchNormCudnnParityTests : IDisposable
+{
+    private readonly DirectGpuTensorEngine _gpu;
+    private readonly bool _gpuReady;
+
+    public CudaBatchNormCudnnParityTests()
+    {
+        try { _gpu = new DirectGpuTensorEngine(); _gpuReady = _gpu.IsGpuAvailable; }
+        catch { _gpuReady = false; }
+    }
+
+    public void Dispose() => _gpu?.Dispose();
+
+    private CudaBackend GetCuda()
+    {
+        if (!_gpuReady) return null;
+        return _gpu.GetBackend() as CudaBackend;   // null on non-CUDA GPUs → test no-ops
+    }
+
+    private const float Eps = 1e-5f;   // == CUDNN_BN_MIN_EPSILON, so both paths use the same value
+    private const float Momentum = 0.1f;
+
+    // Result of one BatchNorm forward: everything the op writes.
+    private struct BnResult
+    {
+        public float[] Output;
+        public float[] SaveMean;      // batch mean (training only)
+        public float[] SaveInvVar;    // 1/sqrt(biasedVar+eps) (training only)
+        public float[] RunningMean;   // updated in place (training) / unchanged (inference)
+        public float[] RunningVar;
+    }
+
+    // Runs CudaBackend.BatchNorm once with the given cuDNN gate, from fresh copies of every input,
+    // and downloads all outputs. runningMean/runningVar are uploaded from runInMean/runInVar and read
+    // back after the (in-place) update.
+    private static BnResult RunBn(
+        CudaBackend cb, bool useCudnn, bool training,
+        float[] input, float[] gamma, float[] beta,
+        float[] runInMean, float[] runInVar,
+        int batch, int channels, int spatialSize)
+    {
+        var prev = TensorCodecOptions.Current;
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions { UseCudnnBatchNorm = useCudnn });
+        try
+        {
+            int n = batch * channels * spatialSize;
+            var inBuf = cb.AllocateBuffer(input);
+            var outBuf = cb.AllocateBuffer(n);
+            var gammaBuf = cb.AllocateBuffer(gamma);
+            var betaBuf = cb.AllocateBuffer(beta);
+            var rmBuf = cb.AllocateBuffer((float[])runInMean.Clone());
+            var rvBuf = cb.AllocateBuffer((float[])runInVar.Clone());
+            var saveMeanBuf = cb.AllocateBuffer(channels);
+            var saveInvVarBuf = cb.AllocateBuffer(channels);
+            try
+            {
+                cb.BatchNorm(inBuf, outBuf, gammaBuf, betaBuf, rmBuf, rvBuf, saveMeanBuf, saveInvVarBuf,
+                    batch, channels, spatialSize, Eps, Momentum, training);
+
+                var r = new BnResult
+                {
+                    Output = new float[n],
+                    SaveMean = new float[channels],
+                    SaveInvVar = new float[channels],
+                    RunningMean = new float[channels],
+                    RunningVar = new float[channels],
+                };
+                cb.DownloadBuffer(outBuf, r.Output);
+                cb.DownloadBuffer(saveMeanBuf, r.SaveMean);
+                cb.DownloadBuffer(saveInvVarBuf, r.SaveInvVar);
+                cb.DownloadBuffer(rmBuf, r.RunningMean);
+                cb.DownloadBuffer(rvBuf, r.RunningVar);
+                return r;
+            }
+            finally
+            {
+                (inBuf as IDisposable)?.Dispose();
+                (outBuf as IDisposable)?.Dispose();
+                (gammaBuf as IDisposable)?.Dispose();
+                (betaBuf as IDisposable)?.Dispose();
+                (rmBuf as IDisposable)?.Dispose();
+                (rvBuf as IDisposable)?.Dispose();
+                (saveMeanBuf as IDisposable)?.Dispose();
+                (saveInvVarBuf as IDisposable)?.Dispose();
+            }
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(prev);
+        }
+    }
+
+    private static float[] Rand(int seed, int n, double mag)
+    {
+        var rng = new Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)((rng.NextDouble() * 2.0 - 1.0) * mag);
+        return a;
+    }
+
+    private static void AssertClose(float[] actual, double[] expected, double tol, string what)
+    {
+        double maxErr = 0;
+        for (int i = 0; i < expected.Length; i++)
+            maxErr = Math.Max(maxErr, Math.Abs(actual[i] - expected[i]));
+        Assert.True(maxErr < tol, $"{what}: max_abs_err {maxErr:E3} exceeded {tol:E1}");
+    }
+
+    [SkippableFact]
+    public void CudnnBatchNorm_Training_MatchesCpuReference_AndHandWrittenPath()
+    {
+        var cb = GetCuda();
+        Skip.If(cb is null, "CUDA backend not available");
+        Skip.If(!CuDnnContext.IsAvailable, "cuDNN not available on this host");
+
+        const int batch = 4, channels = 3, spatialSize = 5;   // N=batch*spatial=20 → Bessel 20/19
+        int n = batch * channels * spatialSize;
+        var input = Rand(1, n, 2.0);
+        var gamma = Rand(2, channels, 1.0);
+        var beta = Rand(3, channels, 0.5);
+        var runInMean = Rand(4, channels, 0.3);
+        var runInVar = new float[channels];
+        for (int c = 0; c < channels; c++) runInVar[c] = 0.5f + 0.5f * c;   // positive
+
+        // --- CPU double-precision reference, per channel ---
+        int N = batch * spatialSize;
+        var mean = new double[channels];
+        var biasedVar = new double[channels];
+        var unbiasedVar = new double[channels];
+        var expOut = new double[n];
+        var expSaveMean = new double[channels];
+        var expSaveInvVar = new double[channels];
+        var expRunMean = new double[channels];
+        var expRunVarBiased = new double[channels];
+        var expRunVarUnbiased = new double[channels];
+        for (int c = 0; c < channels; c++)
+        {
+            double sum = 0;
+            for (int b = 0; b < batch; b++)
+                for (int s = 0; s < spatialSize; s++)
+                    sum += input[(b * channels + c) * spatialSize + s];
+            mean[c] = sum / N;
+            double vs = 0;
+            for (int b = 0; b < batch; b++)
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    double d = input[(b * channels + c) * spatialSize + s] - mean[c];
+                    vs += d * d;
+                }
+            biasedVar[c] = vs / N;
+            unbiasedVar[c] = vs / (N - 1);
+            double invStd = 1.0 / Math.Sqrt(biasedVar[c] + Eps);
+            expSaveMean[c] = mean[c];
+            expSaveInvVar[c] = invStd;
+            expRunMean[c] = (1.0 - Momentum) * runInMean[c] + Momentum * mean[c];
+            expRunVarBiased[c] = (1.0 - Momentum) * runInVar[c] + Momentum * biasedVar[c];
+            expRunVarUnbiased[c] = (1.0 - Momentum) * runInVar[c] + Momentum * unbiasedVar[c];
+            for (int b = 0; b < batch; b++)
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    int idx = (b * channels + c) * spatialSize + s;
+                    expOut[idx] = gamma[c] * (input[idx] - mean[c]) * invStd + beta[c];
+                }
+        }
+
+        var hand = RunBn(cb, useCudnn: false, training: true, input, gamma, beta, runInMean, runInVar, batch, channels, spatialSize);
+        var cudnn = RunBn(cb, useCudnn: true, training: true, input, gamma, beta, runInMean, runInVar, batch, channels, spatialSize);
+
+        // Both paths: forward output, saveMean, saveInvVar, runningMean identical to reference.
+        AssertClose(hand.Output, expOut, 1e-4, "hand output");
+        AssertClose(cudnn.Output, expOut, 1e-4, "cuDNN output");
+        AssertClose(hand.SaveMean, expSaveMean, 1e-4, "hand saveMean");
+        AssertClose(cudnn.SaveMean, expSaveMean, 1e-4, "cuDNN saveMean");
+        AssertClose(hand.SaveInvVar, expSaveInvVar, 1e-3, "hand saveInvVar");
+        AssertClose(cudnn.SaveInvVar, expSaveInvVar, 1e-3, "cuDNN saveInvVar");
+        AssertClose(hand.RunningMean, expRunMean, 1e-4, "hand runningMean");
+        AssertClose(cudnn.RunningMean, expRunMean, 1e-4, "cuDNN runningMean");
+
+        // Running variance: hand-written = biased; cuDNN = unbiased (Bessel). Each matches its own
+        // convention. The two differ measurably (N/(N-1) = 20/19), which we also assert to lock the
+        // documented behaviour in place.
+        AssertClose(hand.RunningVar, expRunVarBiased, 2e-3, "hand runningVar (biased)");
+        AssertClose(cudnn.RunningVar, expRunVarUnbiased, 2e-3, "cuDNN runningVar (unbiased/Bessel)");
+        double maxDelta = 0;
+        for (int c = 0; c < channels; c++)
+            maxDelta = Math.Max(maxDelta, Math.Abs(cudnn.RunningVar[c] - hand.RunningVar[c]));
+        Assert.True(maxDelta > 1e-4,
+            $"expected a measurable biased-vs-unbiased runningVar difference, got {maxDelta:E3}");
+    }
+
+    [SkippableFact]
+    public void CudnnBatchNorm_Inference_MatchesCpuReference_AndHandWrittenPath()
+    {
+        var cb = GetCuda();
+        Skip.If(cb is null, "CUDA backend not available");
+        Skip.If(!CuDnnContext.IsAvailable, "cuDNN not available on this host");
+
+        const int batch = 2, channels = 4, spatialSize = 6;
+        int n = batch * channels * spatialSize;
+        var input = Rand(11, n, 1.5);
+        var gamma = Rand(12, channels, 1.0);
+        var beta = Rand(13, channels, 0.5);
+        var runMean = Rand(14, channels, 0.4);
+        var runVar = new float[channels];
+        for (int c = 0; c < channels; c++) runVar[c] = 0.7f + 0.3f * c;
+
+        // CPU reference: normalize with the provided running stats (no stat update in inference).
+        var expOut = new double[n];
+        for (int c = 0; c < channels; c++)
+        {
+            double invStd = 1.0 / Math.Sqrt(runVar[c] + Eps);
+            for (int b = 0; b < batch; b++)
+                for (int s = 0; s < spatialSize; s++)
+                {
+                    int idx = (b * channels + c) * spatialSize + s;
+                    expOut[idx] = gamma[c] * (input[idx] - runMean[c]) * invStd + beta[c];
+                }
+        }
+
+        var hand = RunBn(cb, useCudnn: false, training: false, input, gamma, beta, runMean, runVar, batch, channels, spatialSize);
+        var cudnn = RunBn(cb, useCudnn: true, training: false, input, gamma, beta, runMean, runVar, batch, channels, spatialSize);
+
+        AssertClose(hand.Output, expOut, 1e-4, "hand inference output");
+        AssertClose(cudnn.Output, expOut, 1e-4, "cuDNN inference output");
+        // Inference must not mutate the running stats on either path.
+        AssertClose(hand.RunningMean, Array.ConvertAll(runMean, x => (double)x), 1e-6, "hand runningMean unchanged");
+        AssertClose(cudnn.RunningMean, Array.ConvertAll(runMean, x => (double)x), 1e-6, "cuDNN runningMean unchanged");
+    }
+
+    [SkippableFact]
+    public void CudnnBatchNorm_DispatchTelemetry_RecordsVendorPath()
+    {
+        var cb = GetCuda();
+        Skip.If(cb is null, "CUDA backend not available");
+        Skip.If(!CuDnnContext.IsAvailable, "cuDNN not available on this host");
+
+        var profiler = PerformanceProfiler.Instance;
+        bool prevEnabled = profiler.Enabled;
+        var prevOpts = TensorCodecOptions.Current;
+        profiler.Enabled = true;
+        profiler.Clear();
+        try
+        {
+            const int batch = 2, channels = 3, spatialSize = 4;
+            var input = Rand(21, batch * channels * spatialSize, 1.0);
+            var gamma = Rand(22, channels, 1.0);
+            var beta = new float[channels];
+            var rm = new float[channels];
+            var rv = new float[channels];
+            for (int c = 0; c < channels; c++) rv[c] = 1f;
+
+            RunBn(cb, useCudnn: true, training: true, input, gamma, beta, rm, rv, batch, channels, spatialSize);
+            var vendor = profiler.GetStats("BatchNorm.cuDNN");
+            Assert.True(vendor is not null && vendor.CallCount >= 1,
+                "expected the cuDNN BatchNorm dispatch path to be recorded (BatchNorm.cuDNN)");
+
+            profiler.Clear();
+            RunBn(cb, useCudnn: false, training: true, input, gamma, beta, rm, rv, batch, channels, spatialSize);
+            var generic = profiler.GetStats("BatchNorm.generic");
+            Assert.True(generic is not null && generic.CallCount >= 1,
+                "expected the hand-written BatchNorm path to be recorded (BatchNorm.generic)");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(prevOpts);
+            profiler.Enabled = prevEnabled;
+            profiler.Clear();
+        }
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaBatchNormCudnnParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CudaBatchNormCudnnParityTests.cs
@@ -204,16 +204,23 @@ public sealed class CudaBatchNormCudnnParityTests : IDisposable
         AssertClose(hand.RunningMean, expRunMean, 1e-4, "hand runningMean");
         AssertClose(cudnn.RunningMean, expRunMean, 1e-4, "cuDNN runningMean");
 
-        // Running variance: hand-written = biased; cuDNN = unbiased (Bessel). Each matches its own
-        // convention. The two differ measurably (N/(N-1) = 20/19), which we also assert to lock the
-        // documented behaviour in place.
-        AssertClose(hand.RunningVar, expRunVarBiased, 2e-3, "hand runningVar (biased)");
+        // Running variance: BOTH paths use the UNBIASED (Bessel-corrected) estimate — the
+        // paper-faithful choice (Ioffe & Szegedy 2015 §3.1). The hand-written kernel was updated to
+        // match cuDNN, so the two now agree (they no longer differ by the old N/(N-1) biased-vs-unbiased
+        // gap). expRunVarBiased is retained only as a guard that we are NOT accidentally storing biased.
+        AssertClose(hand.RunningVar, expRunVarUnbiased, 2e-3, "hand runningVar (unbiased/Bessel)");
         AssertClose(cudnn.RunningVar, expRunVarUnbiased, 2e-3, "cuDNN runningVar (unbiased/Bessel)");
         double maxDelta = 0;
         for (int c = 0; c < channels; c++)
             maxDelta = Math.Max(maxDelta, Math.Abs(cudnn.RunningVar[c] - hand.RunningVar[c]));
-        Assert.True(maxDelta > 1e-4,
-            $"expected a measurable biased-vs-unbiased runningVar difference, got {maxDelta:E3}");
+        Assert.True(maxDelta < 2e-3,
+            $"hand-written and cuDNN runningVar should now agree (both unbiased), got delta {maxDelta:E3}");
+        // Sanity: the unbiased estimate is measurably larger than the biased one for this N (20 vs 19),
+        // so confirm we did NOT regress to biased on either path.
+        double biasedGap = 0;
+        for (int c = 0; c < channels; c++)
+            biasedGap = Math.Max(biasedGap, Math.Abs(expRunVarUnbiased[c] - expRunVarBiased[c]));
+        Assert.True(biasedGap > 1e-4, $"test setup sanity: unbiased vs biased should differ, got {biasedGap:E3}");
     }
 
     [SkippableFact]


### PR DESCRIPTION
Completes **ooples/AiDotNet#1159** — verifies the CUDA vendor-dispatch status AND wires the one op that was still missing (`BatchNorm` → cuDNN). Verified on real hardware: **NVIDIA GeForce GTX 1660 Ti, CUDA 13.1, cuDNN 9**.

## Per-op vendor dispatch (now all wired)

| Op | Routes to vendor? |
|---|---|
| **Conv2D** | ✅ cuDNN — `CuDnnConvolution.Conv2DForwardGpu` (`cudnnConvolutionForward`) when `UseCudnnForConv` |
| **MatMul / GEMM** | ✅ cuBLAS — `cublasSgemm` (unconditional; scope `"MatMul.cuBLAS"`) |
| **BatchNorm** | ✅ **NEW** cuDNN — `CuDnnBatchNorm.ForwardTrainingGpu` / `ForwardInferenceGpu` (`cudnnBatchNormalizationForwardTraining`/`...Inference`) when `UseCudnnForBatchNorm` |

## What changed

1. **`CudaBackend.BatchNorm` → cuDNN fast path** (gated on `UseCudnnForBatchNorm`, default on when cuDNN is present; falls through to the hand-written `batchnorm_forward` kernel otherwise). The op's `[batch, channels, spatialSize]` layout maps to cuDNN NCHW as `n=batch, c=channels, h=spatialSize, w=1`; `Spatial` mode normalizes per-channel. Epsilon clamped to ≥ `1e-5` (`CUDNN_BN_MIN_EPSILON`); momentum passed as `exponentialAverageFactor`.

2. **Fixed a latent cuDNN context-binding bug** that would also have broken the Conv2D cuDNN path on its first real use. `CuDnnContext()` created its **own** `CudaBlasContext`, so `cudnnCreate` bound the handle to a *different* CUDA context than `CudaBackend`'s stream + device buffers → `cudnnSetStream` failed with `CUDNN_STATUS_BAD_PARAM_STREAM_MISMATCH` (and cuDNN couldn't address the caller's device pointers). Added `CuDnnContext.ForCurrentContext()` which binds the handle to the caller's already-current context; `EnsureCudnnConv` / `EnsureCudnnBatchNorm` now use it (both run under `PushContext`).

3. **Made the hand-written BatchNorm kernels paper-faithful.** The CUDA/HIP/OpenCL `batchnorm_forward` kernels stored the **biased** (`/N`) batch variance in the running variance, whereas cuDNN — and the paper (Ioffe & Szegedy 2015 §3.1) — accumulate the **unbiased** (Bessel-corrected, `/(N-1)`) estimate. Aligned all three hand-written kernels to the unbiased running variance (guarding `N==1`). The current-batch **normalization** still uses the biased variance on every path (also per the paper), so the forward output / saveMean / saveInvVar are unchanged; only the accumulated `runningVar` changes — and the cuDNN and hand-written paths now **agree**.

## Verification (local GTX 1660 Ti)

- `CudaBatchNormCudnnParityTests` **3/3** — both paths checked against a CPU double-precision reference (training + inference), cuDNN dispatch confirmed via `PerformanceProfiler` (`BatchNorm.cuDNN`), and both paths' `runningVar` asserted to match the **unbiased** reference and agree with each other.
- `GpuConvKernelCoverageTests` + `GpuCpuConsistencyTests` **22/22** — Conv2D now exercised through the (context-fixed) cuDNN path with no regression.
- Tests are `[SkippableFact]`, guarded on CUDA **and** cuDNN availability, and `#if !NETFRAMEWORK` — CI hosts without a GPU/cuDNN skip cleanly.

Closes the deferred work from the original docs-only version of this PR.

Refs ooples/AiDotNet#1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)