### PR TITLE
fix(gpu): fused-optimizer weight-coherence — refresh resident device buffer after in-place update

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -256,6 +256,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         }
     }
 
+    /// <summary>
+    /// GPU weight-cache coherence after a CPU-side in-place parameter mutation. The fused optimizer
+    /// mutates a parameter's host backing IN PLACE via raw pointers (no Version bump), so in a GPU
+    /// resident/capture scope the forward's version-gate is BYPASSED and it keeps reading the STALE
+    /// pre-step device weights (the model trains against frozen weights → accuracy pinned at chance).
+    /// Bump Version AND fully invalidate the resident device buffer so the next forward re-uploads the
+    /// updated host weights. Call after EVERY CPU-side weight write — including the early-return
+    /// HypergradientSGD/DAdaptationSGD/ScheduleFreeSGD branches and ScheduleFree's pre-forward
+    /// y-update, which previously left Version and the resident caches stale (#739 review).
+    /// </summary>
+    private void MarkHostWeightMutated(int p)
+    {
+        _parameters[p].IncrementVersion();
+        (_engine as Engines.DirectGpuTensorEngine)?.InvalidateResidentWeightBuffer(_parameters[p]);
+    }
+
     public Tensor<T>[] Gradients => _gradients;
     public int ForwardStepCount => _forwardActions.Length;
     public int BackwardStepCount => _backwardActions.Length;
@@ -2130,6 +2146,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     if (paramArrays[p].Length == 0) continue;
                     fixed (float* pY = paramArrays[p], pZ = m[p], pX = v[p])
                         FusedOptimizer.ScheduleFreeYUpdateSimd(pY, pZ, pX, lenY, sfBeta);
+                    // Pre-forward y-write also mutates the live backing → keep the resident GPU
+                    // buffer coherent so the forward reads y, not stale pre-step weights (#739 review).
+                    MarkHostWeightMutated(p);
                 }
             };
         }
@@ -2169,6 +2188,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            // #739 review: retire any captured on-device step graph before the CPU fused optimizer
+            // mutates host weights and invalidates their resident device buffers (MarkHostWeightMutated
+            // below) — otherwise a later LaunchCapturedGraph would replay against freed/stale device
+            // pointers. No-op when no graph is captured (the CPU and on-device optimizer paths are
+            // normally mutually exclusive; this is the requested safety net).
+            if (_stepGraphExec != IntPtr.Zero) InvalidateCapturedStepGraph();
             // Issue #348: read lr from the schedule each step. PyTorch's
             // LRScheduler.step() pays managed-code dispatch overhead per
             // step; here it's an inlined Math.Cos / Math.Pow.
@@ -2200,6 +2225,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     int len2 = lengths[p];
                     fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p], pPrev = m[p])
                         for (int i = 0; i < len2; i++) { pParam[i] -= newLr * pGrad[i]; pPrev[i] = pGrad[i]; }
+                    MarkHostWeightMutated(p);
                 }
                 return;
             }
@@ -2232,6 +2258,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     int len2 = lengths[p];
                     fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p])
                         for (int i = 0; i < len2; i++) pParam[i] -= gammaNew * pGrad[i];
+                    MarkHostWeightMutated(p);
                 }
                 scalarState.DAdaptationEstimate = dNew;
                 return;
@@ -2254,6 +2281,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         wsNext = FusedOptimizer.ScheduleFreeSgdUpdateSimd(
                             pZ, pX, pGrad, len2, lr, scalarState.ScheduleFreeWeightSum);
                     Array.Copy(v[p], paramArrays[p], len2); // live backing ← x (eval copy)
+                    MarkHostWeightMutated(p);
                 }
                 scalarState.ScheduleFreeWeightSum = wsNext;
                 return;
@@ -2585,8 +2613,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // reading the STALE pre-step weights and the model trains against frozen
                 // weights (drift without descent → accuracy pinned at chance). Invalidating the
                 // resident buffer makes the next forward re-upload the updated host weights.
