### PR TITLE
fix(gpu): LayerNorm/RMSNorm normalize over gamma dims for rank > 2 (fixes GPU transformer forward)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12588,6 +12588,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // path feeds Predict (TryForwardGpuOptimized), so held-out accuracy was measured on corrupted
         // activations even after training. Derive the sizes from gamma (matches CpuEngine.LayerNorm).
         int normalizedSize = gamma.Length > 0 ? gamma.Length : (shape.Length > 1 ? shape[shape.Length - 1] : shape[0]);
+        // Guard the launch geometry: batchSize below floor-divides, so a normalizedSize that does not evenly
+        // divide input.Length would silently drop the tail sample(s) and hand the backend a mismatched launch.
+        if (normalizedSize <= 0 || input.Length % normalizedSize != 0)
+        {
+            throw new ArgumentException(
+                $"LayerNormGpu: input length {input.Length} is not evenly divisible by the normalized size " +
+                $"{normalizedSize} (gamma.Length); the input's trailing dimension(s) must match gamma.",
+                nameof(input));
+        }
         int batchSize = input.Length / normalizedSize;
 
         // Upload gamma and beta to GPU

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12580,14 +12580,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             throw new InvalidOperationException("No GPU backend available for LayerNormGpu");
 
         int[] shape = input.Shape._dims;
-        int batchSize = shape[0];
-        int normalizedSize = shape.Length > 1 ? shape[1] : shape[0];
-
-        // For higher-rank tensors, flatten the normalized dimensions
-        for (int i = 2; i < shape.Length; i++)
-        {
-            normalizedSize *= shape[i];
-        }
+        // LayerNorm normalizes over the trailing dims that gamma spans (gamma.Length), treating every
+        // leading position as an independent sample. The previous code took normalizedSize = shape[1]
+        // (times shape[2..]) with batchSize = shape[0], which is only correct for a rank-2 [B, D] input.
+        // For a transformer's rank-3 [B, S, D] activations that flattened S into the normalized size
+        // (normalizedSize = S*D) and read gamma/beta (length D) out of bounds → garbage output. This
+        // path feeds Predict (TryForwardGpuOptimized), so held-out accuracy was measured on corrupted
+        // activations even after training. Derive the sizes from gamma (matches CpuEngine.LayerNorm).
+        int normalizedSize = gamma.Length > 0 ? gamma.Length : (shape.Length > 1 ? shape[shape.Length - 1] : shape[0]);
+        int batchSize = input.Length / normalizedSize;
 
         // Upload gamma and beta to GPU
         using var gammaBuffer = GetOrCacheWeightBuffer(backend, gamma.GetDataArray(), PersistentTensorRole.Weights);
