### PR TITLE
ci: pass --repo to gh release upload in the publish pipeline

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -567,4 +567,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "v${{ needs.version-and-build.outputs.package_version }}" out/*.nupkg --clobber
+          gh release upload "v${{ needs.version-and-build.outputs.package_version }}" out/*.nupkg --clobber --repo "${{ github.repository }}"


### PR DESCRIPTION
## Problem

The `Create GitHub Release` job in `automated-release.yml` (fired on `release: published`) downloads the package artifacts but **never checks out the repo**. Its final step runs:

```
gh release upload "v<version>" out/*.nupkg --clobber
```

With no `.git` present, `gh` can't resolve the target repo and fails with `fatal: not a git repository`. This **red-failed every release run** and skipped attaching the `.nupkg` files as GitHub-release download assets. (The NuGet push itself is a separate, earlier job and was unaffected — e.g. `0.111.0` published fine.)

## Fix

Pass an explicit `--repo "${{ github.repository }}"` so `gh release upload` resolves the repo from the flag instead of the (absent) git remote.

The `0.111.0` assets that this bug skipped have already been attached to the `v0.111.0` release manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)