### PR TITLE
perf(simd): multi-tensor (foreach) fused AdamW optimizer

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -3324,6 +3324,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             double stepBc1 = 1.0 - System.Math.Pow(b1, _optimizerStep);
             double stepBc2 = 1.0 - System.Math.Pow(b2, _optimizerStep);
             double lr = lrSchedule.GetLr(_optimizerStep);
+            // Multi-tensor (PyTorch foreach) fast path: update EVERY parameter in one
+            // fused-AdamW call — the SIMD constant vectors are built once instead of
+            // rebuilt (plus a method call) per tensor, the redundancy a deep model with
+            // hundreds of small tensors pays every step. Bit-identical to the per-param
+            // loop below (same math, same per-tensor SIMD/scalar-tail split). This
+            // (non-grouped double) path is pure CPU fp32-moment AdamW — no GPU-resident
+            // or bf16/int8 branch to preserve — so the fast path is unconditional here.
+            if (optType == OptimizerType.AdamW)
+            {
+                FusedOptimizer.AdamWUpdateSimdMulti(paramArrays, gradArrays, m, v, lengths, paramCount,
+                    lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
+                return;
+            }
             for (int p = 0; p < paramCount; p++)
             {
                 // Skip params with no gradient OR no materialized weight backing (#1738).

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2188,6 +2188,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
+            float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
             // #739 review: retire any captured on-device step graph before the CPU fused optimizer
             // mutates host weights and invalidates their resident device buffers (MarkHostWeightMutated
             // below) — otherwise a later LaunchCapturedGraph would replay against freed/stale device
@@ -2531,7 +2533,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                         lr, b1, b2, epsVal, _optimizerStep);
                             else
                                 FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
-                                    lr, b1, b2, epsVal, _optimizerStep);
+                                    lr, b1, b2, epsVal, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AdamW:
                             if (useBf16Moments)
@@ -2540,7 +2542,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                         lr, b1, b2, epsVal, wd, _optimizerStep);
                             else
                                 FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
-                                    lr, b1, b2, epsVal, wd, _optimizerStep);
+                                    lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AMSGrad:
                             // AMSGrad (#74): Adam with a running max of v̂ so the
@@ -2930,6 +2932,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
+            float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
             // #739 review: retire any captured on-device step graph before this CPU fused optimizer
             // invalidates resident weight buffers below — else a later LaunchCapturedGraph replays
             // against freed/stale device pointers. No-op when no graph is captured.
@@ -3101,7 +3105,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                         lr, b1, b2, epsVal, _optimizerStep);
                             else
                                 FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
-                                    lr, b1, b2, epsVal, _optimizerStep);
+                                    lr, b1, b2, epsVal, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AdamW:
                             if (useBf16Moments)
@@ -3110,7 +3114,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                         lr, b1, b2, epsVal, wd, _optimizerStep);
                             else
                                 FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
-                                    lr, b1, b2, epsVal, wd, _optimizerStep);
+                                    lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AMSGrad:
                             // AMSGrad (#74): Adam with a running max of v̂ so the
@@ -3314,6 +3318,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
+            // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
+            // (bit-identical — a deep model with many small tensors paid ~2x(param count) Pow/step).
+            double stepBc1 = 1.0 - System.Math.Pow(b1, _optimizerStep);
+            double stepBc2 = 1.0 - System.Math.Pow(b2, _optimizerStep);
             double lr = lrSchedule.GetLr(_optimizerStep);
             for (int p = 0; p < paramCount; p++)
             {
@@ -3330,11 +3339,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             break;
                         case OptimizerType.Adam:
                             FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, _optimizerStep);
+                                lr, b1, b2, epsVal, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, wd, _optimizerStep);
+                                lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AMSGrad:
                             // AMSGrad (#74): Adam with a running max of v̂ so the
@@ -3459,6 +3468,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _optimizerUpdate = () =>
         {
             _optimizerStep++;
+            // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
+            // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
+            // (bit-identical — a deep model with many small tensors paid ~2x(param count) Pow/step).
+            double stepBc1 = 1.0 - System.Math.Pow(b1, _optimizerStep);
+            double stepBc2 = 1.0 - System.Math.Pow(b2, _optimizerStep);
             for (int g = 0; g < groupCount; g++)
                 groupLrs[g] = schedules[g].GetLr(_optimizerStep);
 
@@ -3479,11 +3493,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             break;
                         case OptimizerType.Adam:
                             FusedOptimizer.AdamUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, _optimizerStep);
+                                lr, b1, b2, epsVal, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AdamW:
                             FusedOptimizer.AdamWUpdateSimd(pParam, pGrad, pM, pV, len,
-                                lr, b1, b2, epsVal, wd, _optimizerStep);
+                                lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
                             break;
                         case OptimizerType.AMSGrad:
                             // AMSGrad (#74): Adam with a running max of v̂ so the

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -476,6 +476,75 @@ internal static class FusedOptimizer
         }
     }
 
