### PR TITLE
fix(autodiff): manual backward tape nodes propagate input gradients through the graph path

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -304,6 +304,33 @@ public sealed class GradientTape<T> : IDisposable
         }
 
         _entries.Add(entry);
+
+        // Graph-path visibility for MANUAL backward nodes. This public Record(entry) API is the
+        // manual-backward entry point (e.g. the neural-network layer library's
+        // RegisterManualBackwardNode, used for Conv im2col → col2im input-gradient wiring). Engine
+        // ops record via RecordSlot and additionally set output.GradFn so the graph-based backward
+        // fast path (ComputeGradientsViaGraph) — which traverses per-tensor GradFn links and does NOT
+        // walk the tape entry list — can reach them. A manual node that only appended a tape entry set
+        // NO GradFn, so the fast path treated its output as a leaf and silently DROPPED the node's
+        // input gradient (every Conv3D layer but the last was frozen during training). Mirror the
+        // RecordUnary GradFn wiring here so manual nodes are seen by BOTH backward paths. Only wire
+        // when the output has no GradFn yet (a fresh materialized tensor, e.g. im2col output) and the
+        // node actually has a backward to run.
+        var manualOutput = entry.Output;
+        if (manualOutput is not null && entry.Backward is not null && manualOutput.GradFn is null)
+        {
+            var node = GradNodePool<T>.Rent();
+            node.OwningTape = this;
+            node.Backward = entry.Backward;
+            node.Output = manualOutput;
+            node.Input0 = entry.Input0;
+            node.Input1 = entry.Input1;
+            node.Input2 = entry.Input2;
+            node.InputCount = entry.InputCount;
+            node.InputsOverflow = entry.InputsOverflow;
+            node.SavedState = entry.SavedState;
+            manualOutput.GradFn = node;
+        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ManualBackwardNodeGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ManualBackwardNodeGradientTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Regression tests for manual-backward tape nodes (the mechanism the neural-network layer library
+/// uses via <c>LayerBase.RegisterManualBackwardNode</c>). A manual node records a custom
+/// <see cref="BackwardFunction{T}"/> that converts the gradient of a freshly-materialized output
+/// tensor (e.g. Conv im2col) back into the gradient of a differentiable input (e.g. col2im). The
+/// node's input gradient MUST propagate to upstream ops on the tape — the Conv3D im2col training
+/// path relied on this and it was silently dropped, freezing every conv layer but the last.
+/// </summary>
+public class ManualBackwardNodeGradientTests
+{
+    private readonly CpuEngine _engine = new();
+
+    // Mimics Conv3DLayer.ForwardIm2Col exactly:
+    //   input --(manual node: identity backward, like col2im)--> m --MatMul(w)--> y --sum--> loss
+    // The manual node is recorded the way RegisterManualBackwardNode records it (InputCount = 0xFF +
+    // InputsOverflow). Its input gradient must reach `input`.
+    [Fact]
+    public void ManualBackwardNode_InputGradient_PropagatesThroughDownstreamMatMul()
+    {
+        var input = new Tensor<double>(new[] { 2, 3 },
+            new Vector<double>(new double[] { 1, 2, 3, 4, 5, 6 }));
+        var w = new Tensor<double>(new[] { 3, 2 },
+            new Vector<double>(new double[] { 1, 0, 0, 1, 1, 1 }));
+
+        using var tape = new GradientTape<double>();
+
+        // "im2col": a fresh output tensor filled from input by a non-tape scalar copy.
+        var m = new Tensor<double>(new[] { 2, 3 });
+        var inSpan = input.Data.Span;
+        var mSpan = m.Data.Span;
+        for (int i = 0; i < mSpan.Length; i++) mSpan[i] = inSpan[i];
+
+        // Manual backward node: Output = m, differentiable input = input, backward = identity
+        // (grad_input = grad_output) — the simplest col2im. Recorded EXACTLY like
+        // LayerBase.RegisterManualBackwardNode (InputCount = 0xFF + InputsOverflow + Input0 slots).
+        var differentiableInputs = new[] { input };
+        var entry = new TapeEntry<double>
+        {
+            OperationName = "TestManualBackward",
+            Output = m,
+            InputCount = 0xFF,
+            InputsOverflow = differentiableInputs,
+            Backward = (gradOutput, inputs, output, saved, eng, grads) =>
+            {
+                for (int i = 0; i < inputs.Length; i++)
+                {
+                    var g = gradOutput; // identity col2im
+                    if (grads.TryGetValue(inputs[i], out var existing))
+                        eng.TensorAddInPlace(existing, g);
+                    else
+                        grads[inputs[i]] = g;
+                }
+            }
+        };
+        entry.Input0 = differentiableInputs[0];
+        tape.Record(entry);
+
+        var y = _engine.TensorMatMul(m, w);          // [2,2]
+        var loss = _engine.ReduceSum(y, new[] { 0, 1 }, keepDims: false);
+
+        var grads = tape.ComputeGradients(loss, new[] { input, w });
+
+        // The weight gradient always worked; the INPUT gradient was silently dropped (the bug).
+        Assert.True(grads.ContainsKey(w) && grads[w] is not null, "weight gradient missing");
+        Assert.True(grads.ContainsKey(input) && grads[input] is not null,
+            "manual-backward node did NOT propagate the input gradient (dropped dX).");
+
+        // Identity backward + dLoss/dy = 1 everywhere => dLoss/dm = w row-sums broadcast, and
+        // dLoss/dinput == dLoss/dm. Just assert it is non-zero and finite.
+        double sumAbs = 0;
+        var gi = grads[input].Data.Span;
+        for (int i = 0; i < gi.Length; i++) sumAbs += System.Math.Abs(gi[i]);
+        Assert.True(sumAbs > 0, "input gradient is all zeros");
+    }
+}


### PR DESCRIPTION
## Problem

`GradientTape.ComputeGradients` uses a graph-based fast path (`ComputeGradientsViaGraph`) that traverses per-tensor `GradFn` links and does **not** walk the recorded tape-entry list. Engine ops (`RecordUnary`/`RecordBinary`/…) set `output.GradFn` in addition to appending a tape entry, so the fast path reaches them.

The public `Record(entry)` API — the **manual-backward-node** entry point used by consumers like the neural-network layer library's Conv `im2col → col2im` input-gradient wiring (`RegisterManualBackwardNode`) — appended a tape entry but set **no** `GradFn`. So the fast path treated the manual node's output as a leaf and **silently dropped its input gradient**.

**Effect:** every `Conv3DLayer` but the last received a null input gradient and stayed frozen at init during training (weight gradients flowed, input gradients did not) — collapsing deep 3D-conv model training.

## Fix

`Record(entry)` now also wires `output.GradFn` from the entry (mirroring `RecordUnary`), so manual nodes are visible to **both** the graph fast path and the tape-walk slow path. Guarded to only fire when the output has no `GradFn` yet (a freshly materialized tensor, e.g. the im2col output) and the node has a backward. `Record(entry)` has no internal callers, so this is scoped to the manual-node path.

## Verification

- New regression test `ManualBackwardNodeGradientTests` reproduces the exact `im2col-node → MatMul` scenario and asserts the input gradient propagates (fails before, passes after).
- **All 718 Autodiff tests pass** (0 failed, 29 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)