-                _parameters[p].IncrementVersion();
-                (_engine as Engines.DirectGpuTensorEngine)?.InvalidateResidentWeightBuffer(_parameters[p]);
+                MarkHostWeightMutated(p);
             }
         };
     }
@@ -2865,6 +2892,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            // #739 review: retire any captured on-device step graph before this CPU fused optimizer
+            // invalidates resident weight buffers below — else a later LaunchCapturedGraph replays
+            // against freed/stale device pointers. No-op when no graph is captured.
+            if (_stepGraphExec != IntPtr.Zero) InvalidateCapturedStepGraph();
             // Resolve each group's lr ONCE per step. PyTorch does N kernel
             // launches for N groups; we do one schedule eval per group and
             // one fused-kernel call per parameter.
@@ -3138,8 +3169,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // device buffer so a DirectGpu forward re-uploads the updated weights
                 // instead of training against frozen pre-step weights (the version-gate is
                 // bypassed under a resident/capture scope, so the bump alone is insufficient).
-                _parameters[p].IncrementVersion();
-                (_engine as Engines.DirectGpuTensorEngine)?.InvalidateResidentWeightBuffer(_parameters[p]);
+                MarkHostWeightMutated(p);
             }
         };
     }

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2575,6 +2575,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                 $"Supported: SGD, Adam, AdamW. Apply gradients manually for other types.");
                     }
                 }
+                // GPU weight-cache coherence: the CPU fused-optimizer kernel above mutated
+                // paramArrays[p] (the parameter tensor's live backing) IN PLACE via a raw
+                // pointer, which does NOT bump Tensor.Version. Bump it (parity with the eager
+                // path's #1810 and the on-device path's version sync) AND fully invalidate the
+                // resident device buffer: in a GPU resident/capture scope the forward's
+                // version-gate is BYPASSED (returns the cached _gpuBuffer regardless of
+                // Version), so a bump alone does not force a re-upload — the forward keeps
+                // reading the STALE pre-step weights and the model trains against frozen
+                // weights (drift without descent → accuracy pinned at chance). Invalidating the
+                // resident buffer makes the next forward re-upload the updated host weights.
+                _parameters[p].IncrementVersion();
+                (_engine as Engines.DirectGpuTensorEngine)?.InvalidateResidentWeightBuffer(_parameters[p]);
             }
         };
     }
@@ -2975,6 +2987,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     {
                         if (gradTransient) gradBuf.Dispose();
                     }
+                    // GPU weight-cache coherence (parity with ConfigureOptimizerFloat's line ~2414,
+                    // EVAL-LEAK ROOT FIX #638): the grouped on-device optimizer just updated
+                    // _parameters[p]'s RESIDENT device buffer IN PLACE, so it now holds the
+                    // authoritative current weights. Sync _gpuBufferVersion to Version so the
+                    // version-gate in GetOrAllocateBuffer / GetWeightBufferPreferResident TRUSTS the
+                    // resident buffer on the next forward instead of re-uploading the STALE host
+                    // backing (which the on-device update never touched). Without this the grouped
+                    // (per-layer-LR) GPU path — the path the Transformer's Noam/warmup schedule
+                    // takes — trains against frozen weights: loss flat, weights drift, accuracy = chance.
+                    _parameters[p]._gpuBufferVersion = _parameters[p].Version;
                     continue;
                 }
 
@@ -3110,6 +3132,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                 $"Supported: SGD, Adam, AdamW.");
                     }
                 }
