### PR TITLE
perf(arena): persistent-pool deep-model buffers + fused-optimizer Adam moments

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -218,6 +218,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        ReturnPooledMoments(_optimizerRuntimeState);
         _optimizerRuntimeState = null;
 
         if (_residentGradBuffers is not null)
@@ -785,6 +786,29 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // the Adam-family m/v state owned by the fused optimizer closure.
     private FusedMomentStorageMode _momentStorageMode = FusedMomentStorageMode.Float32;
     private int _int8MomentBlockSize = 2048;
+
+    // Return a prior configuration's fp32 Adam m/v/vMax buffers to the cross-arena
+    // persistent pool so the NEXT ConfigureOptimizer* re-rents them instead of
+    // allocating fresh. ConfigureOptimizer runs every time the compiled plan is
+    // invalidated (lazy layer init during warmup), and each run previously did
+    // `new double[len]` for every moment — the ~2 GB/step Double[] churn PerfView
+    // attributed to ConfigureOptimizerDouble on the VALL-E-X-clone. The moments are
+    // long-lived (they must survive the transient per-step arena), so they use the
+    // PERSISTENT tier, not the transient ring. Reduced-precision (bf16/int8) and GPU
+    // moment buffers are left as-is — they have their own lifecycles.
+    private static void ReturnPooledMoments(FusedOptimizerRuntimeState? old)
+    {
+        if (old is null) return;
+        ReturnMomentJagged(old.MDouble); ReturnMomentJagged(old.VDouble); ReturnMomentJagged(old.VMaxDouble);
+        ReturnMomentJagged(old.MFloat); ReturnMomentJagged(old.VFloat); ReturnMomentJagged(old.VMaxFloat);
+    }
+
+    private static void ReturnMomentJagged<TElem>(TElem[][]? bufs)
+    {
+        if (bufs is null) return;
+        for (int i = 0; i < bufs.Length; i++)
+            if (bufs[i] is { Length: > 0 } b) TensorArena.ReturnPersistentBuffer(b);
+    }
 
     /// <summary>
     /// Requests bfloat16 storage for the Adam/AdamW moment state on the float
@@ -1836,6 +1860,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        ReturnPooledMoments(_optimizerRuntimeState);
         _optimizerRuntimeState = null;
         // A captured step graph holds kernel nodes wired to the OLD optimizer state
         // buffers + update; those are about to be freed/replaced, so drop it (replay
@@ -2090,8 +2115,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
             else
             {
-                m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
-                v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+                m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
+                v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
                 mB[p] = Array.Empty<ushort>();
                 vB[p] = Array.Empty<ushort>();
                 mQuant[p] = Array.Empty<byte>();
@@ -2099,7 +2124,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 mScales[p] = Array.Empty<double>();
                 vScales[p] = Array.Empty<double>();
             }
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -2668,6 +2693,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        ReturnPooledMoments(_optimizerRuntimeState);
         _optimizerRuntimeState = null;
         // Drop any captured step graph wired to the old optimizer state (see
         // ConfigureOptimizerFloat — replay would target freed/stale buffers).
@@ -2874,8 +2900,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
             else
             {
-                m[p] = needsMomentum ? new float[lengths[p]] : Array.Empty<float>();
-                v[p] = needsSecondMoment ? new float[lengths[p]] : Array.Empty<float>();
+                m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
+                v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
                 mB[p] = Array.Empty<ushort>();
                 vB[p] = Array.Empty<ushort>();
                 mQuant[p] = Array.Empty<byte>();
@@ -2883,7 +2909,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 mScales[p] = Array.Empty<double>();
                 vScales[p] = Array.Empty<double>();
             }
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new float[lengths[p]] : Array.Empty<float>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
         _optimizerStep = 0;
@@ -3218,6 +3244,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        ReturnPooledMoments(_optimizerRuntimeState);
         _optimizerRuntimeState = null;
         _preForwardParamTransform = null;
         InvalidateCapturedStepGraph();
