### PR TITLE
fix(cpu): support groups<deformGroups in DeformableConv2DGrouped

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -17774,14 +17774,17 @@ public partial class CpuEngine : ITensorLevelEngine
         int inCpg = inChannels / groups;
         int outCpg = outChannels / groups;
         if (kernelInChannels != inCpg) throw new ArgumentException($"Kernel in_channels ({kernelInChannels}) must equal inChannels/groups ({inCpg}).");
-        // deformGroups must DIVIDE groups: there each output group maps to exactly one deformable group
-        // (dg = g·deformGroups/groups), and that mapping coincides with the GPU kernel's per-input-channel
-        // mapping (ic/(inChannels/deformGroups)). The groups<deformGroups case (deformGroups not dividing
-        // groups) would put multiple deformable groups inside one group's channel span — the CPU
-        // composition path can't express that and would silently diverge from the GPU kernel — so reject it.
-        if (groups % deformGroups != 0)
-            throw new ArgumentException($"deformGroups ({deformGroups}) must divide groups ({groups}). " +
-                "The groups<deformGroups configuration is not supported (it would diverge between the CPU and GPU paths).");
+        // A deformable group owns a contiguous span of INPUT channels — an input channel's deform group
+        // is ic/(inChannels/deformGroups), the same mapping the GPU kernel uses. So the only requirement
+        // is that deformGroups partitions the input channels evenly. The previous groups%deformGroups==0
+        // restriction (mapping the deform group per OUTPUT group as dg = g·deformGroups/groups) rejected
+        // the standard groups=1, deformGroups=N config (torchvision DeformConv2d / BasicVSR++'s flow-guided
+        // deformable alignment, Chan et al. 2022). Per-input-channel mapping (applied in the ic loop below)
+        // reduces to the same dg for every previously-allowed case (deformGroups | groups) and additionally
+        // handles groups < deformGroups, matching the GPU.
+        if (inChannels % deformGroups != 0)
+            throw new ArgumentException($"Input channels ({inChannels}) must be divisible by deformGroups ({deformGroups}).");
+        int inChannelsPerDeformGroup = inChannels / deformGroups;
 
         int strideH = stride[0], strideW = stride[1];
         int padH = padding[0], padW = padding[1];
@@ -17807,10 +17810,7 @@ public partial class CpuEngine : ITensorLevelEngine
             int b = idx / outChannels;
             int oc = idx % outChannels;
             int g = oc / outCpg;                                   // output group
-            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups; // deformable group
             int icBase = g * inCpg;                                // first input channel of this group
