### PR TITLE
perf: zero-alloc training via TensorArena reuse + shape-safe ring (DRAFT)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -86,7 +86,11 @@ public static class GradientCheckpointing<T>
                     // SymbolicBackwardGraphBuilder.Analyze when the cached pattern
                     // does not match the current tape's reachable entries).
                     using var recomputeTape = new GradientTape<T>(
-                        new GradientTapeOptions { Persistent = false });
+                        // SuppressArenaScope: this inner tape runs mid-backward, where the outer
+                        // tape has nulled the thread-current tape, so it would otherwise look like a
+                        // step-boundary tape and Reset() the OUTER tape's arena — corrupting the
+                        // accumulating gradients (#734). It borrows the arena for scratch only.
+                        new GradientTapeOptions { Persistent = false, SuppressArenaScope = true });
                     var reInput = inputs[0];
                     // Detach the segment input so the recompute graph is SELF-CONTAINED: its backward
                     // stops at the segment boundary instead of following reInput's producer into an

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -92,6 +92,19 @@ public sealed class GradientTape<T> : IDisposable
     private bool _ownsArena;
     private Helpers.TensorArena? _ownedArena;
 
+    // Opt-in (default OFF; #734). When enabled, a TOP-LEVEL tape with no arena already
+    // active creates+owns one for its lifetime — extending per-step arena recycling to
+    // custom training loops that go through no model base / Optimize() call site (which
+    // already open their own arena). DEFAULT OFF because a tape-owned arena's tensor ring
+    // pins activation WRAPPERS for reuse, which is fundamentally incompatible with
+    // ComputeGradientsStreaming's activation release (the streaming test asserts the
+    // released activation wrapper becomes collectable). Standard training via the model
+    // bases / Optimize() is UNAFFECTED — those open an explicit arena and still get the
+    // per-step reuse. Enable (AIDOTNET_TAPE_OWNED_ARENA=1) only for hand-rolled loops that
+    // use neither streaming nor gradient checkpointing.
+    internal static bool EnableTapeOwnedArena { get; set; }
+        = System.Environment.GetEnvironmentVariable("AIDOTNET_TAPE_OWNED_ARENA") == "1";
+
 
     /// <summary>
     /// Gets the number of operations recorded on this tape.
@@ -197,7 +210,8 @@ public sealed class GradientTape<T> : IDisposable
         // Dispose (existing #1804 behaviour). Nested tapes (Hvp/Hessian) never own an
         // arena. This is what extends zero-alloc training to backprop paths that go
         // through none of the model bases or Optimize() call sites.
