### PR TITLE
feat(engine): DepthwiseConv1D primitive (CPU + GPU) for time-channel separable convs

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -988,6 +988,23 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
     }
 
+    /// <summary>DepthwiseConv1D backward: uses engine.DepthwiseConv1DBackwardInput and DepthwiseConv1DBackwardKernel</summary>
+    internal static void DepthwiseConv1DBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var stride = (int)savedState[0];
+        var padding = (int)savedState[1];
+
+        var gradInput = engine.DepthwiseConv1DBackwardInput(
+            gradOutput, inputs[1], inputs[0]._shape, stride, padding);
+        var gradKernel = engine.DepthwiseConv1DBackwardKernel(
+            gradOutput, inputs[0], inputs[1]._shape, stride, padding);
+
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+    }
+
     /// <summary>Conv3D backward: uses engine.Conv3DBackwardInput and Conv3DBackwardKernel</summary>
     internal static void Conv3DBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -60,7 +60,7 @@ internal static class OpRegistry
 
         // Convolution
         "Conv2D", "Conv1D", "Conv3D",
-        "DepthwiseConv2D", "ConvTranspose2D", "ConvTranspose3D", "LocallyConnectedConv2D",
+        "DepthwiseConv2D", "DepthwiseConv1D", "ConvTranspose2D", "ConvTranspose3D", "LocallyConnectedConv2D",
 
         // Normalization
         "BatchNorm", "BatchNormAffine", "LayerNorm", "GroupNorm", "RMSNorm", "InstanceNorm",
@@ -277,6 +277,7 @@ internal static class OpRegistry
         "ConvTranspose2DBackwardInput", "ConvTranspose2DBackwardKernel",
         "ConvTranspose3DBackwardInput", "ConvTranspose3DBackwardKernel",
         "DepthwiseConv2DBackwardInput", "DepthwiseConv2DBackwardKernel",
+        "DepthwiseConv1DBackwardInput", "DepthwiseConv1DBackwardKernel",
         "LocallyConnectedConv2DBackwardInput", "LocallyConnectedConv2DBackwardWeights", "LocallyConnectedConv2DBackwardBias",
         "DeformableConv2DBackwardInput", "DeformableConv2DBackwardKernel",
         "DeformableConv2DBackwardOffset", "DeformableConv2DBackwardMask",

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9215,6 +9215,72 @@ public partial class CpuEngine : ITensorLevelEngine
         return Reshape(result4D, kernelShape);
     }
 