+    /// <summary>
+    /// Multi-tensor (PyTorch <c>foreach</c>-style) fused AdamW over a LIST of parameter
+    /// tensors. Builds the step-global SIMD constant vectors ONCE and reuses them for
+    /// every parameter, instead of rebuilding all eight broadcasts (and paying a method
+    /// call + the per-call bias-correction) once per tensor — the redundancy that a deep
+    /// model with hundreds of parameter tensors pays every step. Bit-identical to calling
+    /// the single-tensor bc1/bc2 overload per parameter: identical arithmetic, identical
+    /// SIMD / scalar-tail split per tensor. Tensors with <c>lengths[t] == 0</c> (unexercised
+    /// params with no live gradient) are skipped, matching the per-param loop's guard.
+    /// </summary>
+    internal static unsafe void AdamWUpdateSimdMulti(
+        double[][] paramArrays, double[][] gradArrays, double[][] mArrays, double[][] vArrays,
+        int[] lengths, int count,
+        double lr, double beta1, double beta2, double eps, double weightDecay, double bc1, double bc2)
+    {
+        double lrAdj = lr / bc1;
+        double wdScale = 1.0 - weightDecay * lr;
+#if NET5_0_OR_GREATER
+        bool useSimd = Fma.IsSupported;
+        var vB1 = Vector256.Create(beta1);
+        var v1mB1 = Vector256.Create(1.0 - beta1);
+        var vB2 = Vector256.Create(beta2);
+        var v1mB2 = Vector256.Create(1.0 - beta2);
+        var vLr = Vector256.Create(-lrAdj);
+        var vEps = Vector256.Create(eps);
+        var vBc2Inv = Vector256.Create(1.0 / bc2);
+        var vWd = Vector256.Create(wdScale);
+#endif
+        for (int t = 0; t < count; t++)
+        {
+            int length = lengths[t];
+            if (length == 0) continue;
+            var pa = paramArrays[t]; var ga = gradArrays[t]; var ma = mArrays[t]; var va = vArrays[t];
+            if (pa.Length == 0 || ga.Length == 0) continue;
+            fixed (double* param = pa, grad = ga, m = ma, v = va)
+            {
+                int i = 0;
+#if NET5_0_OR_GREATER
+                if (useSimd && length >= 4)
+                {
+                    int simdLen = length & ~3;
+                    for (; i < simdLen; i += 4)
+                    {
+                        var g = Avx.LoadVector256(grad + i);
+                        var mNew = Fma.MultiplyAdd(vB1, Avx.LoadVector256(m + i), Avx.Multiply(v1mB1, g));
+                        Avx.Store(m + i, mNew);
+                        var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
+                        Avx.Store(v + i, vNew);
+                        var vHat = Avx.Multiply(vNew, vBc2Inv);
+                        var denom = Avx.Add(Avx.Sqrt(vHat), vEps);
+                        var update = Avx.Divide(mNew, denom);
+                        var pScaled = Avx.Multiply(Avx.LoadVector256(param + i), vWd);
+                        Avx.Store(param + i, Fma.MultiplyAdd(vLr, update, pScaled));
+                    }
+                }
+#endif
+                for (; i < length; i++)
+                {
+                    m[i] = beta1 * m[i] + (1.0 - beta1) * grad[i];
+                    v[i] = beta2 * v[i] + (1.0 - beta2) * grad[i] * grad[i];
+                    double mHat = m[i] / bc1;
+                    double vHat = v[i] / bc2;
+                    double pScaled = param[i] * wdScale;
+                    param[i] = pScaled - lr * mHat / (System.Math.Sqrt(vHat) + eps);
+                }
+            }
+        }
+    }
+
     /// <summary>AVX2 AdamW: Adam with decoupled weight decay</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static unsafe void AdamWUpdateSimd(
@@ -538,6 +607,68 @@ internal static class FusedOptimizer
             float vHat = v[i] / bc2;
             float pScaled = param[i] * wdScale;
             param[i] = pScaled - lr * mHat / (MathF.Sqrt(vHat) + eps);
