### PR TITLE
perf: cache per-op env-var reads + skip zero-fill on small RentUninitialized

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -415,6 +415,14 @@ internal static class DifferentiableOps
         return false;
     }
 
+    // Cached once at type init. AccumulateGrad runs per-op on the backward
+    // pass, and the env read below executed BEFORE the cheap engine-type check
+    // short-circuited, so it fired on every CPU backward op too — part of the
+    // ~5.8% GetEnvironmentVariable hot-path cost in the N-BEATS profile
+    // (#728/#1804). Debug-only flag; env vars are process-stable.
+    private static readonly bool _graphCaptureDebug =
+        Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1";
+
     /// <summary>
     /// Accumulates a gradient for a tensor in the gradient dictionary.
     /// If the tensor already has a gradient, the new gradient is added to it.
@@ -462,7 +470,7 @@ internal static class DifferentiableOps
         // preserves graph connectivity through the original grad
         // reference. Keep the original `grad` for the out-of-place
         // path; only materialize for in-place add storage.
-        if (Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1"
+        if (_graphCaptureDebug
             && engine is AiDotNet.Tensors.Engines.DirectGpuTensorEngine gde && gde.ResidentStepActive)
         {
             Tensor<T>? exi = grads.TryGetValue(tensor, out var ed) ? ed : null;

--- a/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorAllocator.cs
@@ -419,8 +419,19 @@ public static class TensorAllocator
             return Tensor<T>.FromPooledMemory(memory, shape, pooled);
         }
 
-        // Small allocation: new T[] is zeroed by CLR but that's unavoidable
-        T[] arr = new T[totalSize];
+        // Small allocation (below the ArrayPool threshold — the common case for
+        // deep-model training temporaries: every op output/grad/optimizer temp
+        // in an N-BEATS step lands here). RentUninitialized's contract is that
+        // the caller writes every logical element — the pooled paths above
+        // already skip clearing the logical region on that basis — so the CLR
+        // zero-fill a plain `new T[]` pays is wasted work for value types. It
+        // was ~25% of N-BEATS train wall-clock in the profile (#1804).
+        // GC.AllocateUninitializedArray skips the memset for value types;
+        // reference types MUST stay zeroed so the GC never walks uninitialized
+        // object references.
+        T[] arr = RuntimeHelpers.IsReferenceOrContainsReferences<T>()
+            ? new T[totalSize]
+            : GC.AllocateUninitializedArray<T>(totalSize);
         return Tensor<T>.FromMemory(new Memory<T>(arr), shape);
 #else
         return new Tensor<T>(shape);

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -201,12 +201,21 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// <para><b>Performance:</b> O(1) when already contiguous (just returns this).
     /// O(n) only when the tensor is a non-contiguous view (e.g., from Transpose).</para>
     /// </remarks>
+    // Cached once at type init. Contiguous() is a per-op hot path — every
+    // BLAS/permute/reshape operand that isn't already contiguous materializes
+    // through here — so reading the env var on every call cost ~5.8% of N-BEATS
+    // train wall-clock in a PerfView profile (#728/#1804). The flag is a
+    // debug-only diagnostic and env vars don't change mid-process, so reading
+    // it once at startup is both correct and free on the hot path.
+    private static readonly bool _debugContig =
+        Environment.GetEnvironmentVariable("AIDOTNET_DEBUG_CONTIG") == "1";
+
     public Tensor<T> Contiguous()
     {
         ThrowIfSparse();
         if (IsContiguous && _storageOffset == 0) return this;
 
-        if (Environment.GetEnvironmentVariable("AIDOTNET_DEBUG_CONTIG") == "1" && Length >= 256)
+        if (_debugContig && Length >= 256)
         {
             try
             {


### PR DESCRIPTION
## What

Three managed-only micro-optimizations on N-BEATS / deep-model CPU training hot paths, surfaced by a PerfView profile (Tensors #728 / ooples/AiDotNet #1804). No behavior change; the debug diagnostics still work (env vars are process-stable, so reading them once at type init is equivalent).

### (a) Two per-op `GetEnvironmentVariable` reads, now cached in `static readonly` fields

- **`Tensor.Contiguous()`** read `AIDOTNET_DEBUG_CONTIG` on *every* call. `Contiguous()` is a per-op hot path — roughly every BLAS/permute/reshape operand that isn't already contiguous materializes through here.
- **`DifferentiableOps.AccumulateGrad()`** read `AIDOTNET_GRAPH_CAPTURE_DEBUG` per backward op — and the read executed *before* the cheap `engine is DirectGpuTensorEngine` check short-circuited, so it fired on every CPU backward op too.

`GetEnvironmentVariable` walks the process environment block on each call. Both flags are debug-only diagnostics and env vars don't change mid-process, so each is now read once into a `static readonly bool` at type init and free on the hot path. Together these were ~5.8% of N-BEATS train wall-clock in the profile.

### (b) Skip the zero-fill on the small-tensor `RentUninitialized` path

`TensorAllocator.RentUninitialized`'s small-allocation branch (below the 256K `ArrayPool` threshold — the common case: essentially every op output / grad / optimizer temp in an N-BEATS step lands here) used `new T[]`, which the CLR zeroes. `RentUninitialized`'s contract is that the caller writes every logical element — the pooled paths above it already skip clearing the logical region on exactly that basis — so the memset is wasted work. Value types now use `GC.AllocateUninitializedArray<T>` (under the existing `#if NET5_0_OR_GREATER`); reference types stay on `new T[]` so the GC never walks uninitialized object references. The profile attributed ~25% of N-BEATS train wall-clock to this zero-fill.

## Measured

Harness: console app training `NBEATSModel<float>` (LookbackWindow=96, ForecastHorizon=12, NumStacks=3, NumBlocksPerStack=3, HiddenLayerSize=256, Epochs=8, BatchSize=64, n=4000), forced `CpuEngine`, net10.0. 128-core box, run quiet, all configs back-to-back in one session, each config run twice.

| Config | AiDotNet | Tensors | wall run1 / run2 | avg cores run1 / run2 |
|---|---|---|---|---|
| A. Baseline | 0.229.3-master2 | 0.110.0 | 41.4s / 43.8s | 11.36 / 11.04 |
| B. Tensors-only (this PR) | 0.229.3-master2 | 0.110.1-perf | 40.1s / 40.7s | 12.68 / 12.90 |
| C. + AiDotNet Adam-parallel | 0.229.4-adampar | 0.110.1-perf | 29.9s / 26.3s | 18.53 / 18.41 |

- **Tensors-side delta (B vs A):** ~42.6s → ~40.4s, about **2.2s (~5%)** faster, avg cores 11.2 → 12.8.
- **All-three total (C vs A):** ~42.6s → ~28.1s, about **14.5s (~34%)** faster, avg cores 11.2 → 18.4.
- **vs PyTorch reference (16.6s):** C at ~28.1s is still ~1.7x slower.

### Honest note on the size of the Tensors-side win

The measured B-vs-A delta (~5%) is **substantially smaller** than the profile's headline 25% (zero-fill) + 5.8% (env reads) suggested. The bulk of that ~25% profile weight was the *allocation itself*; this change removes only the *zero-fill memset*, not the allocation, so the realized saving is a fraction of the profiled cost. The large jump to config C comes from the AiDotNet-side Adam-parallelism change (`0.229.4-adampar`, avg cores 12.9 → 18.4), which is out of scope for this repo. These edits are still a clean, no-risk win on a genuinely hot path, but I want to be upfront that they are a few-percent improvement, not the ~30% the raw profile column implied.

## Refs

Contributes to ooples/AiDotNet#1804. References #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