-        if (_parent is null && Helpers.TensorArena.Current is null)
+        if (EnableTapeOwnedArena && _parent is null && !_options.SuppressArenaScope
+            && Helpers.TensorArena.Current is null)
         {
             _ownedArena = Helpers.TensorArena.Create();
             _ownsArena = true;
@@ -2278,8 +2292,14 @@ public sealed class GradientTape<T> : IDisposable
         {
             _ownedArena?.Dispose();
         }
-        else if (_parent is null)
+        else if (_parent is null && !_options.SuppressArenaScope)
         {
+            // #734: a transient INNER tape (the GradientCheckpointing recompute tape) is
+            // created mid-backward when the outer tape has nulled the thread-current tape,
+            // so it also sees _parent == null. It must NOT Reset() the arena here — that
+            // rewinds the OUTER tape's arena ring cursors mid-backward and the outer walk
+            // then reuses buffers still holding live gradients, corrupting them. Inner tapes
+            // set SuppressArenaScope so only the genuine step-boundary tape resets per step.
             Helpers.TensorArena.Current?.Reset();
         }
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -2225,6 +2225,24 @@ public sealed class GradientTape<T> : IDisposable
         // Return arena to thread-local cache for reuse by next GradientTape
         _entries.Reset();
         _cachedArena = _entries;
+
+        // Transparent per-step TensorArena recycling (AiDotNet #1804). When the
+        // OUTERMOST tape on this thread disposes, one training/compute step has
+        // completed — rewind the active TensorArena's scratch cursors so the
+        // next step reuses those backing arrays instead of GC-allocating fresh
+        // (this is the PyTorch caching-allocator parity that closes the ~25%
+        // per-op allocation gap on deep-model training). Any code that runs one
+        // GradientTape per step inside a TensorArena scope (e.g. the model
+        // training bases) gets zero-alloc training after warmup with NO
+        // per-model wiring. Guarded to the top-level tape (_parent is null) so
+        // nested / higher-order (Hvp/Hessian) tapes never reset mid-step.
+        // No-op when no arena is active (inference, non-arena callers).
+        // Contract: the optimizer step must run within the tape's scope so the
+        // gradient tensors (arena-backed) are consumed before this reset — the
+        // standard one-tape-per-step loop satisfies this; model weights and
+        // optimizer moments are plain-heap Tensors and are unaffected.
+        if (_parent is null)
+            Helpers.TensorArena.Current?.Reset();
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -80,6 +80,18 @@ public sealed class GradientTape<T> : IDisposable
     private readonly Engines.DirectGpuTensorEngine? _snapshotEngine;
     private readonly long _activationSnapshot;
 
+    // GLOBAL tape-owned arena (extends #734). A top-level GradientTape with no
+    // arena already active (i.e. not created through a model base or Optimize()
+    // call site that opens its own TensorArena) CREATES and OWNS one for the
+    // duration of the tape. This gives EVERY backprop path — including custom
+    // training loops that go through none of those wrappers — zero-alloc training
+    // after warmup with no per-path wiring. On Dispose the owned arena is
+    // Dispose()d (pooling its large buffers to the cross-arena persistent pool and
+    // restoring the previous arena); an externally-owned long-lived arena is left
+    // to its owner and only Reset() per step (the pre-existing #1804 behaviour).
+    private bool _ownsArena;
+    private Helpers.TensorArena? _ownedArena;
+
 
     /// <summary>
     /// Gets the number of operations recorded on this tape.
@@ -177,6 +189,20 @@ public sealed class GradientTape<T> : IDisposable
         _engine = AiDotNetEngine.Current;
         _engineExplicitlyBound = false;
         _parent = _current;
+
+        // GLOBAL tape-owned arena: a TOP-LEVEL tape (_parent is null) with NO arena
+        // already active on this thread opens one it owns. When an arena is already
+        // active (a model base / Optimize() call site opened it), we do NOT create
+        // our own — that arena stays externally owned and is only Reset() per step in
+        // Dispose (existing #1804 behaviour). Nested tapes (Hvp/Hessian) never own an
+        // arena. This is what extends zero-alloc training to backprop paths that go
+        // through none of the model bases or Optimize() call sites.
+        if (_parent is null && Helpers.TensorArena.Current is null)
+        {
+            _ownedArena = Helpers.TensorArena.Create();
+            _ownsArena = true;
+        }
+
         _savedReplayMode = Compilation.AutoTrainingCompiler.ReplayMode;
 
         // Capture the activation-cache baseline for the OUTERMOST tape on a GPU engine.
@@ -2241,8 +2267,21 @@ public sealed class GradientTape<T> : IDisposable
         // gradient tensors (arena-backed) are consumed before this reset — the
         // standard one-tape-per-step loop satisfies this; model weights and
         // optimizer moments are plain-heap Tensors and are unaffected.
-        if (_parent is null)
+        //
+        // GLOBAL tape-owned arena: if THIS tape created the arena (no arena was
+        // active at ctor and this is a top-level tape), Dispose it — that pools its
+        // large backing buffers to the cross-arena persistent pool and restores the
+        // previous arena, so the NEXT top-level tape reuses them (zero-alloc after
+        // warmup). Otherwise, if this is the top-level tape over an externally-owned
+        // long-lived arena, Reset() it per step (the pre-existing #1804 behaviour).
+        if (_ownsArena)
+        {
+            _ownedArena?.Dispose();
+        }
+        else if (_parent is null)
+        {
             Helpers.TensorArena.Current?.Reset();
+        }
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
@@ -61,4 +61,15 @@ public sealed class GradientTapeOptions
     /// Disabled by default to avoid dictionary allocation overhead.
     /// </summary>
     public bool EnableHooks { get; init; }
+
+    /// <summary>
+    /// When true, this tape never owns/creates a <see cref="AiDotNet.Tensors.Helpers.TensorArena"/>
+    /// and never <c>Reset()</c>s the active arena on Dispose. Set for transient INNER tapes created
+    /// DURING an outer tape's backward pass — notably the <c>GradientCheckpointing</c> recompute tape.
+    /// Such a tape borrows the active arena for scratch, but must NOT manage its step lifecycle:
+    /// because the outer tape nulls the thread-current tape while walking backward, an inner tape sees
+    /// <c>_parent == null</c> and would otherwise be mistaken for a step-boundary tape and reset the
+    /// OUTER tape's arena mid-backward, corrupting every accumulating gradient (#734).
+    /// </summary>
+    public bool SuppressArenaScope { get; init; }
 }

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -308,7 +308,18 @@ public sealed class TensorArena : IDisposable
                 if (cursor < bucket.Count)
                 {
                     _tensorRingCursors[i] = cursor + 1;
-                    return (LinearAlgebra.Tensor<T>)bucket[cursor];
+                    var cached = (LinearAlgebra.Tensor<T>)bucket[cursor];
+                    // The ring buckets by element COUNT, not shape. The cached wrapper
+                    // carries the shape it was FIRST created with, so a same-count /
+                    // different-shape request (e.g. an [B,L] vs [L,B] permute in N-BEATS)
+                    // must be re-issued under the REQUESTED shape — otherwise a stale-shaped
+                    // tensor flows downstream and crashes shape checks on this post-Reset
+                    // reuse path (AiDotNet #1804). The buffer is contiguous with matching
+                    // element count, so this is a zero-copy metadata swap that does NOT
+                    // record a Reshape node on the active tape.
+                    if (!cached._shape.AsSpan().SequenceEqual(shape))
+                        cached.ArenaReshapeInPlace(shape);
+                    return cached;
                 }
 
                 // Need one more tensor of this size — reuse a persistent-pool

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -802,20 +802,20 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// Internal shape array. Direct access for same-assembly code (CpuEngine, etc.) — zero overhead.
     /// External consumers use the Shape property which returns an immutable TensorShape wrapper.
     /// </summary>