@@ -18171,8 +18172,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         bool ownershipTransferred = false;
         try
         {
-            int outerSize = input.Shape._dims[0];
-            int normSize = input.Length / outerSize;
+            // LayerNorm normalizes over the trailing dims that gamma spans (gamma.Length),
+            // treating every leading dim as a row. For a rank-2 [rows, D] input dims[0] equals
+            // the row count so `outerSize = dims[0]` was correct, but for rank > 2 (e.g. a
+            // transformer's [B, S, D] activations) `outerSize = dims[0]` = B set
+            // `normSize = Length/B = S*D`, so the kernel read gamma/beta (length D) out of
+            // bounds and normalized over S*D elements → garbage output (CPU-vs-GPU maxDiff ~70).
+            // Derive normSize from gamma (matches the CpuEngine reference + the kernel's
+            // per-row gamma/beta contract) and fold all leading dims into outerSize.
+            int normSize = gamma.Length;
+            int outerSize = input.Length / normSize;
 
             // FP16 Half-resident store (keystone-enabled): read IsFp16 input/gamma/beta directly, FP16-native
             // layernorm (Half output + FP32 mean/var), store Half output — keeps the per-layer norm Half.
@@ -18334,8 +18343,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         bool ownershipTransferred = false;
         try
         {
-            int outerSize = input.Shape._dims[0];
-            int normSize = input.Length / outerSize;
+            // Normalize over gamma's trailing dims (gamma.Length), folding every leading dim
+            // into outerSize. `outerSize = dims[0]` was only correct for rank-2 input; for a
+            // rank-3 [B, S, D] tensor it set normSize = S*D and read gamma (length D) out of
+            // bounds → garbage. See the LayerNorm fix above for the full rationale.
+            int normSize = gamma.Length;
+            int outerSize = input.Length / normSize;
             using var bufIn = GetOrAllocateBuffer(backend, input);
             using var bufGamma = GetOrAllocateBuffer(backend, gamma);
             bufOut = AllocateOutputBuffer(backend, input.Length);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -112,6 +112,42 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
         Assert.True(err < Tol, $"{op}: GPU vs CPU max_abs_err {err:E3} exceeded tolerance {Tol:E3}");
     }
 
+    // Regression: LayerNorm must normalize over the trailing (gamma-length) dims for EVERY rank,
+    // not just rank-2. The GPU path previously took outerSize = shape[0] / normSize = Length/shape[0],
+    // which for a transformer's rank-3 [B, S, D] input normalized over S*D and read gamma/beta
+    // (length D) out of bounds → garbage (measured CPU-vs-GPU max_abs_err ~70 on [2,8,48]). rank-2
+    // happened to work because shape[0] equals the row count. This drove a transformer trained through
+    // the AiDotNet facade to chance accuracy on the GPU engine (its [B,S,D] activations were corrupted).
+    public static IEnumerable<object[]> LayerNormShapes() => new List<object[]>
+    {
+        new object[] { new[] { 16, 48 } },       // rank-2 (always worked)
+        new object[] { new[] { 1, 8, 48 } },     // rank-3, batch 1 (the Predict shape)
+        new object[] { new[] { 2, 8, 48 } },     // rank-3 [B,S,D]
+        new object[] { new[] { 4, 3, 32 } },     // rank-3, non-square
+        new object[] { new[] { 2, 2, 4, 16 } },  // rank-4
+    };
+
+    [Theory]
+    [MemberData(nameof(LayerNormShapes))]
+    public void LayerNorm_RankGe2_GpuMatchesCpu(int[] shape)
+    {
+        if (!EnsureGpuReady()) return;
+        int d = shape[shape.Length - 1];
+        var input = Rand(101, shape);
+        var gamma = Rand(102, d);
+        var beta = Rand(103, d);
+
+        var cpu = _cpu.TensorLayerNorm(input, gamma, beta, 1e-5);
+        var gpu = _gpu.TensorLayerNorm(input, gamma, beta, 1e-5);
+        AssertGpuMatchesCpu(gpu, cpu, $"TensorLayerNorm[{string.Join(",", shape)}]");
+
+        // The GPU-resident forward path (LayerNormGpu, used by Predict/TryForwardGpuOptimized)
+        // must normalize identically for rank >= 3. It requires a GPU-resident input.
+        var gpuInput = input.Gpu();
+        var (gpuResident, _, _) = _gpu.LayerNormGpu(gpuInput, gamma, beta, 1e-5);
+        AssertGpuMatchesCpu(gpuResident, cpu, $"LayerNormGpu[{string.Join(",", shape)}]");
+    }
+
     // Shapes span: <128 (the #364 hot zone), tile boundaries around WGD=32,
     // exact/off-by-one multiples, non-square, degenerate 1-dims, and >=128.
     public static IEnumerable<object[]> GemmSizes() => new List<object[]>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -144,8 +144,29 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
         // The GPU-resident forward path (LayerNormGpu, used by Predict/TryForwardGpuOptimized)
         // must normalize identically for rank >= 3. It requires a GPU-resident input.
         var gpuInput = input.Gpu();
-        var (gpuResident, _, _) = _gpu.LayerNormGpu(gpuInput, gamma, beta, 1e-5);
+        var (gpuResident, gpuMean, gpuInvVar) = _gpu.LayerNormGpu(gpuInput, gamma, beta, 1e-5);
         AssertGpuMatchesCpu(gpuResident, cpu, $"LayerNormGpu[{string.Join(",", shape)}]");
+
+        // Close the loop on the full tuple: the saved per-sample mean / inverse-variance (consumed by the
+        // backward pass) must be correct too, not just the normalized output. Recompute them the way LayerNorm
+        // does over each gamma-spanning sample — population mean and inverse std 1 / sqrt(var + eps).
+        int normSize = d;
+        int samples = input.Length / normSize;
+        var flat = input.ToArray();
+        var expMean = new float[samples];
+        var expInvVar = new float[samples];
+        for (int s = 0; s < samples; s++)
+        {
+            double sum = 0;
+            for (int j = 0; j < normSize; j++) sum += flat[s * normSize + j];
+            double mean = sum / normSize;
+            double varAcc = 0;
+            for (int j = 0; j < normSize; j++) { double diff = flat[s * normSize + j] - mean; varAcc += diff * diff; }
+            expMean[s] = (float)mean;
+            expInvVar[s] = (float)(1.0 / Math.Sqrt(varAcc / normSize + 1e-5));
+        }
+        AssertGpuMatchesCpu(gpuMean, new Tensor<float>(expMean, new[] { samples }), $"LayerNormGpu.SaveMean[{string.Join(",", shape)}]");
+        AssertGpuMatchesCpu(gpuInvVar, new Tensor<float>(expInvVar, new[] { samples }), $"LayerNormGpu.SaveInvVar[{string.Join(",", shape)}]");
     }
 
     // Shapes span: <128 (the #364 hot zone), tile boundaries around WGD=32,


