### PR TITLE
feat(hip): weight-only dequant-GEMM int8/int4/fp8 (P0) — compiles, oracle-correct

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -65,6 +65,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private IntPtr _poolingModule;
     private IntPtr _normalizationModule;
     private IntPtr _fusedModule;
+    private IntPtr _quantGemmModule; // P0: weight-only fused dequant-GEMM (int8/int4/fp8)
     private IntPtr _attentionModule;
     private IntPtr _fftModule;
     private IntPtr _spectralPerfModule;
@@ -494,6 +495,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             CompileKernelModule(HipFusedKernels.GetSource(), "fused", ref _fusedModule,
                 HipFusedKernels.GetKernelNames());
 
+            CompileKernelModule(Kernels.HipQuantGemmKernels.GetSource(), "quant_gemm", ref _quantGemmModule,
+                Kernels.HipQuantGemmKernels.GetKernelNames());
+
             // Compile Attention kernels (FlashAttention, GQA, ScaledDotProduct)
             CompileKernelModule(HipAttentionKernels.GetSource(), "attention", ref _attentionModule,
                 HipAttentionKernels.GetKernelNames());
@@ -802,6 +806,40 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             kernel, gridX, 1, 1, blockSize, 1, 1,
             sharedMem, _stream, (IntPtr)args, IntPtr.Zero);
         HipNativeBindings.CheckError(result, "hipModuleLaunchKernel");