-    internal readonly int[] _shape;
+    internal int[] _shape;
 
     /// <summary>
     /// Pre-computed strides for each dimension, following PyTorch's stride convention.
     /// For row-major order: strides[i] = product of shape[i+1..end].
     /// For transposed views: strides are permuted without copying data.
     /// </summary>
-    internal readonly int[] _strides;
+    internal int[] _strides;
 
     /// <summary>
     /// Offset into the underlying storage where this tensor's data begins.
     /// Zero for non-view tensors. Non-zero for sliced views.
     /// </summary>
-    internal readonly int _storageOffset;
+    internal int _storageOffset;
 
     /// <summary>
     /// Tracks the device where this tensor's data currently resides.
@@ -1146,7 +1146,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// When true, raw span/array access is safe. When false, Contiguous() must be called
     /// before passing to BLAS/SIMD operations.
     /// </summary>
-    public bool IsContiguous { get; }
+    public bool IsContiguous { get; private set; }
 
     /// <summary>
     /// Lifetime / placement hint for the issue-#276 large-model memory paths.
@@ -1291,7 +1291,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// Gets the shape (dimensions) of the tensor as an immutable wrapper.
     /// Use Shape[i] for element access, Shape.Span for zero-copy iteration.
     /// </summary>
-    public TensorShape Shape { get; }
+    public TensorShape Shape { get; private set; }
 
     /// <summary>
     /// Gets the total number of logical elements in this tensor (product of all shape dimensions).
@@ -1403,6 +1403,29 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         Length = totalSize;
         _data = new Vector<T>(totalSize);
         _storage = new TensorStorage<T>(_data);
