### PR TITLE
perf(gemm): beta=0 write-first path — skip redundant C-zeroing on pure C:=A·B

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -140,7 +140,7 @@ public static partial class BlasManaged
         ReadOnlySpan<T> a, int lda, bool transA,
         ReadOnlySpan<T> b, int ldb, bool transB,
         Span<T> c, int ldc, int m, int n, int k,
-        in BlasOptions<T> options) where T : unmanaged
+        in BlasOptions<T> options, bool betaZero) where T : unmanaged
     {
         if (!(typeof(T) == typeof(float) || typeof(T) == typeof(double))) return false;
         if (!System.Runtime.Intrinsics.X86.Fma.IsSupported) return false;
@@ -183,9 +183,21 @@ public static partial class BlasManaged
                     MemoryMarshal.Cast<T, double>(c), m, k, n);
         }
         else if (isFloat)
-            Simd.SimdGemm.SgemmDirectParallelMInto(
-                MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
-                MemoryMarshal.Cast<T, float>(c), m, k, n);
+        {
+            // FP64 no-trans and both trans variants already OVERWRITE every C element
+            // (zero-init accumulators + store + scalar-tail writes), so they never needed a
+            // pre-clear. Only the FP32 no-trans path carries a redundant internal c.Clear();
+            // under beta=0 use the write-first sibling that skips it (bit-identical — the
+            // store-only kernels overwrite the whole tile).
+            if (betaZero)
+                Simd.SimdGemm.SgemmDirectParallelMOverwrite(
+                    MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
+                    MemoryMarshal.Cast<T, float>(c), m, k, n);
+            else
+                Simd.SimdGemm.SgemmDirectParallelMInto(
+                    MemoryMarshal.Cast<T, float>(a), MemoryMarshal.Cast<T, float>(b),
+                    MemoryMarshal.Cast<T, float>(c), m, k, n);
+        }
         else
             Simd.SimdGemm.DgemmDirectParallelMInto(
                 MemoryMarshal.Cast<T, double>(a), MemoryMarshal.Cast<T, double>(b),
@@ -355,6 +367,27 @@ public static partial class BlasManaged
         return required <= span.Length;
     }
 
+    /// <summary>
+    /// Zero the logical [m, n] output tile of C (respecting the leading dimension), NOT the
+    /// whole backing span. With an ldc-padded or offset-based caller the span extends past the
+    /// tile, and a blanket <c>c.Clear()</c> would clobber data the caller owns outside it.
+    /// Used both for the default (beta=1) pre-zero and as the localized beta=0 fallback for any
+    /// strategy path that read-modify-writes C rather than overwriting it.
+    /// </summary>
+    private static void ClearOutputTile<T>(Span<T> c, int ldc, int m, int n) where T : unmanaged
+    {
+        if (ldc == n)
+        {
+            // Contiguous rows — the tile is a single [0, m*n) run.
+            c.Slice(0, m * n).Clear();
+        }
+        else
+        {
+            for (int row = 0; row < m; row++)
+                c.Slice(row * ldc, n).Clear();
+        }
+    }
+
     // Diagnostic timing wrapper (#475 shape audit). When GemmShapeHistogram.Enabled it times
     // only the TOP-LEVEL Gemm call (a ThreadStatic guard skips internal re-dispatches so a
     // shape is attributed once, to the outer call). Disabled → a single bool read + straight
@@ -493,23 +526,41 @@ public static partial class BlasManaged
             }
         }
 
