### PR TITLE
fix(gpu): CUDA Dropout dropped 100% of activations (mask never generated) + stale seed

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -7179,19 +7179,33 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!_kernelCache.TryGetValue("dropout_forward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: dropout_forward");
 
+        // dropout_forward ONLY applies a pre-generated mask (output = input * mask * scale); it does
+        // NOT generate the random mask. The previous code (a) never populated `mask` — the freshly
+        // allocated buffer was all-zero, so every element was multiplied by 0 and 100% of activations
+        // were dropped (mask/output identically 0) — and (b) passed the launch args in the wrong slots
+        // (`size` landed in the kernel's `scale` param and `dropoutRate` in its `size` param, with a
+        // stray 6th `seed` arg the kernel doesn't take). During training this zeroed every dropout
+        // layer's output, so the transformer forward was garbage and GPU training diverged to chance.
+        //
+        // Correct flow: first fill `mask` with the inverted-dropout mask (keepProb = 1 - dropoutRate;
+        // each kept element = 1/keepProb, dropped = 0 — the invKeep scale is baked into the mask, exactly
+        // as CpuEngine.Dropout does), then apply it with scale = 1. When not training / rate <= 0 the
+        // mask kernel keeps everything at scale 1, so output == input (identity), matching the CPU path.
+        float keepProb = training ? (1.0f - dropoutRate) : 1.0f;
+        DropoutMask(mask, size, keepProb, seed);
+
         using var _ = PushContext();
         uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr inputPtr = input.Handle;
         IntPtr outputPtr = output.Handle;
         IntPtr maskPtr = mask.Handle;
-        int trainingInt = training ? 1 : 0;
-        void** args = stackalloc void*[6];
+        float scale = 1.0f; // invKeep is already baked into the mask by dropout_mask
+        void** args = stackalloc void*[5];
         args[0] = &inputPtr;
         args[1] = &outputPtr;
         args[2] = &maskPtr;
