### PR TITLE
ci: skip PR checks on release-please release PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   build:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -239,6 +240,7 @@ jobs:
   # and assert bit-exactness, after which MachineKernelGemm.EnableAvx512 can be
   # flipped on by default.
   avx512-verify:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ vars.AVX512_RUNNER || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gemm-bench.yml
+++ b/.github/workflows/gemm-bench.yml
@@ -53,6 +53,7 @@ env:
 
 jobs:
   gemm-bench:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ${{ vars.GEMM_BENCH_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
A feature PR passes the full CI (net10.0 + net471 build/test, coverage ratchet, AVX-512 verify, gemm-bench gate), then release-please opens a **Release PR** (`release-please--branches--main--components--AiDotNet.Tensors`) that only bumps the version + updates `CHANGELOG.md`/manifest — and that Release PR **re-runs the same build/test suite**, which can't meaningfully fail on a version/changelog-only diff.

## Fix
Guard the PR-triggered jobs with:
```yaml
if: ${{ !startsWith(github.head_ref, 'release-please--') }}
```
- `build.yml` → `build` and `avx512-verify` jobs guarded. The `publish` job is **untouched** (already push-to-master-only, never runs on a PR).
- `gemm-bench.yml` → `gemm-bench` job guarded (it's path-filtered to kernel files, so a release PR never triggered it anyway — this makes the intent explicit).

**Release PR** → all PR jobs skip. **Normal PRs / pushes** → unaffected (`head_ref` is empty on push).

Same change applied to the AiDotNet repo (which also uses release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)