+        }
+    }
+
+    /// <summary>Multi-tensor (foreach-style) fused AdamW over a LIST of float parameter
+    /// tensors — see the double overload. Builds the SIMD constants once, reuses across
+    /// every tensor; bit-identical to the per-parameter bc1/bc2 overload.</summary>
+    internal static unsafe void AdamWUpdateSimdMulti(
+        float[][] paramArrays, float[][] gradArrays, float[][] mArrays, float[][] vArrays,
+        int[] lengths, int count,
+        float lr, float beta1, float beta2, float eps, float weightDecay, float bc1, float bc2)
+    {
+        float lrAdj = lr / bc1;
+        float wdScale = 1f - weightDecay * lr;
+#if NET5_0_OR_GREATER
+        bool useSimd = Fma.IsSupported;
+        var vB1 = Vector256.Create(beta1);
+        var v1mB1 = Vector256.Create(1f - beta1);
+        var vB2 = Vector256.Create(beta2);
+        var v1mB2 = Vector256.Create(1f - beta2);
+        var vLr = Vector256.Create(-lrAdj);
+        var vEps = Vector256.Create(eps);
+        var vBc2Inv = Vector256.Create(1f / bc2);
+        var vWd = Vector256.Create(wdScale);
+#endif
+        for (int t = 0; t < count; t++)
+        {
+            int length = lengths[t];
+            if (length == 0) continue;
+            var pa = paramArrays[t]; var ga = gradArrays[t]; var ma = mArrays[t]; var va = vArrays[t];
+            if (pa.Length == 0 || ga.Length == 0) continue;
+            fixed (float* param = pa, grad = ga, m = ma, v = va)
+            {
+                int i = 0;
+#if NET5_0_OR_GREATER
+                if (useSimd && length >= 8)
+                {
+                    int simdLen = length & ~7;
+                    for (; i < simdLen; i += 8)
+                    {
+                        var g = Avx.LoadVector256(grad + i);
+                        var mNew = Fma.MultiplyAdd(vB1, Avx.LoadVector256(m + i), Avx.Multiply(v1mB1, g));
+                        Avx.Store(m + i, mNew);
+                        var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
+                        Avx.Store(v + i, vNew);
+                        var vHat = Avx.Multiply(vNew, vBc2Inv);
+                        var denom = Avx.Add(Avx.Sqrt(vHat), vEps);
+                        var update = Avx.Divide(mNew, denom);
+                        var pScaled = Avx.Multiply(Avx.LoadVector256(param + i), vWd);
+                        Avx.Store(param + i, Fma.MultiplyAdd(vLr, update, pScaled));
+                    }
+                }
+#endif
+                for (; i < length; i++)
+                {
+                    m[i] = beta1 * m[i] + (1f - beta1) * grad[i];
+                    v[i] = beta2 * v[i] + (1f - beta2) * grad[i] * grad[i];
+                    float mHat = m[i] / bc1;
+                    float vHat = v[i] / bc2;
+                    float pScaled = param[i] * wdScale;
+                    param[i] = pScaled - lr * mHat / (MathF.Sqrt(vHat) + eps);
+                }
+            }
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -384,20 +384,58 @@ internal static class FusedOptimizer
         double* param, double* grad, double* m, double* v, int length,
         double lr, double beta1, double beta2, double eps, double weightDecay, int step)
     {
+        // SINGLE-PASS fused AdamW. The prior form did a separate full pass over
+        // `param` (read+write every element) to apply the decoupled weight decay,
+        // then called AdamUpdateSimd which read+wrote `param` AGAIN — two
+        // memory-bound passes over the parameter array where Adam does one. Fold
+        // the decay (param *= 1 - wd*lr) into the Adam update loop so `param` is
+        // touched once. Bit-identical to the two-pass form: the scaled parameter
+        // is a double, so keeping it in a register is exactly the value the old
+        // pre-scale pass stored to memory and the Adam pass reloaded. Mirrors the
+        // single-pass structure Adam already had (the optimization AdamW missed).
+        double bc1 = 1.0 - System.Math.Pow(beta1, step);
+        double bc2 = 1.0 - System.Math.Pow(beta2, step);
+        double lrAdj = lr / bc1;
+        double wdScale = 1.0 - weightDecay * lr;   // hoisted out of the loop
+
         int i = 0;
 #if NET5_0_OR_GREATER
-        if (Avx.IsSupported && length >= 4)
+        if (Fma.IsSupported && length >= 4)
         {
-            var vWdLr = Vector256.Create(1.0 - weightDecay * lr);
+            var vB1 = Vector256.Create(beta1);
+            var v1mB1 = Vector256.Create(1.0 - beta1);
+            var vB2 = Vector256.Create(beta2);
+            var v1mB2 = Vector256.Create(1.0 - beta2);
+            var vLr = Vector256.Create(-lrAdj);
+            var vEps = Vector256.Create(eps);
+            var vBc2Inv = Vector256.Create(1.0 / bc2);
+            var vWd = Vector256.Create(wdScale);
             int simdLen = length & ~3;
+
             for (; i < simdLen; i += 4)
-                Avx.Store(param + i, Avx.Multiply(Avx.LoadVector256(param + i), vWdLr));
+            {
+                var g = Avx.LoadVector256(grad + i);
+                var mNew = Fma.MultiplyAdd(vB1, Avx.LoadVector256(m + i), Avx.Multiply(v1mB1, g));
+                Avx.Store(m + i, mNew);
+                var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
+                Avx.Store(v + i, vNew);
+                var vHat = Avx.Multiply(vNew, vBc2Inv);
+                var denom = Avx.Add(Avx.Sqrt(vHat), vEps);
+                var update = Avx.Divide(mNew, denom);
+                var pScaled = Avx.Multiply(Avx.LoadVector256(param + i), vWd);   // decoupled wd, in-register
+                Avx.Store(param + i, Fma.MultiplyAdd(vLr, update, pScaled));
+            }
         }
 #endif
         for (; i < length; i++)
-            param[i] *= (1.0 - weightDecay * lr);
-
-        AdamUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, step);
+        {
+            m[i] = beta1 * m[i] + (1.0 - beta1) * grad[i];
+            v[i] = beta2 * v[i] + (1.0 - beta2) * grad[i] * grad[i];
+            double mHat = m[i] / bc1;
+            double vHat = v[i] / bc2;
+            double pScaled = param[i] * wdScale;
+            param[i] = pScaled - lr * mHat / (System.Math.Sqrt(vHat) + eps);
+        }
     }
 
     /// <summary>AVX2 AdamW: Adam with decoupled weight decay</summary>
