### PR TITLE
perf(autotune): eliminate per-GEMM disk touches on the compiled-replay hot path

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BlasManagedAutotune.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BlasManagedAutotune.cs
@@ -162,9 +162,15 @@ internal static class BlasManagedAutotune
     /// </summary>
     public static (ParallelismAxis Axis, int Mc, int Nc, int Kc, int ThreadCount)? TryLookup(ShapeProfile shape)
     {
+        if (_blockMemo.TryGetValue(shape, out var memo))
+            return memo;
+
         KernelChoice? choice = AutotuneCache.Lookup(GemmKernelId, shape);
-        if (choice is null) return null;
-        return DecodeChoice(choice);
+        (ParallelismAxis Axis, int Mc, int Nc, int Kc, int ThreadCount)? result =
+            choice is null ? null : DecodeChoice(choice);
+        if (_blockMemo.Count >= StrategyMemoCap) _blockMemo.Clear(); // bound memory (same cap as strategy memo)
+        _blockMemo[shape] = result;  // memoize hit or miss (null)
+        return result;
     }
 
     /// <summary>
@@ -174,6 +180,9 @@ internal static class BlasManagedAutotune
     {
         var choice = EncodeChoice(axis, mc, nc, kc, threadCount, measuredTimeMs);
         AutotuneCache.Store(GemmKernelId, shape, choice);
+        // Refresh the in-memory memo so the freshly-stored block choice is served immediately
+        // on the next TryLookup/Decide without touching disk.
+        _blockMemo[shape] = (axis, mc, nc, kc, threadCount);
     }
 
     /// <summary>
@@ -193,6 +202,13 @@ internal static class BlasManagedAutotune
     // strategy is picked up immediately on the next call.
     private static readonly ConcurrentDictionary<ShapeProfile, StrategyChoice?> _strategyMemo = new();
 
+    // Same #375-G13 rationale as _strategyMemo, but for the block-size TryLookup that Decide()
+    // calls on every GEMM: it went straight to AutotuneCache.Lookup (a filesystem stat per call
+    // even after the read+parse was memoized), which measured ~14% of a compiled Transformer's
+    // replay hot path. Memoize the decoded block-size decision per shape (a null value is a
+    // remembered miss); Store refreshes it so a freshly-tuned block choice is served immediately.
+    private static readonly ConcurrentDictionary<ShapeProfile, (ParallelismAxis Axis, int Mc, int Nc, int Kc, int ThreadCount)?> _blockMemo = new();
+
     /// <summary>
     /// Cap on the in-memory strategy memo (#375 G4 consistency). Real workloads have a
     /// bounded set of distinct GEMM shapes (dozens–hundreds); this only trips on an
@@ -207,7 +223,11 @@ internal static class BlasManagedAutotune
     /// untouched. Used by <c>BlasManaged.ClearCaches</c> and by diagnostics that need to
     /// observe genuine cold-miss behavior rather than warm-memo hits.
     /// </summary>
