### PR TITLE
fix(compile): fill entire output in compiled ReduceMax axis reduction

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -30029,24 +30029,49 @@ public partial class CpuEngine : ITensorLevelEngine
                 return scope.RecordUnary(LazyNodeType.Custom, "ReduceMax", input, outShape,
                     (eng, output) =>
                     {
-                        // Call ReduceMax on captured 'this' after GraphMode check has already
-                        // been handled — the lazy node's execute runs outside scope.Current.
-                        // Use the eager path by materializing input first.
+                        // Axis-aware max that fills EVERY output element. The previous
+                        // implementation computed a single GLOBAL max over the whole
+                        // input and wrote it to output[0] only — correct solely when
+                        // the output is scalar. For a real axis reduction (e.g. softmax
+                        // over the class dim: [B,C,H,W] -> [B,1,H,W]) the output has many
+                        // elements, so writing just [0] left the rest of the rented,
+                        // UNINITIALIZED output buffer as whatever the pool last held. On a
+                        // fresh (zero-init) buffer that only produced wrong values; on a
+                        // pool buffer carrying a prior op's NaN/Inf tail it leaked straight
+                        // into softmax -> loss/grad NaN (net-core SIMD pools; net471's
+                        // zero-init masked it). Mirror the eager odometer below so the
+                        // recorded/compiled path matches the eager result exactly.
                         var materializedInput = capturedInput.IsContiguous ? capturedInput : capturedInput.Contiguous();
                         var numOps = MathHelper.GetNumericOperations<T>();
                         var inputData = materializedInput.GetFlattenedData();
-                        T maxVal = inputData[0];
-                        int maxIdx = 0;
-                        for (int k = 1; k < inputData.Length; k++)
+                        var inShape = materializedInput._shape;
+                        var normAxes = ValidateAndNormalizeAxes(capturedEffectiveAxes, inShape.Length);
+                        var outShapeLocal = output._shape;
+                        int outSize = output.Length;
+                        var outSpan = output.Data.Span;
+                        var idxArr = new int[outSize];
+                        T minVal = numOps.MinValue;
+                        for (int i = 0; i < outSize; i++) { outSpan[i] = minVal; idxArr[i] = -1; }
+                        int rank = inShape.Length;
+                        var outStrideForDim = BuildReducedOutStrideForDim(inShape, outShapeLocal, normAxes);
+                        var coord = new int[rank];
+                        int outFlat = 0;
+                        int lenIn = materializedInput.Length;
+                        for (int i = 0; i < lenIn; i++)
                         {
-                            if (numOps.ToDouble(inputData[k]) > numOps.ToDouble(maxVal))
+                            if (numOps.GreaterThan(inputData[i], outSpan[outFlat]))
                             {
-                                maxVal = inputData[k];
-                                maxIdx = k;
+                                outSpan[outFlat] = inputData[i];
+                                idxArr[outFlat] = i;
+                            }
+                            for (int d = rank - 1; d >= 0; d--)
+                            {
+                                coord[d]++; outFlat += outStrideForDim[d];
+                                if (coord[d] < inShape[d]) break;
+                                coord[d] = 0; outFlat -= outStrideForDim[d] * inShape[d];
                             }
                         }
-                        output.GetDataArray()[0] = maxVal;
-                        savedStateArr[0] = new[] { maxIdx };
+                        savedStateArr[0] = idxArr;
                     },
                     BackwardFunctions<T>.ReduceMaxBackward,
                     savedStateArr);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledReduceMaxAxisTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledReduceMaxAxisTests.cs