-        args[3] = &size;
-        args[4] = &dropoutRate;
-        args[5] = &seed;
+        args[3] = &scale;
+        args[4] = &size;
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 
@@ -7200,17 +7214,24 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!_kernelCache.TryGetValue("dropout_backward", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: dropout_backward");
 
+        // dropout_backward kernel signature is (gradOutput, mask, gradInput, float scale, int size).
+        // The previous launch passed `size` into the kernel's `scale` slot and `dropoutRate` into its
+        // `size` slot (mismatched arg order), so the backward gradient was scaled by a garbage factor
+        // and covered a garbage element count. The forward bakes invKeep into the mask and applies
+        // scale = 1, so the backward must also use scale = 1 to stay consistent (gradInput =
+        // gradOutput * mask, with mask = 1/keepProb on kept units, 0 on dropped units).
         using var _ = PushContext();
         uint grid = (uint)((size + DefaultBlockSize - 1) / DefaultBlockSize);
         IntPtr gradOutputPtr = gradOutput.Handle;
         IntPtr maskPtr = mask.Handle;
         IntPtr gradInputPtr = gradInput.Handle;
+        float scale = 1.0f; // invKeep already baked into the mask by dropout_mask
         void** args = stackalloc void*[5];
         args[0] = &gradOutputPtr;
         args[1] = &maskPtr;
         args[2] = &gradInputPtr;
-        args[3] = &size;
-        args[4] = &dropoutRate;
+        args[3] = &scale;
+        args[4] = &size;
         LaunchKernel(kernel, grid, DefaultBlockSize, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -256,6 +256,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // Version tracking for invalidation
     private readonly ConcurrentDictionary<object, int> _tensorVersions = new();
 
+    // Monotonic per-call counter for stochastic-op seeds (dropout, etc.). The old code seeded the
+    // GPU dropout RNG from Environment.TickCount / DateTime.UtcNow.Ticks. TickCount has ~15 ms
+    // resolution, so the many dropout calls a training step fires in <1 ms all got the SAME seed →
+    // the Philox mask kernel (seed ^ index) produced an IDENTICAL mask for every dropout layer AND
+    // across consecutive steps, so a fixed subset of units was permanently dropped and the network
+    // could not learn. An advancing counter gives every call an independent, well-spread seed and is
+    // deterministic across runs (reproducible training) — the golden-ratio multiplier decorrelates
+    // sequential counter values for Philox.
+    private long _stochasticSeedCounter;
+    private ulong NextStochasticSeed() =>
+        unchecked((ulong)System.Threading.Interlocked.Increment(ref _stochasticSeedCounter) * 0x9E3779B97F4A7C15UL);
+
     // CSR buffer cache for sparse tensors — avoids re-uploading static sparse matrices every call.
     // Key: CsrCacheKey (SparseTensor + Backend reference pair) to avoid cross-backend buffer reuse.
     private readonly ConcurrentDictionary<CsrCacheKey, CsrGpuCache> _csrBufferCache = new();
@@ -13388,7 +13400,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             int size = input.Length;
-            ulong seed = (ulong)DateTime.UtcNow.Ticks;
+            ulong seed = NextStochasticSeed();
 
             using var inputBuffer = GetOrAllocateBuffer(backend, input);
             using var outputBuffer = AllocateOutputBuffer(backend, size);
@@ -18872,7 +18884,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         try
         {
-            ulong seed = (ulong)Environment.TickCount;
+            ulong seed = NextStochasticSeed();
             using var bufIn = GetOrAllocateBuffer(backend, input);
             var bufOut = AllocateOutputBuffer(backend, input.Length);
             var bufMask = AllocateOutputBuffer(backend, input.Length);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -112,6 +112,62 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
         Assert.True(err < Tol, $"{op}: GPU vs CPU max_abs_err {err:E3} exceeded tolerance {Tol:E3}");
     }
 
+    // Regression: the GPU training-mode Dropout must actually generate an inverted-dropout mask.
+    // The CUDA path launched dropout_forward (which only APPLIES a pre-generated mask) without ever
+    // filling the mask buffer and with mismatched launch args, so the mask was all-zero and 100% of
+    // activations were dropped (output identically 0). That zeroed every dropout layer during training,
+    // so any model with dropout > 0 could not learn on the GPU. Assert the mask actually keeps roughly
+    // (1 - rate) of the units, applies the 1/keepProb inverted-dropout scale, is finite, and that
+    // forward/backward are consistent (backward passes the same units through, at the same scale).
+    [Theory]
+    [InlineData(0.1)]
+    [InlineData(0.3)]
+    [InlineData(0.5)]
+    public void Dropout_Training_GpuGeneratesMaskLikeCpu(double rate)
+    {
+        if (!EnsureGpuReady()) return;
+        const int n = 8192;
+        var ones = new Tensor<float>(Enumerable.Repeat(1.0f, n).ToArray(), new[] { n });
+
+        var gpuOut = _gpu.Dropout(ones, rate, training: true, out var gpuMask);
+        var og = gpuOut.ToArray();
+        var mg = gpuMask.ToArray();
+
+        int zeros = 0; double keptSum = 0; int kept = 0;
+        for (int i = 0; i < n; i++)
+        {
+            Assert.False(float.IsNaN(og[i]) || float.IsInfinity(og[i]), $"GPU dropout produced non-finite {og[i]}");
+            Assert.Equal(og[i] == 0f, mg[i] == 0f); // mask and output agree on which units are dropped
+            if (og[i] == 0f) zeros++; else { keptSum += og[i]; kept++; }
+        }
+        double fracDropped = (double)zeros / n;
+        // The previous bug dropped 100%; a correct kernel drops ~rate. Wide band tolerates RNG variance
+        // but firmly excludes the all-dropped (1.0) and no-dropped (0.0) failure modes.
+        Assert.True(Math.Abs(fracDropped - rate) < 0.06,
+            $"GPU dropout fraction {fracDropped:F3} not ~{rate:F3} (100%-drop bug regression?)");
+        Assert.True(kept > 0, "GPU dropout dropped everything (mask never generated)");
+        double invKeep = 1.0 / (1.0 - rate);
+        double meanKept = keptSum / kept;
+        Assert.True(Math.Abs(meanKept - invKeep) < 1e-3,
+            $"GPU dropout kept-value {meanKept:F4} not the inverted-dropout scale {invKeep:F4}");
+
+        // Backward must pass gradients through the SAME kept units at the SAME scale (gradInput = gradOut * mask).
+        var gradOut = Rand(202, n);
+        var gradIn = ((AiDotNet.Tensors.Engines.IEngine)_gpu).DropoutBackward(gradOut, gpuMask, rate);
+        var gi = gradIn.ToArray(); var go = gradOut.ToArray();
+        for (int i = 0; i < n; i++)
+        {
+            float expected = go[i] * mg[i];
+            Assert.True(Math.Abs(gi[i] - expected) < 1e-3f,
+                $"GPU dropout backward {gi[i]} != gradOut*mask {expected} at {i}");
+        }
+
+        // Inference (training: false) must be identity.
+        var infer = _gpu.Dropout(ones, rate, training: false, out _);
+        foreach (var v in infer.ToArray())
+            Assert.True(Math.Abs(v - 1.0f) < 1e-4f, "GPU dropout in inference mode must be identity");
+    }
+
     // Shapes span: <128 (the #364 hot zone), tile boundaries around WGD=32,
     // exact/off-by-one multiples, non-square, degenerate 1-dims, and >=128.
     public static IEnumerable<object[]> GemmSizes() => new List<object[]>


### PR DESCRIPTION
## Summary
`CudaBackend.Dropout` / `DropoutBackward` launch the `dropout_forward` / `dropout_backward` kernels, which **only apply** a pre-generated mask (`output = input * mask * scale`). Two bugs made them catastrophically wrong in training mode:

1. **The mask was never generated.** `Dropout` allocated a fresh mask buffer and passed it straight to `dropout_forward` without filling it, so every element was multiplied by an all-zero mask → **100% of activations dropped** (output and mask identically 0). Verified on an all-ones input: GPU `fracZero = 1.000` vs CPU `0.30`.
2. **Mismatched launch args.** `dropout_forward`'s signature is `(input, output, mask, float scale, int size)` but the launch passed `(input, output, mask, size, dropoutRate, seed)` — `size` landed in `scale`, `dropoutRate` in `size`, plus a stray 6th arg. `dropout_backward` had the same size/scale swap.

**Impact:** any model with dropout > 0 (e.g. a `Transformer<T>`, default rate 0.1) had a garbage forward on the GPU engine — every dropout layer zeroed its output — so it sat at chance held-out accuracy while the CpuEngine trained normally. This is broad: it corrupts training for **every** dropout-using model on the CUDA backend, not just transformers.

## Fix
Generate the inverted-dropout mask with the existing `dropout_mask` kernel (`keepProb = 1 - rate`; kept = `1/keepProb`, dropped = 0 — invKeep baked into the mask exactly as `CpuEngine.Dropout`), then apply / gradient with `scale = 1` and the correct arg order. Inference (`training: false`) keeps everything at scale 1 (identity).

Also fixes the **RNG seed**: it was seeded from `Environment.TickCount` (~15 ms resolution), so the many dropout calls a training step fires within one tick all got the *same* seed → the Philox kernel produced an identical mask for every dropout layer and across consecutive steps (correlated/degenerate dropout). Replaced with a monotonic per-call counter (golden-ratio-mixed) — independent, well-spread, and deterministic run-to-run.

## Verification (RTX 3080, CUDA)
- Op-level, all-ones input, rate 0.3: **before** `fracZero=1.000, keptVal=0`; **after** `fracZero=0.303, keptVal=1.4286` (== `1/(1-0.3)`), matching CpuEngine.
- New regression test `Dropout_Training_GpuGeneratesMaskLikeCpu` (rates 0.1/0.3/0.5): asserts drop fraction ≈ rate, inverted-dropout scale, forward/backward consistency, and inference identity. Fails on the old 100%-drop kernel; passes after.

## Note
This is one of (at least) two GPU-training-correctness bugs found while investigating a facade `Transformer<float>` that trained on CpuEngine but sat at chance on the GPU engine. The LayerNorm rank-3 fix is #730. With both fixes the catastrophic corruptions are gone; a separate, deeper GPU-residency/determinism issue (the trained weights still inflate ~5x vs CPU over a full multi-epoch run) remains and is tracked separately.