### PR TITLE
fix(gpu): resident params no longer flat-line FP32 fused-Adam training

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2329,12 +2329,37 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // Reading the tensor's CURRENT resident buffer each step makes the optimizer consume the grads
                     // the captured backward actually produced. Mirrors the param-side pin near the GPU fast path.
                     // Eager paths are unaffected: a non-resident grad still yields null here → gpuGrad/host fallback.
-                    Engines.DirectGpu.IGpuBuffer? gradBuf = (_gradients[p]?.TryGetGpuBuffer()) ?? gpuGrad[p];
+                    // The #638 line trusts the grad tensor's resident GPU buffer as authoritative. That is correct
+                    // ONLY when that buffer actually holds the gradient the backward produced THIS step. Two backward
+                    // paths write it and keep its version in sync with the tensor Version: (a) CUDA-graph capture —
+                    // the captured backward writes it in place; (b) the FP16-hetero resident backward. But the plain
+                    // eager backward instead accumulates into the grad's HOST backing (gradArrays[p]) and leaves the
+                    // resident buffer at its memset-zero: Version bumps, _gpuBufferVersion does NOT. Consuming that
+                    // stale-zero buffer makes the fused optimizer apply ~ZERO grads, so the weights barely move and
+                    // the loss goes FLAT — the GPU-resident-param mistrain (7.70->7.70 resident vs 7.70->1.31
+                    // non-resident on the same graph; the TimeSeries family runs this path by default). So trust the
+                    // resident grad buffer only when it is version-FRESH (or we are mid stream-capture, where a host
+                    // download is impossible anyway); otherwise upload the authoritative HOST gradient the backward
+                    // produced. This keeps the #638 capture path AND the FP16 resident backward intact.
+                    bool gradStreamCapturing =
+                        gpuBe is Engines.DirectGpu.CUDA.CudaBackend _cbGrad && _cbGrad.IsStreamCapturing();
+                    var _gradT = _gradients[p];
+                    bool residentGradAuthoritative = _gradT is not null && _gradT.TryGetGpuBuffer() is not null
+                        && (gradStreamCapturing || _gradT._gpuBufferVersion == _gradT.Version);
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = residentGradAuthoritative
+                        ? _gradT!.TryGetGpuBuffer()
+                        : null;
                     bool gradTransient = false;
                     if (gradBuf is null)
                     {
-                        if (gradArrays[p].Length == 0) continue; // no grad recorded
-                        gradBuf = gpuBe.AllocateBuffer(gradArrays[p]);
+                        float[] hostGrad = gradArrays[p];
+                        if (hostGrad.Length == 0)
+                        {
+                            var liveGrad = _gradients[p]?.GetLiveBackingArrayAllowingPaddingOrNull();
+                            hostGrad = liveGrad is not null ? (float[])(object)liveGrad : Array.Empty<float>();
+                        }
+                        if (hostGrad.Length == 0) continue; // no grad recorded
+                        gradBuf = gpuBe.AllocateBuffer(hostGrad);
                         gradTransient = true;
                     }
                     bool diagAU = p == 0 && _optimizerStep == 6 && System.Environment.GetEnvironmentVariable("AIDOTNET_OPT_DIAG") == "1";
@@ -2440,6 +2465,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // re-bumps Version (without this device write) → mismatch returns → correct re-upload. Harmless
                     // to capture (the gate's ResidentStepActive branch already covers it).
                     _parameters[p]._gpuBufferVersion = _parameters[p].Version;
+
+                    // RE-ARM the device→host deferred download so the NEXT host-side read of this parameter
+                    // re-downloads the freshly-updated weights. The eager forward reads its weight operand via
+                    // GetDataArray() (CpuEngine.TensorMatMulFloatInto), which is served by the ONE-SHOT deferred
+                    // materializer BindResidentBuffer registered: it fires + caches on the first read, so every
+                    // later read returns the STALE first-step download while the on-device optimizer keeps moving
+                    // the resident buffer. Net effect: the forward trains on FROZEN weights → the loss goes flat
+                    // (7.70→7.70 resident vs 7.70→1.31 non-resident on the same graph) — the GPU-resident-param
+                    // mistrain that hit the TimeSeries family (AIDOTNET_GPU_RESIDENT_PARAMS on by default).
+                    // Re-registering re-arms the download against the CURRENT device buffer (DeferredArrayMaterializer
+                    // .Register TryAdds, so it's a no-op if a read is still pending, and re-arms after one fired).
+                    if (_engine is Engines.DirectGpuTensorEngine _rebindEngine)
+                        _rebindEngine.BindResidentBuffer(_parameters[p], gpuP, gpuBe);
                     continue;
                 }
 

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -4350,6 +4350,16 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         var floatData = Engines.DirectGpu.DirectGpuEngine.ToFloatArray(logicalData);
         _gpuBuffer = backend.AllocateBuffer(floatData);
         _gpuBackend = backend;
