### PR TITLE
fix(autodiff): make 2D AffineGrid differentiable w.r.t. theta

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -6529,6 +6529,49 @@ internal static class BackwardFunctions<T>
     }
 
     /// <summary>
+    /// AffineGrid (2D) backward — the output grid is linear in theta, so
+    /// ∂grid[n,h,w,r] / ∂theta[n,r,k] = coord_k(h,w) for k ∈ {x, y, 1}.
+    /// Sum the product over all (h, w) to get gradTheta[n, r, k]. Coordinate
+    /// normalization mirrors the forward (align-corners style: 2·i/(size-1) − 1).
+    /// </summary>
+    internal static void AffineGridBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var theta = inputs[0];
+        int outH = (int)savedState[0];
+        int outW = (int)savedState[1];
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int N = theta._shape[0];
+        var gradTheta = new Tensor<T>(theta._shape);
+        var gOut = gradOutput.AsSpan();
+        var gTheta = gradTheta.AsWritableSpan();
+
+        for (int n = 0; n < N; n++)
+        {
+            int tBase = n * 6; // 2 × 3 affine matrix
+            for (int h = 0; h < outH; h++)
+            {
+                double y = outH <= 1 ? 0.0 : 2.0 * h / (outH - 1) - 1.0;
+                for (int w = 0; w < outW; w++)
+                {
+                    double x = outW <= 1 ? 0.0 : 2.0 * w / (outW - 1) - 1.0;
+                    int gBase = ((n * outH + h) * outW + w) * 2;
+                    for (int row = 0; row < 2; row++)
+                    {
+                        double g = numOps.ToDouble(gOut[gBase + row]);
+                        if (g == 0) continue;
+                        gTheta[tBase + row * 3]     = numOps.Add(gTheta[tBase + row * 3],     numOps.FromDouble(g * x));
+                        gTheta[tBase + row * 3 + 1] = numOps.Add(gTheta[tBase + row * 3 + 1], numOps.FromDouble(g * y));
+                        gTheta[tBase + row * 3 + 2] = numOps.Add(gTheta[tBase + row * 3 + 2], numOps.FromDouble(g));
+                    }
+                }
+            }
+        }
+        DifferentiableOps.AccumulateGrad(grads, theta, gradTheta, engine);
+    }
+
+    /// <summary>
     /// RoIAlign backward — scatter each output cell's gradient back across
     /// the 4 (or 2^samplingRatio²) bilinear-sampled source positions.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -200,7 +200,7 @@ internal static class OpRegistry
         // BackwardFunctions<T>.{InterpolateBackward, PadNdBackward,
         // AffineGrid3DBackward}. InterpolateByScale is a delegator to
         // Interpolate.
-        "Interpolate", "PadNd", "AffineGrid3D",
+        "Interpolate", "PadNd", "AffineGrid3D", "AffineGrid",
 
         // Vision RoI family (Issue #217 tail) — backward wired
         // in BackwardFunctions<T>.{RoIAlign,RoIPool,PsRoIAlign,PsRoIPool}Backward.
@@ -255,9 +255,6 @@ internal static class OpRegistry
         // the multi-tensor return type is currently treated as
         // non-differentiable at the tape level.
         "TensorTensorSplit",
-
-        // Grid/geometry (non-learnable)
-        "AffineGrid",
 
         // NeRF/3D ops (typically not differentiated through in training)
         "VolumeRendering", "ImportanceSampling", "RasterizeGaussians",

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -31462,6 +31462,13 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        // The output grid is linear in theta, so AffineGrid is differentiable w.r.t. theta
+        // (its 3D sibling AffineGrid3D already records). Without this, a Spatial Transformer's
+        // localization network receives no tape gradient and is silently untrainable.
+        AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
+            "AffineGrid", grid, theta,
+            AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<T>.AffineGridBackward,
+            new object[] { outputHeight, outputWidth });
         return grid;
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -156,6 +156,24 @@ public class GradientCorrectnessTests : IDisposable
         VerifyGradient(inp => _engine.TensorMatMul(x, inp), w, "MatMul_w");
     }
 
+    // ─── Geometry ───────────────────────────────────────────────
+
+    [Fact]
+    public void AffineGrid_Gradient_MatchesNumerical()
+    {
+        // theta is a [batch=1, 2, 3] affine matrix. The sampling grid is linear in theta,
+        // so a correct backward must reach every theta entry — this pins the tape recording
+        // that a Spatial Transformer's localization network depends on (2D AffineGrid was
+        // previously classified non-differentiable, silently freezing STN training).
+        // NOTE: a plain sum(grid) loss zeroes the gradient of the two linear (xNorm/yNorm)
+        // columns because those coordinates sum to 0 over a symmetric grid — so weight the
+        // grid by a fixed tensor to make ALL six theta gradients non-trivial.
+        const int H = 3, W = 4;
+        var theta = new Tensor<float>(new float[] { 1.0f, 0.2f, 0.1f, -0.15f, 0.9f, -0.05f }, [1, 2, 3]);
+        var weights = MakeFilled([1, H, W, 2], 0.3f, 0.11f);
+        VerifyGradient(inp => _engine.TensorMultiply(_engine.AffineGrid(inp, H, W), weights), theta, "AffineGrid_theta");
+    }
+
     // ─── Activations ────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Problem

2D `Engine.AffineGrid` was classified **NonDifferentiable** while its sibling `AffineGrid3D` is differentiable. As a result, a **Spatial Transformer's localization network received no tape gradient and was silently untrainable** — the generated `SpatialTransformerLayer.TapeGradient_ShouldReachAtLeastOneTrainableParameter` model-family invariant failed for exactly this reason (no trainable parameter received a gradient after tape backward).

## Fix

The output grid is **linear in theta**, so the backward is exact and simple:

- **`BackwardFunctions.AffineGridBackward`** — `∂grid[n,h,w,r]/∂theta[n,r,k] = coord_k(h,w)` for `k ∈ {x, y, 1}`, summed over `(h, w)`. A 2D mirror of the existing `AffineGrid3DBackward`, with coordinate normalization matching the forward (align-corners `2i/(size-1) − 1`).
- **`CpuEngine.AffineGrid`** — record the op on the tape via `RecordUnary`.
- **`OpRegistry`** — move `"AffineGrid"` from `NonDifferentiableOps` to `DifferentiableOps`.

## Validation

- **New** `GradientCorrectnessTests.AffineGrid_Gradient_MatchesNumerical` — finite-difference gradient check with a weighted-grid loss so all six theta gradients are exercised (a plain `sum(grid)` loss zeroes the two linear columns since the coords sum to 0 over a symmetric grid). ✅
- `TapeCompletenessTests` (17) — op classification stays consistent. ✅
- `GpuCpuAutoDifferentialTests` (324) — no coverage regression. ✅
- Full `GradientCorrectnessTests` suite (102) — green. ✅

## Consumer impact

Unblocks the STN `TapeGradient` model-family invariant in `ooples/AiDotNet#1789` (whose consumer-side `ConvertToTransformationMatrix` tape fix is already in place); that test greens once this ships and the package is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)