### PR TITLE
fix(bench): gate gemm-bench on the median per-round paired ON/OFF ratio

### DIFF
--- a/tools/ConvParallelProbe/gemm_bench.py
+++ b/tools/ConvParallelProbe/gemm_bench.py
@@ -27,6 +27,7 @@ Exit code 1 if any TUNED shape regresses past the tolerance.
 import argparse
 import os
 import re
+import statistics
 import subprocess
 import sys
 
@@ -92,6 +93,7 @@ def bench(probe, shapes, maxdop, reps, repeat):
     for label, m, k, n in shapes:
         off = None
         on = None
+        round_ratios = []
         # Interleave OFF/ON per repeat (not all-OFF-then-all-ON): slow machine-load drift on a
         # shared CI runner then biases both flags equally instead of skewing the ON/OFF ratio.
         for _ in range(repeat):
@@ -101,7 +103,19 @@ def bench(probe, shapes, maxdop, reps, repeat):
                 off = o0 if off is None else min(off, o0)
             if o1 is not None:
                 on = o1 if on is None else min(on, o1)
-        ratio = (on / off) if (off and on) else float("nan")
+            # Gate on the ratio of the OFF/ON measured back-to-back in the SAME round: their
+            # shared-runner load is ~equal, so drift cancels - which is the whole point of
+            # interleaving. Taking min(ON) / min(OFF) over ALL rounds independently (the previous
+            # behaviour) discarded that pairing: a lucky-fast OFF round could pair against an
+            # unlucky ON round, skewing the ratio. On a 32-core runner medium GEMMs (square-768/
+            # square-1152) have ~30% best-case dispatch variance, so that skew made this gate
+            # flaky - an identical commit read ratio 1.19 one run and 0.94 the next. Each o0/o1 is
+            # already the min over `reps` inner reps.
+            if o0 and o1:
+                round_ratios.append(o1 / o0)
+        # Median of the per-round paired ratios: robust to a single unlucky round while still
+        # catching a real, sustained regression (the median only moves if MOST rounds regress).
+        ratio = statistics.median(round_ratios) if round_ratios else float("nan")
         rows.append((label, m, k, n, off, on, ratio))
     return rows
 
@@ -122,7 +136,9 @@ def main():
     lines = [
         f"## #653 GEMM small-M tiling A/B  (maxdop={args.maxdop}, reps={args.reps}, repeat={args.repeat}, tol={args.tol:.0%})",
         "",
-        "min_ms = best case across repeats. ratio = ON / OFF (lower is better; <1 = faster with the lever).",
+        "OFF ms / ON ms = best case across repeats (informational). ratio = MEDIAN of the per-round "
+        "paired ON/OFF (each round's ON and OFF are measured back-to-back so runner-load drift cancels) "
+        "- this is the value the gate checks. lower is better; <1 = faster with the lever.",
         "",
         "### TUNED shapes - must not regress (gate)",
         "| shape | MxKxN | OFF ms | ON ms | ratio | verdict |",


### PR DESCRIPTION
## Problem

The #653 GEMM A/B gate (`tools/ConvParallelProbe/gemm_bench.py`) is **flaky** — it intermittently fails unrelated PRs on a tuned shape (most recently `square-768` on #736), then passes on a plain re-run of the *identical* commit (ratio read **1.19 → FAIL**, then **0.94 → PASS**).

## Root cause (a real bug, not just noise)

The gate interleaves OFF/ON per round *specifically* so shared-runner load drift biases both flags equally — but then **throws the pairing away**:

```python
for _ in range(repeat):
    o0 = run_probe_once(..., 0)   # OFF
    o1 = run_probe_once(..., 1)   # ON
    off = min(off, o0)            # global min of OFF, independently
    on  = min(on,  o1)            # global min of ON,  independently
ratio = on / off                 # min(ON) / min(OFF)
```

Taking the global min of ON and OFF *independently* lets a lucky-fast OFF round pair against an unlucky ON round, skewing the ratio. On a 32-core runner the tuned medium GEMMs (`square-768`, `square-1152`) have ~30% best-case dispatch variance (measured), so that skew is enough to blow the tolerance at random.

Verified it is **not** caused by any runtime change (e.g. #736's spin-count drop): `square-768` best-case is identical at spin=32 (1.497 ms) vs spin=2047 (1.498 ms).

## Fix

Compute the ON/OFF ratio **within each interleaved round** (the two are measured back-to-back, so load cancels — which is what the interleaving was *for*), and gate on the **median** of the per-round ratios. Robust to a single unlucky round while still catching a real, sustained regression (the median only moves if most rounds regress).

- **Tolerance is unchanged** (`--tol`) — this does not loosen the regression bar.
- Best-case `OFF ms` / `ON ms` columns stay as informational context; the summary now states the `ratio` column is the median paired ratio.

## Verification

Local run (32-core, `--reps 15 --repeat 4 --tol 0.12`) — all 6 tuned shapes PASS with stable near-1.0 ratios:

| shape | ratio | verdict |
|---|---|---|
| square-1152 | 1.026 | ok |
| square-768 | 1.054 | ok |
| bert-768-768 | 1.001 | ok |
| bert-768-3072 | 0.978 | ok |
| lm-head | 1.003 | ok |
| batched-slice | 0.994 | ok |

`square-768`'s median-paired ratio (1.054) is closer to the true ~1.0 than the old `min/min` (1.618/1.491 = 1.085) that intermittently tipped the gate.