### PR TITLE
Fix set-slice autodiff and tensor assembly

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2533,12 +2533,33 @@ internal static class BackwardFunctions<T>
         var numOps = MathHelper.GetNumericOperations<T>();
 
         // Create a zero gradient with original input shape, then copy chunk into correct position
-        var grad = TensorPool<T>.RentZeroed(originalShape);
-        engine.TensorFill(grad, numOps.Zero);
+        var zeroGradient = TensorPool<T>.RentZeroed(originalShape);
+        engine.TensorFill(zeroGradient, numOps.Zero);
         var startArr = new int[originalShape.Length];
         startArr[axis] = start;
-        engine.TensorSetSlice(grad, gradOutput, startArr);
+        var grad = engine.TensorSetSlice(zeroGradient, gradOutput, startArr);
+        TensorPool<T>.Return(zeroGradient);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
+    }
+
+    /// <summary>
+    /// Set-slice backward: the source receives the overwritten output region,
+    /// while the destination receives every gradient outside that region.
+    /// </summary>
+    internal static void SetSliceBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int[] start = (int[])savedState[0];
+        var sourceShape = inputs[1]._shape;
+
+        var gradSource = engine.TensorSlice(gradOutput, start, sourceShape);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradSource, engine);
+
+        var zeroSlice = TensorPool<T>.RentZeroed(sourceShape);
+        var gradDestination = engine.TensorSetSlice(gradOutput, zeroSlice, start);
+        TensorPool<T>.Return(zeroSlice);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradDestination, engine);
     }
 
     /// <summary>AvgPool1D backward</summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — internal call sites pending migration to BlasManaged.Gemm<T> in later K tasks.
+#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — internal call sites pending migration to BlasManaged.Gemm<T> in later K tasks.
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -33332,6 +33332,30 @@ public partial class CpuEngine : ITensorLevelEngine
                 throw new ArgumentOutOfRangeException(nameof(start), $"Slice starting at {start[i]} with size {source._shape[i]} exceeds destination axis {i} size {destination._shape[i]}");
         }
 
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope is not null)
+            {
+                var capturedDestination = destination;
+                var capturedSource = source;
+                var capturedStart = (int[])start.Clone();
+                return scope.RecordBinary(
+                    LazyNodeType.Custom,
+                    "TensorSetSlice",
+                    destination,
+                    source,
+                    destination._shape,
+                    (eng, output) =>
+                    {
+                        var result = eng.TensorSetSlice(capturedDestination, capturedSource, capturedStart);
+                        DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                    },
+                    BackwardFunctions<T>.SetSliceBackward,
+                    new object[] { capturedStart });
+            }
+        }
+
         // Create a copy of destination to avoid modifying the original
         var result = AutoTensorCache.RentOrAllocate<T>(destination._shape);
         var destData = destination.GetDataArray();
@@ -33359,6 +33383,18 @@ public partial class CpuEngine : ITensorLevelEngine
             resultData[destFlat] = sourceData[flatIdx];
         });
 
+        var savedStart = (int[])start.Clone();
+        DifferentiableOps.RecordBinary(
+            "TensorSetSlice",
+            result,
+            destination,
+            source,
+            BackwardFunctions<T>.SetSliceBackward,
+            new object[] { savedStart });
+        AutoTracer.RecordOp(
+            "TensorSetSlice",
+            result,
+            eng => eng.TensorSetSlice(destination, source, savedStart));
         return result;
     }
 
@@ -35328,9 +35364,52 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
-        // Fast path for axis=0 contiguous tensors: direct Array.Copy (any rank)
+        // Fast path for contiguous tensors concatenated on the last axis.
+        // Each leading-index row is a contiguous block, so copy one block per
+        // input instead of Tensor<T>.Concatenate's element-wise recursive walk.
         Tensor<T> result;
