### PR TITLE
fix(gpu): DetectVendor prefers CUDA over OpenCL device-0 vendor on mixed-GPU boxes

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuBackendFactory.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuBackendFactory.cs
@@ -76,7 +76,18 @@ public static class DirectGpuBackendFactory
     /// </summary>
     public static GpuVendor DetectVendor()
     {
-        // Try OpenCL first (works on all vendors)
+        // Prefer CUDA detection FIRST. The OpenCL probe below returns the vendor of OpenCL device 0,
+        // which on a mixed-vendor box (an NVIDIA discrete GPU alongside an AMD/Intel iGPU that exposes
+        // its own OpenCL platform) can be the integrated AMD/Intel part — silently routing an
+        // NVIDIA+CUDA machine down the AMD/OpenCL fallback path (CreateAmdBackend → OpenCL) even though
+        // cuBLAS/NVRTC load fine. If the CUDA runtime is present this is an NVIDIA box; trust that and
+        // let CreateNvidiaBackend pick CUDA (its own OpenCL fallback still covers a CUDA-init failure).
+        if (CudaBackend.IsCudaAvailable)
+        {
+            return GpuVendor.NVIDIA;
+        }
+
+        // Try OpenCL next (works on all vendors)
         if (DirectOpenClContext.IsAvailable)
         {
             try
@@ -88,12 +99,6 @@ public static class DirectGpuBackendFactory
             {
                 // Fall through to other detection methods
             }
-        }
-
-        // Try CUDA (NVIDIA only)
-        if (CudaBackend.IsCudaAvailable)
-        {
-            return GpuVendor.NVIDIA;
         }
 
         // Try HIP (AMD only)


### PR DESCRIPTION
## Summary
`DirectGpuBackendFactory.DetectVendor()` probed OpenCL **first** and returned the vendor of OpenCL device 0. On a mixed-vendor machine — an NVIDIA discrete GPU alongside an AMD/Intel iGPU that exposes its own OpenCL platform — device 0 can be the integrated part, so the factory reported **AMD** and routed the box down `CreateAmdBackend → OpenCL`, silently using the OpenCL fallback on an NVIDIA + CUDA machine where cuBLAS/NVRTC load fine.

Measured on an RTX 3080 workstation: `DetectedVendor = AMD`, `Factory.Create() = OpenClBackend`, despite `CudaBackend.IsCudaAvailable == true`.

## Fix
Check `CudaBackend.IsCudaAvailable` **first** — if the CUDA runtime is present this is an NVIDIA box, so return `NVIDIA` and let `CreateNvidiaBackend` select CUDA (its own OpenCL fallback still covers a CUDA-init failure). Pure-AMD/Intel boxes (no CUDA runtime) fall through to the unchanged OpenCL probe.

## Verification (RTX 3080)
- Before: `DetectedVendor = AMD`, `Factory.Create() = OpenClBackend`.
- After: `DetectedVendor = NVIDIA`, `Factory.Create() = CudaBackend`.

## Note
`DirectGpuTensorEngine`/`DirectGpuEngine` use their own backend-order (`AIDOTNET_DIRECTGPU_BACKENDS`, default `cuda,opencl,hip`) and already selected CUDA correctly, so this factory path is a separate consumer; the bug was latent for the main engine but affects anything that calls `DirectGpuBackendFactory` directly, and the silent fallback to a slower/less-tested backend is undesirable regardless.