-        // Strategies do read-modify-write on C; zero it here so the first call
-        // produces C = A · B (not C += A · B). Future versions may expose a
-        // beta=1 option that skips this zero, but Phase B's contract is C := A · B.
+        // beta=0 (write-first) hint. When set, the caller wants a pure C := op(A)·op(B) and
+        // does NOT need C preserved/accumulated, so paths that provably overwrite the whole
+        // [m, n] tile may skip the redundant memset. Every path that does NOT overwrite falls
+        // back to a localized ClearOutputTile below, so correctness never depends on the flag.
+        bool betaZero = options.BetaZero;
+
+#if NET5_0_OR_GREATER
+        // #368 thin-M fast path — MOVED above the output clear. The thin-M direct kernels
+        // OVERWRITE every element of C: FP64 no-trans and both transposed variants zero-init
+        // their register accumulators and store (never reading C), and the FP32 no-trans path
+        // dispatches store-only kernels. So the [m, n] clear below is pure redundancy for this
+        // path; running it first lets thin-M (e.g. the N-BEATS m=256 forward shape) skip the
+        // memset entirely — bit-identical to clear-then-overwrite. Under beta=0 the FP32 path
+        // also drops its own internal c.Clear() (the store-only kernels overwrite the full
+        // tile). BlasManaged's general dispatch parallelises thin-M GEMM poorly (the packed /
+        // machine-code paths lose to the no-pack disjoint-row kernel here); this interception
+        // keeps it on the fast kernel and is bounded to the measured winning regime. Force*
+        // pack modes, pre-packed operands, both-transposed, out-of-box and non-FMA shapes fall
+        // through to the tuned strategy paths (see TryThinMDirect). Disjoint rows →
+        // bit-deterministic across thread counts. A fused bias/activation epilogue is applied
+        // after the GEMM so thin-M FusedLinear hits the fast kernel too.
+        if (TryThinMDirect<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k, in options, betaZero))
+            return;
+#endif
+
+        // Strategies do read-modify-write on C; zero it here so the first call produces
+        // C = A · B (not C += A · B). Under beta=0 (BetaZero) the caller wants a pure overwrite
+        // and every downstream path either WRITES every C element (thin-M above) or does its
+        // own localized clear before accumulating, so this global memset is skipped.
         //
         // Clear only the logical [m, n] output tile, NOT the whole span: with an
         // ldc-padded or offset-based caller the backing span extends past the
         // tile, and c.Clear() would clobber data the caller owns outside it.
-        if (ldc == n)
-        {
-            // Contiguous rows — the tile is a single [0, m*n) run.
-            c.Slice(0, m * n).Clear();
-        }
-        else
-        {
-            for (int row = 0; row < m; row++)
-                c.Slice(row * ldc, n).Clear();
-        }
+        if (!betaZero)
+            ClearOutputTile(c, ldc, m, n);
 
         // Sub-R (#408): GEMV fast path. M=1 (row × matrix), N=1 (matrix × col),
         // or K=1 (outer product) bypass the GEMM dispatcher entirely — per-call