+        // Tag the freshly-uploaded buffer with the CURRENT tensor version. The buffer was just filled from this
+        // tensor's host data, so it IS in sync — but every version-gated resident-buffer consumer
+        // (GetOrAllocateBuffer / GetWeightBufferPreferResident: `_gpuBufferVersion == Version`) leaves
+        // _gpuBufferVersion at its -1 sentinel and so immediately judges the buffer STALE, detaching it and
+        // re-uploading a frozen host snapshot on the very next read. For a GPU-resident PARAMETER that is
+        // catastrophic: the compiled forward then reads the frozen re-upload while the on-device fused optimizer
+        // updates the (now orphaned) resident buffer in place → the model trains against frozen weights → the loss
+        // goes completely flat (7.70→7.70 vs 7.70→1.31 non-resident on the same graph). This is the default GPU
+        // path for the TimeSeries family (AIDOTNET_GPU_RESIDENT_PARAMS != 0), so it silently mistrained on GPU.
+        _gpuBufferVersion = Version;
         _device = backend.BackendName?.ToUpperInvariant() switch
         {
             "CUDA" or "NVIDIA" => TensorDevice.CUDA,

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FullParamResidentTrainingReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FullParamResidentTrainingReproTests.cs
@@ -1,0 +1,94 @@
+// REGRESSION (GPU-residency campaign): making the trainable PARAMETERS GPU-resident (Tensor.Gpu()) on the plain
+// FP32 fused-Adam compiled-training path used to SILENTLY BREAK TRAINING — the loss went completely flat. The
+// TimeSeries family (NBEATS / Informer / DeepAR / ...) makes params resident BY DEFAULT on GPU float+Adam
+// (CompiledTapeTrainingStep.TryStepWithFusedOptimizer, AIDOTNET_GPU_RESIDENT_PARAMS != 0), so this was the
+// "compiled fused-tape-plan mistrains on GPU" bug. Measured on an RTX 3080, same graph, only diff = params
+// resident or not: resident 7.70 -> 7.70 (flat) vs non-resident 7.70 -> 1.31. Now BOTH converge (~1.31).
+//
+// The bug was a coupled forward/gradient/weight buffer desync in the on-device fused optimizer path, fixed by
+// three changes this test guards:
+//   1. Tensor.Gpu() now version-tags the uploaded buffer (_gpuBufferVersion = Version) — without it every
+//      version-gated resident-buffer consumer immediately judged the fresh buffer stale and detached it.
+//   2. CompiledTrainingPlan.ConfigureOptimizerFloat consumes the AUTHORITATIVE gradient: it trusts the resident
+//      grad buffer only when it is version-fresh (CUDA-graph capture or the FP16-hetero resident backward);
+//      otherwise the eager backward wrote the HOST grad and the resident buffer is a memset-zero leftover, so it
+//      uploads the host gradient instead of applying ~zero.
+//   3. After each on-device optimizer update it RE-ARMS the device->host deferred download for the parameter, so
+//      the eager forward's next GetDataArray() re-downloads the freshly-updated weights instead of the one-shot
+//      host download cached at first read (which left the forward training on FROZEN weights).
+
+#nullable disable
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+[Collection(MixedPrecisionTestCollection.Name)]
+public class FullParamResidentTrainingReproTests
+{
+    private readonly ITestOutputHelper _out;
+    public FullParamResidentTrainingReproTests(ITestOutputHelper o) { _out = o; }
+
+    private static float[] RandData(int[] shape, int seed, float scale = 1f)
+    {
+        var rng = new Random(seed);
+        int n = 1; foreach (var d in shape) n *= d;
+        var data = new float[n];
+        for (int i = 0; i < n; i++) data[i] = (float)((rng.NextDouble() * 2 - 1) * scale);
+        return data;
+    }
+
+    [SkippableTheory]
+    [InlineData(false)] // baseline: non-resident params train correctly
+    [InlineData(true)]  // GPU-resident params (the TimeSeries default) must train IDENTICALLY, not flat-line
+    public void Fp32FusedPath_ResidentParams_MustTrain(bool residentParams)
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        Skip.If(!gpu.IsGpuAvailable, "needs a DirectGpu backend (CUDA/OpenCL/...).");
+
+        var input = new Tensor<float>(RandData(new[] { 32, 64 }, 1, scale: 0.5f), new[] { 32, 64 });
+        var w1 = new Tensor<float>(RandData(new[] { 64, 64 }, 2, scale: 0.1f), new[] { 64, 64 });
+        var w2 = new Tensor<float>(RandData(new[] { 64, 64 }, 3, scale: 0.1f), new[] { 64, 64 });
+
+        // Make params GPU-resident BEFORE the trace/compile — exactly what the real TimeSeries fused path does
+        // (CompiledTapeTrainingStep.TryStepWithFusedOptimizer calls Tensor.Gpu() on the params before it compiles,
+        // AIDOTNET_GPU_RESIDENT_PARAMS on by default). This is the configuration that used to silently mistrain on
+        // GPU: the on-device fused Adam moved the resident weight buffer while the eager forward kept reading a
+        // frozen one-shot host download of it, so the loss went completely flat.
+        if (residentParams) { w1.Gpu(); w2.Gpu(); }
+
+        CompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var h = gpu.TensorMatMul(input, w1);
+            var pred = gpu.TensorMatMul(h, w2);
+            var sqErr = gpu.TensorMultiply(pred, pred);
+            gpu.ReduceSum(sqErr, null);
+            plan = scope.CompileTraining(new[] { w1, w2 });
+        }
+        GraphMode.SetCurrent(null);
+
+        try
+        {
+            float firstLoss = plan.Step().GetFlat(0);
+            Assert.True(!float.IsNaN(firstLoss) && !float.IsInfinity(firstLoss), $"first loss must be finite, got {firstLoss}.");
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 1e-3f);
+
+            float last = firstLoss;
+            for (int i = 0; i < 15; i++) last = plan.Step().GetFlat(0);
+            _out.WriteLine($"[residentParams={residentParams}] loss: first={firstLoss:G6} last={last:G6}");
+
+            // Whether or not the params are GPU-resident, an identical graph must learn identically — the loss
+            // must drop meaningfully. A GPU-resident-param regression re-freezes the forward's weights → flat loss.
+            Assert.True(last < firstLoss * 0.5f,
+                $"training must reduce the loss regardless of param residency: first={firstLoss}, last={last}.");
+        }
+        finally { plan.Dispose(); }
+    }
+}


