### PR TITLE
feat(gpu): cross-backend CPU/GPU op-parity + full residency (#775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A high-performance .NET tensor library with hand-written AVX2/AVX-512 SIMD kerne
 - **Hand-Tuned SIMD**: Custom AVX2/FMA kernels with 4x loop unrolling, not just `Vector<T>` wrappers
 - **JIT-Compiled Kernels**: Runtime x86-64 machine code generation for size-specialized operations
 - **BLIS-Style GEMM**: Tiled matrix multiply with FMA micro-kernel, cache-aware panel packing
-- **GPU Acceleration**: Optional CUDA, HIP/ROCm, and OpenCL support via separate packages
+- **GPU Acceleration**: Optional CUDA, HIP/ROCm, OpenCL, Metal, Vulkan, and WebGPU support via separate packages, with CPU-vs-GPU op-parity validated across every backend (#775)
 - **Multi-Target**: Supports .NET 10.0 and .NET Framework 4.7.1
 - **Generic Math**: Works with any numeric type via `INumericOperations<T>` interface
 


### PR DESCRIPTION
## Why

PR #777 (the #775 work) merged via a **`test(parity):` squash title**, which Release Please treats as non-releasing — so no version bump, tag, or NuGet publish was cut even though #777 shipped substantial production GPU code. This PR lands a `feat:`-typed commit so Release Please cuts the version that #777 should have.

**IMPORTANT: squash-merge this PR so the `feat(gpu):` title reaches main** (a `test:`/`chore:` title would suppress the release again).

## What shipped in #777 (already on main)

- CPU-vs-GPU op-parity harness over the full `IEngine` surface (double-oracle + ULP + determinism).
- Divergence fixes: GELU (the #775 root cause), GeGLU/ReGLU/SwiGLU gate-half, TensorFrac, ComplexPhase.
- The norm-backward / FFT / Unfold-Fold / GridSample / Mamba quarantine cluster **all fixed — 0 quarantined**.
- 9 extended-conv geometry families + GNN scatter ported to **all 6 backends** (OpenCL/CUDA/HIP/Metal/Vulkan/WebGPU).
- Cross-backend coverage gate reconciled to **0 genuine gaps**; WebGPU brought to full op-family residency parity; capability-parity guard.

## This PR's diff

One line in `README.md` documenting the six supported GPU backends. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the GPU acceleration documentation to include Metal, Vulkan, and WebGPU backends.
  * Clarified that CPU and GPU operation parity is validated across all supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->