### PR TITLE
Fix single-core deep-model training via cooperative-pool backward parallelism

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardParallel.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardParallel.cs
@@ -43,7 +43,7 @@ internal static class BackwardParallel
     /// dispatch beats serial execution. Below this, the
     /// <see cref="Parallel.For"/> setup cost dominates the body work.
     /// </summary>
-    internal const long MinWorkForParallel = 64L * 1024;
+    internal const long MinWorkForParallel = 8L * 1024;
 
     /// <summary>
     /// Max parallelism for backward operations. Capped lower than
@@ -95,8 +95,11 @@ internal static class BackwardParallel
         _inBackwardParallel = true;
         try
         {
-            var po = new ParallelOptions { MaxDegreeOfParallelism = MaxDegreeOfParallelism };
-            Parallel.For(0, rows, po, body);
+            // Route through the cooperative pool (StreamingWorkerPool-backed) instead of a raw Parallel.For:
+            // its per-dispatch cost is far lower, so small per-op backward work (the autodiff tape's bread and
+            // butter — e.g. N-BEATS FC-block gradients) actually fans out instead of the ForkJoin setup cost
+            // dominating and forcing single-threaded execution. The pool applies its own grain-size gate.
+            CpuParallelSettings.ParallelForOrSerial(0, rows, totalWork, body);
         }
         finally
         {


### PR DESCRIPTION
Closes #728.

Autodiff backward row-parallelism used a raw Parallel.For (high ForkJoin dispatch cost) so small per-op gradients ran serial -> deep-model training pinned to 1/128 cores. `ForRows` now dispatches through `CpuParallelSettings.ParallelForOrSerial` (the cooperative StreamingWorkerPool primitive) and lowers `MinWorkForParallel` 64K->8K so small backward ops fan out.

Verified: N-BEATS<float> (hidden 512, 3x3 blocks, forced CpuEngine) training core usage 1.0 -> ~8 cores (7.4-9.9 across four 5s samples), at BOTH batch 32 and 512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)