### PR TITLE
fix(compile): zero only accumulating multi-consumer grad buffers (N-BEATS resident blow-up)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -4478,11 +4478,48 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
         }
 
-        // If all backward steps are specialized (overwrite), we can skip gradient zeroing entirely.
-        // Under pooling, force the clear-all path (null) so every physical buffer is
-        // zeroed at step start (covering each shared buffer's FIRST tenant); the
-        // re-zero schedule clears it again before each subsequent tenant.
-        int[]? genericGradIndices = (!useGradPool && genericBackwardCount == 0) ? new int[0] : null;
+        // If all backward steps are specialized we CAN skip zeroing most gradient
+        // buffers — but NOT the ones a specialized delegate ACCUMULATES into. Most
+        // specialized delegates OVERWRITE their buffer (beta=0), but a delegate that
+        // writes a MULTI-CONSUMER tensor's gradient accumulates in place
+        // (TensorAddInto / +=), because a tensor consumed by N ops has gradient =
+        // Σ contributions (the BroadcastAdd bias-grad path is the clearest case).
+        // If such a buffer is never zeroed, each step's accumulation lands on top of
+        // the PRIOR step's gradient, so the gradient — and the Adam update — grows
+        // without bound while the loss barely moves (N-BEATS's doubly-residual stack,
+        // whose residual tensors are inherently multi-consumer, blew its weights up
+        // to ~1e13 this way).
+        //
+        // So instead of skip-all (which was silently wrong for these buffers) OR
+        // clear-all (correct but pays to zero every buffer), zero PRECISELY the
+        // accumulating buffers: the grad buffers of the multi-consumer tensors. Every
+        // other buffer is fully overwritten by its beta=0 delegate and stays skipped.
+        // When there are no multi-consumer tensors this yields an empty array — the
+        // exact skip-all fast path as before, so feed-forward graphs are unchanged.
+        int[]? genericGradIndices;
+        if (!useGradPool && genericBackwardCount == 0)
+        {
+            // allGrads holds the distinct physical grad buffers (id == index), so a
+            // reverse map gives each multi-consumer tensor's grad-buffer index.
+            var gradBufferIndex = new Dictionary<Tensor<T>, int>(allGrads.Count);
+            for (int gi = 0; gi < allGrads.Count; gi++) gradBufferIndex[allGrads[gi]] = gi;
+
+            var accumulatingGradIndices = new List<int>();
+            var seenGradIndices = new HashSet<int>();
+            foreach (var kv in consumerCount)
+            {
+                if (kv.Value <= 1) continue; // single-consumer buffers are overwritten, no zeroing needed
+                if (gradMap.TryGetValue(kv.Key, out var gradBuf)
+                    && gradBufferIndex.TryGetValue(gradBuf, out int bufIdx)
+                    && seenGradIndices.Add(bufIdx))
+                    accumulatingGradIndices.Add(bufIdx);
+            }
+            genericGradIndices = accumulatingGradIndices.ToArray();
+        }
+        else
+        {
+            genericGradIndices = null; // clear-all (unchanged: generic backward or grad pooling)
+        }
 
         // #1624 drift guard: the re-zero schedule (indexed by backward ACTION index)
         // was planned in BuildPooledGradMap from the fusion/analytic DECISIONS made

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -320,9 +320,20 @@ public class ConfigureOptimizerFusedDispatchTests
             Assert.True(!float.IsNaN(d[i]) && !float.IsInfinity(d[i]), "D-Adaptation produced a non-finite parameter");
             maxMove = Math.Max(maxMove, Math.Abs(d[i] - init[i]));
         }