+    }
+
+    /// <summary>
+    /// Zero-copy, NON-tape-recording in-place reshape used ONLY by the
+    /// <see cref="AiDotNet.Tensors.Helpers.TensorArena"/> reuse path (AiDotNet #1804).
+    /// The arena's tensor ring buckets pooled buffers by element COUNT, so a buffer
+    /// first handed out as e.g. [B,L] can be re-issued for an [L,B] request of the same
+    /// count on the post-Reset reuse path; the caller fully overwrites the buffer, so only
+    /// the shape / stride metadata must be swapped to the requested shape. Requires a
+    /// contiguous, offset-0 buffer with a MATCHING element count (always true for arena
+    /// scratch). Unlike the public <c>Reshape</c>, this does NOT allocate a new wrapper and
+    /// does NOT record a Reshape node on the active gradient tape, so it is safe to call
+    /// mid-forward without corrupting autodiff. Element count is asserted by the caller
+    /// (same ring bucket) so no re-validation is done here.
+    /// </summary>
+    internal void ArenaReshapeInPlace(int[] newShape)
+    {
+        _shape = (int[])newShape.Clone();
+        Shape = TensorShape.WrapUnsafe(_shape);
+        _strides = ComputeRowMajorStrides(_shape);
+        _rowMajorStridesCache = null;
+        _storageOffset = 0;
+        IsContiguous = true;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaReshapeRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaReshapeRegressionTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) AiDotNet. All rights reserved.
+//
+// Regression + invariant suite for the TensorArena "zero-alloc training"
+// mechanism (Helpers/TensorArena.cs). These tests pin down the exact shape
+// bug fixed in AiDotNet #1804: the tensor RING buckets pooled buffers by
+// element COUNT, so a same-count / different-shape rent after Reset() must
+// re-issue the pooled tensor under the REQUESTED shape (ArenaReshapeInPlace),
+// including recomputing strides AND clearing the row-major strides cache.
+// Without the fix a stale-shaped tensor flows downstream and either crashes
+// shape checks or reads through the wrong strides.
+
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+/// <summary>
+/// Serializes the arena reshape/regression tests onto a single runner thread.
+/// <see cref="TensorArena.Current"/> is [ThreadStatic] and xUnit reuses worker
+/// threads across collections, so a leaked arena from a parallel test could be
+/// observed here. Same rationale as <see cref="TensorArenaPinnedTests"/>.
+/// </summary>
+[CollectionDefinition(nameof(TensorArenaReshapeRegressionTests), DisableParallelization = true)]
+public sealed class TensorArenaReshapeRegressionTestsCollection { }
+
+[Collection(nameof(TensorArenaReshapeRegressionTests))]
+public class TensorArenaReshapeRegressionTests
+{
+    /// <summary>
+    /// THE bug (AiDotNet #1804). Rent a [3,256] tensor (count 768) from the
+    /// ring, stamp linear values, Reset, then rent count 768 at shape [256,3].
+    /// The ring re-issues the SAME backing buffer; it MUST be reshaped to the
+    /// requested [256,3] with fresh row-major strides [3,1] (not the stale
+    /// [3,256] strides [256,1]). Flat indexing must still see the original
+    /// linear data, and 2D indexing must decode using the NEW strides.
+    /// Without the fix this test fails: either the shape assert or the 2D read
+    /// (row index up to 255 is out of range for a stale [3,256] shape).
+    /// </summary>
+    [Fact]
+    public void ArenaReshapeInPlace_SameCountDifferentShape_ReshapesCorrectly()
+    {
+        using var arena = TensorArena.Create();
+
+        var first = arena.TryRentTensor<float>(768, new[] { 3, 256 });
+        Assert.NotNull(first);
+        Assert.Equal(new[] { 3, 256 }, first!._shape);
+
+        // Stamp known linear values: element i == i.
+        for (int i = 0; i < 768; i++) first[i] = i;
+
+        arena.Reset();
+
+        // Same element count (768), DIFFERENT shape [256,3].
+        var second = arena.TryRentTensor<float>(768, new[] { 256, 3 });
+        Assert.NotNull(second);
+
+        // Must be re-issued under the requested shape with correct metadata.
+        Assert.Equal(new[] { 256, 3 }, second!._shape);
+        Assert.Equal(768, second.Length);
+        Assert.Equal(new[] { 3, 1 }, second.Strides.ToArray());
+        // The cached row-major strides must have been invalidated by the reshape.
+        Assert.Equal(new[] { 3, 1 }, second.RowMajorStrides);
+        Assert.True(second.IsContiguous);
+
+        // Same backing buffer -> linear data preserved (ring path never clears).
+        for (int i = 0; i < 768; i++)
+            Assert.Equal((float)i, second[i]);
+
+        // 2D read must decode with the NEW [256,3] strides: [r,c] -> r*3 + c.
+        for (int r = 0; r < 256; r++)
+            for (int c = 0; c < 3; c++)
+                Assert.Equal((float)(r * 3 + c), second[r, c]);
+    }
+
+    /// <summary>
+    /// The reshape must be a metadata-only swap that also works back the other
+    /// way (round-trip), so repeated permute-style reuse across steps is stable.
+    /// </summary>
+    [Fact]
+    public void ArenaReshapeInPlace_RoundTripsAcrossResets()
+    {
+        using var arena = TensorArena.Create();
+
+        var a = arena.TryRentTensor<double>(12, new[] { 3, 4 });
+        Assert.Equal(new[] { 4, 1 }, a!.Strides.ToArray());
+
+        arena.Reset();
+        var b = arena.TryRentTensor<double>(12, new[] { 4, 3 });
+        Assert.Equal(new[] { 4, 3 }, b!._shape);
+        Assert.Equal(new[] { 3, 1 }, b.Strides.ToArray());
+
+        arena.Reset();
+        var c = arena.TryRentTensor<double>(12, new[] { 2, 6 });
+        Assert.Equal(new[] { 2, 6 }, c!._shape);
+        Assert.Equal(new[] { 6, 1 }, c.Strides.ToArray());
+        Assert.Equal(12, c.Length);
+    }
+
+    /// <summary>
+    /// Ring reuse hands back the SAME backing buffer without clearing (the
+    /// documented "caller overwrites every element" contract). This verifies
+    /// both halves: (a) the buffer is genuinely reused (still carries the prior
+    /// sentinel immediately after re-rent, proving zero-alloc reuse), and
+    /// (b) once the consumer writes every element the reads are exactly what it
+    /// wrote (no stale leak into a full-overwrite consumer).
+    /// </summary>
+    [Fact]
+    public void RingReuse_ReusesBuffer_CallerFullyOverwrites()
+    {
+        using var arena = TensorArena.Create();
+
+        var t1 = arena.TryRentTensor<float>(64, new[] { 64 });
+        Assert.NotNull(t1);
+        for (int i = 0; i < 64; i++) t1![i] = 7f; // sentinel
+
+        arena.Reset();
+
+        var t2 = arena.TryRentTensor<float>(64, new[] { 64 });
+        Assert.NotNull(t2);
+        // (a) Same buffer reused: uninitialized ring path did NOT clear, so the
+        // sentinel is still present. This is the zero-alloc reuse guarantee.
+        Assert.Same(t1, t2);
+        for (int i = 0; i < 64; i++) Assert.Equal(7f, t2![i]);
+
+        // (b) Consumer that writes every element fully controls contents.
+        for (int i = 0; i < 64; i++) t2![i] = i * 2f;
+        for (int i = 0; i < 64; i++) Assert.Equal(i * 2f, t2![i]);
+    }
+
+    /// <summary>
+    /// Pinned/heap allocations (optimizer moments, weights) must NOT be
+    /// recycled by Reset(). A pinned tensor's contents survive a Reset +
+    /// re-rent-of-same-size cycle even when the scratch consumer scribbles
+    /// over freshly rented buffers.
+    /// </summary>
+    [Fact]
+    public void Reset_PreservesPinnedAndHeap_MomentsSurvive()
+    {
+        using var arena = TensorArena.Create();
+
+        // Simulate Adam moment state via the pinned tier.
+        var moment = TensorAllocator.RentPinned<float>(new[] { 32 });
+        var mspan = moment.AsWritableSpan();
+        for (int i = 0; i < 32; i++) mspan[i] = 0.5f + i;
+
+        // A plain heap tensor (new ctor) is not arena-managed at all.
+        var heap = new Tensor<float>(new[] { 32 });
+        for (int i = 0; i < 32; i++) heap[i] = 1000f + i;
+
+        // Do scratch work, reset, do more scratch work over the SAME size.
+        var scratch1 = arena.TryRentTensor<float>(32, new[] { 32 });
+        for (int i = 0; i < 32; i++) scratch1![i] = -1f;
+
+        arena.Reset();
+
+        var scratch2 = arena.TryRentTensor<float>(32, new[] { 32 });
+        for (int i = 0; i < 32; i++) scratch2![i] = -99f;
+
+        // Pinned moment untouched.
+        var mAfter = moment.AsSpan();
+        for (int i = 0; i < 32; i++) Assert.Equal(0.5f + i, mAfter[i]);
+
+        // Heap tensor untouched.
+        for (int i = 0; i < 32; i++) Assert.Equal(1000f + i, heap[i]);
+    }
+
+    /// <summary>
+    /// Nested arenas must not cross-contaminate. An inner arena's rented
+    /// buffers are independent of the outer arena's; after the inner disposes
+    /// (restoring the outer as Current), the outer's buffers are intact and a
+    /// fresh outer rent does not collide with inner data.
+    /// </summary>
+    [Fact]
+    public void NestedArena_NoCrossContamination()
+    {
+        using var outer = TensorArena.Create();
+        Assert.Same(outer, TensorArena.Current);
+
+        var outerBuf = outer.TryRentTensor<float>(48, new[] { 48 });
+        for (int i = 0; i < 48; i++) outerBuf![i] = 11f;
+
+        using (var inner = TensorArena.Create())
+        {
+            Assert.Same(inner, TensorArena.Current);
+            var innerBuf = inner.TryRentTensor<float>(48, new[] { 48 });
+            // Distinct backing object from the outer buffer.
+            Assert.NotSame(outerBuf, innerBuf);
+            for (int i = 0; i < 48; i++) innerBuf![i] = 22f;
+            // Writing inner must not touch outer.
+            for (int i = 0; i < 48; i++) Assert.Equal(11f, outerBuf![i]);
+        }
+
+        // Inner disposed -> outer restored as Current.
+        Assert.Same(outer, TensorArena.Current);
+
+        // Outer buffer still intact.
+        for (int i = 0; i < 48; i++) Assert.Equal(11f, outerBuf![i]);
+
+        // A further outer reset + rent reuses the OUTER buffer (same object),
+        // never anything from the disposed inner arena.
+        outer.Reset();
+        var outerBuf2 = outer.TryRentTensor<float>(48, new[] { 48 });
+        Assert.Same(outerBuf, outerBuf2);
+    }
+}


