### PR TITLE
fix: two CUDA/CPU concurrency races (GridSample-3D backward scatter + GPU submission serialization)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -7317,20 +7317,24 @@ public partial class CpuEngine : ITensorLevelEngine
         // Initialize gradient grid with zeros
         var gradGrid = AutoTensorCache.RentOrAllocate<T>(grid._shape);
 
-        // Use thread-local gradients to avoid contention, then combine
-        int numThreads = CpuParallelSettings.MaxDegreeOfParallelism;
-        var threadLocalGrads = new double[numThreads][];
-        for (int t = 0; t < numThreads; t++)
-        {
-            threadLocalGrads[t] = new double[depth * height * width * channels];
-        }
+        // Per-thread gradient accumulators so the trilinear scatter-add never
+        // contends. The prior code sized a fixed threadLocalGrads[MaxDegreeOf-
+        // Parallelism] array and indexed it by (ManagedThreadId % numThreads) —
+        // NOT collision-free: two worker threads whose managed ids are congruent
+        // mod numThreads select the SAME buffer and race on it, corrupting the
+        // gradient (observed as NaN under concurrent training). ThreadLocal with
+        // trackAllValues gives every participating thread its OWN buffer with no
+        // index arithmetic, so both the scatter below and the aggregation are
+        // race-free by construction.
+        int gradLen = depth * height * width * channels;
+        using var threadLocalGrads = new System.Threading.ThreadLocal<double[]>(
+            () => new double[gradLen], trackAllValues: true);
 
         CpuParallelSettings.ParallelForOrSerial(0, numPositions,
             (long)numPositions * 8, // 8 trilinear-corner accumulator updates per position
-            () => Thread.CurrentThread.ManagedThreadId % numThreads,
-            (n, _, threadIndex) =>
+            n =>
         {
-            var localGrad = threadLocalGrads[threadIndex];
+            var localGrad = threadLocalGrads.Value!;
 
             // Get position (z, y, x)
             T pz = positions[n, 0];
@@ -7388,19 +7392,19 @@ public partial class CpuEngine : ITensorLevelEngine
                 localGrad[idx111] += w111 * grad;
             }
 
-            return threadIndex;
-        }, _ => { });
+        });
 
-        // Combine thread-local gradients
-        int totalElements = depth * height * width * channels;
+        // Combine every participating thread's accumulator. Each buffer was
+        // written by exactly one thread, so this sum is race-free; snapshot
+        // Values into an array so the parallel combine indexes a stable set.
+        int totalElements = gradLen;
         var gradGridData = gradGrid.GetDataArray();