@@ -3281,9 +3308,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
                 or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
-            m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
-            v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new double[lengths[p]] : Array.Empty<double>();
+            m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
@@ -3368,6 +3395,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
         _gpuOptimizerBuffers.Clear();
+        ReturnPooledMoments(_optimizerRuntimeState);
         _optimizerRuntimeState = null;
         _preForwardParamTransform = null;
         InvalidateCapturedStepGraph();
@@ -3425,9 +3453,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
                 or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
 
-            m[p] = needsMomentum ? new double[lengths[p]] : Array.Empty<double>();
-            v[p] = needsSecondMoment ? new double[lengths[p]] : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? new double[lengths[p]] : Array.Empty<double>();
+            m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
         }
 
         _optimizerStep = 0;

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -112,11 +112,19 @@ public sealed class TensorArena : IDisposable
     /// allocation/GC is cheap and pooling churns the dictionary for no gain.</summary>
     private const int PersistThresholdElems = 64 * 1024;
 
-    /// <summary>Max retained buffers per (type, size). A single-threaded training
-    /// step rents each distinct size O(1) times, so a small cap fully covers
-    /// steady-state reuse while bounding worst-case retained memory to a few ×
-    /// the model's transient working set.</summary>
-    private const int MaxPersistPerSize = 4;
+    /// <summary>Max retained buffers per (type, size). Retention is SELF-LIMITING:
+    /// a single arena's Dispose returns exactly as many same-size buffers as the
+    /// step actually used, so a shallow model that rents a size once retains one —
+    /// raising this cap costs nothing for it. The cap only bites DEEP models: an
+    /// N-layer transformer produces N same-shaped hidden-state / gradient tensors
+    /// per step (NOT "O(1) per size" as an earlier revision assumed), so with the
+    /// old cap of 4 a fresh-arena-per-step trainer dropped N-4 of them on Dispose
+    /// and re-allocated them next step — measured as ~2 GB/step of Double[] churn
+    /// for an 18-layer VALL-E-X-clone (PerfView, TensorArena.TryRentTensor). 64
+    /// covers realistic deep stacks (ViT/GPT-scale) while the returned-count self-
+    /// limit keeps the extra retention bounded by the model's own working set,
+    /// which already had to be resident during the step.</summary>
+    private const int MaxPersistPerSize = 64;
 
     private static Array? RentPersistent(Type type, int elementCount)
     {

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -166,6 +166,41 @@ public sealed class TensorArena : IDisposable
         // else: at cap — drop the reference, let GC reclaim (don't hoard).
     }
 
+    /// <summary>
+    /// Rents a ZEROED backing array from the cross-arena persistent pool, or
+    /// allocates a fresh zeroed one on a pool miss. For LONG-LIVED state that
+    /// must outlive the transient per-step arena and be reused across
+    /// re-allocations — e.g. a fused optimizer's Adam m/v moment buffers, which
+    /// the plan re-creates every time the compiled plan is invalidated (lazy
+    /// layer init during warmup). Using the transient arena for these would let
+    /// the ring recycle them mid-step (corruption); a plain <c>new T[]</c> per
+    /// re-create is the ~2 GB/step Double[] churn PerfView flagged in
+    /// <c>ConfigureOptimizerDouble</c>. The persistent pool sits ABOVE the
+    /// transient tier: entries survive arena Dispose and are handed back here,
+    /// so they pool across re-creations without ever being recycled as scratch.
+    /// Return with <see cref="ReturnPersistentBuffer{T}"/> when the state is
+    /// discarded (on the next re-configure). Buffers below
+    /// <see cref="PersistThresholdElems"/> aren't pooled (they GC cheaply) — a
+    /// fresh zeroed array is returned, matching the pooled path's zero-init.
+    /// </summary>
+    internal static T[] RentPersistentZeroed<T>(int elementCount)
+    {
+        if (elementCount == 0) return Array.Empty<T>();
+        return RentPersistent(typeof(T), elementCount) as T[] ?? new T[elementCount];
+    }
+
+    /// <summary>
+    /// Returns a buffer previously handed out by <see cref="RentPersistentZeroed{T}"/>
+    /// to the cross-arena persistent pool for reuse. No-op for arrays below the
+    /// pooling threshold or already at the per-size cap (they GC). The caller
+    /// must not touch the array after returning it.
+    /// </summary>
+    internal static void ReturnPersistentBuffer<T>(T[] arr)
+    {
+        if (arr is null || arr.Length == 0) return;
+        ReturnPersistent(typeof(T), arr.Length, arr);
+    }
+
     // ---------------------------------------------------------------------
     // Boundary-CARRY pool (#1824). Separate from _persistent because carries
     // pool at ANY size (the scratch pool skips < PersistThresholdElems, since

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
@@ -162,6 +162,33 @@ public class TensorArenaPersistentPoolTests
     }
 
     /// <summary>