### PR DESCRIPTION
**Draft — WIP.** Core mechanism validated; full regression/invariant test suite being finalized.

## What
Activate the `TensorArena` buffer-reuse path during training (per-step reset on top-level `GradientTape.Dispose`), so per-op forward/backward scratch is recycled instead of GC-allocated — the PyTorch caching-allocator equivalent.

## The bug this also fixes
The arena's tensor ring buckets pooled buffers by **element count, not shape**. On the post-reset reuse path, `TryRentTensor` returned the cached wrapper with its **stale shape**, so a same-count/different-shape request (e.g. N-BEATS's `[B,L]`↔`[L,B]` permute) crashed `TensorAdd` (`[3,256]` vs `[256,3]`). Fix: `TensorBase.ArenaReshapeInPlace` — a zero-copy, **non-tape-recording** in-place reshape (the public `Reshape` records an autodiff node, unusable mid-forward) that also resets `_rowMajorStridesCache` — called on the reuse path when shapes differ.

## Evidence (N-BEATS)
- **Correctness:** forecast + MAE **bit-identical** to no-arena (pure allocation change).
- **Allocation:** 11,714.9 MB → **1,707.9 MB (85.4% cut)**, reproducible.

## Still to land before un-drafting
- Regression (arena-on ≡ arena-off across the model zoo) + invariant tests.
- Review of the `readonly`-removal on core `Tensor` shape fields.

Pairs with the AiDotNet-side arena activation (separate draft PR). Contributes to ooples/AiDotNet#1804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)