@@ -519,6 +570,9 @@ public static partial class BlasManaged
         // path so callers can force-test the strategy if needed.
         if (GemvKernel.QualifiesFor(m, n, k) && options.PackingMode == PackingMode.Auto)
         {
+            // GEMV read-modify-writes C; under beta=0 the global clear was skipped, so zero the
+            // tile here before it accumulates (GEMV is not converted to write-first).
+            if (betaZero) ClearOutputTile(c, ldc, m, n);
             GemvKernel.Run<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
             var gemvEpilogue = options.Epilogue;
             EpilogueChain.Apply<T>(c, ldc, m, n, in gemvEpilogue);
@@ -533,6 +587,8 @@ public static partial class BlasManaged
         // microkernel-tile picking and route directly to StreamingStrategy.
         if ((long)m * n * k <= TinyShapeWorkThreshold && options.PackingMode == PackingMode.Auto)
         {
+            // Streaming read-modify-writes C; zero the tile under beta=0 (not write-first).
+            if (betaZero) ClearOutputTile(c, ldc, m, n);
             StreamingStrategy.Run<T>(
                 a, lda, transA,
                 b, ldb, transB,
@@ -544,22 +600,6 @@ public static partial class BlasManaged
             EpilogueChain.Apply<T>(c, ldc, m, n, in fastEpilogue);
             return;
         }
-
-#if NET5_0_OR_GREATER
-        // #368 thin-M fast path: BlasManaged's general dispatch parallelises thin-M
-        // GEMM poorly — at the AIsEval MLP L0 128×784×512 float falls to the #409
-        // machine-code path (~55 GF/s) and double stays ~60, both LOSING to a no-pack
-        // direct parallel kernel that splits disjoint output-row blocks (float 6×16
-        // ~400-464 GF/s, beating OpenBLAS ~335; double 4×8 ~172). Disjoint rows →
-        // bit-deterministic across thread counts (no K-split → no Deterministic-mode
-        // concern). Also applies a fused bias/activation epilogue after the GEMM, so
-        // thin-M FusedLinear hits the fast kernel. Bounded to the measured winning
-        // regime; the Force* pack modes (caller pinned a strategy), pre-packed operands,
-        // transposed (its serial transpose regresses thin-M — see TryThinMDirect),
-        // out-of-box and non-FMA shapes fall through to the tuned strategy paths.
-        if (TryThinMDirect<T>(a, lda, transA, b, ldb, transB, c, ldc, m, n, k, in options))
-            return;
-#endif
 
 #if NET5_0_OR_GREATER
         // GotoBLAS FP32 parallel path (the rewrite) — the production large-float GEMM. Fires for BOTH
@@ -579,6 +619,9 @@ public static partial class BlasManaged
             && (long)m * n * k >= GotoGemmFp32.ParallelMinWork && GotoGemmFp32.BeatsPackBoth(m, n, k)
             && GotoGemmFp32.IsAvailable)
         {
+            // GotoGemm accumulates into a pre-zeroed C; under beta=0 the global clear was
+            // skipped, so zero the tile here (this path is not converted to write-first).
+            if (betaZero) ClearOutputTile(c, ldc, m, n);
             var gepi = options.Epilogue;
             {
                 var gfa = MemoryMarshal.Cast<T, float>(a);
@@ -637,6 +680,9 @@ public static partial class BlasManaged
                 && (s_forceMachineKernel || !PrefersStrategyOverMachineKernel(m, n, k, typeof(T) == typeof(float)))
                 && EpilogueFlagsCompute.Compute(in epi409) == EpilogueFlags.None)
             {
+                // Machine-code kernel accumulates into a pre-zeroed C (and its Streaming M/N
+                // tails do too); under beta=0 the global clear was skipped, so zero here.
+                if (betaZero) ClearOutputTile(c, ldc, m, n);
                 int mAl = m - (m % mkMr); // interior rows (× Mr)
                 int nAl = n - (n % mkNr); // interior cols (× Nr)
                 bool ran = typeof(T) == typeof(double)
@@ -672,6 +718,16 @@ public static partial class BlasManaged
         // actual call (the shapes reaching strategy selection are typically transposed —
         // Sub-S already handled non-transposed aligned GEMM above).
         PackingMode strategy = Dispatcher.SelectStrategy(m, n, k, transA, transB, in options);
+
+        // beta=0 fallback for the tuned-strategy family (Streaming / PackAOnly / PackBoth and
+        // the partial-M/N tail decomposition): these all read-modify-write C (Streaming loads
+        // the C accumulator; PackBoth accumulates C across K-panels; the tail-split relies on a
+        // globally pre-zeroed C). None is converted to write-first, so under beta=0 — where the
+        // global clear was skipped — zero the [m, n] tile once here. Every path below is then
+        // identical to the historical clear-then-accumulate contract (bit-exact, no numeric
+        // risk); the memset-skip win is confined to the proven-overwrite thin-M path above.
+        if (betaZero)
+            ClearOutputTile(c, ldc, m, n);
 
         // PackAOnly does not support transB=true in Phase B — fall back to
         // PackBoth (which absorbs the transpose into its pack) or Streaming

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasOptions.cs
@@ -45,6 +45,29 @@ public readonly ref struct BlasOptions<T> where T : unmanaged
     /// throughput at the cost of ±1-2 ULP cross-thread variability.
     /// </summary>
     public BlasMode Mode { get; init; }
+
+    /// <summary>
+    /// beta = 0 hint (write-first, skip output-zeroing). When <see langword="true"/>, the
+    /// caller declares it wants a pure overwrite <c>C := op(A)·op(B)</c> and does NOT need
+    /// C's prior contents preserved or accumulated into — so the dispatcher may skip the
+    /// redundant <c>C.Clear()</c> memset for any path that provably WRITES every element of
+    /// the [m, n] output tile (rather than read-modify-writing it).
+    ///
+    /// <para>
+    /// Bit-exactness: for a write-first path the accumulator starts at <c>+0.0</c> and the
+    /// first fused-multiply-add is <c>fma(a, b, +0.0)</c> — identical to the
+    /// zero-then-accumulate path where the pre-cleared C supplies that same <c>+0.0</c>. So
+    /// the result is bit-for-bit identical, just without the memset.
+    /// </para>
+    ///
+    /// <para>
+    /// Default <see langword="false"/> preserves the historical contract (C is zeroed on
+    /// entry, then accumulated) so every existing caller is unchanged. Paths that cannot be
+    /// proven write-first fall back to a localized clear of the output tile even when this is
+    /// set, so the result is always correct regardless of which strategy the shape routes to.
+    /// </para>
+    /// </summary>
+    public bool BetaZero { get; init; }
 }
 
 public enum PackingMode

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2777,9 +2777,15 @@ public partial class CpuEngine : ITensorLevelEngine
                 // (BlasManaged's fast path declines transA&&transB; parallel dispatch loses on few rows).
                 if (m >= 64 && !(transA && transB))
                 {
+                    // BetaZero: this is a pure C := A·B (result is a freshly rented, write-only
+                    // buffer), so let the dispatcher skip the redundant C-zeroing memset on any
+                    // path that provably overwrites the whole output tile — notably the thin-M
+                    // direct kernel that intercepts the N-BEATS m=256 forward shape. Bit-exact
+                    // (write-first accumulators start at +0.0, identical to zero-then-accumulate);
+                    // non-overwrite paths fall back to a localized clear, so always correct.
                     Engines.BlasManaged.BlasManaged.Gemm<float>(
                         aFloat, lda, transA, bFloat, ldb, transB, cFloat, n, m, n, k,
-                        new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune });
+                        new Engines.BlasManaged.BlasOptions<float> { PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune, BetaZero = true });
                 }
                 else
                 {

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -2057,6 +2057,24 @@ internal static partial class SimdGemm
     }
 
     /// <summary>
