### PR TITLE
revert: undo accidentally-merged arena diagnostic (#725)

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -365,36 +365,6 @@ public static class TensorAllocator
         for (int i = 0; i < shape.Length; i++)
             totalSize = checked(totalSize * shape[i]);
 
-        // #1767 diagnostic: a foundation-scale (~661M-element), arena-state-dependent
-        // "Source array was not long enough" surfaces from this rent during BF16 Adam Step, but only
-        // on the fast CI runner — the local repro's 100-iter training times out before the failing
-        // step, so it can't be reproduced on a dev box. Scoped to >=100M-element rents (zero cost on
-        // ordinary allocations); on failure it rethrows with the requested shape/size and the live
-        // arena/pool state so the nightly HeavyTimeout run captures the true cause. See AiDotNet#1767.
-        if (totalSize >= LargeRentDiagnosticThreshold)
-        {
-            try
-            {
-                return RentUninitializedCore<T>(shape, totalSize);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    $"TensorAllocator.RentUninitialized failed: T={typeof(T).Name}, " +
-                    $"shape=[{string.Join(",", shape)}], totalSize={totalSize}. " +
-                    TensorArena.DescribeCurrentStateForDiagnostics(), ex);
-            }
-        }
-
-        return RentUninitializedCore<T>(shape, totalSize);
-    }
-
-    /// <summary>Element-count floor above which <see cref="RentUninitialized{T}"/> captures arena/pool
-    /// diagnostics on failure (#1767). Well above any ordinary activation/weight tensor.</summary>
-    private const int LargeRentDiagnosticThreshold = 100_000_000;
-
-    private static Tensor<T> RentUninitializedCore<T>(int[] shape, int totalSize)
-    {
         // #318: when ForceFreshAllocations is enabled the caller wants
         // backing arrays exactly logical-Length sized. Skip both the
         // arena and pool tiers — go straight to new Tensor<T>(shape).

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -177,53 +177,6 @@ public sealed class TensorArena : IDisposable
     /// </summary>
     internal static TensorArena? Current => _current;
 
-    /// <summary>
-    /// Returns a compact, never-throwing description of the calling thread's active arena and the
-    /// cross-arena persistent pool. Diagnostic-only: used to enrich a large-allocation failure so the
-    /// nightly HeavyTimeout run can capture the arena-state-dependent BF16 Adam rent failure (AiDotNet#1767).
-    /// Reports the tensor-ring sizes, dictionary-pool keys with their backing-array lengths (to expose a
-    /// size/length mismatch), and the pinned/backing/persistent counts.
-    /// </summary>
-    internal static string DescribeCurrentStateForDiagnostics()
-    {
-        try
-        {
-            var a = _current;
-            var sb = new System.Text.StringBuilder();
-            sb.Append("arenaActive=").Append(a != null);
-            if (a != null)
-            {
-                sb.Append(", tensorRingCount=").Append(a._tensorRingCount);
-                sb.Append(", tensorRingSizes=[");
-                if (a._tensorRingSizes != null)
-                    for (int i = 0; i < a._tensorRingCount && i < a._tensorRingSizes.Length; i++)
-                    { if (i > 0) sb.Append(','); sb.Append(a._tensorRingSizes[i]); }
-                sb.Append(']');
-                sb.Append(", pinnedArrays=").Append(a._pinnedArrays.Count);
-                sb.Append(", ringBackingArrays=").Append(a._ringBackingArrays.Count);
-                sb.Append(", pool={");
-                bool first = true;
-                foreach (var kv in a._pool)
-                {
-                    if (!first) sb.Append(';'); first = false;
-                    sb.Append(kv.Key.Item1?.Name).Append(':').Append(kv.Key.Item2).Append("=>");
-                    sb.Append(kv.Value?.Count ?? 0).Append('#');
-                    // backing-array lengths for this (type,size) bucket — a length != key size is the bug signature.
-                    if (kv.Value != null)
-                        for (int i = 0; i < kv.Value.Count; i++)
-                        { if (i > 0) sb.Append('/'); sb.Append(kv.Value[i]?.Length ?? -1); }
-                }
-                sb.Append('}');
-            }
-            sb.Append(", persistentPoolKeys=").Append(_persistent?.Count ?? 0);
-            return sb.ToString();
-        }
-        catch (Exception e)
-        {
-            return "arenaDiag-unavailable(" + e.GetType().Name + ")";
-        }
-    }
-
     private TensorArena(TensorArena? previous)
     {
         _previous = previous;


### PR DESCRIPTION
## What

Reverts PR #725 (`diag: capture arena/pool state on large RentUninitialized failure`, squash commit `d154bb0c`) from `main`.

## Why

#725 was **diagnostic-only** instrumentation — a temporary aid for investigating [AiDotNet#1767](https://github.com/ooples/AiDotNet/issues/1767) (ParaformerLarge BF16 8-bit Adam `Step` throwing `Source array was not long enough` at ~661M-element scale on the fast CI runner). It was **merged to `main` accidentally**; it was never meant to be a permanent change.

## Impact of leaving it (why this is safe, not urgent)

- **Nothing shipped it.** `diag:` is not a release-triggering commit type, and it was the only commit since the last tag, so the auto-release correctly bumped nothing. Latest release is still **v0.109.0** (`ec9b8892`, which predates the merge); no tag points at `d154bb0c`.
- **No downstream effect.** AiDotNet consumes Tensors as a pinned NuGet package well below 0.109.0, so it never saw this code.
- The only real risk of leaving it was the instrumentation being **swept into the next release** whenever an unrelated feat/fix/perf triggers one.

## This revert

- Purely additive undo: **2 files, −77 lines** (`TensorAllocator.cs`, `TensorArena.cs`), restoring the original inline `RentUninitialized` path. No happy-path behavior change.
- Builds clean on **net10.0 / net8.0 / net471**; no dangling references to the removed `RentUninitializedCore` / `DescribeCurrentStateForDiagnostics`.
- The diagnostic diff remains preserved on PR #725 / commit `d154bb0c`, so it can be **redeployed deliberately** (release + pin bump) when AiDotNet#1767 is actively picked up.

Refs AiDotNet#1767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large tensor allocation failures now surface more directly, without extra allocator state details in the error message.

* **Refactor**
  * Simplified the tensor allocation and arena diagnostics internals for a leaner failure path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->