+    /// <inheritdoc/>
+    public virtual Tensor<T> DepthwiseConv1D<T>(Tensor<T> input, Tensor<T> kernel, int stride = 1, int padding = 0)
+    {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (kernel == null) throw new ArgumentNullException(nameof(kernel));
+        if (input.Rank != 3) throw new ArgumentException($"DepthwiseConv1D requires 3D input [batch, channels, length]. Got rank {input.Rank}.", nameof(input));
+        if (kernel.Rank != 3) throw new ArgumentException($"DepthwiseConv1D requires 3D kernel [channels, multiplier, kernel_length]. Got rank {kernel.Rank}.", nameof(kernel));
+
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                int outL = (input._shape[2] + 2 * padding - kernel._shape[2]) / stride + 1;
+                int outCh = input._shape[1] * kernel._shape[1];
+                var outShape = new[] { input._shape[0], outCh, outL };
+                var capturedInput = input;
+                var capturedKernel = kernel;
+                int s = stride, p = padding;
+                return scope.RecordBinary(LazyNodeType.Custom, "DepthwiseConv1D", input, kernel, outShape,
+                    (eng, output) => { var r = eng.DepthwiseConv1D(capturedInput, capturedKernel, s, p); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
+                    BackwardFunctions<T>.DepthwiseConv1DBackward, new object[] { stride, padding });
+            }
+        }
+
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("DepthwiseConv1D", input._shape); if (ac is not null) return ac.Execute(); }
+
+        // Reshape to 4D: [B, C, 1, L] and [C, multiplier, 1, K]
+        var input4D = Reshape(input, new[] { input._shape[0], input._shape[1], 1, input._shape[2] });
+        var kernel4D = Reshape(kernel, new[] { kernel._shape[0], kernel._shape[1], 1, kernel._shape[2] });
+
+        var result4D = DepthwiseConv2D(input4D, kernel4D, new[] { 1, stride }, new[] { 0, padding });
+
+        // Squeeze height dimension: [B, C*mult, 1, outL] -> [B, C*mult, outL]
+        var result = Reshape(result4D, new[] { result4D._shape[0], result4D._shape[1], result4D._shape[3] });
+
+        DifferentiableOps.RecordBinary("DepthwiseConv1D", result, input, kernel, BackwardFunctions<T>.DepthwiseConv1DBackward,
+            new object[] { stride, padding });
+        AutoTracer.RecordOp("DepthwiseConv1D", result, eng => eng.DepthwiseConv1D(input, kernel, stride, padding));
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> DepthwiseConv1DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> kernel, int[] inputShape, int stride, int padding)
+    {
+        // Reshape to 4D and use DepthwiseConv2DBackwardInput
+        var grad4D = Reshape(gradOutput, new[] { gradOutput._shape[0], gradOutput._shape[1], 1, gradOutput._shape[2] });
+        var kernel4D = Reshape(kernel, new[] { kernel._shape[0], kernel._shape[1], 1, kernel._shape[2] });
+        var inputShape4D = new[] { inputShape[0], inputShape[1], 1, inputShape[2] };
+
+        var result4D = DepthwiseConv2DBackwardInput(grad4D, kernel4D, inputShape4D, new[] { 1, stride }, new[] { 0, padding });
+        return Reshape(result4D, inputShape);
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> DepthwiseConv1DBackwardKernel<T>(Tensor<T> gradOutput, Tensor<T> input, int[] kernelShape, int stride, int padding)
+    {
+        // Reshape to 4D and use DepthwiseConv2DBackwardKernel
+        var grad4D = Reshape(gradOutput, new[] { gradOutput._shape[0], gradOutput._shape[1], 1, gradOutput._shape[2] });
+        var input4D = Reshape(input, new[] { input._shape[0], input._shape[1], 1, input._shape[2] });
+        var kernelShape4D = new[] { kernelShape[0], kernelShape[1], 1, kernelShape[2] };
+
+        var result4D = DepthwiseConv2DBackwardKernel(grad4D, input4D, kernelShape4D, new[] { 1, stride }, new[] { 0, padding });
+        return Reshape(result4D, kernelShape);
+    }
+
     public virtual Tensor<T> Conv2D<T>(Tensor<T> input, Tensor<T> kernel, int stride = 1, int padding = 0, int dilation = 1)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8255,6 +8255,32 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    public override Tensor<T> DepthwiseConv1D<T>(Tensor<T> input, Tensor<T> kernel, int stride, int padding)
+    {
+        // Tape-active: use the recording CPU base path so the depthwise conv (and its kernel
+        // gradient) participate in autodiff — the GPU path returns an untracked tensor, which
+        // would freeze training for the Citrinet time-channel separable stack. Mirrors Conv3D.
+        if (IsTapeActive<T>()) return base.DepthwiseConv1D(input, kernel, stride, padding);
+
+        if (!TryGetBackend(out _) || input.Rank != 3 || kernel.Rank != 3)
+            return base.DepthwiseConv1D(input, kernel, stride, padding);
+
+        try
+        {
+            // Reshape [B, C, L] -> [B, C, 1, L] and [C, mult, K] -> [C, mult, 1, K], then run the
+            // existing on-GPU DepthwiseConv2D kernel (real backend kernel on all six backends) and
+            // squeeze the height axis back out.
+            var input4D = Reshape(input, new[] { input.Shape._dims[0], input.Shape._dims[1], 1, input.Shape._dims[2] });
+            var kernel4D = Reshape(kernel, new[] { kernel.Shape._dims[0], kernel.Shape._dims[1], 1, kernel.Shape._dims[2] });
+            var result4D = DepthwiseConv2D(input4D, kernel4D, new[] { 1, stride }, new[] { 0, padding });
+            return Reshape(result4D, new[] { result4D.Shape._dims[0], result4D.Shape._dims[1], result4D.Shape._dims[3] });
+        }
+        catch (Exception)
+        {
+            return base.DepthwiseConv1D(input, kernel, stride, padding);
+        }
+    }
+
     /// <summary>
     /// GPU-resident depthwise 2D convolution with optional bias and activation.
     /// Keeps input and output on GPU for chained layer execution.

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -3129,6 +3129,32 @@ public interface IEngine
     Tensor<T> Conv1DBackwardKernel<T>(Tensor<T> gradOutput, Tensor<T> input, int[] kernelShape, int stride, int padding, int dilation);
 
     /// <summary>
+    /// Performs depthwise 1D convolution on a 3D tensor (batch, channels, length). Each input
+    /// channel is convolved with its own temporal filter (no cross-channel mixing), producing
+    /// <c>channels * multiplier</c> output channels. Implemented by reshaping to
+    /// <see cref="DepthwiseConv2D{T}"/> with height=1 so it reuses the existing depthwise kernel
+    /// on every backend. This is the "time-channel separable" temporal stage of NVIDIA Citrinet /
+    /// QuartzNet 1D time-channel separable convolutions (Majumdar et al., 2021).
+    /// </summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="input">The input tensor [batch, channels, length].</param>
+    /// <param name="kernel">The depthwise kernel [channels, multiplier, kernel_length].</param>
+    /// <param name="stride">The stride of the convolution.</param>
+    /// <param name="padding">The amount of zero-padding to add.</param>
+    /// <returns>The convolved tensor [batch, channels * multiplier, output_length].</returns>
+    Tensor<T> DepthwiseConv1D<T>(Tensor<T> input, Tensor<T> kernel, int stride = 1, int padding = 0);
+
+    /// <summary>
+    /// Computes gradient w.r.t. input for depthwise 1D convolution backward pass.
+    /// </summary>
+    Tensor<T> DepthwiseConv1DBackwardInput<T>(Tensor<T> gradOutput, Tensor<T> kernel, int[] inputShape, int stride, int padding);
+
+    /// <summary>
+    /// Computes gradient w.r.t. kernel for depthwise 1D convolution backward pass.
+    /// </summary>
+    Tensor<T> DepthwiseConv1DBackwardKernel<T>(Tensor<T> gradOutput, Tensor<T> input, int[] kernelShape, int stride, int padding);
+
+    /// <summary>
     /// Performs 2D convolution with asymmetric stride, padding, and dilation.
     /// </summary>
     /// <typeparam name="T">The numeric type of tensor elements.</typeparam>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DepthwiseConv1DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DepthwiseConv1DTests.cs
@@ -1,0 +1,156 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+// DepthwiseConv1D is implemented by reshaping [B,C,L] -> [B,C,1,L] and delegating to the
+// (already-tested) DepthwiseConv2D. These tests pin the reshape wiring: the forward and both
+// backward passes must match an independent scalar 1D depthwise-conv reference across a spread
+// of strides, paddings, and channel-multipliers. Kernel layout is [channels, multiplier, K];
+// output channels = channels * multiplier (oc = ic*mult + m), no cross-channel mixing.
+public class DepthwiseConv1DTests
+{
+    private readonly CpuEngine _engine = new CpuEngine();
+
+    private static Tensor<float> Rnd(int[] shape, int seed)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)System.Math.Sin(i * 0.7 + seed) * 0.5f;
+        return new Tensor<float>(a, shape);
+    }
+
+    private static int OutLen(int L, int K, int s, int p) => (L + 2 * p - K) / s + 1;
+
+    // out[b,oc,ol] = sum_k input[b,ic, ol*s + k - p] * kernel[ic,m,k]
+    private static float[] RefForward(float[] inp, float[] k, int batch, int inC, int mult,
+        int L, int K, int s, int p, int oL)
+    {
+        int outC = inC * mult;
+        var outp = new float[batch * outC * oL];
+        for (int b = 0; b < batch; b++)
+            for (int oc = 0; oc < outC; oc++)
+            {
+                int ic = oc / mult, m = oc % mult;
+                for (int ol = 0; ol < oL; ol++)
+                {
+                    float sum = 0f;
+                    for (int kk = 0; kk < K; kk++)
+                    {
+                        int il = ol * s + kk - p;
+                        if (il < 0 || il >= L) continue;
+                        sum += inp[(b * inC + ic) * L + il] * k[(ic * mult + m) * K + kk];
+                    }
+                    outp[(b * outC + oc) * oL + ol] = sum;
+                }
+            }
+        return outp;
+    }
+
+    private static float[] RefInput(float[] go, float[] k, int batch, int inC, int mult,
+        int L, int K, int s, int p, int oL)
+    {
+        int outC = inC * mult;
+        var gi = new float[batch * inC * L];
+        for (int b = 0; b < batch; b++)
+            for (int oc = 0; oc < outC; oc++)
+            {
+                int ic = oc / mult, m = oc % mult;
+                for (int ol = 0; ol < oL; ol++)
+                {
+                    float g = go[(b * outC + oc) * oL + ol];
+                    for (int kk = 0; kk < K; kk++)
+                    {
+                        int il = ol * s + kk - p;
+                        if (il < 0 || il >= L) continue;
+                        gi[(b * inC + ic) * L + il] += g * k[(ic * mult + m) * K + kk];
+                    }
+                }
+            }
+        return gi;
+    }
+
+    private static float[] RefKernel(float[] go, float[] inp, int batch, int inC, int mult,
+        int L, int K, int s, int p, int oL)
+    {
+        int outC = inC * mult;
+        var gk = new float[inC * mult * K];
+        for (int ic = 0; ic < inC; ic++)
+            for (int m = 0; m < mult; m++)
+            {
+                int oc = ic * mult + m;
+                for (int kk = 0; kk < K; kk++)
+                {
+                    float sum = 0f;
+                    for (int b = 0; b < batch; b++)
+                        for (int ol = 0; ol < oL; ol++)
+                        {
+                            int il = ol * s + kk - p;
+                            if (il < 0 || il >= L) continue;
+                            sum += go[(b * outC + oc) * oL + ol] * inp[(b * inC + ic) * L + il];
+                        }
+                    gk[(ic * mult + m) * K + kk] = sum;
+                }
+            }
+        return gk;
+    }
+
+    [Theory]
+    [InlineData(2, 3, 1, 8, 3, 1, 1)] // stride 1, "same" padding, multiplier 1
+    [InlineData(1, 4, 1, 16, 5, 2, 2)] // stride 2, multiplier 1
+    [InlineData(2, 3, 2, 10, 3, 1, 0)] // multiplier 2, no padding
+    [InlineData(1, 2, 1, 12, 7, 3, 1)] // large kernel
+    public void Forward_MatchesScalarReference(int batch, int inC, int mult, int L, int K, int s, int p)
+    {
+        var input = Rnd(new[] { batch, inC, L }, 1);
+        var kernel = Rnd(new[] { inC, mult, K }, 2);
+        int oL = OutLen(L, K, s, p);
+
+        var actual = _engine.DepthwiseConv1D(input, kernel, s, p);
+        var expected = RefForward(input.GetDataArray(), kernel.GetDataArray(), batch, inC, mult, L, K, s, p, oL);
+
+        Assert.Equal(new[] { batch, inC * mult, oL }, actual.Shape.ToArray());
+        var act = actual.GetDataArray();
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], act[i], 4);
+    }
+
+    [Theory]
+    [InlineData(2, 3, 1, 8, 3, 1, 1)]
+    [InlineData(1, 4, 1, 16, 5, 2, 2)]
+    [InlineData(2, 3, 2, 10, 3, 1, 0)]
+    public void BackwardInput_MatchesScalarReference(int batch, int inC, int mult, int L, int K, int s, int p)
+    {
+        int oL = OutLen(L, K, s, p);
+        var gradOut = Rnd(new[] { batch, inC * mult, oL }, 3);
+        var kernel = Rnd(new[] { inC, mult, K }, 4);
+
+        var actual = _engine.DepthwiseConv1DBackwardInput(gradOut, kernel, new[] { batch, inC, L }, s, p);
+        var expected = RefInput(gradOut.GetDataArray(), kernel.GetDataArray(), batch, inC, mult, L, K, s, p, oL);
+
+        Assert.Equal(new[] { batch, inC, L }, actual.Shape.ToArray());
+        var act = actual.GetDataArray();
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], act[i], 4);
+    }
+
+    [Theory]
+    [InlineData(2, 3, 1, 8, 3, 1, 1)]
+    [InlineData(1, 4, 1, 16, 5, 2, 2)]
+    [InlineData(2, 3, 2, 10, 3, 1, 0)]
+    public void BackwardKernel_MatchesScalarReference(int batch, int inC, int mult, int L, int K, int s, int p)
+    {
+        int oL = OutLen(L, K, s, p);
+        var gradOut = Rnd(new[] { batch, inC * mult, oL }, 5);
+        var input = Rnd(new[] { batch, inC, L }, 6);
+
+        var actual = _engine.DepthwiseConv1DBackwardKernel(gradOut, input, new[] { inC, mult, K }, s, p);
+        var expected = RefKernel(gradOut.GetDataArray(), input.GetDataArray(), batch, inC, mult, L, K, s, p, oL);
+
+        Assert.Equal(new[] { inC, mult, K }, actual.Shape.ToArray());
+        var act = actual.GetDataArray();
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], act[i], 4);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuConvKernelCoverageTests.cs
@@ -99,6 +99,17 @@ public sealed class GpuConvKernelCoverageTests : IDisposable
                     _gpu.DepthwiseConv2D(input, kernel, stride, pad), "DepthwiseConv2D");
     }
 