### PR DESCRIPTION
## Summary
The DirectGpu `LayerNorm` / `RMSNorm` forward paths computed the normalized size from `input.Shape._dims[0]` (`outerSize = dims[0]; normSize = Length/dims[0]`), and `LayerNormGpu` flattened dims 2+ into the normalized size. That is only correct for a **rank-2** `[rows, D]` input.

For a transformer's **rank-3 `[B, S, D]`** activations this set `normSize = S*D` and read `gamma`/`beta` (length `D`) out of bounds, so the GPU normalized over `S*D` elements and produced garbage — measured CPU-vs-GPU `max_abs_err ≈ 70` on `[2,8,48]`.

Because `LayerNormGpu` feeds `Predict` via `TryForwardGpuOptimized`, a `Transformer<float>` trained through the AiDotNet facade scored **chance accuracy on the GPU engine**: its per-position `[B,S,D]` LayerNorm was corrupted on every forward. After this fix the untrained GPU forward is **bit-identical** to the CpuEngine reference.

## Root cause
`normSize` must be derived from the **trailing normalized dims that gamma spans** (`gamma.Length`), with every leading dim folded into `outerSize` — exactly what `CpuEngine.LayerNorm` does. The resident compiled path (`TryLayerNormResidentInto`) and the float-specialized tape path already did this; the eager generic `LayerNorm` override, `RMSNorm`, and `LayerNormGpu` still used `dims[0]`.

## Fix
- `LayerNorm<T>` override: `normSize = gamma.Length; outerSize = input.Length / normSize`.
- `RMSNorm<T>` override: same.
- `LayerNormGpu<T>` (GPU-resident Predict path): `normalizedSize = gamma.Length; batchSize = input.Length / normalizedSize` (drop the flatten-dims-2+ logic).

## Verification (RTX 3080, CUDA backend)
- Op-level CPU-vs-CUDA diff on `[2,8,48]`: `max_abs_err` **69.6 → 2.4e-7**.
- Untrained `Transformer<float>` (d48/L2/h4, SequenceClassification) forward `Predict`: **bit-identical** GPU vs CPU after the fix (garbage before).
- New regression test `LayerNorm_RankGe2_GpuMatchesCpu` (ranks 2/3/4) covering both `TensorLayerNorm` and the `LayerNormGpu` Predict path — all pass.

## Note
This fixes GPU **forward/inference** correctness for `[B,S,D]` LayerNorm. A separate, deeper issue remains where the same tiny transformer's **multi-step GPU training** (AiModelBuilder + AdamOptimizer tape loop) blows up the weights nondeterministically even though each single-batch gradient is deterministic and bit-matches the CPU engine — that is a distinct GPU-residency/weight-sync bug under the training loop's allocation churn, not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU layer normalization for higher-rank tensors so normalization now uses the correct last-dimension size, matching CPU results and avoiding incorrect output on 3D+ inputs.

* **Tests**
  * Added regression coverage to verify GPU and CPU layer normalization produce the same results across rank-2 to rank-4 shapes.
  * Added validation for both CPU-backed and GPU-resident tensor paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->