+    /// The RentPersistentZeroed / ReturnPersistentBuffer API (used for long-lived
+    /// fused-optimizer Adam m/v moment state that must outlive the transient
+    /// per-step arena) hands back a ZEROED buffer, pools it across return/rent, and
+    /// re-zeroes stale data on reuse. This is the transparent replacement for the
+    /// per-reconfigure `new double[len]` that PerfView flagged in
+    /// ConfigureOptimizerDouble (~2 GB churn on the VALL-E-X-clone warmup).
+    /// </summary>
+    [Fact]
+    public void RentPersistentZeroed_ZeroesPoolsAndRezeroesOnReuse()
+    {
+        TensorArena.ClearPersistentPool();
+        int len = 128 * 1024; // above PersistThresholdElems
+
+        var a = TensorArena.RentPersistentZeroed<double>(len);
+        Assert.Equal(len, a.Length);
+        for (int i = 0; i < len; i++) Assert.Equal(0.0, a[i]); // rented zeroed
+        a[0] = 42.0; a[len - 1] = 7.0;                          // dirty it
+        TensorArena.ReturnPersistentBuffer(a);
+        Assert.Equal(0, TensorArena.PersistentReuseHits);
+
+        var b = TensorArena.RentPersistentZeroed<double>(len);
+        Assert.Equal(1, TensorArena.PersistentReuseHits);       // reused, not re-allocated
+        Assert.Same(a, b);                                      // same backing array
+        for (int i = 0; i < len; i++) Assert.Equal(0.0, b[i]);  // stale 42/7 re-zeroed
+    }
+
+    /// <summary>
     /// Small buffers (below the persist threshold) are intentionally NOT pooled
     /// across lifetimes — they GC cheaply and pooling them would bloat the
     /// dictionary. This guards the threshold so the pool stays focused on the

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
@@ -56,6 +56,45 @@ public class TensorArenaPersistentPoolTests
         Assert.Equal(5, TensorArena.PersistentReuseHits);
     }
 