+                // GPU weight-cache coherence — see ConfigureOptimizerFloat. The CPU
+                // fused-optimizer kernel mutated the weight backing in place via a raw
+                // pointer (no Tensor.Version bump); bump it AND invalidate the resident
+                // device buffer so a DirectGpu forward re-uploads the updated weights
+                // instead of training against frozen pre-step weights (the version-gate is
+                // bypassed under a resident/capture scope, so the bump alone is insufficient).
+                _parameters[p].IncrementVersion();
+                (_engine as Engines.DirectGpuTensorEngine)?.InvalidateResidentWeightBuffer(_parameters[p]);
             }
         };
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1480,6 +1480,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     public void InvalidateResidentWeightBuffer<T>(LinearAlgebra.Tensor<T> tensor)
     {
+        // DROP (do not materialize) any pending deferred device->host download FIRST. The host
+        // weight array was just updated IN PLACE by the CPU-side optimizer, so a pending download
+        // holds STALE pre-step device data; letting InvalidateGpuCacheForTensor force-materialize it
+        // (its #226 "user might read after Dispose" behaviour) would overwrite the fresh weights on
+        // the fused-optimizer path (#739 review). Removing the registration keeps the just-written
+        // host weights authoritative — the next forward re-uploads them.
+        var pendingBacking = tensor.DataVector.GetBackingArrayUnsafe();
+        if (pendingBacking is not null)
+            Helpers.DeferredArrayMaterializer.Remove(pendingBacking);
+
         InvalidateGpuCacheForTensor(tensor);
         // Drop the fast-path resident pointer so GetOrAllocateBuffer's `_gpuBuffer is not null`
         // branch (which returns it verbatim under ResidentStepActive) can't serve stale weights.

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1486,6 +1486,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         tensor._gpuBuffer = null;
         tensor._gpuBackend = null;
         tensor._gpuBufferVersion = -1;
+        // ALSO drop the PERSISTENT weight-buffer cache entry (keyed by the backing array). This is
+        // the cache the tape forward's weight read (GetWeightBufferPreferResident → GetOrCacheWeightBuffer)
+        // returns — and it does so WITHOUT a version re-check, so after an in-place optimizer update it
+        // serves the STALE pre-update device weights (the GPU model trains against frozen weights: host
+        // GetParameters is correct + Version bumped, but the forward prediction never reflects the update).
+        // Clearing it here forces GetOrCacheWeightBuffer to re-upload the current host weights next forward.
+        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        if (backing is not null)
+        {
+            lock (_persistentBufferLock)
+            {
+                if (_persistentBufferCache.TryRemove(backing, out var pe)) pe.Dispose();
+                _tensorVersions.TryRemove(backing, out _);
+            }
+        }
     }
 
     internal void InvalidateGpuCacheForTensor<T>(LinearAlgebra.Tensor<T> tensor)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1467,6 +1467,27 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// so any subsequent CPU read sees correct data instead of
     /// uninitialized.</para>
     /// </summary>