-            int offBlock = dg * 2 * numKernelPositions;            // offset channel base for this deform group
-            int maskBlock = dg * numKernelPositions;
 
             for (int oh = 0; oh < outputHeight; oh++)
             {
@@ -17820,6 +17820,12 @@ public partial class CpuEngine : ITensorLevelEngine
                     for (int ic = 0; ic < inCpg; ic++)
                     {
                         int icGlobal = icBase + ic;
+                        // Deformable group is keyed on the INPUT channel (same as the GPU kernel): each
+                        // deform group owns inChannels/deformGroups contiguous input channels. Reduces to
+                        // the old per-output-group dg whenever deformGroups | groups.
+                        int dg = deformGroups == 1 ? 0 : icGlobal / inChannelsPerDeformGroup;
+                        int offBlock = dg * 2 * numKernelPositions;
+                        int maskBlock = dg * numKernelPositions;
                         for (int kh = 0; kh < kernelHeight; kh++)
                         {
                             for (int kw = 0; kw < kernelWidth; kw++)
@@ -17966,9 +17972,10 @@ public partial class CpuEngine : ITensorLevelEngine
 
     // ---- Grouped DCNv3 backward (#1691). Single-pass FUSED kernels: one parallel region over the full
     // output/deform-group space with inline group indexing — no per-group slicing or G separate launches.
-    // (Replaces the earlier per-group composition; finite-difference + GPU-parity verified. The constraint
-    // deformGroups | groups, enforced by the forward, guarantees groupsPerDg = groups/deformGroups output
-    // groups share each deformable group.) ----
+    // (Replaces the earlier per-group composition; finite-difference + GPU-parity verified. Each deformable
+    // group owns the input-channel span [dg·inChannels/deformGroups, (dg+1)·…), keyed on the input channel
+    // exactly as the GPU kernel — so any (groups, deformGroups) with deformGroups | inChannels works,
+    // including the standard groups=1, deformGroups>1 config, #1789.) ----
 
     /// <summary>Grouped <see cref="DeformableConv2D{T}"/> gradient w.r.t. input (#1691, fused single pass).</summary>
     public virtual Tensor<T> DeformableConv2DGroupedBackwardInput<T>(
@@ -18008,7 +18015,9 @@ public partial class CpuEngine : ITensorLevelEngine
             int icGlobal = idx % inChannels;
             int g = icGlobal / inCpg;
             int icl = icGlobal - g * inCpg;
-            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
+            // Deform group keyed on the input channel (matches the forward + GPU); reduces to the old
+            // per-output-group dg when deformGroups | groups, and additionally supports groups < deformGroups.
+            int dg = deformGroups == 1 ? 0 : icGlobal / (inChannels / deformGroups);
             int ocBase = g * outCpg;
             int offBlock = dg * 2 * numKernelPositions;
             int maskBlock = dg * numKernelPositions;
@@ -18076,10 +18085,7 @@ public partial class CpuEngine : ITensorLevelEngine
             (long)batch * outChannels * outputHeight * outputWidth, oc =>
         {
             int g = oc / outCpg;
-            int dg = deformGroups == 1 ? 0 : g * deformGroups / groups;
             int icBase = g * inCpg;
-            int offBlock = dg * 2 * numKernelPositions;
-            int maskBlock = dg * numKernelPositions;
 
             for (int b = 0; b < batch; b++)
             for (int oh = 0; oh < outputHeight; oh++)
@@ -18090,6 +18096,10 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int icl = 0; icl < inCpg; icl++)
                 {
                     int icGlobal = icBase + icl;
+                    // Deform group keyed on the input channel (matches the forward + GPU).
+                    int dg = deformGroups == 1 ? 0 : icGlobal / (inChannels / deformGroups);
+                    int offBlock = dg * 2 * numKernelPositions;
+                    int maskBlock = dg * numKernelPositions;
                     for (int kh = 0; kh < kernelHeight; kh++)
                     for (int kw = 0; kw < kernelWidth; kw++)
                     {
@@ -18129,7 +18139,7 @@ public partial class CpuEngine : ITensorLevelEngine
         int strideH = stride[0], strideW = stride[1], padH = padding[0], padW = padding[1], dilationH = dilation[0], dilationW = dilation[1];
         int outputHeight = gradOutput._shape[2], outputWidth = gradOutput._shape[3];
         int numKernelPositions = kernelHeight * kernelWidth;
-        int inCpg = inChannels / groups, outCpg = outChannels / groups, groupsPerDg = groups / deformGroups;
+        int inCpg = inChannels / groups, outCpg = outChannels / groups, inChannelsPerDeformGroup = inChannels / deformGroups;
         int offChans = 2 * numKernelPositions * deformGroups, maskChans = numKernelPositions * deformGroups;
 
         var gradOffset = AutoTensorCache.RentOrAllocate<T>(offset._shape);
@@ -18148,7 +18158,7 @@ public partial class CpuEngine : ITensorLevelEngine
             int b = idx / deformGroups;
             int dg = idx % deformGroups;
             int offBlock = dg * 2 * numKernelPositions, maskBlock = dg * numKernelPositions;
-            int gStart = dg * groupsPerDg, gEnd = gStart + groupsPerDg;
+            int icDgStart = dg * inChannelsPerDeformGroup, icDgEnd = icDgStart + inChannelsPerDeformGroup;
 
             for (int oh = 0; oh < outputHeight; oh++)
             for (int ow = 0; ow < outputWidth; ow++)
@@ -18170,23 +18180,22 @@ public partial class CpuEngine : ITensorLevelEngine
                 }
 
                 T gradOffsetY = numOps.Zero, gradOffsetX = numOps.Zero;
-                for (int g = gStart; g < gEnd; g++)
+                for (int icGlobal = icDgStart; icGlobal < icDgEnd; icGlobal++)
                 {
-                    int icBase = g * inCpg, ocBase = g * outCpg;
+                    int g = icGlobal / inCpg;              // conv group owning this input channel
+                    int icl = icGlobal - g * inCpg;
+                    int ocBase = g * outCpg;
+                    int kernelIdx = ((ocBase * inCpg + icl) * kernelHeight + kh) * kernelWidth + kw;
+                    var (dH, dW) = BilinearGradient(inputData, b, icGlobal, inChannels, height, width, sampledH, sampledW, numOps);
                     for (int ocl = 0; ocl < outCpg; ocl++)
                     {
                         int oc = ocBase + ocl;
                         int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
                         T gradOutVal = gradOutputData[gradOutIdx];
-                        for (int icl = 0; icl < inCpg; icl++)
-                        {
-                            int icGlobal = icBase + icl;
-                            int kernelIdx = ((oc * inCpg + icl) * kernelHeight + kh) * kernelWidth + kw;
-                            var (dH, dW) = BilinearGradient(inputData, b, icGlobal, inChannels, height, width, sampledH, sampledW, numOps);
-                            T factor = numOps.Multiply(numOps.Multiply(gradOutVal, kernelData[kernelIdx]), modulation);
-                            gradOffsetY = numOps.Add(gradOffsetY, numOps.Multiply(factor, dH));
-                            gradOffsetX = numOps.Add(gradOffsetX, numOps.Multiply(factor, dW));
-                        }
+                        int kIdx = kernelIdx + ocl * inCpg * kernelHeight * kernelWidth;
+                        T factor = numOps.Multiply(numOps.Multiply(gradOutVal, kernelData[kIdx]), modulation);
+                        gradOffsetY = numOps.Add(gradOffsetY, numOps.Multiply(factor, dH));
+                        gradOffsetX = numOps.Add(gradOffsetX, numOps.Multiply(factor, dW));
                     }
                 }
                 gradOffsetData[offYIdx] = gradOffsetY;
@@ -18209,7 +18218,7 @@ public partial class CpuEngine : ITensorLevelEngine
         int strideH = stride[0], strideW = stride[1], padH = padding[0], padW = padding[1], dilationH = dilation[0], dilationW = dilation[1];
         int outputHeight = gradOutput._shape[2], outputWidth = gradOutput._shape[3];
         int numKernelPositions = kernelHeight * kernelWidth;
-        int inCpg = inChannels / groups, outCpg = outChannels / groups, groupsPerDg = groups / deformGroups;
+        int inCpg = inChannels / groups, outCpg = outChannels / groups, inChannelsPerDeformGroup = inChannels / deformGroups;
         int offChans = 2 * numKernelPositions * deformGroups, maskChans = numKernelPositions * deformGroups;
 
         var gradMask = AutoTensorCache.RentOrAllocate<T>(mask._shape);
@@ -18227,7 +18236,7 @@ public partial class CpuEngine : ITensorLevelEngine
             int b = idx / deformGroups;
             int dg = idx % deformGroups;
             int offBlock = dg * 2 * numKernelPositions, maskBlock = dg * numKernelPositions;
-            int gStart = dg * groupsPerDg, gEnd = gStart + groupsPerDg;
+            int icDgStart = dg * inChannelsPerDeformGroup, icDgEnd = icDgStart + inChannelsPerDeformGroup;
 
             for (int oh = 0; oh < outputHeight; oh++)
             for (int ow = 0; ow < outputWidth; ow++)
@@ -18243,21 +18252,19 @@ public partial class CpuEngine : ITensorLevelEngine
                 double sampledW = ow * strideW - padW + kw * dilationW + offsetX;
 
                 T gradMaskVal = numOps.Zero;
-                for (int g = gStart; g < gEnd; g++)
+                for (int icGlobal = icDgStart; icGlobal < icDgEnd; icGlobal++)
                 {
-                    int icBase = g * inCpg, ocBase = g * outCpg;
+                    int g = icGlobal / inCpg;              // conv group owning this input channel
+                    int icl = icGlobal - g * inCpg;
+                    int ocBase = g * outCpg;
+                    T sampledValue = BilinearSample(inputData, b, icGlobal, inChannels, height, width, sampledH, sampledW, numOps);
                     for (int ocl = 0; ocl < outCpg; ocl++)
                     {
                         int oc = ocBase + ocl;
                         int gradOutIdx = ((b * outChannels + oc) * outputHeight + oh) * outputWidth + ow;
                         T gradOutVal = gradOutputData[gradOutIdx];
-                        for (int icl = 0; icl < inCpg; icl++)
-                        {
-                            int icGlobal = icBase + icl;
-                            int kernelIdx = ((oc * inCpg + icl) * kernelHeight + kh) * kernelWidth + kw;
-                            T sampledValue = BilinearSample(inputData, b, icGlobal, inChannels, height, width, sampledH, sampledW, numOps);
-                            gradMaskVal = numOps.Add(gradMaskVal, numOps.Multiply(numOps.Multiply(gradOutVal, kernelData[kernelIdx]), sampledValue));
-                        }
+                        int kernelIdx = ((oc * inCpg + icl) * kernelHeight + kh) * kernelWidth + kw;
+                        gradMaskVal = numOps.Add(gradMaskVal, numOps.Multiply(numOps.Multiply(gradOutVal, kernelData[kernelIdx]), sampledValue));
                     }
                 }
                 int maskIdx = ((b * maskChans + maskBlock + kp) * outputHeight + oh) * outputWidth + ow;

--- a/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GroupedDeformableConv2DTests.cs
@@ -136,6 +136,52 @@ public class GroupedDeformableConv2DBackwardTests
     }
 
     /// <summary>
+    /// #1789 (BasicVSR++): groups=1 with deformGroups>1 — the standard torchvision DeformConv2d /
+    /// flow-guided deformable alignment (Chan et al. 2022) config. Previously the CPU path rejected it
+    /// (deformGroups must divide groups); now the deform group is keyed on the input channel span
+    /// (inChannels/deformGroups), matching the GPU. Verify forward runs and the grouped backward
+    /// (input/kernel/offset) agrees with finite differences.
+    /// </summary>
+    [Fact]
+    public void Groups1_DeformGroups2_BackwardMatchesFiniteDifference()
+    {
+        var e = new CpuEngine();
+        const int groups = 1, dg = 2, inC = 4, outC = 4, H = 5, W = 5, k = 3, kk = 9, inCpg = 4;
+        int[] s = [1, 1], p = [1, 1], dl = [1, 1];
+        var input = Rand(21, 1.0, 1, inC, H, W);
+        var kernel = Rand(22, 1.0, outC, inCpg, k, k);
+        var offset = Rand(23, 0.6, 1, 2 * kk * dg, H, W);
+        var gradOut = new Tensor<double>([1, outC, H, W], new Vector<double>(System.Linq.Enumerable.Repeat(1.0, outC * H * W).ToArray()));
+
+        // Forward must not throw and must be finite.
+        var fwd = e.DeformableConv2DGrouped(input, kernel, offset, null, s, p, dl, groups, dg);
+        for (int i = 0; i < fwd.Length; i++)
+            Assert.True(!double.IsNaN(fwd[i]) && !double.IsInfinity(fwd[i]), $"forward[{i}] not finite");
+
+        var gI = e.DeformableConv2DGroupedBackwardInput(gradOut, input, kernel, offset, null, [1, inC, H, W], s, p, dl, groups, dg);
+        var gK = e.DeformableConv2DGroupedBackwardKernel(gradOut, input, offset, null, [outC, inCpg, k, k], s, p, dl, groups, dg);
+        var gO = e.DeformableConv2DGroupedBackwardOffset(gradOut, input, kernel, offset, null, s, p, dl, groups, dg);
+
+        const double eps = 1e-5;
+        void Check(Tensor<double> t, Tensor<double> analytic, string name, double tol)
+        {
+            for (int i = 0; i < t.Length; i++)
+            {
+                double orig = t[i];
+                t[i] = orig + eps; double lp = Loss(e, input, kernel, offset, s, p, dl, groups, dg);
+                t[i] = orig - eps; double lm = Loss(e, input, kernel, offset, s, p, dl, groups, dg);
+                t[i] = orig;
+                double num = (lp - lm) / (2 * eps);
+                Assert.True(System.Math.Abs(num - analytic[i]) <= tol + 1e-2 * System.Math.Abs(num),
+                    $"{name}[{i}]: analytic={analytic[i]:F5} numeric={num:F5}");
+            }
+        }
+        Check(input, gI, "gradInput", 1e-3);
+        Check(kernel, gK, "gradKernel", 1e-3);
+        Check(offset, gO, "gradOffset", 5e-3);
+    }
+
+    /// <summary>
     /// The autodiff wiring (#1691): the grouped forward records on the tape and back-props through the
     /// grouped backward kernels. With loss = sum(output), the upstream gradient is all-ones, so the tape
     /// gradients must equal the manual grouped backward called with gradOut = ones (already finite-diff


### PR DESCRIPTION
## Summary
The CPU `DeformableConv2DGrouped` rejected the standard **groups=1, deformGroups=N** configuration — the torchvision `DeformConv2d` / flow-guided deformable-alignment setup used by **BasicVSR++** (Chan et al. 2022) — with `"deformGroups (N) must divide groups (1)"`.

### Root cause
The CPU path keyed the deformable group **per output group** (`dg = g·deformGroups/groups`) and enforced `groups % deformGroups == 0`. But the **GPU kernel keys the deform group per INPUT channel** (`ic/(inChannels/deformGroups)`) — the standard convention. So the CPU per-output-group mapping *silently diverged from the GPU* for `groups < deformGroups`, and that case was rejected rather than fixed.

### Fix
Key the deform group on the **input channel** in the forward and all three grouped backward kernels (input / kernel / offset / mask). Each deform group owns the contiguous input-channel span `[dg·inChannels/deformGroups, …)`. This is:
- **Identical** to the old mapping for every previously-allowed case (`deformGroups | groups` → same `(oc, ic)` coverage), and
- Additionally correct for `groups < deformGroups`, matching the GPU.

The only remaining requirement is `inChannels % deformGroups == 0`.

### Tests
- New `Groups1_DeformGroups2_BackwardMatchesFiniteDifference` — the previously-rejected config: forward is finite + grouped backward (input/kernel/offset) matches central finite differences.
- Existing grouped tests (`deformGroups | groups`) unchanged: **10/10 pass**.

### Downstream
Unblocks BasicVSR++'s deformable-alignment modules (`deformGroups: 8`, `groups: 1`) in ooples/AiDotNet#1789.

Note: the GPU kernel already uses the per-input-channel mapping, so CPU/GPU are now consistent for `groups < deformGroups`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)