### PR TITLE
fix(fft): guard IRFFT against degenerate length-1 transform (nFft=0 OOR)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -38812,6 +38812,18 @@ public partial class CpuEngine : ITensorLevelEngine
         int numFreqs = input._shape[^1] / 2; // Interleaved real/imag
         int nFft = (numFreqs - 1) * 2;
 
+        // Degenerate tiny-transform guard (#778 / AiDotNet#1856): a length-1 forward RFFT
+        // pads to nFft = NextPowerOf2(1) = 1, which is ODD, so numFreqs = nFft/2 + 1 collapses
+        // to 1 and the even-only inverse formula (numFreqs-1)*2 yields nFft = 0 — a zero-point
+        // transform whose empty realOut[] makes the copy loop below throw IndexOutOfRange
+        // (surfaced during RFFT's autodiff backward at TFC's n=1 frequency axis). The caller
+        // always passes the true signal length as outputLength; for every non-degenerate case
+        // the padded (numFreqs-1)*2 already equals or exceeds it, so clamping up only affects
+        // the numFreqs==1 case, where the single DC bin IS the signal and a 1-point inverse is
+        // exact. Never below 1 so the Vector allocation and FFTCore stay well-formed.
+        if (nFft < outputLength) nFft = outputLength;
+        if (nFft < 1) nFft = 1;
+
         // Output shape
         var outputShape = input.Shape.ToArray();
         outputShape[^1] = outputLength;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RfftBackwardTinyTransformTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RfftBackwardTinyTransformTests.cs