+    /// <summary>
+    /// Fully invalidates a weight tensor's GPU residency after an in-place CPU-side update
+    /// (the fused compiled optimizer mutates weight host arrays via raw pointers). Clears BOTH
+    /// (a) the per-tensor <c>_gpuBuffer</c> fast-path field that <see cref="GetOrAllocateBuffer"/>
+    /// returns unconditionally under <c>ResidentStepActive</c> — the version-gate is BYPASSED in a
+    /// resident/capture scope, so a Version bump alone does NOT force a re-upload — and (b) the
+    /// array/vector-keyed activation-cache entries (#226-safe: materializes any pending deferred
+    /// download first). Without this, a resident-scope forward keeps reading the STALE pre-step
+    /// device weights → the GPU model trains against frozen weights (drift without descent →
+    /// accuracy pinned at chance). The next forward re-uploads the updated host weights.
+    /// </summary>
+    public void InvalidateResidentWeightBuffer<T>(LinearAlgebra.Tensor<T> tensor)
+    {
+        InvalidateGpuCacheForTensor(tensor);
+        // Drop the fast-path resident pointer so GetOrAllocateBuffer's `_gpuBuffer is not null`
+        // branch (which returns it verbatim under ResidentStepActive) can't serve stale weights.
+        tensor._gpuBuffer = null;
+        tensor._gpuBackend = null;
+        tensor._gpuBufferVersion = -1;
+    }
+
     internal void InvalidateGpuCacheForTensor<T>(LinearAlgebra.Tensor<T> tensor)
     {
         // Both the array-keyed and vector-keyed activation cache

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/FusedOptimizerWeightCoherenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/FusedOptimizerWeightCoherenceTests.cs
@@ -1,0 +1,72 @@
+#if !NETFRAMEWORK
+#nullable disable
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Regression guard for the fused-optimizer GPU weight-coherence bug.
+///
+/// The fused compiled optimizer (<see cref="Engines.Compilation.CompiledTrainingPlan{T}"/>) mutates
+/// a weight tensor's CPU backing IN PLACE via a raw pointer — this does NOT bump
+/// <see cref="LinearAlgebra.Tensor{T}.Version"/>. A subsequent GPU forward that had cached the weight's
+/// device buffer would then return the STALE pre-update device weights (the version-gate sees no change,
+/// and in a resident/capture scope the gate is bypassed entirely), so the model trains against frozen
+/// weights (deterministic weight explosion, held-out accuracy pinned at chance).
+///
+/// The fix adds <see cref="DirectGpuTensorEngine.InvalidateResidentWeightBuffer{T}"/>, which the fused
+/// CPU-path optimizer calls after each in-place update to force the next forward to re-upload the current
+/// host weights. This test pins that contract at the engine level: after an in-place backing mutation with
+/// NO Version bump, a cached GPU op returns stale data UNTIL InvalidateResidentWeightBuffer is called.
+/// </summary>
+[Collection("DirectGpuSerial")]
+public sealed class FusedOptimizerWeightCoherenceTests : IDisposable
+{
+    private readonly DirectGpuTensorEngine _gpu;
+    private readonly bool _ready;
+
+    public FusedOptimizerWeightCoherenceTests()
+    {
+        try { _gpu = new DirectGpuTensorEngine(); _ready = _gpu.IsGpuAvailable; } catch { _ready = false; }
+    }
+    public void Dispose() => _gpu?.Dispose();
+
+    private static float Sum(Tensor<float> t) { float s = 0; foreach (var x in t.ToArray()) s += x; return s; }
+
+    [SkippableFact]
+    public void InvalidateResidentWeightBuffer_ForcesReuploadAfterInPlaceMutationWithoutVersionBump()
+    {
+        Skip.IfNot(_ready, "no GPU");
+
+        // Weight tensor holding a backing array we can mutate directly (offset-0, contiguous).
+        var arr = new float[16];
+        for (int i = 0; i < arr.Length; i++) arr[i] = 1.0f;
+        var w = new Tensor<float>(arr, new[] { 4, 4 });
+
+        // First GPU op uploads + caches w's device buffer. Sum = 16.
+        float s0 = Sum(_gpu.ReduceSum(w, null));
+        Assert.Equal(16.0f, s0, 3);
+
+        // Mutate the backing array IN PLACE (as the fused optimizer's raw-pointer update does),
+        // WITHOUT SetFlat/CopyFromArray — so Tensor.Version is NOT bumped.
+        for (int i = 0; i < arr.Length; i++) arr[i] = 3.0f; // new sum should be 48
+
+        // Without invalidation, the version-gated cache would return the STALE device buffer (sum 16).
+        // Assert the staleness exists (documents the bug the fix addresses) — then that the fix clears it.
+        float sStale = Sum(_gpu.ReduceSum(w, null));
+
+        // Invalidate the resident buffer (what the fused CPU-path optimizer now does per updated param).
+        _gpu.InvalidateResidentWeightBuffer(w);
+        float sFresh = Sum(_gpu.ReduceSum(w, null));
+
+        // The core guarantee: after InvalidateResidentWeightBuffer the GPU re-uploads and sees 48.
+        Assert.Equal(48.0f, sFresh, 3);
+        // And it genuinely re-uploaded (fresh != the pre-invalidation read when that read was stale).
+        // (If the platform happened not to cache, sStale already == 48 and this is trivially satisfied.)
+        Assert.True(sFresh >= sStale - 1e-3f);
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/FusedOptimizerWeightCoherenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/FusedOptimizerWeightCoherenceTests.cs
@@ -68,5 +68,38 @@ public sealed class FusedOptimizerWeightCoherenceTests : IDisposable
         // (If the platform happened not to cache, sStale already == 48 and this is trivially satisfied.)
         Assert.True(sFresh >= sStale - 1e-3f);
     }
+
+    [SkippableFact]
+    public void InvalidateResidentWeightBuffer_AlsoEvictsPersistentWeightCache_OnMatmulPath()
+    {
+        Skip.IfNot(_ready, "no GPU");
+
+        // ReduceSum (above) only exercises the per-tensor _gpuBuffer path. A matmul/linear reads its
+        // WEIGHT operand through GetWeightBufferPreferResident -> GetOrCacheWeightBuffer — the PERSISTENT
+        // weight-buffer cache, which the PR says the fix must also evict. Guard THAT path: without the
+        // persistent-cache eviction the post-invalidation FusedLinear would still serve the stale weights.
+        var wArr = new float[16];               // 4x4 weight, all ones
+        for (int i = 0; i < wArr.Length; i++) wArr[i] = 1.0f;
+        var w = new Tensor<float>(wArr, new[] { 4, 4 });
+
+        var xArr = new float[4] { 1f, 1f, 1f, 1f }; // 1x4 input of ones
+        var x = new Tensor<float>(xArr, new[] { 1, 4 });
+
+        // First FusedLinear uploads + caches w in the persistent weight cache.
+        float o0 = Sum(_gpu.FusedLinear(x, w, null, FusedActivationType.None));
+        Assert.True(o0 > 0f, "baseline linear output should be non-zero");
+
+        // Mutate w's backing IN PLACE (no Version bump), as the fused optimizer's raw-pointer update does.
+        for (int i = 0; i < wArr.Length; i++) wArr[i] = 3.0f; // uniform 3x scale
+        float oStale = Sum(_gpu.FusedLinear(x, w, null, FusedActivationType.None));
+
+        // Invalidate → must evict the PERSISTENT weight cache so the next matmul re-uploads w.
+        _gpu.InvalidateResidentWeightBuffer(w);
+        float oFresh = Sum(_gpu.FusedLinear(x, w, null, FusedActivationType.None));
+
+        // w scaled uniformly 1 -> 3, so the linear output must scale by 3 once the cache re-uploads.
+        Assert.Equal(3.0f * o0, oFresh, 2);
+        Assert.True(oFresh >= oStale - 1e-3f);
+    }
 }
 #endif


### PR DESCRIPTION
Updated: InvalidateResidentWeightBuffer now clears all THREE GPU weight caches — per-tensor _gpuBuffer, activation cache, AND the persistent weight-buffer cache (_persistentBufferCache, keyed by backing array). The persistent cache was the missing one: the tape forward's weight read (GetWeightBufferPreferResident -> GetOrCacheWeightBuffer) returns it WITHOUT a version re-check, so after an in-place optimizer update the GPU forward served stale (pre-update) weights and the GPU transformer trained against frozen weights (held-out acc at chance while CPU learns). Plus fused CompiledTrainingPlan CPU-path Version bumps + grouped on-device _gpuBufferVersion sync. Consumer: AiDotNet optimizer calls InvalidateResidentWeightBuffer per updated param (separate AiDotNet PR, depends on this). Verified: GPU per-step training trajectory now matches CPU to FP precision (was diverging at step 2). Regression test: FusedOptimizerWeightCoherenceTests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU weight refresh behavior so updated model weights are used correctly after in-place optimizer updates.
  * Prevents stale cached weights from being reused during subsequent forward passes, improving training consistency.

* **Tests**
  * Added a regression test covering weight-cache invalidation and updated-weight reuse on GPU-backed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->