+    // ---- DepthwiseConv1D (reshapes to the on-GPU DepthwiseConv2D kernel) ----
+    [SkippableFact]
+    public void DepthwiseConv1D_Gpu_MatchesCpu()
+    {
+        SkipIfUnavailable();
+        var input = R(1, 1, 3, 8);   // [batch, channels, length]
+        var kernel = R(2, 3, 1, 3);  // [channels, mult, K]
+        AssertClose(_cpu.DepthwiseConv1D(input, kernel, 1, 1),
+                    _gpu.DepthwiseConv1D(input, kernel, 1, 1), "DepthwiseConv1D");
+    }
+
     // ---- DeformableConv2D (forward + all four backward) ----
     private (Tensor<float> input, Tensor<float> kernel, Tensor<float> offset, Tensor<float> mask,
              int[] stride, int[] pad, int[] dil, Tensor<float> fwd, Tensor<float> grad) DeformSetup()

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -454,6 +454,10 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         "DeformableConv2DBackwardMask(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
         "DeformableConv2DBackwardOffset(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[],Int32[],Int32[])",
         "DepthwiseConv2D(Tensor<T>,Tensor<T>,Int32[],Int32[])",
+        // DepthwiseConv1D reshapes [B,C,L]->[B,C,1,L] onto the DepthwiseConv2D GPU kernel; input and
+        // kernel have distinct shapes (feature map vs [C,mult,K]) so the single-shape generic harness
+        // can't drive it. Dedicated GPU-vs-CPU parity in GpuConvKernelCoverageTests.DepthwiseConv1D_Gpu_MatchesCpu.
+        "DepthwiseConv1D(Tensor<T>,Tensor<T>,Int32,Int32)",
         "FlashAttentionBackward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Double,Boolean,out Tensor<T>,out Tensor<T>,out Tensor<T>,Tensor<T>)",
         "FusedConv3D(Tensor<T>,Tensor<T>,Tensor<T>,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,FusedActivationType)",
         "FusedConvTranspose2D(Tensor<T>,Tensor<T>,Tensor<T>,Int32,Int32,Int32,Int32,Int32,Int32,FusedActivationType)",