@@ -1,0 +1,65 @@
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Regression guards for #778 / AiDotNet#1856: the RFFT autodiff backward (which runs
+/// <see cref="IEngine.IRFFT{T}"/>) threw <see cref="ArgumentOutOfRangeException"/> for a
+/// length-1 transform axis. A length-1 forward RFFT pads to nFft = NextPowerOf2(1) = 1,
+/// which is ODD, so numFreqs collapses to 1 and the even-only inverse formula
+/// <c>(numFreqs-1)*2</c> produced nFft = 0 — an empty inverse whose output copy indexed
+/// out of range. IRFFT now clamps nFft up to the caller-supplied outputLength, so the
+/// single DC bin (which IS the signal for n = 1) round-trips exactly.
+/// </summary>
+[Collection("EngineCurrentGlobalState")]
+public class RfftBackwardTinyTransformTests
+{
+    private readonly IEngine _engine = new CpuEngine();
+
+    // Forward RFFT of a length-1 axis is the identity DC bin; its adjoint (IRFFT with
+    // outputLength = 1) must reconstruct without throwing, for any leading batch shape.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(3)]
+    public void IRFft_LengthOneAxis_DoesNotThrow(int batch)
+    {
+        // RFFT([batch, 1]) -> [batch, 2] (interleaved DC re/im). Feed that straight back
+        // into IRFFT(outputLength: 1) — the exact shape RFFT's backward produces.
+        var spectrum = new Tensor<double>(new[] { batch, 2 });
+        var sd = spectrum.GetDataArray();
+        var rng = new Random(5);
+        for (int i = 0; i < sd.Length; i++) sd[i] = rng.NextDouble() * 2 - 1;
+
+        var ex = Record.Exception(() => _engine.IRFFT(spectrum, outputLength: 1));
+        Assert.Null(ex);
+    }
+
+    // The full tape path #1856 hit: backprop a scalar loss through Engine.RFFT over a
+    // length-1 axis. Must produce a finite gradient of the input's shape, not throw.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    public void RfftBackward_LengthOneAxis_ProducesFiniteGradient(int batch)
+    {
+        var x = new Tensor<double>(new[] { batch, 1 });
+        var xd = x.GetDataArray();
+        var rng = new Random(11);
+        for (int i = 0; i < xd.Length; i++) xd[i] = rng.NextDouble() * 2 - 1;
+
+        using var tape = new GradientTape<double>();
+        var spectrum = _engine.RFFT(x);
+        var loss = _engine.ReduceSum(spectrum, null);
+        var grads = tape.ComputeGradients(loss, new[] { x });
+
+        Assert.True(grads.TryGetValue(x, out var gx));
+        Assert.Equal(x.Length, gx.Length);
+        for (int i = 0; i < gx.Length; i++)
+            Assert.False(double.IsNaN(gx[i]) || double.IsInfinity(gx[i]),
+                $"grad[{i}] not finite: {gx[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RfftBackwardTinyTransformTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RfftBackwardTinyTransformTests.cs
@@ -14,42 +14,78 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// <c>(numFreqs-1)*2</c> produced nFft = 0 — an empty inverse whose output copy indexed
 /// out of range. IRFFT now clamps nFft up to the caller-supplied outputLength, so the
 /// single DC bin (which IS the signal for n = 1) round-trips exactly.
+///
+/// <para>For n = 1 every quantity is analytic, so these assert exact values rather than
+/// merely "does not throw": RFFT([x]) = [x, 0] (DC bin only), IRFFT([re, im], 1) = [re]
+/// (scale 1/nFft = 1), and d(Σ RFFT(x))/dx = 1 elementwise (the always-zero imaginary bin
+/// contributes no gradient).</para>
 /// </summary>
 [Collection("EngineCurrentGlobalState")]
 public class RfftBackwardTinyTransformTests
 {
     private readonly IEngine _engine = new CpuEngine();
 
-    // Forward RFFT of a length-1 axis is the identity DC bin; its adjoint (IRFFT with
-    // outputLength = 1) must reconstruct without throwing, for any leading batch shape.
+    // IRFFT of a length-1 spectrum returns exactly its real part (the DC bin), scaled by
+    // 1/nFft = 1. The imaginary bin is discarded — correct for a real inverse. Deterministic
+    // inputs so the reconstructed value is checked against a closed form, per batch row.
     [Theory]
     [InlineData(1)]
     [InlineData(8)]
     [InlineData(3)]
-    public void IRFft_LengthOneAxis_DoesNotThrow(int batch)
+    public void IRFft_LengthOneAxis_ReturnsRealPart(int batch)
     {
-        // RFFT([batch, 1]) -> [batch, 2] (interleaved DC re/im). Feed that straight back
-        // into IRFFT(outputLength: 1) — the exact shape RFFT's backward produces.
+        // spectrum[b] = [re_b, im_b]; re/im chosen distinct and non-trivial per row.
         var spectrum = new Tensor<double>(new[] { batch, 2 });
         var sd = spectrum.GetDataArray();
-        var rng = new Random(5);
-        for (int i = 0; i < sd.Length; i++) sd[i] = rng.NextDouble() * 2 - 1;
+        for (int b = 0; b < batch; b++)
+        {
+            sd[b * 2] = b + 1.5;          // re_b
+            sd[b * 2 + 1] = -(b + 0.25);  // im_b (must be ignored by the inverse)
+        }
 
-        var ex = Record.Exception(() => _engine.IRFFT(spectrum, outputLength: 1));
-        Assert.Null(ex);
+        var y = _engine.IRFFT(spectrum, outputLength: 1);
+
+        Assert.Equal(2, y.Rank);
+        Assert.Equal(batch, y.Shape[0]);
+        Assert.Equal(1, y.Shape[1]);
+        for (int b = 0; b < batch; b++)
+            Assert.Equal(b + 1.5, y[b], precision: 12); // == re_b, im_b dropped
     }
 
-    // The full tape path #1856 hit: backprop a scalar loss through Engine.RFFT over a
-    // length-1 axis. Must produce a finite gradient of the input's shape, not throw.
+    // Round-trip: IRFFT(RFFT(x), 1) == x for a length-1 axis (RFFT([x]) = [x, 0], inverse
+    // recovers x exactly with unit scale).
     [Theory]
     [InlineData(1)]
-    [InlineData(8)]
-    public void RfftBackward_LengthOneAxis_ProducesFiniteGradient(int batch)
+    [InlineData(5)]
+    public void Rfft_IRfft_LengthOneAxis_RoundTripsExactly(int batch)
     {
         var x = new Tensor<double>(new[] { batch, 1 });
         var xd = x.GetDataArray();
-        var rng = new Random(11);
-        for (int i = 0; i < xd.Length; i++) xd[i] = rng.NextDouble() * 2 - 1;
+        for (int b = 0; b < batch; b++) xd[b] = 0.75 - 0.5 * b;
+
+        var spectrum = _engine.RFFT(x);
+        Assert.Equal(2, spectrum.Shape[1]); // [re, im] DC only
+        for (int b = 0; b < batch; b++)
+        {
+            Assert.Equal(xd[b], spectrum[b * 2 + 0], precision: 12); // re == x
+            Assert.Equal(0.0, spectrum[b * 2 + 1], precision: 12);   // im == 0
+        }
+
+        var back = _engine.IRFFT(spectrum, outputLength: 1);
+        for (int b = 0; b < batch; b++)
+            Assert.Equal(xd[b], back[b], precision: 12);
+    }
+
+    // The full tape path #1856 hit: backprop Σ RFFT(x) over a length-1 axis. The gradient is
+    // exactly 1 for every element (dRe/dx = 1, dIm/dx = 0), and must carry the input's shape.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    public void RfftBackward_LengthOneAxis_GradientIsAllOnes(int batch)
+    {
+        var x = new Tensor<double>(new[] { batch, 1 });
+        var xd = x.GetDataArray();
+        for (int b = 0; b < batch; b++) xd[b] = 0.3 * (b + 1);
 
         using var tape = new GradientTape<double>();
         var spectrum = _engine.RFFT(x);
@@ -57,9 +93,10 @@ public class RfftBackwardTinyTransformTests
         var grads = tape.ComputeGradients(loss, new[] { x });
 
         Assert.True(grads.TryGetValue(x, out var gx));
-        Assert.Equal(x.Length, gx.Length);
+        Assert.Equal(x.Rank, gx.Rank);
+        Assert.Equal(x.Shape[0], gx.Shape[0]);
+        Assert.Equal(x.Shape[1], gx.Shape[1]);
         for (int i = 0; i < gx.Length; i++)
-            Assert.False(double.IsNaN(gx[i]) || double.IsInfinity(gx[i]),
-                $"grad[{i}] not finite: {gx[i]}");
+            Assert.Equal(1.0, gx[i], precision: 12);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #778. `Engine.RFFT`'s autodiff backward (which runs `IRFFT`) threw `ArgumentOutOfRangeException` for a **length-1 transform axis**. The forward RFFT is correct; only the gradient path failed.

### Root cause
A length-1 forward RFFT pads to `nFft = NextPowerOf2(1) = 1` (ODD), so `numFreqs = nFft/2 + 1` collapses to `1`. In the backward, `IRFFT` recomputes `nFft = (numFreqs-1)*2 = 0` — a zero-point transform. That allocates an empty `realOut[]`, and the output-copy loop indexes `realOut[0]` out of range. Because IRFFT dispatches its batch loop through the serial `ParallelForOrSerial` path (which captures the first body exception and rethrows it), the stack pointed at `ParallelForOrSerial` rather than the real IRFFT indexing — the misleading signature reported in #778.

Verified by instrumentation on the failing path: `IRFFT rank=2 shape=[8,2] numFreqs=1 nFft=0 batchSize=8 outLen=1`.

### Fix
Clamp `nFft` up to the caller-supplied `outputLength` (never below 1). For every non-degenerate size the padded `(numFreqs-1)*2` already equals or exceeds `outputLength` (the only odd `NextPowerOf2` is `n=1`), so the clamp **only** affects the `numFreqs == 1` case — where the single DC bin *is* the signal and a 1-point inverse is exact.

### Tests
- New `RfftBackwardTinyTransformTests`: the length-1 `IRFFT` call across batch shapes, and a full tape backward through `Engine.RFFT` at `n=1` (finite, correctly-shaped gradient).
- Full FFT suite green locally: **191/191** (round-trip, gradcheck, kernels).

### Downstream
This is the real bug behind AiDotNet#1856 (Finance CSDI/TFC forecasting-foundation). AiDotNet's TFC currently `StopGradient`-detaches its parameter-free DFT to dodge this; that workaround can be removed once this ships. Verified end-to-end: with the fix + workaround removed, AiDotNet CSDI+TFC pass **264/264** (double+float).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inverse real Fourier transforms could fail for length-one axes.
  * Improved autodiff behavior for tiny transforms, preventing invalid results and ensuring finite gradients.

* **Tests**
  * Added regression coverage for length-one Fourier transform and backpropagation scenarios across multiple batch sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->