-    public static void ClearStrategyMemo() => _strategyMemo.Clear();
+    public static void ClearStrategyMemo()
+    {
+        _strategyMemo.Clear();
+        _blockMemo.Clear();
+    }
 
     public static void StoreStrategy(ShapeProfile shape, PackingMode mode, ParallelismAxis axis,
         int mc, int nc, int kc, int threadCount, string kernelVersion)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -232,6 +232,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         {
             var step = steps[i];
             bool allowCachedB = !IsMutableSecondMatMulInput(step, compiledInputTensor);
+            MaybeRegisterFrozenMatMulWeight(step, allowCachedB);
             var spec = CompiledTrainingPlan<T>.TryBuildSpecializedForward(step, pinnedHandles, allowCachedB);
             if (spec != null)
             {
@@ -1339,6 +1340,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             }
 
             bool allowCachedB = !IsMutableSecondMatMulInput(step, inputTensor);
+            MaybeRegisterFrozenMatMulWeight(step, allowCachedB);
             var specialized = CompiledTrainingPlan<T>.TryBuildSpecializedForward(step, pinnedHandles, allowCachedB);
             if (specialized != null)
             {
@@ -1515,6 +1517,28 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             && step.OpType == OpType.TensorMatMul
             && step.Inputs.Length >= 2
             && ReferenceEquals(step.Inputs[1], mutableInput);
+    }
+
+    /// <summary>
+    /// When a compiled matmul's second operand B is a frozen constant weight (not the mutable
+    /// input, i.e. <paramref name="allowCachedB"/> is true), register it in the process-wide
+    /// <see cref="AiDotNet.Tensors.Engines.BlasManaged.FrozenWeightRegistry"/> so the eager
+    /// TensorMatMul path adopts a pre-packed B (via WeightPackCache) instead of re-packing the
+    /// weight on every Execute. Nothing populated that registry before, so TryGetHandle always
+    /// missed and compiled-replay re-packed B per call (~14% of the compiled hot path). Only rank-2
+    /// float/double weights are packable; anything else (or a failure) simply falls back to the
+    /// existing re-pack. B's tensor identity is stable across Execute() calls for a frozen weight,
+    /// which is exactly what the identity-keyed registry needs.
+    /// </summary>
+    private static void MaybeRegisterFrozenMatMulWeight(CompiledStep<T> step, bool allowCachedB)
+    {
+        if (!allowCachedB || step.OpType != OpType.TensorMatMul || step.Inputs.Length < 2) return;
+        var b = step.Inputs[1];
+        if (b is { Rank: 2 } && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
+        {
+            try { AiDotNet.Tensors.Engines.BlasManaged.FrozenWeightRegistry.Register(b); }
+            catch { /* best effort: unregistered B just re-packs, same as before */ }
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
@@ -52,6 +52,18 @@ public static class AutotuneCache
 
     private static readonly object _lock = new();
 
+    // Process-wide in-memory memo of the (resolved-path -> parsed choice) lookup result, keyed by
+    // path and VALIDATED against the file's last-write time. Re-reading + JSON-parsing the autotune
+    // JSON from disk on every GEMM call was pure per-call overhead — File.ReadAllText +
+    // JsonSerializer.Deserialize dominated the compiled-replay hot path (measured ~33% of runtime).
+    // A cache hit now costs a single FileInfo stat (the same File.Exists stat the old code already
+    // did) instead of a full read+parse. Validating against LastWriteTimeUtc keeps the memo honest
+    // when the file changes out-of-band (Store rewrites it, ClearCurrentHardware deletes it, or a
+    // sibling process updates it), so correctness matches a fresh disk read while the hot path skips
+    // the read+parse. Concurrent-safe; a first-access race just repeats the idempotent disk read.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (DateTime WriteUtc, KernelChoice? Choice)> _memo
+        = new(System.StringComparer.Ordinal);
+
     /// <summary>
     /// Default cache root. Resolves to <c>~/.aidotnet/autotune/</c> unless the
     /// <c>AIDOTNET_AUTOTUNE_CACHE_PATH</c> environment variable is set (in which
@@ -86,9 +98,36 @@ public static class AutotuneCache
     /// </summary>
     public static KernelChoice? Lookup(KernelId kernelId, ShapeProfile shape)
     {
+        // Stat-validated memo (see _memo): one FileInfo stat replaces the per-call read+parse on a
+        // cache hit, while re-reading whenever the on-disk file changes (or disappears).
+        string path = ResolvePath(kernelId, shape);
         try
         {
-            string path = ResolvePath(kernelId, shape);
+            var fi = new FileInfo(path);
+            if (!fi.Exists)
+            {
+                _memo.TryRemove(path, out _);
+                return null;
+            }
+            DateTime writeUtc = fi.LastWriteTimeUtc;   // reuses the stat FileInfo.Exists already did
+            if (_memo.TryGetValue(path, out var e) && e.WriteUtc == writeUtc)
+                return e.Choice;                        // hit: skip the read + JSON parse
+
+            KernelChoice? result = LookupFromDisk(path);
+            _memo[path] = (writeUtc, result);
+            return result;
+        }
+        catch
+        {
+            // Stat failure (permissions, race) — fall back to a direct disk read, don't memoize.
+            return LookupFromDisk(path);
+        }
+    }
+
+    private static KernelChoice? LookupFromDisk(string path)
+    {
+        try
+        {
             if (!File.Exists(path)) return null;
 
             string json = File.ReadAllText(path);
@@ -254,6 +293,8 @@ public static class AutotuneCache
             try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { /* best effort */ }
             throw;
         }
+        // No explicit memo update needed: the write bumps the file's last-write time, and Lookup's
+        // stat-validation (see _memo) re-reads whenever the on-disk timestamp changes.
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -391,6 +391,11 @@ class Program
             PyTorchComparison.GapInvestigationBench.SelectStrategyHotPath();
             return;
         }
+        if (args[0] == "--decide-hotpath")
+        {
+            PyTorchComparison.GapInvestigationBench.DecideHotPath();
+            return;
+        }
         if (args[0] == "--hybrid-win")
         {
             PyTorchComparison.GapInvestigationBench.HybridWin();

--- a/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/GapInvestigationBench.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/PyTorchComparison/GapInvestigationBench.cs
@@ -187,6 +187,33 @@ internal static class GapInvestigationBench
     }
 
     /// <summary>
+    /// Isolated latency of <see cref="AutotuneDispatcher.Decide{T}"/> on a WARM (cached)
+    /// shape — the block-size autotune path every GEMM hits. Before the #3 in-memory block memo,
+    /// each warm call still paid a FileInfo stat inside AutotuneCache.Lookup (~14% of a compiled
+    /// Transformer replay); with the memo it is a pure dictionary hit. Sibling of
+    /// <see cref="SelectStrategyHotPath"/> for the strategy path.
+    /// </summary>
+    public static void DecideHotPath()
+    {
+        Console.WriteLine("=== AutotuneDispatcher.Decide hot-path latency (#3 block memo) ===");
+        const int M = 197, N = 197, K = 64, mr = 8, nr = 16, procs = 16;
+        // Seed the cache so every timed call is a warm HIT (the path the memo governs).
+        var shape = BlasManagedAutotune.EncodeShape<double>(M, N, K, false, false, mr, nr, false);
+        BlasManagedAutotune.Store(shape, ParallelismAxis.M, mc: 128, nc: 512, kc: 512, threadCount: 8, measuredTimeMs: 1.0);
+
+        for (int w = 0; w < 1000; w++)
+            AutotuneDispatcher.Decide<double>(M, N, K, false, false, mr, nr, procs, false, false, PackingMode.Auto);
+        const int iters = 200_000;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < iters; i++)
+            AutotuneDispatcher.Decide<double>(M, N, K, false, false, mr, nr, procs, false, false, PackingMode.Auto);
+        sw.Stop();
+        double nsPerCall = sw.Elapsed.TotalMilliseconds * 1e6 / iters;
+        Console.WriteLine($"  Decide (warm hit): {nsPerCall:F0} ns/call over {iters} iters");
+        Console.WriteLine($"  → memo hit is tens of ns; a per-call FileInfo stat shows as hundreds of ns.");
+    }
+
+    /// <summary>
     /// #375: demonstrate the hybrid win. Over a set of TRANSPOSED shapes (the ones the hybrid
     /// governs) spanning regimes where different strategies win, compare three policies on
     /// aggregate wall-clock: always-Streaming, always-PackBoth, and hybrid Auto (per-shape


### PR DESCRIPTION
## Summary

Three related optimizations that remove filesystem work from the per-GEMM autotune dispatch path, which dominated compiled-inference replay. Motivated by a **Serial Perf** regression: the compiled Transformer replay was ~2.82 ms/step; the fixes here bring it to ~1.50 ms/step and remove the residual per-call disk stat.

### 1. `perf(autotune): stat-validated in-memory memo for AutotuneCache.Lookup`
`AutotuneCache.Lookup` did `File.ReadAllText` + JSON parse **per call** (~33% of compiled runtime). Added a `LastWriteTimeUtc`-validated in-memory memo: a warm lookup is now a cheap `FileInfo` stat + dictionary hit; the read+parse happens at most once per file version. Out-of-band disk changes are still detected (the stat validates the memo), so all 73 `AutotuneCache` tests pass unchanged.

### 2. `perf(compile): register frozen matmul weights so compiled replay reuses pre-packed B`
`CompiledInferencePlan` now registers a matmul's constant second operand `B` in `FrozenWeightRegistry` when it is a rank-2 float/double weight (not the mutable input). Nothing populated that registry before, so the eager `TensorMatMul` path always missed `WeightPackCache` and re-packed `B` every `Execute`. A frozen weight's tensor identity is stable across calls — exactly what the identity-keyed registry needs. Best-effort (falls back to the existing re-pack on any failure).

### 3. `perf(autotune): in-memory memo for the block-size Decide lookup (~71× warm path)`
`AutotuneDispatcher.Decide` calls `BlasManagedAutotune.TryLookup` on **every** GEMM; it went straight to `AutotuneCache.Lookup` — a `FileInfo` stat per call even after #1 memoized the read. Mirrors the existing `#375-G13 _strategyMemo` pattern with a `_blockMemo` over the block-size decision (a null entry is a remembered miss). `Store` refreshes it so a freshly-tuned choice is served immediately; `ClearStrategyMemo` clears both.

## Verification

- New `--decide-hotpath` A/B microbench (`GapInvestigationBench`), sibling of `--selectstrategy-hotpath`. Warm `Decide` latency:

  | State | ns/call (median of 5, tight variance) |
  |---|---|
  | Before #3 (via `AutotuneCache.Lookup`) | ~20,700 |
  | After #3 (`_blockMemo` dict hit) | ~290 |

  (~71× — larger than the ~14% profiled share because the dev box's `~/.aidotnet` cache is under a OneDrive-synced profile where even a `FileInfo` stat is pathologically slow. Eliminating the disk touch entirely is the correct fix regardless of stat cost.)
- All 285 `Autotune` + `ScalarKernel` tests pass on net10.0 (284 on net471), unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)