### PR TITLE
fix(compile): zero grad buffers when a specialized backward accumulates (multi-consumer)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -4478,11 +4478,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
         }
 
-        // If all backward steps are specialized (overwrite), we can skip gradient zeroing entirely.
-        // Under pooling, force the clear-all path (null) so every physical buffer is
-        // zeroed at step start (covering each shared buffer's FIRST tenant); the
-        // re-zero schedule clears it again before each subsequent tenant.
-        int[]? genericGradIndices = (!useGradPool && genericBackwardCount == 0) ? new int[0] : null;
+        // If all backward steps are specialized we CAN skip gradient zeroing — but ONLY
+        // when every specialized delegate truly OVERWRITES its gradient buffer. Some
+        // specialized delegates (e.g. the BroadcastAdd bias-grad path) instead
+        // ACCUMULATE in place (TensorAddInto / +=) whenever their input tensor has more
+        // than one consumer, because a multi-consumer tensor's gradient is the SUM of
+        // the contributions from each consumer. Skipping the zeroing for such a buffer
+        // makes it accumulate onto the PRIOR step's gradient every step, so the
+        // gradient — and the Adam update — grows without bound while the loss barely
+        // moves (observed on N-BEATS's doubly-residual graph, whose residual tensors
+        // are inherently multi-consumer: weights blew up to ~1e13). So the skip-zeroing
+        // optimization is only sound when no tensor has multiple consumers; otherwise
+        // fall back to the clear-all path (null) which zeroes every buffer each step.
+        bool anyMultiConsumer = false;
+        foreach (var cc in consumerCount.Values)
+            if (cc > 1) { anyMultiConsumer = true; break; }
+        int[]? genericGradIndices =
+            (!useGradPool && genericBackwardCount == 0 && !anyMultiConsumer) ? new int[0] : null;
 
         // #1624 drift guard: the re-zero schedule (indexed by backward ACTION index)
         // was planned in BuildPooledGradMap from the fusion/analytic DECISIONS made

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiConsumerGradZeroingTests.cs
@@ -1,0 +1,89 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression for the compiled-plan gradient-zeroing bug.
+///
+/// The compiled training plan skips ALL gradient-buffer zeroing when every
+/// backward step is specialized (genericBackwardCount == 0), on the assumption
+/// that a specialized delegate always OVERWRITES its gradient buffer (beta=0).
+/// That assumption is false for a MULTI-CONSUMER tensor: the specialized
+/// BroadcastAdd bias-grad delegate ACCUMULATES in place (+=) because a tensor
+/// consumed by N ops receives the SUM of N gradient contributions. With the
+/// buffer never zeroed, each step's accumulation lands on top of the PRIOR
+/// step's gradient, so the gradient grows without bound — the N-BEATS
+/// doubly-residual resident path blew its weights up to ~1e13 this way.
+/// </summary>
+[Collection("CompilationGlobalState")]
+public class MultiConsumerGradZeroingTests
+{
+    /// <summary>
+    /// A single bias <c>b</c> broadcast-added to TWO distinct inputs, so <c>b</c>
+    /// is multi-consumer and its gradient accumulates from both BroadcastAdd
+    /// backwards. The whole graph (BroadcastAdd + scalar ReduceSum + Add) compiles
+    /// to an all-specialized backward, which is exactly the path that skipped
+    /// zeroing. loss = sum(x1 + b) + sum(x2 + b), so d(loss)/db[f] = 2*batch on
+    /// EVERY step (input- and b-independent). With the bug the second step reports
+    /// ~2x that (accumulated onto step 1); the fix keeps it constant.
+    /// </summary>
+    [Fact]
+    public void AllSpecialized_MultiConsumerBias_GradientStableAcrossSteps()
+    {
+        var engine = new CpuEngine();
+        const int batch = 4, features = 3;
+
+        var rng = new System.Random(7);
+        var x1 = new Tensor<double>(new[] { batch, features });
+        var x2 = new Tensor<double>(new[] { batch, features });
+        for (int i = 0; i < x1.Length; i++) { x1[i] = rng.NextDouble(); x2[i] = rng.NextDouble(); }
+
+        var b = new Tensor<double>(new[] { features });
+        for (int i = 0; i < features; i++) b[i] = 0.0;
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h1 = engine.TensorBroadcastAdd(x1, b); // b consumer #1
+            var h2 = engine.TensorBroadcastAdd(x2, b); // b consumer #2 → multi-consumer
+            var s1 = engine.ReduceSum(h1, null);       // scalar
+            var s2 = engine.ReduceSum(h2, null);       // scalar
+            engine.TensorAdd(s1, s2);                  // scalar loss
+            plan = scope.CompileTraining(new[] { b });
+        }
+
+        const double expected = 2.0 * batch; // 8: each branch contributes `batch` per feature
+        using (plan)
+        {
+            // lr = 0 so the optimizer does not move b — keeps the analytic gradient
+            // clean and identical every step (the gradient is b-independent anyway).
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+
+            plan.Step();
+            var g1 = SnapshotGrad(b, features);
+
+            plan.Step();
+            var g2 = SnapshotGrad(b, features);
+
+            for (int f = 0; f < features; f++)
+            {
+                Assert.Equal(expected, g1[f], 6);
+                // Pre-fix this is ~16 (8 accumulated onto 8); post-fix it stays 8.
+                Assert.Equal(expected, g2[f], 6);
+                Assert.Equal(g1[f], g2[f], 9);
+            }
+        }
+    }
+
+    private static double[] SnapshotGrad(Tensor<double> param, int n)
+    {
+        var grad = param.Grad ?? throw new System.InvalidOperationException("param.Grad was null after Step");
+        var copy = new double[n];
+        for (int i = 0; i < n; i++) copy[i] = grad[i];
+        return copy;
+    }
+}


### PR DESCRIPTION
## Problem

The compiled training plan skips **all** gradient-buffer zeroing when every backward step is specialized (`genericBackwardCount == 0`), on the assumption that a specialized delegate always **overwrites** its gradient buffer (beta=0).

That assumption is false for a **multi-consumer** tensor. A tensor consumed by N ops receives the **sum** of N gradient contributions, so specialized delegates that write such a buffer **accumulate in place** (`TensorAddInto` / `+=`) — the `BroadcastAdd` bias-grad path is the clearest case (its `accumA`/`accumB` branches). When that buffer is never zeroed, each step's accumulation lands on top of the **prior** step's gradient, so the gradient — and the Adam update — grows without bound while the loss barely moves.

This is exactly the failure the AiDotNet time-series **N-BEATS** resident path documented: its doubly-residual stack makes the residual tensors inherently multi-consumer, the graph compiles to an all-specialized backward, and the un-zeroed accumulators blew the weights up to ~1e13 (so the model validation-rejected the resident run and fell back to eager every time).

## Fix

Only take the skip-all-zeroing fast path when **no tensor has multiple consumers** (no accumulation can occur). Otherwise fall back to the existing clear-all path that zeroes every gradient buffer at step start. Feed-forward graphs keep the optimization; multi-consumer graphs are now correct.

## Verification

New regression test `MultiConsumerGradZeroingTests` (runs on `CpuEngine`, no GPU needed): a multi-consumer bias broadcast-added to two inputs has analytic gradient `2*batch = 8` on **every** step.

- **Before the fix:** step 1 → 8, step 2 → **16** (8 accumulated onto the un-zeroed 8) — the exact "grows every step" blow-up.
- **After the fix:** stays 8. ✅

Confirmed fail-before / pass-after on `net10.0` and `net471`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)