### PR TITLE
fix(gpu): LayerNorm forward returns TRUE variance so compiled-replay backward is correct

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12221,6 +12221,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             float[] meanFloat = backend.DownloadBuffer(saveMeanBuffer.Buffer);
             float[] varFloat = backend.DownloadBuffer(saveVarBuffer.Buffer);
 
+            // VARIANCE-SEMANTICS FIX: the CUDA layernorm_forward kernel writes INVERSE-STD
+            // (saveInvVar = rsqrtf(var/N + eps)) into the save-variance buffer, but this method's contract —
+            // matching CpuEngine.LayerNorm, which the tape/GraphMode path falls back to — is that the
+            // `variance` out-param is the TRUE variance. Both LayerNormBackward consumers re-derive
+            // invVar = 1/sqrt(variance+eps) from this out-param (the host path via 1f/MathF.Sqrt(varF+eps);
+            // the resident GPU path via AddScalar+Sqrt+Reciprocal). Handed the kernel's invVar instead of
+            // true variance they double-invert → systematically WRONG gradGamma/gradInput on the
+            // compiled-replay path (this GPU forward runs there, no tape). Convert invVar → true variance
+            // here so BOTH the forward's out-param semantics AND the backward's re-derivation are correct:
+            // invVar = 1/sqrt(V+eps) ⇒ V = 1/invVar² − eps.
+            for (int i = 0; i < varFloat.Length; i++)
+            {
+                float iv = varFloat[i];
+                varFloat[i] = iv > 0f ? 1f / (iv * iv) - (float)epsilon : 0f;
+            }
+
             mean = new Tensor<T>(DirectGpuEngine.FromFloatArray<T>(meanFloat), batchShape);
             variance = new Tensor<T>(DirectGpuEngine.FromFloatArray<T>(varFloat), batchShape);
             return new Tensor<T>(DirectGpuEngine.FromFloatArray<T>(outputFloat), input.Shape.ToArray());


### PR DESCRIPTION
## Summary

This PR lands the **one genuinely-missing** correctness fix from an internal "BUG-2 chain" of 4 compiled-GPU-training fixes. On careful verification against current `main` (@ 0.114.3), **3 of the 4 are already in `main`** (merged separately, including via #764) — so only the LayerNorm variance-semantics fix is applied here, as a clean minimal diff.

## The included fix — LayerNorm forward variance semantics

**Before:** The CUDA `layernorm_forward` kernel writes **inverse-std** into its save buffer:

```
// CudaNormalizationKernels.cs, layernorm_forward
float invVar = rsqrtf(smem[0] / (float)normalizedSize + epsilon);
...
saveInvVar[b] = invVar;   // <-- inverse-std, NOT variance
```

`IEngine.LayerNorm` (the GPU eager forward) downloaded that buffer and returned it **verbatim** as its `variance` out-param. But the out-param contract — matching `CpuEngine.LayerNorm`, which the tape/GraphMode path falls back to — is the **TRUE variance**. Both `LayerNormBackward` consumers re-derive `invVar = 1/sqrt(variance+eps)` from that out-param:
- managed host path: `invVarF[i] = 1f / MathF.Sqrt(varF[i] + eps)`
- resident GPU path: `AddScalar(var,+eps) → Sqrt → Reciprocal`

Handed the kernel's `invVar` instead of true variance, both **double-invert** → systematically wrong `gradGamma`/`gradInput` on the compiled-replay path (this GPU forward runs there, no tape). LayerNorm is in every transformer layer, so the backward signal is corrupted at every layer.

**After:** Convert `invVar → true variance` (`V = 1/invVar² − eps`) immediately after the download, so BOTH the forward's out-param semantics AND the backward's re-derivation are correct. The normalized forward output is unchanged (only the returned `variance` value changes).

```csharp
for (int i = 0; i < varFloat.Length; i++)
{
    float iv = varFloat[i];
    varFloat[i] = iv > 0f ? 1f / (iv * iv) - (float)epsilon : 0f;
}
```

## The other 3 fixes — ALREADY IN MAIN, intentionally NOT reintroduced

| Fix | Status | Evidence in current `main` |
|-----|--------|-----|
| **Capture zero-grad self-heal** | Superseded / not needed | The capture-**failure** stale-resident-grad poisoning is neutralized by the grad-version authority gate in `ConfigureOptimizerFloat`: the fused optimizer trusts a resident grad buffer only when `gradStreamCapturing \|\| _gradT._gpuBufferVersion == _gradT.Version`. After a failed capture the eager fallback bumps `Version` without bumping `_gpuBufferVersion`, so the stale buffer is rejected and the host grad is used. The separate zero-grad-on-**successful**-capture self-heal targets a pathological embedding-first-capture scenario that could not be reproduced/validated headless, so it is deliberately excluded from this minimal correctness PR rather than shipped unverified. |
| **Grad-clip GPU no-op** | Already in `main` | `main` has a real GPU-native global-L2 clip `TryClipGradientsGlobalL2Gpu` (device sum-of-squares → scale in place), invoked on the compiled path before the optimizer, plus a hard `NotSupportedException` guard in the CPU `ClipGradientsGlobalL2` that replaces the old silent no-op. |
| **Weight host↔device coherence** | Already in `main` (**#764**) | `main` re-arms coherence via `BindResidentBuffer(...)` after the fused on-device optimizer update (in `ConfigureOptimizerFloat`), alongside the `_gpuBufferVersion = Version` sync. The internal branch's `RearmResidentParamHostAfterDeviceUpdate` is a superseded alternative and is **not** reintroduced. |

## Tests (RTX 3080, net10.0, Release)

- **51/51** LayerNorm tests pass (incl. GPU vs CPU forward + saved mean/inv-var parity)
- **120/120** `GpuCpuAutoDifferentialTests` (GPU vs CPU backward parity) pass
- **6/6** `CompiledReplayRecomputeParityTests` (incl. `LayerNorm_CompiledReplay_ReflectsLiveInput`) pass
- `NormConvAccuracyTests` pass (343 total across the combined GPU run, 0 failed)
- Build: `net471` + `net8.0` + `net10.0`, 0 warnings / 0 errors

Note: a post-run CUDA finalizer-teardown crash in `CudaBackend.DrainPendingFinalizerFrees()` aborts the *test host after* results are tallied. It is pre-existing and unrelated to this change (a value conversion in a host-download path cannot reach a GC finalizer-free path); **no test failed** in any run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GPU layer normalization variance calculations.
  * Improved accuracy for forward and backward operations in compiled replay workflows.
  * Added safeguards for non-positive variance-related values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->