@@ -406,20 +444,52 @@ internal static class FusedOptimizer
         float* param, float* grad, float* m, float* v, int length,
         float lr, float beta1, float beta2, float eps, float weightDecay, int step)
     {
+        // SINGLE-PASS fused AdamW — see the double overload above. Folds the
+        // decoupled weight decay into the Adam update loop so `param` is read+
+        // written once instead of twice. Bit-identical to the prior two-pass form.
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        float lrAdj = lr / bc1;
+        float wdScale = 1f - weightDecay * lr;
+
         int i = 0;
 #if NET5_0_OR_GREATER
-        if (Avx.IsSupported && length >= 8)
+        if (Fma.IsSupported && length >= 8)
         {
-            var vWdLr = Vector256.Create(1f - weightDecay * lr);
+            var vB1 = Vector256.Create(beta1);
+            var v1mB1 = Vector256.Create(1f - beta1);
+            var vB2 = Vector256.Create(beta2);
+            var v1mB2 = Vector256.Create(1f - beta2);
+            var vLr = Vector256.Create(-lrAdj);
+            var vEps = Vector256.Create(eps);
+            var vBc2Inv = Vector256.Create(1f / bc2);
+            var vWd = Vector256.Create(wdScale);
             int simdLen = length & ~7;
+
             for (; i < simdLen; i += 8)
-                Avx.Store(param + i, Avx.Multiply(Avx.LoadVector256(param + i), vWdLr));
+            {
+                var g = Avx.LoadVector256(grad + i);
+                var mNew = Fma.MultiplyAdd(vB1, Avx.LoadVector256(m + i), Avx.Multiply(v1mB1, g));
+                Avx.Store(m + i, mNew);
+                var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
+                Avx.Store(v + i, vNew);
+                var vHat = Avx.Multiply(vNew, vBc2Inv);
+                var denom = Avx.Add(Avx.Sqrt(vHat), vEps);
+                var update = Avx.Divide(mNew, denom);
+                var pScaled = Avx.Multiply(Avx.LoadVector256(param + i), vWd);
+                Avx.Store(param + i, Fma.MultiplyAdd(vLr, update, pScaled));
+            }
         }
 #endif
         for (; i < length; i++)
-            param[i] *= (1f - weightDecay * lr);
-
-        AdamUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, step);
+        {
+            m[i] = beta1 * m[i] + (1f - beta1) * grad[i];
+            v[i] = beta2 * v[i] + (1f - beta2) * grad[i] * grad[i];
+            float mHat = m[i] / bc1;
+            float vHat = v[i] / bc2;
+            float pScaled = param[i] * wdScale;
+            param[i] = pScaled - lr * mHat / (MathF.Sqrt(vHat) + eps);
+        }
     }
 
     /// <summary>AVX2 Adagrad: accum += g^2; param -= lr*g/(sqrt(accum)+eps)</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -85,8 +85,19 @@ internal static class FusedOptimizer
         float* param, float* grad, float* m, float* v, int length,
         float lr, float beta1, float beta2, float eps, int step)
     {
+        // Thin wrapper — hoist the step-global bias-correction MathF.Pow (see the
+        // double AdamUpdateSimd wrapper) so a per-parameter loop pays it once/step.
         float bc1 = 1f - MathF.Pow(beta1, step);
         float bc2 = 1f - MathF.Pow(beta2, step);
+        AdamUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, bc1, bc2);
+    }
+
+    /// <summary>Adam (float) with precomputed step-global bias corrections. Bit-identical
+    /// to the step overload; lets a per-parameter loop pay the two MathF.Pow once/step.</summary>
+    internal static unsafe void AdamUpdateSimd(
+        float* param, float* grad, float* m, float* v, int length,
+        float lr, float beta1, float beta2, float eps, float bc1, float bc2)
+    {
         float lrAdj = lr / bc1;
 
         int i = 0;
@@ -337,8 +348,24 @@ internal static class FusedOptimizer
         double* param, double* grad, double* m, double* v, int length,
         double lr, double beta1, double beta2, double eps, int step)
     {
+        // Thin wrapper: bc1 = 1-β1^step, bc2 = 1-β2^step are STEP-GLOBAL (identical
+        // for every parameter in a step), but this kernel runs once PER PARAMETER —
+        // so the two Math.Pow here cost ~2×(param count) transcendental calls per
+        // step, concentrated on a deep model's many small tensors. A per-parameter
+        // loop should compute bc1/bc2 ONCE and call the bc-taking overload below.
         double bc1 = 1.0 - System.Math.Pow(beta1, step);
         double bc2 = 1.0 - System.Math.Pow(beta2, step);
+        AdamUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, bc1, bc2);
+    }
+
+    /// <summary>Adam update with the STEP-GLOBAL bias corrections precomputed by the
+    /// caller (bc1 = 1-β1^step, bc2 = 1-β2^step). Bit-identical to the step overload;
+    /// exists so a per-parameter loop pays the two Math.Pow once per step, not per
+    /// parameter.</summary>
+    internal static unsafe void AdamUpdateSimd(
+        double* param, double* grad, double* m, double* v, int length,
+        double lr, double beta1, double beta2, double eps, double bc1, double bc2)
+    {
         double lrAdj = lr / bc1;
 
         int i = 0;
@@ -384,6 +411,19 @@ internal static class FusedOptimizer
         double* param, double* grad, double* m, double* v, int length,
         double lr, double beta1, double beta2, double eps, double weightDecay, int step)
     {
+        // Thin wrapper — hoist the step-global bias-correction Math.Pow (see the
+        // AdamUpdateSimd wrapper) so a per-parameter loop pays it once per step.
+        double bc1 = 1.0 - System.Math.Pow(beta1, step);
+        double bc2 = 1.0 - System.Math.Pow(beta2, step);
+        AdamWUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, weightDecay, bc1, bc2);
+    }
+
+    /// <summary>Single-pass fused AdamW with precomputed step-global bias corrections
+    /// (bc1 = 1-β1^step, bc2 = 1-β2^step). Bit-identical to the step overload.</summary>
+    internal static unsafe void AdamWUpdateSimd(
+        double* param, double* grad, double* m, double* v, int length,
+        double lr, double beta1, double beta2, double eps, double weightDecay, double bc1, double bc2)
+    {
         // SINGLE-PASS fused AdamW. The prior form did a separate full pass over
         // `param` (read+write every element) to apply the decoupled weight decay,
         // then called AdamUpdateSimd which read+wrote `param` AGAIN — two
@@ -393,8 +433,6 @@ internal static class FusedOptimizer
         // is a double, so keeping it in a register is exactly the value the old
         // pre-scale pass stored to memory and the Adam pass reloaded. Mirrors the
         // single-pass structure Adam already had (the optimization AdamW missed).
-        double bc1 = 1.0 - System.Math.Pow(beta1, step);
-        double bc2 = 1.0 - System.Math.Pow(beta2, step);
         double lrAdj = lr / bc1;
         double wdScale = 1.0 - weightDecay * lr;   // hoisted out of the loop
 
@@ -444,11 +482,22 @@ internal static class FusedOptimizer
         float* param, float* grad, float* m, float* v, int length,
         float lr, float beta1, float beta2, float eps, float weightDecay, int step)
     {
+        // Thin wrapper — hoist the step-global bias-correction MathF.Pow so a
+        // per-parameter loop pays it once/step (see the double overloads).
+        float bc1 = 1f - MathF.Pow(beta1, step);
+        float bc2 = 1f - MathF.Pow(beta2, step);
+        AdamWUpdateSimd(param, grad, m, v, length, lr, beta1, beta2, eps, weightDecay, bc1, bc2);
+    }
+
+    /// <summary>Single-pass fused AdamW (float) with precomputed step-global bias
+    /// corrections. Bit-identical to the step overload.</summary>
+    internal static unsafe void AdamWUpdateSimd(
+        float* param, float* grad, float* m, float* v, int length,
+        float lr, float beta1, float beta2, float eps, float weightDecay, float bc1, float bc2)
+    {
         // SINGLE-PASS fused AdamW — see the double overload above. Folds the
         // decoupled weight decay into the Adam update loop so `param` is read+
         // written once instead of twice. Bit-identical to the prior two-pass form.
-        float bc1 = 1f - MathF.Pow(beta1, step);
-        float bc2 = 1f - MathF.Pow(beta2, step);
         float lrAdj = lr / bc1;
         float wdScale = 1f - weightDecay * lr;
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
@@ -53,6 +53,56 @@ public class FusedAdamWSinglePassParityTests
             Assert.Equal(BitConverter.DoubleToInt64Bits(a[i]), BitConverter.DoubleToInt64Bits(b[i]));
     }
 