+    /// beta=0 write-first sibling of <see cref="SgemmDirectParallelMInto"/>: computes
+    /// C := A·B WITHOUT the leading <c>c.Clear()</c>. Safe because
+    /// <see cref="SgemmDirectParallelM"/> with <c>clearedOutput: true</c> dispatches only the
+    /// store-only kernels (<c>DirectKernel6x16Store</c> / <c>DirectKernelMxNMaskedStore</c>),
+    /// which OVERWRITE every element of the [m, n] tile (full Mr-row blocks over all N,
+    /// masked N-tail, and the M-edge rows) — nothing is read from C. The result is therefore
+    /// bit-identical to zero-then-store, just without the redundant memset. Callers that need
+    /// C accumulated (C += A·B) must NOT use this; use the SgemmAdd entry points instead.
+    /// </summary>
+    [MethodImpl(Hot)]
+    public static void SgemmDirectParallelMOverwrite(
+        ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c,
+        int m, int k, int n)
+    {
+        SgemmDirectParallelM(a, k, b, n, c, m, k, n, clearedOutput: true);
+    }
+
+    /// <summary>
     /// FP64 analog of <see cref="SgemmDirectParallelMInto"/> (#368): overwrite GEMM
     /// (C = A·B) via a no-pack register-blocked 4×8 <see cref="Vector256{T}"/> double
     /// microkernel, parallelised over disjoint M-row-blocks. For thin/moderate-M

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GemmBeta0BitExactTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GemmBeta0BitExactTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// beta=0 (write-first, skip output-zeroing) correctness suite.
+///
+/// <para>
+/// The core contract of <see cref="BlasOptions{T}.BetaZero"/> is that a pure
+/// <c>C := op(A)·op(B)</c> is computed <b>bit-for-bit identically</b> to the historical
+/// zero-then-accumulate path (<c>BetaZero=false</c>), just without the redundant <c>C.Clear()</c>
+/// memset. Writing X is identical to <c>0 + X</c> (the accumulator starts at <c>+0.0</c> either
+/// way), so every path must agree to the last bit.
+/// </para>
+///
+/// <para>
+/// Each case runs the SAME <see cref="BlasManagedLib.Gemm{T}"/> twice — once with
+/// <c>BetaZero=false</c> into a zero-initialized C (the reference / current behavior) and once
+/// with <c>BetaZero=true</c> into a C whose backing buffer is POISONED with a large sentinel —
+/// then asserts:
+/// <list type="number">
+///   <item>the [m, n] output tile is byte-for-byte identical between the two runs (bit-exact,
+///         and — because the beta=0 buffer was poisoned — proof that beta=0 OVERWRITES every
+///         tile element rather than reading stale C);</item>
+///   <item>the beta=0 run leaves every buffer byte OUTSIDE the [m, n] tile (ldc padding, leading
+///         and trailing offset) untouched (still the sentinel) — beta=0 must not clobber memory
+///         the caller owns outside the logical tile;</item>
+///   <item>the beta=1 (BetaZero=false) run also fully overwrites a poisoned buffer's tile
+///         (clear-then-accumulate semantics preserved).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// The matrix spans thin-M / thin-N / K=1 (GEMV / outer-product edges), the N-BEATS m=96/256
+/// forward shapes, square small/medium, non-square and a large shape; K spanning one-panel and
+/// multi-panel (1, 64, 96, 256, 512); both dtypes (float, double); all four transpose combos
+/// (NN, NT, TN, TT); contiguous AND ldc-padded/offset C; and each routable strategy forced via
+/// <see cref="PackingMode"/> so every path's beta=0 handling is covered. Runs on net10.0 (AVX2
+/// microkernels + thin-M direct) and net471 (scalar fallbacks).
+/// </para>
+/// </summary>
+// Serialize against global GEMM-path mutators (determinism flag / stats) so a concurrent
+// toggle can't change the reduction order mid-assertion.
+[Collection("BlasManaged-Stats-Serial")]
+public class GemmBeta0BitExactTests
+{
+    // Distinctive, large-but-finite sentinel poison. Large so that any path that erroneously
+    // READS a "cleared" C (instead of overwriting) produces a wildly wrong value → mismatch;
+    // finite so comparisons stay well-defined (no NaN games).
+    private const float PoisonF = 3.0e30f;
+    private const double PoisonD = 3.0e30;
+
+    private static readonly PackingMode[] Modes =
+    {
+        PackingMode.Auto,
+        PackingMode.DisableAutotune,   // the mode CpuEngine's pure-matmul float path uses
+        PackingMode.ForceStreaming,
+        PackingMode.ForcePackBoth,
+        PackingMode.ForcePackAOnly,
+    };
+
+    // ── shape list: (m, n, k). n is kept a multiple of 8 on the shapes meant to exercise the
+    //    thin-M direct kernel; the rest cover edges / non-alignment. ──────────────────────────
+    public static TheoryData<int, int, int> Shapes()
+    {
+        var d = new TheoryData<int, int, int>();
+        // thin-M (below the m>=64 direct-kernel gate → tuned strategy / streaming)
+        d.Add(1, 16, 8); d.Add(2, 32, 64); d.Add(5, 24, 96); d.Add(8, 64, 128);
+        // thin-N
+        d.Add(96, 1, 64); d.Add(128, 4, 96); d.Add(256, 8, 128);
+        // K=1 (outer product / GEMV edge)
+        d.Add(1, 8, 1); d.Add(64, 64, 1); d.Add(96, 32, 1);
+        // N-BEATS forward shapes (m=96 / m=256, n%8==0 → thin-M direct on Auto/DisableAutotune)
+        d.Add(96, 256, 256); d.Add(256, 256, 256); d.Add(256, 512, 512); d.Add(256, 128, 96);
+        // square small / medium
+        d.Add(16, 16, 16); d.Add(64, 64, 64); d.Add(128, 128, 128);
+        // non-square + multi-panel K
+        d.Add(96, 80, 512); d.Add(200, 72, 300); d.Add(130, 130, 130);
+        // larger (exercises GotoGemm / PackBoth cache-blocking under beta=0)
+        d.Add(384, 384, 384);
+        return d;
+    }
+
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void Beta0_IsBitExact_ToBeta1_AndOverwritesTile(int m, int n, int k)
+    {
+        foreach (var mode in Modes)
+        {
+            // Transposes: NN, NT, TN, TT.
+            for (int t = 0; t < 4; t++)
+            {
+                bool transA = (t & 1) != 0;
+                bool transB = (t & 2) != 0;
+
+                // C layouts: contiguous (ldc=n, no offset) AND padded+offset.
+                CheckOne<float>(m, n, k, transA, transB, mode, ldcPad: 0, lead: 0, trail: 0, seed: 1234);
+                CheckOne<double>(m, n, k, transA, transB, mode, ldcPad: 0, lead: 0, trail: 0, seed: 1234);
+                CheckOne<float>(m, n, k, transA, transB, mode, ldcPad: 3, lead: 5, trail: 7, seed: 5678);
+                CheckOne<double>(m, n, k, transA, transB, mode, ldcPad: 3, lead: 5, trail: 7, seed: 5678);
+            }
+        }
+    }
+
+    private static void CheckOne<T>(
+        int m, int n, int k, bool transA, bool transB, PackingMode mode,
+        int ldcPad, int lead, int trail, int seed) where T : unmanaged
+    {
+        bool isDouble = typeof(T) == typeof(double);
+
+        // Stored (possibly transposed) operand layouts + leading dims.
+        int lda = transA ? m : k;              // A: !transA=[m,k] lda=k ; transA=[k,m] lda=m
+        int ldb = transB ? k : n;              // B: !transB=[k,n] ldb=n ; transB=[n,k] ldb=k
+        int aRows = transA ? k : m;
+        int bRows = transB ? n : k;
+        int aLen = aRows * lda;
+        int bLen = bRows * ldb;
+
+        int ldc = n + ldcPad;
+        int cTileSpan = (m - 1) * ldc + n;     // last touched element of the logical tile
+        int cBufLen = lead + m * ldc + trail;  // full backing buffer (tile occupies [lead, lead+m*ldc))
+
+        var a = new T[aLen];
+        var b = new T[bLen];
+        FillRandom(a, seed);
+        FillRandom(b, seed ^ 0x5bd1e995);
+
+        // Reference: BetaZero=false into a ZERO buffer (current behavior).
+        var cRefBuf = new T[cBufLen];   // default-zeroed
+        var cRefSpan = new Span<T>(cRefBuf, lead, cBufLen - lead);
+        BlasManagedLib.Gemm<T>(a, lda, transA, b, ldb, transB, cRefSpan, ldc, m, n, k,
+            new BlasOptions<T> { PackingMode = mode, BetaZero = false });
+
+        // beta=0: BetaZero=true into a fully POISONED buffer.
+        var cBetaBuf = new T[cBufLen];
+        Poison(cBetaBuf);
+        var cBetaSpan = new Span<T>(cBetaBuf, lead, cBufLen - lead);
+        BlasManagedLib.Gemm<T>(a, lda, transA, b, ldb, transB, cBetaSpan, ldc, m, n, k,
+            new BlasOptions<T> { PackingMode = mode, BetaZero = true });
+
+        string ctx = $"[{typeof(T).Name} {m}x{n}x{k} tA={transA} tB={transB} mode={mode} pad={ldcPad} lead={lead}]";
+
+        // (1) tile bit-exact between beta=0 and beta=1, cell by cell (respecting ldc stride).
+        for (int r = 0; r < m; r++)
+        {
+            for (int col = 0; col < n; col++)
+            {
+                int idx = lead + r * ldc + col;
+                AssertBitEqual(cRefBuf[idx], cBetaBuf[idx], $"tile bit mismatch at ({r},{col}) {ctx}");
+            }
+        }
+
+        // (2) beta=0 must NOT touch anything outside the [m,n] tile: leading offset, per-row
+        //     ldc padding, and the trailing region all remain the poison sentinel.
+        for (int i = 0; i < lead; i++)
+            AssertIsPoison(cBetaBuf[i], $"beta=0 clobbered LEADING offset at {i} {ctx}");
+        for (int r = 0; r < m; r++)
+            for (int col = n; col < ldc; col++)
+                AssertIsPoison(cBetaBuf[lead + r * ldc + col], $"beta=0 clobbered ldc PADDING at row {r} col {col} {ctx}");
+        for (int i = lead + cTileSpan; i < cBufLen; i++)
+            AssertIsPoison(cBetaBuf[i], $"beta=0 clobbered TRAILING region at {i} {ctx}");
+
+        // (3) beta=1 (BetaZero=false) still fully overwrites a POISONED buffer's tile
+        //     (clear-then-accumulate contract preserved — no stale C leaks through).
+        var cBeta1Buf = new T[cBufLen];
+        Poison(cBeta1Buf);
+        var cBeta1Span = new Span<T>(cBeta1Buf, lead, cBufLen - lead);
+        BlasManagedLib.Gemm<T>(a, lda, transA, b, ldb, transB, cBeta1Span, ldc, m, n, k,
+            new BlasOptions<T> { PackingMode = mode, BetaZero = false });
+        for (int r = 0; r < m; r++)
+            for (int col = 0; col < n; col++)
+            {
+                int idx = lead + r * ldc + col;
+                AssertBitEqual(cRefBuf[idx], cBeta1Buf[idx], $"beta=1 poisoned-buffer tile mismatch at ({r},{col}) {ctx}");
+            }
+    }
+
+    /// <summary>
+    /// Independent correctness anchor: on a handful of small shapes, confirm the beta=0 result
+    /// actually equals A·B computed by a naive double-accumulation reference (guards against the
+    /// beta=0 and beta=1 paths being identically wrong).
+    /// </summary>
+    [Theory]
+    [InlineData(64, 64, 64, false, false)]
+    [InlineData(96, 32, 128, false, false)]
+    [InlineData(72, 40, 96, true, false)]
+    [InlineData(64, 48, 80, false, true)]
+    [InlineData(56, 56, 56, true, true)]
+    public void Beta0_Matches_NaiveReference(int m, int n, int k, bool transA, bool transB)
+    {
+        var rng = new Random(99);
+        int lda = transA ? m : k;
+        int ldb = transB ? k : n;
+        var a = new float[(transA ? k : m) * lda];
+        var b = new float[(transB ? n : k) * ldb];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var c = new float[m * n];
+        Poison(c);
+        BlasManagedLib.Gemm<float>(a, lda, transA, b, ldb, transB, c, n, m, n, k,
+            new BlasOptions<float> { PackingMode = PackingMode.DisableAutotune, BetaZero = true });
+
+        double maxAbs = 0;
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+            {
+                double acc = 0;
+                for (int p = 0; p < k; p++)
+                {
+                    double av = transA ? a[p * lda + i] : a[i * lda + p];
+                    double bv = transB ? b[j * ldb + p] : b[p * ldb + j];
+                    acc += av * bv;
+                }
+                maxAbs = Math.Max(maxAbs, Math.Abs(c[i * n + j] - acc));
+            }
+        Assert.True(maxAbs < 1e-3, $"beta=0 {m}x{n}x{k} tA={transA} tB={transB}: maxAbsDelta={maxAbs} vs naive ref");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+    private static void FillRandom<T>(T[] arr, int seed) where T : unmanaged
+    {
+        var rng = new Random(seed);
+        Span<T> span = arr;
+        if (typeof(T) == typeof(float))
+        {
+            var f = MemoryMarshal.Cast<T, float>(span);
+            for (int i = 0; i < f.Length; i++) f[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+        else
+        {
+            var dbl = MemoryMarshal.Cast<T, double>(span);
+            for (int i = 0; i < dbl.Length; i++) dbl[i] = rng.NextDouble() * 2 - 1;
+        }
+    }
+
+    private static void Poison<T>(T[] arr) where T : unmanaged
+    {
+        Span<T> span = arr;
+        if (typeof(T) == typeof(float))
+            MemoryMarshal.Cast<T, float>(span).Fill(PoisonF);
+        else
+            MemoryMarshal.Cast<T, double>(span).Fill(PoisonD);
+    }
+
+    private static void AssertBitEqual<T>(T expected, T actual, string msg) where T : unmanaged
+    {
+        // Raw-bit comparison (portable across net10.0 / net471): reinterpret to an integer of
+        // the same width. Distinguishes ±0.0 and catches any ULP difference.
+        if (typeof(T) == typeof(float))
+        {
+            uint e = BitConverter.ToUInt32(BitConverter.GetBytes((float)(object)expected!), 0);
+            uint a = BitConverter.ToUInt32(BitConverter.GetBytes((float)(object)actual!), 0);
+            Assert.True(e == a, $"{msg} (expected bits {e:X8}, got {a:X8})");
+        }
+        else
+        {
+            ulong e = BitConverter.ToUInt64(BitConverter.GetBytes((double)(object)expected!), 0);
+            ulong a = BitConverter.ToUInt64(BitConverter.GetBytes((double)(object)actual!), 0);
+            Assert.True(e == a, $"{msg} (expected bits {e:X16}, got {a:X16})");
+        }
+    }
+
+    private static void AssertIsPoison<T>(T value, string msg) where T : unmanaged
+    {
+        if (typeof(T) == typeof(float))
+            Assert.True((float)(object)value! == PoisonF, msg);
+        else
+            Assert.True((double)(object)value! == PoisonD, msg);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `BlasOptions.BetaZero` hint so the managed GEMM can skip the redundant `c.Clear()` memset when the caller wants a pure overwrite `C := op(A)·op(B)` and the selected path provably **writes** every element of the `[m, n]` output tile. Removes the ~12%-of-N-BEATS-train memset (per PerfView) on the thin-M forward path.

## The beta=0 write-first design

The redundant clear exists because the tuned strategies do read-modify-write on C (`C += A_k·B_k` across K-panels), so the first panel needs C pre-zeroed. But the **thin-M direct kernels** (the primary N-BEATS m=256 forward path) already fully **overwrite** C:

- FP64 no-trans (`DgemmDirectParallelMInto`) and both transposed variants zero-init their register accumulators (`Vector256<T>.Zero`) and `Store` — they never read C.
- FP32 no-trans (`SgemmDirectParallelM(clearedOutput: true)`) dispatches store-only kernels (`DirectKernel6x16Store` / `DirectKernelMxNMaskedStore`) that overwrite the full tile.

So the global clear before thin-M was pure redundancy. This PR:

1. **Moves `TryThinMDirect` above the global clear** — benefits all callers, bit-identically (the kernels overwrite C regardless of prior contents).
2. Under **beta=0**, the FP32 path also drops its own internal `c.Clear()` via the new `SgemmDirectParallelMOverwrite` sibling.
3. Wires `CpuEngine`'s pure 2-D float matmul to request `BetaZero=true`.

**Why it's bit-exact:** a write-first accumulator starts at `+0.0`, so the first FMA is `fma(a, b, +0.0)` — identical to the zero-then-accumulate path where the pre-cleared C supplies that same `+0.0`. Same FP ops in the same order → bit-for-bit identical, just without the memset.

## Honest scope — paths gated off beta=0

Only the proven-overwrite **thin-M** path skips the memset. Paths that genuinely read-modify-write C — **Streaming, PackBoth, PackAOnly, GotoGemm, MachineKernel, GEMV, and the partial-M/N tail decomposition** — are **not** converted to write-first. Under beta=0 they fall back to a **localized `ClearOutputTile`**, so the result is always correct regardless of which strategy the shape routes to. No numeric risk is shipped for the multi-panel-accumulate kernels.

## Test matrix — `GemmBeta0BitExactTests`

Asserts the beta=0 result is **byte-for-byte identical** to the current beta=1 (clear-then-accumulate) result across the full matrix:

- **Shapes:** thin-M, thin-N, K=1 (GEMV/outer-product edge), N-BEATS m=96/256, square small/med, non-square, large (384³); **K ∈ {1, 64, 96, 256, 512}** (one-panel and multi-panel).
- **Dtypes:** float + double.
- **Transpose:** all four combos (NN, NT, TN, TT).
- **C layout:** contiguous (ldc=n) **and** ldc-padded + leading/trailing offset.
- **Strategy:** each path forced via `PackingMode` (Auto / DisableAutotune / ForceStreaming / ForcePackBoth / ForcePackAOnly).

The beta=0 buffer is **poisoned** with a large sentinel beforehand, so a bit mismatch also proves **full-tile overwrite**; separate asserts prove beta=0 **never touches memory outside the `[m,n]` tile** (ldc padding + offsets stay poison), and that beta=1 still overwrites a poisoned buffer. A naive double-accumulation reference anchors correctness independently.

**Results:** all green on **net10.0** (AVX2 microkernels + thin-M direct) and **net471** (scalar fallback). 108 existing GEMM correctness/determinism tests still pass.

## Evidence

- **Bit-exact:** full suite green on both TFMs; N-BEATS coreprobe golden reproduced **exactly** — `forecast[0]=47.395111`, `MAE=0.023372`.
- **Allocation:** neutral — base `1657.4 MB` vs beta0 `1657.4 MB` (`c.Clear()` is a memset, not an allocation, so GC bytes don't move). The win is eliminated **memset work** on the thin-M path, not GC bytes.
- **No wall-clock claim:** the measurement box thermally throttles ~2×, so wall is not cited as evidence.

Contributes to ooples/AiDotNet#1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)