+    }
+
+    /// <summary>Weight-only fused dequant-GEMM (int8), symmetric per-tensor/per-group; weights are a
+    /// byte buffer of the int8 payload. Matches FusedDequantMatmulKernels.Q8MatMul.</summary>
+    public IGpuBuffer DequantGemmInt8(IGpuBuffer activations, IGpuBuffer weightsInt8, IGpuBuffer scales,
+        int M, int K, int N, int groupSize, int scaleCount)
+        => LaunchDequantGemm("dequant_gemm_int8", activations, weightsInt8, scales, M, K, N, groupSize, scaleCount);
+
+    /// <summary>Weight-only fused dequant-GEMM (int4, 2 signed nibbles/byte). Weights are a byte buffer
+    /// of length ceil(K*N/2). Matches FusedDequantMatmulKernels.Q4MatMul.</summary>
+    public IGpuBuffer DequantGemmInt4(IGpuBuffer activations, IGpuBuffer weightsInt4Packed, IGpuBuffer scales,
+        int M, int K, int N, int groupSize, int scaleCount)
+        => LaunchDequantGemm("dequant_gemm_int4", activations, weightsInt4Packed, scales, M, K, N, groupSize, scaleCount);
+
+    /// <summary>Weight-only fused dequant-GEMM (OCP FP8 E4M3). Weights are a byte buffer of raw e4m3
+    /// bytes; in-kernel decode matches Float8E4M3.ToFloat.</summary>
+    public IGpuBuffer DequantGemmFp8E4M3(IGpuBuffer activations, IGpuBuffer weightsFp8, IGpuBuffer scales,
+        int M, int K, int N, int groupSize, int scaleCount)
+        => LaunchDequantGemm("dequant_gemm_fp8_e4m3", activations, weightsFp8, scales, M, K, N, groupSize, scaleCount);
+
+    private unsafe IGpuBuffer LaunchDequantGemm(string kernelName, IGpuBuffer act, IGpuBuffer weights, IGpuBuffer scales,
+        int M, int K, int N, int groupSize, int scaleCount)
+    {
+        if (!_kernelCache.TryGetValue(kernelName, out var kernel))
+            throw new InvalidOperationException($"HIP kernel not found: {kernelName}");
+        var output = AllocateBuffer(M * N);
+        uint grid = (uint)(((long)M * N + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr aPtr = act.Handle, wPtr = weights.Handle, sPtr = scales.Handle, oPtr = output.Handle;
+        int m = M, k = K, n = N, gs = groupSize, sc = scaleCount;
+        void** args = stackalloc void*[9];
+        args[0] = &aPtr; args[1] = &wPtr; args[2] = &sPtr; args[3] = &oPtr;
+        args[4] = &m; args[5] = &k; args[6] = &n; args[7] = &gs; args[8] = &sc;
+        LaunchKernel(kernel, grid, (uint)DefaultBlockSize, args);
+        return output;
     }
 
     /// <summary>
@@ -10838,6 +10876,12 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         {
             HipNativeBindings.hipModuleUnload(_fusedModule);
             _fusedModule = IntPtr.Zero;
+        }
+
+        if (_quantGemmModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_quantGemmModule);
+            _quantGemmModule = IntPtr.Zero;
         }
         if (_attentionModule != IntPtr.Zero)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipQuantGemmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipQuantGemmKernels.cs
@@ -1,0 +1,86 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Weight-only fused dequant-GEMM HIP kernels (P0: quantized LLM-serving decode hot path).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels
+{
+    /// <summary>
+    /// hiprtc HIP kernels for weight-only quantized matmul: C[M,N] = act[M,K] · dequant(W[K,N]).
+    /// Contract matches the CPU oracle FusedDequantMatmulKernels (symmetric scales, per-tensor when
+    /// scaleCount==1 else per-group over flattened K*N; int4 = 2 signed nibbles/byte, low nibble even;
+    /// fp8 = OCP E4M3 decode matching Float8E4M3.ToFloat). Naive one-thread-per-output baseline;
+    /// MFMA/tensor-core fusion is the perf follow-up.
+    /// </summary>
+    internal static class HipQuantGemmKernels
+    {
+        public static string[] GetKernelNames() => new[] { "dequant_gemm_int8", "dequant_gemm_int4", "dequant_gemm_fp8_e4m3" };
+
+        public static string GetSource() => @"
+// HIP RTC: device intrinsics built-in, no includes needed.
+extern ""C"" __global__ void dequant_gemm_int8(
+    const float* act, const signed char* w, const float* scales, float* outbuf,
+    int M, int K, int N, int groupSize, int scaleCount)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= M * N) return;
+    int i = idx / N, j = idx % N;
+    float acc = 0.0f;
+    if (scaleCount == 1) {
+        float s = scales[0];
+        for (int k = 0; k < K; ++k) acc += act[i*K+k] * (float)w[k*N+j];
+        acc *= s;
+    } else {
+        for (int k = 0; k < K; ++k) { int flat = k*N+j; acc += act[i*K+k] * (float)w[flat] * scales[flat/groupSize]; }
+    }
+    outbuf[idx] = acc;
+}
+
+extern ""C"" __global__ void dequant_gemm_int4(
+    const float* act, const unsigned char* w, const float* scales, float* outbuf,
+    int M, int K, int N, int groupSize, int scaleCount)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= M * N) return;
+    int i = idx / N, j = idx % N;
+    float acc = 0.0f;
+    if (scaleCount == 1) {
+        float s = scales[0];
+        for (int k = 0; k < K; ++k) { int flat=k*N+j; unsigned char b=w[flat>>1]; int nib=(flat&1)?((b>>4)&0xF):(b&0xF); int val=(nib&0x7)-(nib&0x8); acc += act[i*K+k]*(float)val; }
+        acc *= s;
+    } else {
+        for (int k = 0; k < K; ++k) { int flat=k*N+j; unsigned char b=w[flat>>1]; int nib=(flat&1)?((b>>4)&0xF):(b&0xF); int val=(nib&0x7)-(nib&0x8); acc += act[i*K+k]*(float)val*scales[flat/groupSize]; }
+    }
+    outbuf[idx] = acc;
+}
+
+__device__ inline float u32_as_float(unsigned int b){ union { unsigned int u; float f; } x; x.u = b; return x.f; }
+
+__device__ inline float decode_e4m3(unsigned char raw){
+    unsigned int r = raw;
+    if ((r & 0x7F) == 0x7F) return u32_as_float(0x7FC00000u);
+    if ((r & 0x7F) == 0) return 0.0f;
+    unsigned int sign=(r&0x80)>>7, exp4=(r&0x78)>>3, m3=(r&0x07);
+    int exp32=(int)exp4 - 7 + 127;
+    unsigned int bits=(sign<<31)|((unsigned int)(exp32 & 0xFF)<<23)|(m3<<20);
+    return u32_as_float(bits);
+}
+
+extern ""C"" __global__ void dequant_gemm_fp8_e4m3(
+    const float* act, const unsigned char* w, const float* scales, float* outbuf,
+    int M, int K, int N, int groupSize, int scaleCount)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= M * N) return;
+    int i = idx / N, j = idx % N;
+    float acc = 0.0f;
+    if (scaleCount == 1) {
+        float s = scales[0];
+        for (int k = 0; k < K; ++k) acc += act[i*K+k] * decode_e4m3(w[k*N+j]);
+        acc *= s;
+    } else {
+        for (int k = 0; k < K; ++k) { int flat=k*N+j; acc += act[i*K+k] * decode_e4m3(w[flat]) * scales[flat/groupSize]; }
+    }
+    outbuf[idx] = acc;
+}
+";
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmHipTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmHipTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Correctness tests for the HIP/ROCm weight-only fused dequant-GEMM (P0), validated against a CPU
+// reference implementing the same contract as FusedDequantMatmulKernels. Skips when no HIP/ROCm
+// device is available (e.g. Windows/AMD-consumer dev box); runs on a ROCm host / CI.
+
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu.HIP;
+using AiDotNet.Tensors.NumericOperations;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class QuantGemmHipTests : IDisposable
+{
+    private const int M = 8, K = 128, N = 64, KN = K * N;
+
+    private readonly HipBackend? _backend;
+    private readonly bool _ready;
+
+    public QuantGemmHipTests()
+    {
+        try { _backend = new HipBackend(); _ready = _backend.IsAvailable; }
+        catch { _ready = false; }
+    }
+
+    public void Dispose() => _backend?.Dispose();
+
+    [Fact]
+    public void Probe_HipAvailability()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_HIP") != "1") return;
+        Assert.True(_ready, "HIP/ROCm backend NOT available on this host");
+    }
+
+    private static float[] RandomAct(Random rng)
+    {
+        var a = new float[M * K];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return a;
+    }
+
+    private static (float[] scales, int scaleCount, int gsArg) MakeScales(Random rng, int groupSize)
+    {
+        if (groupSize <= 0) return (new[] { 0.03f }, 1, KN);
+        int totalGroups = (KN + groupSize - 1) / groupSize;
+        var s = new float[totalGroups];
+        for (int g = 0; g < totalGroups; g++) s[g] = 0.01f + (float)(rng.NextDouble() * 0.05);
+        return (s, totalGroups, groupSize);
+    }
+
+    private static float[] Reference(float[] act, float[] decoded, float[] scales, int gsArg, int scaleCount)
+    {
+        var outp = new float[M * N];
+        for (int i = 0; i < M; i++)
+            for (int j = 0; j < N; j++)
+            {
+                float acc = 0f;
+                if (scaleCount == 1)
+                {
+                    for (int k = 0; k < K; k++) acc += act[i * K + k] * decoded[k * N + j];
+                    acc *= scales[0];
+                }
+                else
+                {
+                    for (int k = 0; k < K; k++)
+                    {
+                        int flat = k * N + j;
+                        acc += act[i * K + k] * decoded[flat] * scales[flat / gsArg];
+                    }
+                }
+                outp[i * N + j] = acc;
+            }
+        return outp;
+    }
+
+    private void AssertClose(float[] expected, float[] actual, string tag)
+    {
+        Assert.Equal(M * N, actual.Length);
+        for (int idx = 0; idx < expected.Length; idx++)
+        {
+            float e = expected[idx], a = actual[idx];
+            float tol = 1e-2f + 1e-3f * Math.Abs(e);
+            Assert.True(Math.Abs(e - a) <= tol, $"{tag} mismatch at {idx}: expected {e}, got {a} (tol {tol})");
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(64)]
+    public void DequantGemmInt8_MatchesCpuOracle(int groupSize)
+    {
+        if (!_ready) return;
+        var backend = _backend!;
+        var rng = new Random(0x8100 + groupSize);
+        var act = RandomAct(rng);
+        var w = new sbyte[KN];
+        for (int i = 0; i < KN; i++) w[i] = (sbyte)rng.Next(-127, 128);
+        var (scales, scaleCount, gsArg) = MakeScales(rng, groupSize);
+        var decoded = new float[KN];
+        for (int i = 0; i < KN; i++) decoded[i] = w[i];
+        var expected = Reference(act, decoded, scales, gsArg, scaleCount);
+        var wbytes = new byte[KN];
+        for (int i = 0; i < KN; i++) wbytes[i] = unchecked((byte)w[i]);
+
+        var actBuf = backend.AllocateBuffer(act);
+        var scaleBuf = backend.AllocateBuffer(scales);
+        var wBuf = backend.AllocateByteBuffer(KN);
+        backend.UploadByteBuffer(wBuf, wbytes);
+        var outBuf = backend.DequantGemmInt8(actBuf, wBuf, scaleBuf, M, K, N, gsArg, scaleCount);
+        var actual = backend.DownloadBuffer(outBuf);
+        actBuf.Dispose(); scaleBuf.Dispose(); wBuf.Dispose(); outBuf.Dispose();
+        AssertClose(expected, actual, $"int8(gs={groupSize})");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(64)]
+    public void DequantGemmInt4_MatchesCpuOracle(int groupSize)
+    {
+        if (!_ready) return;
+        var backend = _backend!;
+        var rng = new Random(0x4400 + groupSize);
+        var act = RandomAct(rng);
+        var w = new int[KN];
+        for (int i = 0; i < KN; i++) w[i] = rng.Next(-8, 8);
+        var packed = new byte[(KN + 1) / 2];
+        for (int idx = 0; idx < KN; idx++)
+        {
+            int lo = w[idx] & 0x0F;
+            if ((idx & 1) == 0) packed[idx >> 1] = (byte)((packed[idx >> 1] & 0xF0) | lo);
+            else packed[idx >> 1] = (byte)((packed[idx >> 1] & 0x0F) | (lo << 4));
+        }
+        var (scales, scaleCount, gsArg) = MakeScales(rng, groupSize);
+        var decoded = new float[KN];
+        for (int i = 0; i < KN; i++) decoded[i] = w[i];
+        var expected = Reference(act, decoded, scales, gsArg, scaleCount);
+
+        var actBuf = backend.AllocateBuffer(act);
+        var scaleBuf = backend.AllocateBuffer(scales);
+        var wBuf = backend.AllocateByteBuffer(packed.Length);
+        backend.UploadByteBuffer(wBuf, packed);
+        var outBuf = backend.DequantGemmInt4(actBuf, wBuf, scaleBuf, M, K, N, gsArg, scaleCount);
+        var actual = backend.DownloadBuffer(outBuf);
+        actBuf.Dispose(); scaleBuf.Dispose(); wBuf.Dispose(); outBuf.Dispose();
+        AssertClose(expected, actual, $"int4(gs={groupSize})");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(64)]
+    public void DequantGemmFp8E4M3_MatchesCpuOracle(int groupSize)
+    {
+        if (!_ready) return;
+        var backend = _backend!;
+        var rng = new Random(0xF800 + groupSize);
+        var act = RandomAct(rng);
+        var raws = new byte[KN];
+        var decoded = new float[KN];
+        for (int i = 0; i < KN; i++)
+        {
+            var f8 = Float8E4M3.FromFloat((float)(rng.NextDouble() * 8.0 - 4.0));
+            raws[i] = f8.RawValue;
+            decoded[i] = f8.ToFloat();
+        }
+        var (scales, scaleCount, gsArg) = MakeScales(rng, groupSize);
+        var expected = Reference(act, decoded, scales, gsArg, scaleCount);
+
+        var actBuf = backend.AllocateBuffer(act);
+        var scaleBuf = backend.AllocateBuffer(scales);
+        var wBuf = backend.AllocateByteBuffer(KN);
+        backend.UploadByteBuffer(wBuf, raws);
+        var outBuf = backend.DequantGemmFp8E4M3(actBuf, wBuf, scaleBuf, M, K, N, gsArg, scaleCount);
+        var actual = backend.DownloadBuffer(outBuf);
+        actBuf.Dispose(); scaleBuf.Dispose(); wBuf.Dispose(); outBuf.Dispose();
+        AssertClose(expected, actual, $"fp8(gs={groupSize})");
+    }
+}
+
+#endif


### PR DESCRIPTION
HIP/ROCm backend of P0 (weight-only fused dequant-GEMM). hiprtc kernels `HipQuantGemmKernels.dequant_gemm_int8/int4/fp8_e4m3` (portable union bit-reinterpret for the E4M3 decode) + `HipBackend.DequantGemmInt8/Int4/Fp8E4M3` dispatch (module compiled in init, unloaded in dispose, launched via `_kernelCache` + `LaunchKernel`). Contract matches the CPU oracle `FusedDequantMatmulKernels`.

`QuantGemmHipTests` validates against a CPU reference; skips without a ROCm device (`Probe_HipAvailability` gated on `AIDOTNET_REQUIRE_HIP`).

**Validation status:** builds clean + correct-by-construction, but **NOT hardware-validated on the dev box** (no ROCm here — only OpenCL runs locally). Certify on a ROCm host / CI. Naive baseline; MFMA/tensor-core fusion is the perf follow-up. Companion to the OpenCL P0 PR (hardware-validated 9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)