-        // With d frozen at d0=1e-6 the total move over 20 steps would be ~O(1e-6·lr·20·|g|) ≈ 1e-6.
-        // A meaningfully larger move proves d grew well above d0 (the adaptation is active).
-        Assert.True(maxMove > 1e-3, $"D-Adaptation distance estimate did not grow (max move = {maxMove}).");
+        // With d frozen at d0=1e-6 the total move over 20 steps is ~O(1e-6·lr·20·|g|) ≈ 1e-6.
+        // A move an order of magnitude above that proves d grew well above d0 (adaptation
+        // is active). Here the observed move is ~4.9e-5 — ~48x the frozen baseline.
+        //
+        // This threshold was 1e-3 until the fused-plan gradient-buffer zeroing fix in this
+        // PR. RunGlobal's loss sum(w*w) makes `w` a MULTI-CONSUMER tensor, and the compiled
+        // plan used to skip zeroing its accumulating grad buffer — so w's gradient piled up
+        // across steps (~step*2w instead of 2w), inflating the D-Adaptation move ~1000x and
+        // masking the true dynamics. With the gradient now correct, the real move is ~4.9e-5,
+        // so the threshold is grounded in the actual d0-frozen baseline (~1e-6) instead.
+        const double d0FrozenBaseline = 1e-6; // ≈ D0 (the comment above)
+        Assert.True(maxMove > 10 * d0FrozenBaseline,
+            $"D-Adaptation distance estimate did not grow above d0 (max move = {maxMove}, " +
+            $"frozen-d0 baseline ≈ {d0FrozenBaseline}).");
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
@@ -1,0 +1,89 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression for the compiled-plan gradient-zeroing bug.
+///
+/// The compiled training plan skips ALL gradient-buffer zeroing when every
+/// backward step is specialized (genericBackwardCount == 0), on the assumption
+/// that a specialized delegate always OVERWRITES its gradient buffer (beta=0).
+/// That assumption is false for a MULTI-CONSUMER tensor: the specialized
+/// BroadcastAdd bias-grad delegate ACCUMULATES in place (+=) because a tensor
+/// consumed by N ops receives the SUM of N gradient contributions. With the
+/// buffer never zeroed, each step's accumulation lands on top of the PRIOR
+/// step's gradient, so the gradient grows without bound — the N-BEATS
+/// doubly-residual resident path blew its weights up to ~1e13 this way.
+/// </summary>
+[Collection("CompilationGlobalState")]
+public class MultiConsumerGradZeroingTests
+{
+    /// <summary>
+    /// A single bias <c>b</c> broadcast-added to TWO distinct inputs, so <c>b</c>
+    /// is multi-consumer and its gradient accumulates from both BroadcastAdd
+    /// backwards. The whole graph (BroadcastAdd + scalar ReduceSum + Add) compiles
+    /// to an all-specialized backward, which is exactly the path that skipped
+    /// zeroing. loss = sum(x1 + b) + sum(x2 + b), so d(loss)/db[f] = 2*batch on
+    /// EVERY step (input- and b-independent). With the bug the second step reports
+    /// ~2x that (accumulated onto step 1); the fix keeps it constant.
+    /// </summary>
+    [Fact]
+    public void AllSpecialized_MultiConsumerBias_GradientStableAcrossSteps()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 3;
+
+        var rng = new System.Random(7);
+        var x1 = new Tensor<double>(new[] { batch, features });
+        var x2 = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < x1.Length; i++) { x1[i] = rng.NextDouble(); x2[i] = rng.NextDouble(); }
+
+        var b = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) b[i] = 0.0;
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h1 = engine.TensorBroadcastAdd(x1, b); // b consumer #1
+            var h2 = engine.TensorBroadcastAdd(x2, b); // b consumer #2 → multi-consumer
+            var s1 = engine.ReduceSum(h1, null);       // scalar
+            var s2 = engine.ReduceSum(h2, null);       // scalar
+            engine.TensorAdd(s1, s2);                  // scalar loss
+            plan = scope.CompileTraining(new[] { b });
+        }
+
+        const double expected = 2.0 * batch; // 8: each branch contributes `batch` per feature
+        using (plan)
+        {
+            // lr = 0 so the optimizer does not move b — keeps the analytic gradient
+            // clean and identical every step (the gradient is b-independent anyway).
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+
+            plan.Step();
+            var g1 = SnapshotGrad(b, features);
+
+            plan.Step();
+            var g2 = SnapshotGrad(b, features);
+
+            for (int f = 0; f < features; f++)
+            {
+                Assert.Equal(expected, g1[f], 6);
+                // Pre-fix this is ~16 (8 accumulated onto 8); post-fix it stays 8.
+                Assert.Equal(expected, g2[f], 6);
+                Assert.Equal(g1[f], g2[f], 9);
+            }
+        }
+    }
+
+    private static double[] SnapshotGrad(Tensor<double> param, int n)
+    {
+        var grad = param.Grad ?? throw new System.InvalidOperationException("param.Grad was null after Step");
+        var copy = new double[n];
+        for (int i = 0; i < n; i++) copy[i] = grad[i];
+        return copy;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
@@ -79,10 +79,75 @@ public class MultiConsumerGradZeroingTests
         }
     }
 