+        var allLocals = System.Linq.Enumerable.ToArray(threadLocalGrads.Values);
         CpuParallelSettings.ParallelForOrSerial(0, totalElements, totalElements, i =>
         {
             double sum = 0;
-            for (int t = 0; t < numThreads; t++)
-            {
-                sum += threadLocalGrads[t][i];
-            }
+            for (int t = 0; t < allLocals.Length; t++)
+                sum += allLocals[t][i];
             gradGridData[i] = numOps.FromDouble(sum);
         });
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/GridSample3DBackwardConcurrencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GridSample3DBackwardConcurrencyTests.cs
@@ -1,0 +1,78 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Regression test for the 3D trilinear (GridSample-3D) backward scatter-add.
+/// The prior implementation sized a fixed <c>threadLocalGrads[MaxDegreeOf-
+/// Parallelism]</c> array and selected a thread's accumulator by
+/// <c>(Thread.CurrentThread.ManagedThreadId % numThreads)</c> — NOT collision
+/// free: on a many-core box the internal parallel workers' managed ids collide
+/// mod numThreads, so two workers scatter into the SAME buffer concurrently and
+/// race (lost/torn updates, observed as NaN under concurrent training). The fix
+/// uses a per-thread <see cref="System.Threading.ThreadLocal{T}"/> accumulator,
+/// making the scatter and the aggregation race-free by construction. This test
+/// exercises the many-worker parallel path and asserts the result stays finite
+/// and matches a serial (single-thread) reference across repeated runs — which
+/// the racing implementation could not guarantee.
+/// </summary>
+public class GridSample3DBackwardConcurrencyTests
+{
+    private readonly CpuEngine E = new();
+
+    [Fact]
+    public void TensorTrilinearInterpolateBackward_StaysFinite_AndMatchesSerial_UnderParallelism()
+    {
+        const int D = 6, H = 6, W = 6, C = 4, N = 40000;
+        var rng = new Random(123);
+
+        var grid = new Tensor<double>(new[] { D, H, W, C });     // gradient target shape; values unused
+        var positions = new Tensor<double>(new[] { N, 3 });
+        var gradOut = new Tensor<double>(new[] { N, C });
+        for (int i = 0; i < N; i++)
+        {
+            positions[i, 0] = rng.NextDouble() * (D - 1);
+            positions[i, 1] = rng.NextDouble() * (H - 1);
+            positions[i, 2] = rng.NextDouble() * (W - 1);
+            for (int c = 0; c < C; c++) gradOut[i, c] = rng.NextDouble() * 2.0 - 1.0;
+        }
+
+        // Serial ground truth (no worker fan-out → no possible collision).
+        int savedDop = CpuParallelSettings.MaxDegreeOfParallelism;
+        Tensor<double> reference;
+        try
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = 1;
+            reference = E.TensorTrilinearInterpolateBackward(gradOut, grid, positions);
+        }
+        finally
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = savedDop;
+        }
+
+        int len = reference.Length;
+        for (int i = 0; i < len; i++)
+            Assert.True((!double.IsNaN(reference[i]) && !double.IsInfinity(reference[i])), $"serial reference[{i}] is non-finite");
+
+        // Full-parallel path, repeated: the racing implementation produced
+        // dropped contributions (values off the serial sum) or NaN when worker
+        // ids collided; the fix keeps every run finite and within FP-reduction
+        // tolerance of the serial reference.
+        for (int rep = 0; rep < 25; rep++)
+        {
+            var r = E.TensorTrilinearInterpolateBackward(gradOut, grid, positions);
+            Assert.Equal(len, r.Length);
+            for (int i = 0; i < len; i++)
+            {
+                double v = r[i];
+                Assert.True((!double.IsNaN(v) && !double.IsInfinity(v)), $"rep {rep}: result[{i}] is non-finite (scatter race)");
+                Assert.True(Math.Abs(v - reference[i]) <= 1e-9 + 1e-9 * Math.Abs(reference[i]),
+                    $"rep {rep}: result[{i}]={v} diverges from serial reference {reference[i]} (lost contributions)");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two independent concurrency-correctness fixes in the compute engine, surfaced while tracing nondeterministic NaN in the model-family test suite under xUnit's many-worker parallelism.

## 1. CPU — GridSample-3D backward scatter race (verified)
`TensorTrilinearInterpolateBackward` accumulated into a fixed `threadLocalGrads[MaxDegreeOfParallelism]` array indexed by `(Thread.CurrentThread.ManagedThreadId % numThreads)`. Managed ids are arbitrary, so on a many-core box the internal parallel workers collide mod `numThreads` and two workers scatter-add into the **same** buffer concurrently → lost/torn updates (NaN under concurrent training).

**Fix:** per-thread `ThreadLocal<double[]>(trackAllValues: true)` accumulators — race-free by construction. **Test:** `GridSample3DBackwardConcurrencyTests` (finite + matches serial reference across 25 repeats). Existing parity tests 4/4. ✅ verified.

## 2. GPU — serialize submission to the shared CUDA backend
`CudaBackend` is a singleton sharing **one** stream, **one** cuBLAS handle, and **one** stream-ordered mem pool. NVIDIA documents that a cuBLAS handle must not be used concurrently from multiple threads, and the shared stream's `cuMemAllocAsync`/`cuLaunchKernel`/`cuMemcpy*Async`+`cuStreamSynchronize` sequences are the documented sticky-CUDA-700 risk. Multiple xUnit worker threads driving the singleton at once is exactly that unsafe concurrent access.

**Fix:** a reentrant backend-wide lock held for each GPU op at the `PushContext` chokepoint (serializes host-side submission; the shared stream already executes serially). `Monitor` is reentrant so nested `PushContext` is safe; the lock is released even if `cuCtxPushCurrent` throws.

**On-GPU verification (RTX 3080):**
- `GpuConcurrentSubmissionTests` — 32-thread concurrent GEMM against the singleton backend: results match the CPU reference and the GPU circuit breaker never trips **with the lock**. ✅
- Single-threaded GPU path unaffected (`GridSampleBackward_GpuMatchesCpu` passes). ✅
- **Honest caveat:** the *specific* sticky-700 observed in the model-family suite was **not reproduced** by this isolated matmul stress (it likely needs the training buffer-churn / pinned-host-memcpy pattern and/or coincided with GPU memory pressure). So this lock is justified as correct serialization of NVIDIA-documented not-thread-safe shared resources (cuBLAS handle / stream / pool), verified to keep concurrent submission correct — **not** as a reproduced-and-fixed repro of that exact fault.

**Follow-up (not this PR):** per-thread streams + per-thread cuBLAS/cuDNN + cross-stream events (preserves GPU concurrency; larger change, cross-stream buffer ordering only provable by heavier on-GPU stress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