@@ -1,0 +1,62 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression tests for the compiled/GraphMode <c>ReduceMax</c> path.
+///
+/// The GraphMode-recorded ReduceMax execute delegate used to compute a single
+/// GLOBAL max over the whole input and write it to <c>output[0]</c> only —
+/// correct solely when the output is scalar. For a genuine axis reduction (the
+/// max-subtraction step of a numerically-stable softmax over a class/feature
+/// axis) the output has many elements, so the delegate left <c>output[1..]</c>
+/// as whatever the rented pool buffer last held. On a fresh zero-init buffer
+/// that produced merely-wrong values; on a pooled buffer carrying a prior op's
+/// NaN/Inf tail it leaked straight into softmax → loss/grad NaN, which surfaced
+/// as intermittent, net-core-only training NaNs (e.g. SwinUNETR segmentation).
+///
+/// These tests pin the compiled ReduceMax output to the eager result across
+/// every axis/keepDims combination so the delegate must fill the ENTIRE output.
+/// </summary>
+public class CompiledReduceMaxAxisTests
+{
+    [Theory]
+    [InlineData(1, true)]
+    [InlineData(1, false)]
+    [InlineData(2, true)]
+    [InlineData(0, true)]
+    public void CompiledReduceMax_OverAxis_MatchesEager_FillsWholeOutput(int axis, bool keepDims)
+    {
+        var engine = new CpuEngine();
+
+        // [batch=1, rows=3, cols=4] with distinct per-position values so that
+        // each reduced slot's max is DIFFERENT from the global max — a delegate
+        // that writes only output[0] (the global max) fails every other slot.
+        var input = new Tensor<double>(new[]
+        {
+            1.0, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0,
+            9.0, 1.0, 1.5, 2.5,
+        }, new[] { 1, 3, 4 });
+
+        var expected = engine.ReduceMax(input, new[] { axis }, keepDims, out _);
+
+        using var cache = new CompiledModelCache<double>();
+        var plan = cache.GetOrCompileInference(input._shape,
+            () => engine.ReduceMax(input, new[] { axis }, keepDims, out _));
+        var compiled = plan.Execute();
+
+        Assert.Equal(expected.Shape.ToArray(), compiled.Shape.ToArray());
+        Assert.Equal(expected.Length, compiled.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.False(double.IsNaN(compiled[i]) || double.IsInfinity(compiled[i]),
+                $"compiled ReduceMax(axis={axis},keepDims={keepDims}) produced non-finite at [{i}] " +
+                "— an unwritten output slot leaked pool garbage.");
+            Assert.Equal(expected[i], compiled[i], 10);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The GraphMode-recorded `ReduceMax` execute delegate in `CpuEngine.ReduceMax` computed a **single global max** over the whole input and wrote it to `output[0]` only. That is correct for scalar output, but for a genuine **axis reduction** — the numerically-stable softmax max-subtraction over a class/feature axis (e.g. `[1,14,32,32] → [1,1,32,32]` = 1024 elements) — it left `output[1..]` as whatever the rented pool buffer last held:

- **net471**: the pool zero-inits, so the tail was merely wrong-but-finite → masked.
- **net-core**: the buffer often carried a prior op's NaN/Inf tail, which leaked straight into `logits − max` → softmax → **loss/grad NaN**.

This surfaced as **intermittent, net-core-only training NaNs** — e.g. SwinUNETR segmentation (`ForwardPass`/`MoreData`/`Training`/`OptimizerStep`/`Clone` failing 5–6/25 on net10, 0/25 on net471), and it affects **any compiled-training model doing softmax/logsumexp over an axis**. Same bug *class* as the concat axis-0 uninitialized-tail fix (#755), different op.

The delegate also saved a single global argmax index, so `ReduceMaxBackward` scattered the gradient to one input position instead of one per reduced slot.

## Fix

Replace the delegate with the axis-aware odometer reduction (the same logic the eager path already uses), so **every** output element is written and per-output argmax indices are stored for the backward pass.

## Tests

Adds `CompiledReduceMaxAxisTests` comparing compiled vs eager `ReduceMax` across axis/keepDims combinations. **Fails 4/4 without this fix, passes with it.**

Verified downstream: SwinUNETR net10.0 26/26 across 3 runs, net471 25/25, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)