+    /// <summary>
+    /// Same invariant on the GPU (float): the fix's GPU-resident zeroing path is a
+    /// SEPARATE code path (MemsetBuffer over the precise buffer indices) from the CPU
+    /// one (Array.Clear), so this exercises it directly. Soft-skips when no usable GPU
+    /// is present — the CpuEngine test above still proves the fix on any runner.
+    /// </summary>
+    [Fact]
+    public void AllSpecialized_MultiConsumerBias_GradientStableAcrossSteps_OnGpu()
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        if (!gpu.SupportsGpu)
+            return; // no usable GPU here; CPU test covers correctness
+
+        const int batch = 4, features = 3;
+        var rng = new System.Random(7);
+        var x1 = new Tensor<float>(new[] { batch, features });
+        var x2 = new Tensor<float>(new[] { batch, features });
+        for (int i = 0; i < x1.Length; i++) { x1[i] = (float)rng.NextDouble(); x2[i] = (float)rng.NextDouble(); }
+        var b = new Tensor<float>(new[] { features });
+
+        var prior = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = gpu;
+        try
+        {
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var h1 = gpu.TensorBroadcastAdd(x1, b);
+                var h2 = gpu.TensorBroadcastAdd(x2, b);
+                var s1 = gpu.ReduceSum(h1, null);
+                var s2 = gpu.ReduceSum(h2, null);
+                gpu.TensorAdd(s1, s2);
+                plan = scope.CompileTraining(new[] { b });
+            }
+
+            const float expected = 2.0f * batch; // 8
+            using (plan)
+            {
+                plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+                plan.Step();
+                var g1 = SnapshotGradF(b, features);
+                plan.Step();
+                var g2 = SnapshotGradF(b, features);
+                for (int f = 0; f < features; f++)
+                {
+                    Assert.Equal(expected, g1[f], 3);
+                    Assert.Equal(expected, g2[f], 3); // pre-fix would be ~16 on step 2
+                    Assert.Equal(g1[f], g2[f], 4);
+                }
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = prior;
+        }
+    }
+
     private static double[] SnapshotGrad(Tensor<double> param, int n)
     {
         var grad = param.Grad ?? throw new System.InvalidOperationException("param.Grad was null after Step");
         var copy = new double[n];
+        for (int i = 0; i < n; i++) copy[i] = grad[i];
+        return copy;
+    }
+
+    private static float[] SnapshotGradF(Tensor<float> param, int n)
+    {
+        var grad = param.Grad ?? throw new System.InvalidOperationException("param.Grad was null after Step");
+        var copy = new float[n];
         for (int i = 0; i < n; i++) copy[i] = grad[i];
         return copy;
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PermuteBroadcastAddCompiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PermuteBroadcastAddCompiledBackwardTests.cs
@@ -1,0 +1,411 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// AiDotNet #1841 regression: the compiled-plan backward for the
+/// <c>TensorPermute + TensorMatMul + TensorBroadcastAdd</c> chain used by every
+/// NBEATS / NHiTS block (paper §3.2 doubly-residual MLP: permute input to
+/// column-major, matmul with weight, broadcast-add bias) produces exploding Adam
+/// updates on the linked Tensors build. The junior dev's PR body reports
+/// weights blowing up to ~1e13 while the reported loss barely moves — a clear
+/// sign that the compiled gradient disagrees with the eager gradient.
+///
+/// <para>The eager gradient is the ground truth (finite-difference-verified in
+/// other tests). This test compares the compiled backward output against the
+/// eager backward output for the exact NBEATS block forward chain. If they
+/// disagree beyond fp32 tolerance, the bug is confirmed and we know which op
+/// (weight vs. bias) diverges.</para>
+/// </summary>
+public class PermuteBroadcastAddCompiledBackwardTests
+{
+    /// <summary>
+    /// Minimal repro of the NBEATS block forward chain. Batch B=4, input dim
+    /// inSize=3, output dim outSize=2 — small enough to reason about but
+    /// exercises the exact op sequence:
+    /// <c>x[B,in]  ─Permute[1,0]→  x[in,B]  ─MatMul(W[out,in], x[in,B])→  linear[out,B]  ─BroadcastAdd(linear, biasCol[out,1])→  y[out,B]</c>
+    /// Then a ReduceSum-to-scalar loss so a single scalar backward has clear
+    /// analytic gradients w.r.t. W and bias.
+    /// </summary>
+    [Fact]
+    public void CompiledBackward_MatchesEager_ForNBEATSBlockForwardChain()
+    {
+        var engine = new CpuEngine();
+        const int B = 4, inSize = 3, outSize = 2;
+
+        // Deterministic parameters — hand-crafted so a mismatch reproduces every run.
+        var input = new Tensor<float>(new float[]
+        {
+            1f, 2f, 3f,
+            4f, 5f, 6f,
+            7f, 8f, 9f,
+            10f, 11f, 12f,
+        }, new[] { B, inSize });
+        var weight = new Tensor<float>(new float[]
+        {
+            0.1f, 0.2f, 0.3f,
+            0.4f, 0.5f, 0.6f,
+        }, new[] { outSize, inSize });
+        var bias = new Tensor<float>(new float[] { 0.01f, 0.02f }, new[] { outSize });
+
+        // ── EAGER PATH via GradientTape<T> ────────────────────────────────
+        Tensor<float> weightGradEager, biasGradEager;
+        using (var tape = new GradientTape<float>())
+        {
+var x = engine.TensorPermute(input, new[] { 1, 0 });         // [in, B]
+            var linear = engine.TensorMatMul(weight, x);                 // [out, B]
+            var biasCol = engine.Reshape(bias, new[] { outSize, 1 });    // [out, 1]
+            var y = engine.TensorBroadcastAdd(linear, biasCol);          // [out, B]
+            var loss = engine.ReduceSum(y, null);                        // scalar
+            var grads = tape.ComputeGradients(loss, new[] { weight, bias });
+            weightGradEager = grads[weight];
+            biasGradEager = grads[bias];
+        }
+
+        // ── COMPILED PATH via CompileTraining + plan.Step() ───────────────
+        Tensor<float> weightGradCompiled, biasGradCompiled;
+        {
+            var weightC = new Tensor<float>((float[])weight.ToArray().Clone(), new[] { outSize, inSize });
+            var biasC = new Tensor<float>((float[])bias.ToArray().Clone(), new[] { outSize });
+            var inputC = new Tensor<float>((float[])input.ToArray().Clone(), new[] { B, inSize });
+
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var x = engine.TensorPermute(inputC, new[] { 1, 0 });
+                var linear = engine.TensorMatMul(weightC, x);
+                var biasCol = engine.Reshape(biasC, new[] { outSize, 1 });
+                var y = engine.TensorBroadcastAdd(linear, biasCol);
+                engine.ReduceSum(y, null);
+                plan = scope.CompileTraining(new[] { weightC, biasC });
+            }
+
+            using (plan)
+            {
+                plan.Step();
+                // The plan writes gradients into weightC.Grad / biasC.Grad after Step().
+                Assert.NotNull(weightC.Grad);
+                Assert.NotNull(biasC.Grad);
+                weightGradCompiled = weightC.Grad!;
+                biasGradCompiled = biasC.Grad!;
+            }
+        }
+
+        // ── VERIFY: compiled must match eager within fp32 tolerance ───────
+        AssertTensorNear(weightGradEager, weightGradCompiled, tol: 1e-5f,
+            label: "weight gradient (NBEATS-block compiled backward vs. eager)");
+        AssertTensorNear(biasGradEager, biasGradCompiled, tol: 1e-5f,
+            label: "bias gradient (NBEATS-block compiled backward vs. eager)");
+    }
+
+    /// <summary>
+    /// Same forward chain with an MSE-style loss (matches NBEATS's actual loss)
+    /// so gradOut is not the trivial all-ones from ReduceSum-only. Exercises
+    /// the broadcast-reduce backward with non-uniform gradient values.
+    /// </summary>
+    [Fact]
+    public void CompiledBackward_MatchesEager_ForNBEATSBlockWithMseLoss()
+    {
+        var engine = new CpuEngine();
+        const int B = 4, inSize = 3, outSize = 2;
+
+        var input = new Tensor<float>(new float[]
+        {
+            1f, 2f, 3f,
+            4f, 5f, 6f,
+            7f, 8f, 9f,
+            10f, 11f, 12f,
+        }, new[] { B, inSize });
+        var weight = new Tensor<float>(new float[]
+        {
+            0.1f, 0.2f, 0.3f,
+            0.4f, 0.5f, 0.6f,
+        }, new[] { outSize, inSize });
+        var bias = new Tensor<float>(new float[] { 0.01f, 0.02f }, new[] { outSize });
+        // Target for MSE: same shape as forward output [out, B].
+        var target = new Tensor<float>(new float[]
+        {
+            0.5f, 1.0f, 1.5f, 2.0f,
+            0.6f, 1.1f, 1.6f, 2.1f,
+        }, new[] { outSize, B });
+
+        Tensor<float> weightGradEager, biasGradEager;
+        using (var tape = new GradientTape<float>())
+        {
+var x = engine.TensorPermute(input, new[] { 1, 0 });
+            var linear = engine.TensorMatMul(weight, x);
+            var biasCol = engine.Reshape(bias, new[] { outSize, 1 });
+            var y = engine.TensorBroadcastAdd(linear, biasCol);
+            var diff = engine.TensorSubtract(y, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            var loss = engine.ReduceMean(sq, new[] { 0, 1 }, keepDims: false);
+            var grads = tape.ComputeGradients(loss, new[] { weight, bias });
+            weightGradEager = grads[weight];
+            biasGradEager = grads[bias];
+        }
+
+        Tensor<float> weightGradCompiled, biasGradCompiled;
+        {
+            var weightC = new Tensor<float>((float[])weight.ToArray().Clone(), new[] { outSize, inSize });
+            var biasC = new Tensor<float>((float[])bias.ToArray().Clone(), new[] { outSize });
+            var inputC = new Tensor<float>((float[])input.ToArray().Clone(), new[] { B, inSize });
+            var targetC = new Tensor<float>((float[])target.ToArray().Clone(), new[] { outSize, B });
+
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var x = engine.TensorPermute(inputC, new[] { 1, 0 });
+                var linear = engine.TensorMatMul(weightC, x);
+                var biasCol = engine.Reshape(biasC, new[] { outSize, 1 });
+                var y = engine.TensorBroadcastAdd(linear, biasCol);
+                var diff = engine.TensorSubtract(y, targetC);
+                var sq = engine.TensorMultiply(diff, diff);
+                engine.ReduceMean(sq, new[] { 0, 1 }, keepDims: false);
+                plan = scope.CompileTraining(new[] { weightC, biasC });
+            }
+
+            using (plan)
+            {
+                plan.Step();
+                Assert.NotNull(weightC.Grad);
+                Assert.NotNull(biasC.Grad);
+                weightGradCompiled = weightC.Grad!;
+                biasGradCompiled = biasC.Grad!;
+            }
+        }
+
+        AssertTensorNear(weightGradEager, weightGradCompiled, tol: 1e-5f,
+            label: "weight gradient (NBEATS-block + MSE compiled backward vs. eager)");
+        AssertTensorNear(biasGradEager, biasGradCompiled, tol: 1e-5f,
+            label: "bias gradient (NBEATS-block + MSE compiled backward vs. eager)");
+    }
+
+    /// <summary>
+    /// Multi-step Adam training loop through the compiled + fused-optimizer path
+    /// (the path <c>NBEATSModel.TryTrainGpuResident</c> uses via
+    /// <c>CompiledTapeTrainingStep&lt;T&gt;.TryStepWithFusedOptimizer</c>).
+    /// Runs 20 identical steps and asserts the loss trajectory is finite and
+    /// bounded — if the fused Adam kernel corrupts state or the persistent-input
+    /// mechanism feeds stale data, weights explode within a few steps and the
+    /// loss goes non-finite (mirrors the NBEATS "1e13 weights" symptom).
+    /// </summary>
+    [Fact]
+    public void CompiledFusedAdamLoop_LossStaysFinite_ForNBEATSBlockChain()
+    {
+        var engine = new CpuEngine();
+        const int B = 4, inSize = 3, outSize = 2, steps = 20;
+
+        var input = new Tensor<float>(new float[]
+        {
+            1f, 2f, 3f,
+            4f, 5f, 6f,
+            7f, 8f, 9f,
+            10f, 11f, 12f,
+        }, new[] { B, inSize });
+        var weight = new Tensor<float>(new float[]
+        {
+            0.1f, 0.2f, 0.3f,
+            0.4f, 0.5f, 0.6f,
+        }, new[] { outSize, inSize });
+        var bias = new Tensor<float>(new float[] { 0.01f, 0.02f }, new[] { outSize });
+        var target = new Tensor<float>(new float[]
+        {
+            0.5f, 1.0f, 1.5f, 2.0f,
+            0.6f, 1.1f, 1.6f, 2.1f,
+        }, new[] { outSize, B });
+
+        // Compile ONCE with graph mode; replay Step() `steps` times.
+        // ConfigureOptimizerFloat wires Adam into the plan so plan.Step() runs
+        // forward + backward + fused Adam update in one on-device call.
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var x = engine.TensorPermute(input, new[] { 1, 0 });
+            var linear = engine.TensorMatMul(weight, x);
+            var biasCol = engine.Reshape(bias, new[] { outSize, 1 });
+            var y = engine.TensorBroadcastAdd(linear, biasCol);
+            var diff = engine.TensorSubtract(y, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            engine.ReduceMean(sq, new[] { 0, 1 }, keepDims: false);
+            plan = scope.CompileTraining(new[] { weight, bias });
+        }
+
+        var losses = new float[steps];
+        using (plan)
+        {
+            plan.ConfigureOptimizer(
+                OptimizerType.Adam,
+                learningRate: 0.01f,
+                beta1: 0.9f, beta2: 0.999f, eps: 1e-8f, weightDecay: 0f);
+
+            for (int s = 0; s < steps; s++)
+            {
+                var lossT = plan.Step();
+                losses[s] = lossT[0];
+            }
+        }
+
+        // Every step's loss must be finite. Non-finite anywhere = the "exploding
+        // Adam updates" symptom. (NBEATS's guard fires on IsNaN or IsInfinity of
+        // the reported step loss — this asserts exactly that.)
+        for (int s = 0; s < steps; s++)
+        {
+            Assert.True(!float.IsNaN(losses[s]) && !float.IsInfinity(losses[s]),
+                $"Step {s} loss is non-finite ({losses[s]:R}) — fused-Adam divergence on NBEATS-block chain. " +
+                $"Prior losses: [{string.Join(", ", System.Linq.Enumerable.Range(0, s).Select(i => losses[i].ToString("R")))}]");
+        }
+
+        // NBEATS's stricter guard also fires when step_N > 1e3 AND step_N > step_0 * 1e3.
+        for (int s = 1; s < steps; s++)
+        {
+            bool exploding = losses[s] > 1e3f && losses[s] > losses[0] * 1e3f;
+            Assert.False(exploding,
+                $"Step {s} loss ({losses[s]:R}) exceeds NBEATS's explosion guard (>1e3 AND >1000× step 0 loss {losses[0]:R}). " +
+                $"Fused-Adam divergence confirmed.");
+        }
+
+        // Sanity: loss should trend DOWN over 20 Adam steps on this trivial fixture
+        // (Adam on a small quadratic converges within a few steps).
+        Assert.True(losses[steps - 1] < losses[0] * 1.1f,
+            $"Loss did not decrease meaningfully over {steps} steps: {losses[0]:R} → {losses[steps - 1]:R}. " +
+            $"Fused Adam step may be running but not updating weights correctly.");
+    }
+
+    /// <summary>
+    /// Exact NBEATS doubly-residual stack pattern (paper §3.2): two blocks share
+    /// the same Permute+MatMul+BroadcastAdd forward, block N's output is
+    /// SUBTRACTED from the residual fed to block N+1, and per-block forecasts
+    /// are SUMMED. The subtract-from-residual + sum-of-forecasts chain is what
+    /// the junior dev's NBEATS PR comment blames for the "compiled fused
+    /// plan produces exploding Adam updates" divergence — this test replays
+    /// that exact op graph through the fused-Adam plan for 20 steps to catch
+    /// any interaction the single-block tests above wouldn't surface.
+    /// </summary>
+    [Fact]
+    public void CompiledFusedAdam_DoublyResidualStack_LossStaysFinite()
+    {
+        var engine = new CpuEngine();
+        const int B = 4, L = 6, H = 3, steps = 20;
+        // Two blocks with the NBEATS shape: input=[B,L] -> permute -> matmul(W_bc [L,L]) -> bias_bc [L]
+        // for backcast, and matmul(W_fc [H,L]) -> bias_fc [H] for forecast. Deterministic init.
+        var input = new Tensor<float>(new float[]
+        {
+            1f, 2f, 3f, 4f, 5f, 6f,
+            2f, 3f, 4f, 5f, 6f, 7f,
+            3f, 4f, 5f, 6f, 7f, 8f,
+            4f, 5f, 6f, 7f, 8f, 9f,
+        }, new[] { B, L });
+
+        // Block 1
+        var w1_bc = new Tensor<float>(RandArr(L * L, seed: 11), new[] { L, L });
+        var b1_bc = new Tensor<float>(new float[L], new[] { L });
+        var w1_fc = new Tensor<float>(RandArr(H * L, seed: 12), new[] { H, L });
+        var b1_fc = new Tensor<float>(new float[H], new[] { H });
+        // Block 2
+        var w2_bc = new Tensor<float>(RandArr(L * L, seed: 21), new[] { L, L });
+        var b2_bc = new Tensor<float>(new float[L], new[] { L });
+        var w2_fc = new Tensor<float>(RandArr(H * L, seed: 22), new[] { H, L });
+        var b2_fc = new Tensor<float>(new float[H], new[] { H });
+
+        var target = new Tensor<float>(new float[]
+        {
+            1f, 1f, 1f, 1f,
+            1f, 1f, 1f, 1f,
+            1f, 1f, 1f, 1f,
+        }, new[] { H, B });
+
+        Tensor<float> Block(Tensor<float> resIn, Tensor<float> wBc, Tensor<float> bBc, Tensor<float> wFc, Tensor<float> bFc,
+            out Tensor<float> newRes, out Tensor<float> fc)
+        {
+            var x = engine.TensorPermute(resIn, new[] { 1, 0 });                    // [L, B]
+            var bcLin = engine.TensorMatMul(wBc, x);                                 // [L, B]
+            var bcCol = engine.Reshape(bBc, new[] { L, 1 });
+            var bc = engine.TensorBroadcastAdd(bcLin, bcCol);                        // [L, B]
+            var bcT = engine.TensorPermute(bc, new[] { 1, 0 });                      // [B, L]
+            newRes = engine.TensorSubtract(resIn, bcT);                              // residual chain
+
+            var fcLin = engine.TensorMatMul(wFc, x);                                 // [H, B]
+            var fcCol = engine.Reshape(bFc, new[] { H, 1 });
+            fc = engine.TensorBroadcastAdd(fcLin, fcCol);                            // [H, B]
+            return fc;
+        }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            Block(input, w1_bc, b1_bc, w1_fc, b1_fc, out var res1, out var fc1);
+            Block(res1, w2_bc, b2_bc, w2_fc, b2_fc, out _, out var fc2);
+            var agg = engine.TensorAdd(fc1, fc2);                                    // [H, B] doubly-residual sum
+            var diff = engine.TensorSubtract(agg, target);
+            var sq = engine.TensorMultiply(diff, diff);
+            engine.ReduceMean(sq, new[] { 0, 1 }, keepDims: false);
+            plan = scope.CompileTraining(new[] { w1_bc, b1_bc, w1_fc, b1_fc, w2_bc, b2_bc, w2_fc, b2_fc });
+        }
+
+        var losses = new float[steps];
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f,
+                beta1: 0.9f, beta2: 0.999f, eps: 1e-8f, weightDecay: 0f);
+            for (int s = 0; s < steps; s++)
+                losses[s] = plan.Step()[0];
+        }
+
+        for (int s = 0; s < steps; s++)
+        {
+            Assert.True(!float.IsNaN(losses[s]) && !float.IsInfinity(losses[s]),
+                $"Step {s} loss non-finite ({losses[s]:R}) — doubly-residual stack triggered fused-Adam divergence. " +
+                $"Trajectory: [{string.Join(", ", losses[..(s+1)].Select(v => v.ToString("R")))}]");
+        }
+        // Sanity: doubly-residual stack + Adam should converge on the constant target.
+        Assert.True(losses[steps - 1] < losses[0],
+            $"Loss did not decrease over {steps} steps on doubly-residual stack: {losses[0]:R} → {losses[steps - 1]:R}");
+
+        // Weights must stay finite — the junior dev reported "1e13 weights"; assert every param is bounded.
+        AssertAllFinite(w1_bc, "w1_bc"); AssertAllFinite(b1_bc, "b1_bc");
+        AssertAllFinite(w1_fc, "w1_fc"); AssertAllFinite(b1_fc, "b1_fc");
+        AssertAllFinite(w2_bc, "w2_bc"); AssertAllFinite(b2_bc, "b2_bc");
+        AssertAllFinite(w2_fc, "w2_fc"); AssertAllFinite(b2_fc, "b2_fc");
+    }
+
+    private static float[] RandArr(int n, int seed)
+    {
+        var rng = new System.Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)((rng.NextDouble() - 0.5) * 0.2);
+        return a;
+    }
+
+    private static void AssertAllFinite(Tensor<float> t, string label)
+    {
+        var arr = t.ToArray();
+        for (int i = 0; i < arr.Length; i++)
+            Assert.True(!float.IsNaN(arr[i]) && !float.IsInfinity(arr[i]) && System.MathF.Abs(arr[i]) < 1e10f,
+                $"{label}[{i}] = {arr[i]:R} — fused Adam produced non-finite or exploding weight");
+    }
+
+    private static void AssertTensorNear(Tensor<float> expected, Tensor<float> actual, float tol, string label)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var e = expected.ToArray();
+        var a = actual.ToArray();
+        int mismatches = 0;
+        float maxAbsDiff = 0f;
+        int worstIdx = -1;
+        for (int i = 0; i < e.Length; i++)
+        {
+            float diff = System.MathF.Abs(e[i] - a[i]);
+            if (diff > maxAbsDiff) { maxAbsDiff = diff; worstIdx = i; }
+            if (diff > tol) mismatches++;
+        }
+        if (mismatches > 0)
+        {
+            Assert.Fail($"{label}: {mismatches}/{e.Length} elements diverge beyond tol={tol}. " +
+                        $"Worst @ idx={worstIdx}: expected={e[worstIdx]:R} actual={a[worstIdx]:R} diff={maxAbsDiff:R}");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PermuteBroadcastAddCompiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PermuteBroadcastAddCompiledBackwardTests.cs
@@ -359,7 +359,7 @@ var x = engine.TensorPermute(input, new[] { 1, 0 });
         {
             Assert.True(!float.IsNaN(losses[s]) && !float.IsInfinity(losses[s]),
                 $"Step {s} loss non-finite ({losses[s]:R}) — doubly-residual stack triggered fused-Adam divergence. " +
-                $"Trajectory: [{string.Join(", ", losses[..(s+1)].Select(v => v.ToString("R")))}]");
+                $"Trajectory: [{string.Join(", ", losses.Take(s + 1).Select(v => v.ToString("R")))}]");
         }
         // Sanity: doubly-residual stack + Adam should converge on the constant target.
         Assert.True(losses[steps - 1] < losses[0],


### PR DESCRIPTION
## TL;DR

The compiled fused-optimizer plan **accumulated gradients across training steps** for any tensor with more than one consumer, because it skipped zeroing those gradient buffers. N-BEATS's doubly-residual stack is full of multi-consumer tensors, so its gradients grew every step until the weights blew up (~1e13). This PR fixes it precisely (zero only the affected buffers) and ships a regression test that reproduces it on `CpuEngine` — **no GPU needed**.

## The bug, in one number

A bias `b` broadcast-added to two inputs (multi-consumer). Its true gradient is a **constant `8` on every step** (input- and value-independent). What the compiled plan actually produced:

| Step | Correct grad | Before this PR | After this PR |
|-----:|:------------:|:--------------:|:-------------:|
| 1 | 8 | **8** | 8 |
| 2 | 8 | **16** | 8 |
| 3 | 8 | **24** | 8 |
| … | 8 | grows every step → ~1e13 weights | 8 |

The gradient was being **summed across steps** instead of recomputed. Under SGD this explodes the weights directly; under Adam the magnitude is partly masked (1/√v normalization) so the loss can still look "finite and decreasing" — which is why a loss-only check misses it.

## Root cause

When every backward op is specialized (`genericBackwardCount == 0`), the plan skipped **all** gradient-buffer zeroing, assuming specialized delegates always *overwrite* (beta=0). That is false for a **multi-consumer** tensor: a tensor consumed by N ops has gradient = Σ of N contributions, so its specialized delegate **accumulates in place** (`TensorAddInto` / `+=`) — the `BroadcastAdd` bias-grad path is the clearest case. An un-zeroed accumulator adds onto the prior step's value every step.

## Why the earlier diagnostic tests passed

The original tests here (kept in this PR — they're valuable) proved the **single-step** backward math is correct, and that a doubly-residual graph *using `TensorPermute`* trains finitely. But `TensorPermute` has a **generic** backward → that graph takes the safe clear-all path and never triggers the bug. The bug needs an **all-specialized** multi-consumer graph, which the new `MultiConsumerGradZeroingTests` builds — and which **fails before / passes after** the fix.

## The fix — precise, zero perf cost on correct paths

For an all-specialized graph, zero **only** the grad buffers of the multi-consumer tensors (the ones a delegate accumulates into). Every other buffer is still fully overwritten by its beta=0 delegate and stays skipped.

| Graph shape | Before | After |
|---|---|---|
| Uses gradient pooling | clear-all | clear-all *(unchanged)* |
| Has any generic backward | clear-all | clear-all *(unchanged)* |
| All-specialized, no multi-consumer tensor | skip-all | skip-all *(byte-for-byte unchanged)* |
| All-specialized **with** multi-consumer tensor | skip-all *(**BUGGY**)* | zero **only** the accumulating buffers |

- The multi-consumer scan is **one-time at compile**, not per-step.
- **No previously-correct graph changes behavior or speed.** Feed-forward all-specialized graphs still hit the exact skip-all fast path.
- The only per-step cost added is a `memset` of the *accumulating* buffers on graphs that were **broken** before — the minimum required for correctness, and far less than clear-all.
- Both the CPU (`Array.Clear`) and GPU-resident (`MemsetBuffer`) zeroing loops already honor this precise index list.

## Tests

- `MultiConsumerGradZeroingTests` (new) — the fail-before/pass-after regression above.
- `PermuteBroadcastAddCompiledBackwardTests` (from the original diagnostic) — single-step compiled-vs-eager parity + multi-step finiteness. Also fixed a **net471 build error** (a C# range expression `losses[..(s+1)]` needs `RuntimeHelpers.GetSubArray`, absent on net471) that was failing the build.
- All 5 tests pass on **net10.0** and **net471**.

## Downstream

Unblocks AiDotNet #1841's N-BEATS / N-HiTS GPU-resident training, which was validation-rejecting every resident run and falling back to eager because of this blow-up. After this lands + a Tensors release, that PR bumps the Tensors version and the resident path trains correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)