### PR TITLE
perf: raise GEMM parallel-work threshold 32K->16M (kill tiny-GEMM dispatch barrier, ~37%)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/AxisSelector.cs
@@ -52,7 +52,15 @@ internal static class AxisSelector
     /// dispatch overhead. Same value used by
     /// <see cref="Helpers.CpuParallelSettings.ParallelForOrSerial"/>.
     /// </summary>
-    public const long ParallelWorkThreshold = 32_768;
+    // Raised from 32_768: on high-core boxes the pool DISPATCH BARRIER (waking + syncing
+    // 12-32 workers via ManualResetEventSlim) dwarfs the math for small GEMMs — a PerfView
+    // profile of N-BEATS training (GEMMs 0.6M-4.2M MACs, m=96-256) showed the driver blocked
+    // ~45% of wall on this barrier while worker compute was ~1%. Below this many MACs, run
+    // serial on the calling thread (no dispatch). M-axis partitioning is disjoint-row (no
+    // cross-thread reduction), so serial-vs-parallel is bit-exact. Tunable via
+    // AIDOTNET_GEMM_PARALLEL_MINWORK. 16M keeps N-BEATS-scale GEMMs serial while genuinely
+    // large GEMMs (transformers, d>=512) still fan out.
+    public const long ParallelWorkThreshold = 16_777_216;
 
     /// <summary>
     /// Pick the parallelism axis for the given shape, microkernel tile, and


### PR DESCRIPTION
PerfView showed N-BEATS CPU training is **dispatch-bound**: the driver blocks **~45% of wall** on the GEMM-pool barrier because every small GEMM (0.6M-4.2M MACs) clears the 32,768-MAC threshold and fans to 12-32 workers for ~8 rows each — the wake/sync barrier dwarfs the math (worker compute ~1%). Raising the threshold to 16M runs N-BEATS-scale GEMMs **serial on the driver** (no dispatch). **Bit-exact** (M-axis partitioning = disjoint rows, no cross-thread reduction). **Measured min-of-7: 28.9s -> 18.3s (~37%)**, forecast+MAE identical. Tunable via `AIDOTNET_GEMM_PARALLEL_MINWORK`.

**Review note:** global default tuned for high-core + small-M; validate across the model zoo or make it a rows-per-worker/core-scaled gate. Contributes to ooples/AiDotNet#1804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)