+    // The multi-tensor (foreach) AdamW kernel must be BIT-IDENTICAL to calling the
+    // single-tensor bc1/bc2 overload once per parameter — it only hoists the SIMD
+    // constant setup out of the per-tensor loop, changing no arithmetic. Exercises a
+    // list mixing SIMD-tail lengths and empty (len==0, unexercised) tensors.
+    [Fact]
+    public unsafe void AdamWMultiTensor_BitIdenticalToPerParam_Double()
+    {
+        const double lr = 5e-4, b1 = 0.9, b2 = 0.999, eps = 1e-8, wd = 1e-2;
+        int[] lens = { 1, 3, 4, 7, 8, 15, 16, 17, 31, 100, 4096, 0, 5, 8193 };
+        int count = lens.Length;
+        for (int step = 1; step <= 3; step++)
+        {
+            double bc1 = 1.0 - Math.Pow(b1, step), bc2 = 1.0 - Math.Pow(b2, step);
+            var rng = new Random(31 + step);
+            double[][] P = new double[count][], G = new double[count][], M = new double[count][], V = new double[count][];
+            double[][] Pr = new double[count][], Mr = new double[count][], Vr = new double[count][];
+            for (int t = 0; t < count; t++)
+            {
+                int L = lens[t];
+                P[t] = new double[L]; G[t] = new double[L]; M[t] = new double[L]; V[t] = new double[L];
+                for (int i = 0; i < L; i++)
+                {
+                    P[t][i] = rng.NextDouble() * 2 - 1;
+                    G[t][i] = (rng.NextDouble() * 2 - 1) * 0.1;
+                    M[t][i] = (rng.NextDouble() * 2 - 1) * 0.05;
+                    V[t][i] = rng.NextDouble() * 0.01;
+                }
+                Pr[t] = (double[])P[t].Clone(); Mr[t] = (double[])M[t].Clone(); Vr[t] = (double[])V[t].Clone();
+            }
+
+            // Reference: per-parameter bc1/bc2 overload (grads unchanged by AdamW, so shared).
+            for (int t = 0; t < count; t++)
+            {
+                int L = lens[t]; if (L == 0) continue;
+                fixed (double* p = Pr[t], g = G[t], m = Mr[t], v = Vr[t])
+                    FusedOptimizer.AdamWUpdateSimd(p, g, m, v, L, lr, b1, b2, eps, wd, bc1, bc2);
+            }
+            // Multi-tensor path.
+            FusedOptimizer.AdamWUpdateSimdMulti(P, G, M, V, lens, count, lr, b1, b2, eps, wd, bc1, bc2);
+
+            for (int t = 0; t < count; t++)
+                for (int i = 0; i < lens[t]; i++)
+                {
+                    Assert.Equal(BitConverter.DoubleToInt64Bits(Pr[t][i]), BitConverter.DoubleToInt64Bits(P[t][i]));
+                    Assert.Equal(BitConverter.DoubleToInt64Bits(Mr[t][i]), BitConverter.DoubleToInt64Bits(M[t][i]));
+                    Assert.Equal(BitConverter.DoubleToInt64Bits(Vr[t][i]), BitConverter.DoubleToInt64Bits(V[t][i]));
+                }
+        }
+    }
+
     [Theory]
     [MemberData(nameof(Lengths))]
     public void FusedAdamW_Double_BitIdenticalToTwoPass(int len)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