### PR DESCRIPTION
## Problem

Making trainable parameters GPU-resident (`Tensor.Gpu()`, the default for the TimeSeries family via `AIDOTNET_GPU_RESIDENT_PARAMS`, `CompiledTapeTrainingStep.TryStepWithFusedOptimizer`) **silently broke on-device fused-Adam training** — the loss went completely flat and the model never learned.

**Measured on an RTX 3080** (same graph, only difference = params resident or not):

| | before | after |
|---|---|---|
| non-resident params | 7.70 → 1.31 | 7.70 → 1.31 |
| **resident params** | **7.70 → 7.70 (flat)** | **7.70 → 1.31 ✅** |

## Root cause — a coupled forward/gradient/weight buffer desync

1. **`Tensor.Gpu()` never version-tagged its uploaded buffer.** `_gpuBufferVersion` stayed at its `-1` sentinel, so every version-gated resident-buffer consumer (`GetOrAllocateBuffer` / `GetWeightBufferPreferResident`: `_gpuBufferVersion == Version`) immediately judged the fresh upload stale (`-1 != 0`) and detached + re-uploaded it.
2. **The optimizer consumed a stale-zero resident grad buffer.** The eager backward accumulates gradients into the grad's *host* backing, leaving the resident grad buffer at its memset-zero. The `#638` line consumed that zero → the fused Adam applied ~zero → weights barely moved.
3. **The eager forward read a one-shot frozen weight download.** `CpuEngine.TensorMatMulFloatInto` reads the weight via `GetDataArray()`, served by a deferred download that fires + caches once. The forward then trained on the frozen first-step weights while the optimizer moved the resident buffer.

## Fix

1. `Tensor.Gpu()` sets `_gpuBufferVersion = Version` after upload (the buffer is in sync — it was just filled from the tensor).
2. `ConfigureOptimizerFloat` trusts the resident grad buffer only when it is **version-fresh** (CUDA-graph capture, or the FP16-hetero resident backward); otherwise it uploads the authoritative **host** gradient. (Gating on `IsStreamCapturing` alone regressed `Fp16FullyResidentTrainingTests` — its FP16-hetero resident backward writes the resident grad *without* stream capture; the version-fresh check handles both paths.)
3. After each on-device optimizer update it **re-arms the device→host deferred download** for the parameter, so the forward's next `GetDataArray()` re-downloads the freshly-updated weights.

## Testing

New regression guard `FullParamResidentTrainingReproTests.Fp32FusedPath_ResidentParams_MustTrain` (both resident + non-resident must converge). No regressions:

- net10.0: **Compilation 650/650**, **Autodiff 709/709**, **DirectGpu 31/31**
- `Fp16FullyResidentTrainingTests`, `ConfigureOptimizerParamUpdateTests`, `MultiMatMulFusedAdamParamUpdateTests` — green
- net471 sanity — green

## Follow-up (not in this PR)

Residency **throughput** gaps remain — per-step host round-trips in grad accumulation (`TensorAddInPlace`, the `#638` A1/A2 `s_residentInPlace` path that is still opt-in while its CUDA-700 async races are localized) and full-reduction `ReduceSum`. Those are a separate, partly-hazardous incremental campaign; this PR is the correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU-accelerated training to use current-step gradients instead of stale buffers.
  * Ensured updated device weights are correctly reflected in subsequent CPU-side reads.
  * Prevented unnecessary data transfers after tensors are uploaded to the GPU.
  * Restored proper loss reduction and convergence when training with GPU-resident parameters.

* **Tests**
  * Added regression coverage for fused Adam training with both CPU-resident and GPU-resident parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->