### PR TITLE
ci: grant issues write to release-please for autorelease labels

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,6 @@ on:
       - main
       - master
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
-
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
@@ -32,6 +27,12 @@ jobs:
   release-please:
     name: Maintain Release PR / cut release
     runs-on: ubuntu-latest
+    # Least-privilege: scope write permissions to this job (the only job in this workflow)
+    # instead of the workflow level, so issues:write is not granted more broadly than needed.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.1.3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
 
 concurrency:
   group: release-please-${{ github.ref }}


### PR DESCRIPTION
## Problem

The **Release Please** workflow has been failing on every push to `main` with:

```
release-please failed: Resource not accessible by personal access token
```

release-please creates the tree/commit and updates the release branch ref successfully, then 403s when it goes to create/apply its `autorelease: pending` / `autorelease: tagged` labels via GitHub's **Issues API**. The workflow only granted `contents: write` + `pull-requests: write`.

## Fix

Add `issues: write` to the `permissions:` block so release-please can manage its labels (and the `GITHUB_TOKEN` fallback path is fully functional).

## Note

The workflow authenticates with `AUTOFIX_PAT`, whose permissions aren't governed by the workflow `permissions:` block — so the **`AUTOFIX_PAT` fine-grained token also needs `Issues: Read and write`** for the primary (PAT) path. This PR covers the workflow side; the two `autorelease:` labels have also been pre-created in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)