### PR DESCRIPTION
## What

Adds a **depthwise 1D convolution** engine primitive: `DepthwiseConv1D` + `DepthwiseConv1DBackwardInput` + `DepthwiseConv1DBackwardKernel` on `IEngine`, `CpuEngine`, and `DirectGpuTensorEngine`.

Each input channel is convolved with its own temporal filter (no cross-channel mixing). Kernel layout `[channels, multiplier, K]`; output channels = `channels * multiplier`.

## Why

This is the **temporal stage of NVIDIA Citrinet / QuartzNet 1D time-channel separable convolutions** (Majumdar et al., 2021, https://arxiv.org/abs/2104.01721). It is consumed downstream by AiDotNet's new `CitrinetBlockLayer` so `NeMoCitrinet` can be built paper-faithfully (depthwise-temporal + pointwise-channel + SE + residual) instead of the current plain dense stack. No depthwise-1D primitive existed (`Conv1DLayer` is a full conv; depthwise layers are rank-4/2D).

## How

Implemented by reshaping `[B,C,L] → [B,C,1,L]` and delegating to the existing, fully-backend-covered `DepthwiseConv2D` (mirrors how `Conv1D` reuses `Conv2D`). **No new per-backend GPU kernel** — all six DirectGpu backends are exercised via the existing `DepthwiseConv2D` kernel. The GPU override defers to the recording CPU base path when the autodiff tape is active (mirrors `Conv3D`) so training gradients flow.

## Verification

- **10 CPU parity tests** (`DepthwiseConv1DTests`): forward + both backward passes vs an independent scalar reference across strides / padding / multiplier, on net10.0 + net471. ✅
- **GPU-vs-CPU parity** (`GpuConvKernelCoverageTests.DepthwiseConv1D_Gpu_MatchesCpu`): passed on CUDA (GTX 1660 Ti) with `ThrowOnGpuKernelFallback` active, proving the real on-GPU kernel executed. ✅

## Release / consumer

On merge, `automated-release.yml` `feat`-bumps the current **0.113.0 → 0.114.0**. AiDotNet PR #1789 pins `AiDotNet.Tensors` 0.114.0 and consumes `DepthwiseConv1D` via its new `CitrinetBlockLayer`; that PR's CI restore requires **0.114.0 published to NuGet** (i.e. this PR merged + released) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)