+    /// <summary>
+    /// Deep-model churn guard: a training step for an N-layer network rents MANY
+    /// same-size large buffers (one hidden-state / gradient per layer), not "O(1)
+    /// per size". The cross-arena pool must retain and reuse ALL of them across a
+    /// fresh-arena-per-step trainer — with the old per-size cap of 4 an 18-layer
+    /// model dropped N-4 buffers on Dispose and re-allocated them every step
+    /// (~2 GB/step Double[] churn measured on VALL-E-X-clone via PerfView). Renting
+    /// 16 same-size large buffers per cycle must yield 16 reuse hits next cycle.
+    /// </summary>
+    [Fact]
+    public void ManySameSizeBuffers_PerStep_AllReusedAcrossLifetimes()
+    {
+        TensorArena.ClearPersistentPool();
+        const int n = 16;                       // > old cap (4); models a deep stack
+        int[] shape = { 128 * 1024 };           // 512 KB float — above PersistThresholdElems
+
+        // Cycle 1: cold — allocate n fresh, all returned to the pool on dispose.
+        using (var arena = TensorArena.Create())
+        {
+            for (int i = 0; i < n; i++)
+            {
+                var t = TensorAllocator.RentUninitialized<float>(shape);
+                t.AsWritableSpan()[0] = i;
+            }
+        }
+        Assert.Equal(0, TensorArena.PersistentReuseHits);
+
+        // Cycle 2: every one of the n same-size buffers must come from the pool.
+        using (var arena = TensorArena.Create())
+        {
+            for (int i = 0; i < n; i++)
+            {
+                var t = TensorAllocator.RentUninitialized<float>(shape);
+                t.AsWritableSpan()[0] = i;
+            }
+        }
+        Assert.Equal(n, TensorArena.PersistentReuseHits);
+    }
+
 #if NET5_0_OR_GREATER
     /// <summary>
     /// Same guarantee, measured directly: steady-state per-step allocation must


### PR DESCRIPTION
Two related changes to the cross-arena **persistent pool** — the tier that lets a fresh-`TensorArena`-per-training-step trainer reuse large backing arrays instead of re-allocating them each step (#478).

## 1. Raise the per-size retention cap (4 → 64)

The pool capped retention at **4 buffers per (type, size)**, assuming "a training step rents each distinct size O(1) times". True for shallow nets, **wrong for deep transformers**: an N-layer stack produces N same-shaped hidden-state / gradient tensors per step. At cap 4, a fresh-arena-per-step trainer dropped N−4 of them on `Dispose` and re-allocated them next step — PerfView measured **~2 GB/step of `Double[]` churn** on an 18-layer VALL-E-X-clone (`TensorArena.TryRentTensor`).

Raise to 64. Retention is **self-limiting** — a `Dispose` only returns as many same-size buffers as the step actually used — so shallow models are unchanged; only deep models retain more, bounded by their own working set.

## 2. Pool fused-optimizer Adam moments through the persistent tier

`ConfigureOptimizerDouble/Float` allocated the Adam `m`/`v`/`vMax` buffers as raw `new double[len]` per param. `ConfigureOptimizer` re-runs every time the compiled plan is invalidated (repeatedly during warmup as lazy layers materialize), re-allocating the **entire** moment set each time — PerfView attributed **~2 GB** to `ConfigureOptimizerDouble` on the VALL-E-X-clone warmup.

The moments are long-lived (must survive the transient per-step arena — the ring would recycle them mid-step, and `RentPinned` would re-allocate every step), so the persistent tier is the right fit. Expose `TensorArena.RentPersistentZeroed<T>` / `ReturnPersistentBuffer<T>` (zeroed on rent, re-zeroed on reuse — preserving the moments' `new[]` zero-init) and route the m/v/vMax allocations through it; a prior config's moments return to the pool on each plan-invalidate / re-configure. GPU-init temporaries and bf16/int8 moment buffers keep their own lifecycles.

## Tests

- `ManySameSizeBuffers_PerStep_AllReusedAcrossLifetimes` — 16 same-size buffers per cycle all reused next cycle (fails at cap 4).
- `RentPersistentZeroed_ZeroesPoolsAndRezeroesOnReuse` — the new API's zero/pool/re-zero contract.
- Full fused-optimizer + convergence suites (108 tests) stay green, proving the pooled moments are never recycled mid-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory reuse for training optimizer buffers, reducing repeated large allocations during optimizer reconfiguration and plan disposal.
  * Increased persistent buffer retention to better support deep models and repeated allocation patterns.
  * Ensured reused buffers are reset to zero before being provided again.

* **Tests**
  * Added coverage for persistent buffer reuse, zero-initialization, and deep allocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->