@@ -1,0 +1,127 @@
+using System;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// The fused single-pass AdamW SIMD kernel must be BIT-IDENTICAL to the prior
+/// two-pass form (a full weight-decay pre-scale pass over <c>param</c>, then
+/// <see cref="FusedOptimizer"/>.AdamUpdateSimd). The fusion only removes the
+/// redundant second read+write of the parameter array; it changes no arithmetic,
+/// so training trajectories must be unchanged to the last bit. These tests
+/// reconstruct the exact two-pass reference and compare raw bit patterns across
+/// SIMD-tail lengths and a range of steps / learning rates / weight decays.
+/// </summary>
+public class FusedAdamWSinglePassParityTests
+{
+    public static TheoryData<int> Lengths => new() { 1, 3, 4, 7, 8, 9, 15, 16, 17, 31, 100, 257, 1024, 4099 };
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void FusedAdamW_Double_BitIdenticalToTwoPass(int len)
+    {
+        const double lr = 3e-4, b1 = 0.9, b2 = 0.999, eps = 1e-8, wd = 1e-2;
+        for (int step = 1; step <= 3; step++)
+        {
+            var (param, grad, m, v) = MakeDouble(len, 100 + len + step);
+
+            // Reference: the OLD two-pass form. Weight-decay pre-scale (scalar
+            // multiply is bit-identical to the old SIMD Avx.Multiply for the same
+            // inputs), then the UNCHANGED AdamUpdateSimd kernel.
+            var pRef = (double[])param.Clone();
+            var mRef = (double[])m.Clone();
+            var vRef = (double[])v.Clone();
+            double wdScale = 1.0 - wd * lr;
+            for (int i = 0; i < len; i++) pRef[i] *= wdScale;
+            unsafe
+            {
+                fixed (double* pp = pRef, pg = grad, pm = mRef, pv = vRef)
+                    FusedOptimizer.AdamUpdateSimd(pp, pg, pm, pv, len, lr, b1, b2, eps, step);
+            }
+
+            // Fused single-pass AdamW.
+            var pFused = (double[])param.Clone();
+            var mFused = (double[])m.Clone();
+            var vFused = (double[])v.Clone();
+            unsafe
+            {
+                fixed (double* pp = pFused, pg = grad, pm = mFused, pv = vFused)
+                    FusedOptimizer.AdamWUpdateSimd(pp, pg, pm, pv, len, lr, b1, b2, eps, wd, step);
+            }
+
+            for (int i = 0; i < len; i++)
+            {
+                Assert.Equal(BitConverter.DoubleToInt64Bits(pRef[i]), BitConverter.DoubleToInt64Bits(pFused[i]));
+                Assert.Equal(BitConverter.DoubleToInt64Bits(mRef[i]), BitConverter.DoubleToInt64Bits(mFused[i]));
+                Assert.Equal(BitConverter.DoubleToInt64Bits(vRef[i]), BitConverter.DoubleToInt64Bits(vFused[i]));
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public void FusedAdamW_Float_BitIdenticalToTwoPass(int len)
+    {
+        const float lr = 3e-4f, b1 = 0.9f, b2 = 0.999f, eps = 1e-8f, wd = 1e-2f;
+        for (int step = 1; step <= 3; step++)
+        {
+            var (param, grad, m, v) = MakeFloat(len, 200 + len + step);
+
+            var pRef = (float[])param.Clone();
+            var mRef = (float[])m.Clone();
+            var vRef = (float[])v.Clone();
+            float wdScale = 1f - wd * lr;
+            for (int i = 0; i < len; i++) pRef[i] *= wdScale;
+            unsafe
+            {
+                fixed (float* pp = pRef, pg = grad, pm = mRef, pv = vRef)
+                    FusedOptimizer.AdamUpdateSimd(pp, pg, pm, pv, len, lr, b1, b2, eps, step);
+            }
+
+            var pFused = (float[])param.Clone();
+            var mFused = (float[])m.Clone();
+            var vFused = (float[])v.Clone();
+            unsafe
+            {
+                fixed (float* pp = pFused, pg = grad, pm = mFused, pv = vFused)
+                    FusedOptimizer.AdamWUpdateSimd(pp, pg, pm, pv, len, lr, b1, b2, eps, wd, step);
+            }
+
+            for (int i = 0; i < len; i++)
+            {
+                Assert.Equal(BitConverter.SingleToInt32Bits(pRef[i]), BitConverter.SingleToInt32Bits(pFused[i]));
+                Assert.Equal(BitConverter.SingleToInt32Bits(mRef[i]), BitConverter.SingleToInt32Bits(mFused[i]));
+                Assert.Equal(BitConverter.SingleToInt32Bits(vRef[i]), BitConverter.SingleToInt32Bits(vFused[i]));
+            }
+        }
+    }
+
+    private static (double[] p, double[] g, double[] m, double[] v) MakeDouble(int len, int seed)
+    {
+        var rng = new Random(seed);
+        double[] p = new double[len], g = new double[len], m = new double[len], v = new double[len];
+        for (int i = 0; i < len; i++)
+        {
+            p[i] = (rng.NextDouble() * 2 - 1);
+            g[i] = (rng.NextDouble() * 2 - 1) * 0.1;
+            m[i] = (rng.NextDouble() * 2 - 1) * 0.05;
+            v[i] = rng.NextDouble() * 0.01;   // second moment >= 0
+        }
+        return (p, g, m, v);
+    }
+
+    private static (float[] p, float[] g, float[] m, float[] v) MakeFloat(int len, int seed)
+    {
+        var rng = new Random(seed);
+        float[] p = new float[len], g = new float[len], m = new float[len], v = new float[len];
+        for (int i = 0; i < len; i++)
+        {
+            p[i] = (float)(rng.NextDouble() * 2 - 1);
+            g[i] = (float)((rng.NextDouble() * 2 - 1) * 0.1);
+            m[i] = (float)((rng.NextDouble() * 2 - 1) * 0.05);
+            v[i] = (float)(rng.NextDouble() * 0.01);
+        }
+        return (p, g, m, v);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedAdamWSinglePassParityTests.cs
@@ -17,6 +17,42 @@ public class FusedAdamWSinglePassParityTests
 {
     public static TheoryData<int> Lengths => new() { 1, 3, 4, 7, 8, 9, 15, 16, 17, 31, 100, 257, 1024, 4099 };
 
+    // The step-taking Adam/AdamW kernels now delegate to a bc1/bc2-taking overload
+    // so a per-parameter loop can hoist the two step-global Math.Pow to once/step.
+    // These pin the wrapper's bias-correction formula: the step overload must be
+    // bit-identical to the bc overload fed bc1=1-β1^step, bc2=1-β2^step.
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public unsafe void AdamAndAdamW_BcOverload_BitIdenticalToStepOverload_Double(int len)
+    {
+        const double lr = 5e-4, b1 = 0.9, b2 = 0.999, eps = 1e-8, wd = 1e-2;
+        for (int step = 1; step <= 4; step++)
+        {
+            double bc1 = 1.0 - Math.Pow(b1, step), bc2 = 1.0 - Math.Pow(b2, step);
+            var (param, grad, m, v) = MakeDouble(len, 55 + len + step);
+
+            // Adam: step overload vs bc overload.
+            double[] pA = (double[])param.Clone(), mA = (double[])m.Clone(), vA = (double[])v.Clone();
+            double[] pB = (double[])param.Clone(), mB = (double[])m.Clone(), vB = (double[])v.Clone();
+            fixed (double* p = pA, g = grad, mm = mA, vv = vA) FusedOptimizer.AdamUpdateSimd(p, g, mm, vv, len, lr, b1, b2, eps, step);
+            fixed (double* p = pB, g = grad, mm = mB, vv = vB) FusedOptimizer.AdamUpdateSimd(p, g, mm, vv, len, lr, b1, b2, eps, bc1, bc2);
+            AssertBitEqual(pA, pB); AssertBitEqual(mA, mB); AssertBitEqual(vA, vB);
+
+            // AdamW: step overload vs bc overload.
+            double[] pC = (double[])param.Clone(), mC = (double[])m.Clone(), vC = (double[])v.Clone();
+            double[] pD = (double[])param.Clone(), mD = (double[])m.Clone(), vD = (double[])v.Clone();
+            fixed (double* p = pC, g = grad, mm = mC, vv = vC) FusedOptimizer.AdamWUpdateSimd(p, g, mm, vv, len, lr, b1, b2, eps, wd, step);
+            fixed (double* p = pD, g = grad, mm = mD, vv = vD) FusedOptimizer.AdamWUpdateSimd(p, g, mm, vv, len, lr, b1, b2, eps, wd, bc1, bc2);
+            AssertBitEqual(pC, pD); AssertBitEqual(mC, mD); AssertBitEqual(vC, vD);
+        }
+    }
+
+    private static void AssertBitEqual(double[] a, double[] b)
+    {
+        for (int i = 0; i < a.Length; i++)
+            Assert.Equal(BitConverter.DoubleToInt64Bits(a[i]), BitConverter.DoubleToInt64Bits(b[i]));
+    }
+
     [Theory]
     [MemberData(nameof(Lengths))]
     public void FusedAdamW_Double_BitIdenticalToTwoPass(int len)


### PR DESCRIPTION
First phase of the fused multi-tensor optimizer (PyTorch `foreach` / `fused` style). Bulk-processes the parameter set to kill per-tensor overhead.

## This PR (Phase 1 — CPU foreach, double AdamW)

The CPU fused optimizer rebuilt all eight AVX constant broadcasts (β1, 1-β1, β2, 1-β2, -lrAdj, eps, 1/bc2, wd-scale) **plus a method call** once **per parameter tensor** — redundant work a deep model with hundreds of small tensors pays every step.

- `AdamWUpdateSimdMulti` (double + float): builds the step-global SIMD constants **once**, loops the tensor list internally. **Bit-identical** to the per-parameter `bc1/bc2` overload.
- Wired the non-grouped double-AdamW fused closure to it (its pure CPU fp32-moment path has no GPU-resident / bf16 / int8 branch to preserve).

**Tests:** `AdamWMultiTensor_BitIdenticalToPerParam_Double` (multi vs per-param, raw bit pattern, SIMD-tail + empty tensors); fused-optimizer + `OptimizerConvergence` suites (139) green.

## Follow-on phases (scoped, not in this PR)

- **1c — float + grouped closures.** The float closure carries GPU-resident + bf16/int8 branches; wiring the multi-tensor path there needs per-case guards.
- **2 — contiguous flatten (amortize per-tensor SIMD scalar tails).** The full `fused=True` win needs params/grads laid out contiguously; the fused path currently binds per-tensor (bypassing the eager `ParameterBuffer`), so this is a consumer + Tensors change.
- **3 — GPU `multi_tensor_apply`.** The high-value case (each per-tensor op is a kernel launch). Needs a CUDA box to verify (this dev box is AMD/OpenCL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)