-        if (axis == 0 && tensors.All(t => t.IsContiguous))
+        int concatRank = tensors[0].Rank;
+        int normalizedAxis = axis < 0 ? concatRank + axis : axis;
+        if (normalizedAxis == concatRank - 1 && tensors.All(t => t.IsContiguous))
+        {
+            var outShape = (int[])tensors[0]._shape.Clone();
+            int outerRows = 1;
+            for (int d = 0; d < concatRank - 1; d++)
+                outerRows *= outShape[d];
+
+            int outputWidth = 0;
+            for (int i = 0; i < tensors.Length; i++)
+            {
+                var shape = tensors[i]._shape;
+                if (shape.Length != concatRank)
+                    throw new ArgumentException("All tensors must have the same rank.", nameof(tensors));
+                for (int d = 0; d < concatRank - 1; d++)
+                {
+                    if (shape[d] != outShape[d])
+                        throw new ArgumentException(
+                            "All tensors must have the same shape except along the concatenation axis.",
+                            nameof(tensors));
+                }
+                outputWidth += shape[concatRank - 1];
+            }
+            outShape[concatRank - 1] = outputWidth;
+
+            result = AutoTensorCache.RentOrAllocate<T>(outShape);
+            var destination = result.AsWritableSpan();
+            for (int row = 0; row < outerRows; row++)
+            {
+                int destinationOffset = row * outputWidth;
+                for (int i = 0; i < tensors.Length; i++)
+                {
+                    int width = tensors[i]._shape[concatRank - 1];
+                    tensors[i].AsSpan().Slice(row * width, width)
+                        .CopyTo(destination.Slice(destinationOffset, width));
+                    destinationOffset += width;
+                }
+            }
+        }
+        // Fast path for axis=0 contiguous tensors: direct Array.Copy (any rank)
+        else if (axis == 0 && tensors.All(t => t.IsContiguous))
         {
             // Compute output shape first
             var outShape = (int[])tensors[0]._shape.Clone();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledSetSliceTrainingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledSetSliceTrainingTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Regression coverage for neighborhood-assembly graphs used by mesh models.
+/// </summary>
+[Collection("CompiledTrainingPlanSerial")]
+public class CompiledSetSliceTrainingTests
+{
+    [Fact]
+    public void TensorConcatenate_ContiguousLastAxis_CopiesRowBlocksInOrder()
+    {
+        var engine = new CpuEngine();
+        var left = Tensor(new[] { 2, 2 }, 1f, 2f, 3f, 4f);
+        var middle = Tensor(new[] { 2, 1 }, 5f, 6f);
+        var right = Tensor(new[] { 2, 2 }, 7f, 8f, 9f, 10f);
+
+        var result = engine.TensorConcatenate(new[] { left, middle, right }, axis: 1);
+
+        Assert.Equal(new[] { 2, 5 }, result.Shape.ToArray());
+        Assert.Equal(
+            new[] { 1f, 2f, 5f, 7f, 8f, 3f, 4f, 6f, 9f, 10f },
+            result.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void TensorSplit_EagerBackward_RestoresChunkGradientAtOriginalOffset()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor(
+            new[] { 2, 4 },
+            1f, 2f, 3f, 4f,
+            5f, 6f, 7f, 8f);
+
+        using var tape = new GradientTape<float>();
+        var chunks = engine.TensorSplit(input, numSplits: 2, axis: 1);
+        var loss = engine.ReduceSum(chunks[1], null);
+        var gradient = tape.ComputeGradients(loss, new[] { input })[input];
+
+        Assert.Equal(
+            new[] { 0f, 0f, 1f, 1f, 0f, 0f, 1f, 1f },
+            gradient.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void TensorSetSlice_EagerBackward_ChainedOverwritesRouteExactGradients()
+    {
+        var engine = new CpuEngine();
+        var destination = Tensor(
+            new[] { 2, 4 },
+            1f, 2f, 3f, 4f,
+            5f, 6f, 7f, 8f);
+        var sourceA = Tensor(new[] { 2, 1 }, 9f, 10f);
+        var sourceB = Tensor(new[] { 2, 2 }, 11f, 12f, 13f, 14f);
+
+        using var tape = new GradientTape<float>();
+        var withA = engine.TensorSetSlice(destination, sourceA, new[] { 0, 0 });
+        var withB = engine.TensorSetSlice(withA, sourceB, new[] { 0, 2 });
+        var loss = engine.ReduceSum(withB, null);
+        var gradients = tape.ComputeGradients(loss, new[] { destination, sourceA, sourceB });
+
+        Assert.Equal(
+            new[] { 0f, 1f, 0f, 0f, 0f, 1f, 0f, 0f },
+            gradients[destination].AsSpan().ToArray());
+        Assert.Equal(new[] { 1f, 1f }, gradients[sourceA].AsSpan().ToArray());
+        Assert.Equal(new[] { 1f, 1f, 1f, 1f }, gradients[sourceB].AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void TensorSetSlice_CompiledBackward_ConnectsOverwrittenSourceToLoss()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor(new[] { 2, 2 }, 0.2f, -0.4f, 0.7f, 0.3f);
+        var upstreamWeight = Tensor(new[] { 2, 2 }, 0.5f, -0.2f, 0.1f, 0.8f);
+        var readoutWeight = Tensor(new[] { 4, 1 }, 0.4f, -0.6f, 0.9f, 0.2f);
+        var destination = new Tensor<float>(new[] { 2, 4 });
+
+        using ICompiledTrainingPlan<float> plan = Compile(
+            engine,
+            new[] { upstreamWeight, readoutWeight },
+            () =>
+            {
+                var source = engine.TensorMatMul(input, upstreamWeight);
+                var assembled = engine.TensorSetSlice(destination, source, new[] { 0, 1 });
+                var output = engine.TensorMatMul(assembled, readoutWeight);
+                return engine.ReduceSum(engine.TensorMultiply(output, output), null);
+            });
+
+        plan.Step();
+
+        var upstreamGradient = plan.Gradients[0].AsSpan().ToArray();
+        Assert.All(upstreamGradient, value => Assert.True(IsFinite(value)));
+        Assert.Contains(upstreamGradient, value => MathF.Abs(value) > 1e-6f);
+    }
+
+    [Fact]
+    public void AdamStep_DisconnectedParameter_RemainsFiniteAndUnchanged()
+    {
+        var engine = new CpuEngine();
+        var input = Tensor(new[] { 2, 2 }, 0.2f, -0.4f, 0.7f, 0.3f);
+        var connectedWeight = Tensor(new[] { 2, 1 }, 0.5f, -0.2f);
+        var disconnectedWeight = Tensor(new[] { 2, 2 }, 0.1f, 0.2f, 0.3f, 0.4f);
+        var before = disconnectedWeight.AsSpan().ToArray();
+
+        using ICompiledTrainingPlan<float> plan = Compile(
+            engine,
+            new[] { connectedWeight, disconnectedWeight },
+            () =>
+            {
+                var output = engine.TensorMatMul(input, connectedWeight);
+                return engine.ReduceSum(engine.TensorMultiply(output, output), null);
+            });
+
+        plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+        plan.Step();
+
+        var after = disconnectedWeight.AsSpan().ToArray();
+        Assert.All(after, value => Assert.True(IsFinite(value)));
+        Assert.Equal(before, after);
+    }
+
+    private static ICompiledTrainingPlan<float> Compile(
+        CpuEngine engine,
+        Tensor<float>[] parameters,
+        Func<Tensor<float>> forward)
+    {
+        using var scope = GraphMode.Enable();
+        _ = forward();
+        return scope.CompileTraining(parameters);
+    }
+
+    private static Tensor<float> Tensor(int[] shape, params float[] values)
+        => new(values, shape);
+
+    private static bool IsFinite(float value)
+        => !float.IsNaN(value) && !float.IsInfinity(value);
+}


### PR DESCRIPTION
## What changed

- record `TensorSetSlice` in eager autodiff, AutoTracer, and GraphMode compiled graphs
- add the exact set-slice backward rule for both the overwritten source and surviving destination regions
- fix `TensorSplit` backward to retain the out-of-place set-slice result
- add a contiguous last-axis concatenate fast path for row-block tensor assembly
- cover eager and compiled gradients, split offsets, concatenate ordering, and disconnected optimizer parameters

## Root cause

`CpuEngine.TensorSetSlice` returned a new tensor but did not record an autodiff or compiled-graph operation. Models that assembled layer inputs with set-slice therefore severed parameter-to-loss connectivity. `SplitBackward` also called this out-of-place operation without retaining its return value, producing zero split gradients.

The replacement concatenate path was correct but used the generic recursive element walker for last-axis assembly. Copying contiguous row blocks avoids that overhead for neighborhood feature assembly.

## Impact

Compiled mesh and spiral training retain nonzero gradients through assembled neighborhood features. Eager split gradients are restored at the correct offsets, and contiguous last-axis concatenation is materially cheaper without changing tensor values.

## Validation

- full `AiDotNet.Tensors.slnx` Release build: passed across core, native wrappers, CLI, tests, license tooling, and benchmarks
- focused regression suite: 5/5 passed on `net10.0`; 5/5 passed on `net471`
- existing concatenate and math invariant suites: 213/213 passed on `net10.0`; 213/213 passed on `net471`
- downstream AiDotNet SpiralNet gradient and convergence tests: passed
- downstream AiDotNet MeshCNN gradient, convergence, and full 50-vs-200 iteration data-scaling tests: passed
