### PR TITLE
feat(opencl): paged-attention decode kernel (P1) — GPU-validated

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/PagedAttentionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/PagedAttentionKernels.cs
@@ -1,0 +1,67 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU paged-attention kernels (P1): attention that gathers K/V through a block table (vLLM-style),
+// so the KV cache need not be contiguous. Works on ALL .NET versions incl. .NET Framework 4.6.2.
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels
+{
+    /// <summary>
+    /// Paged-attention decode kernel. K/V live in a physical block pool laid out as
+    /// <c>[maxBlocks, blockSize, heads, headDim]</c> (matching the CPU <c>PagedKVCache</c>); a per-sequence
+    /// block table maps logical block index -&gt; physical block id. For a single query token this computes
+    /// <c>out[h] = softmax(scale · Q[h]·K[.,h]) · V[.,h]</c> over the sequence, reading K/V via the block
+    /// table — the core mechanism that lets vLLM pack many sequences without KV fragmentation.
+    /// </summary>
+    /// <remarks>
+    /// Online-softmax (FlashAttention-style) single pass; one work-item per head; correctness-first
+    /// baseline (headDim ≤ 256). Validated against a CPU attention oracle on the materialized K/V.
+    /// </remarks>
+    internal static class PagedAttentionKernels
+    {
+        public static string[] GetKernelNames() => new[] { "paged_attention_decode" };
+
+        public static string GetSource()
+        {
+            return @"
+#define PA_MAX_HEAD_DIM 256
+// Single-query paged attention. Block pool: [maxBlocks, blockSize, heads, headDim].
+__kernel void paged_attention_decode(
+    __global const float* q,          // [heads*headDim]
+    __global const float* kcache,     // [maxBlocks*blockSize*heads*headDim]
+    __global const float* vcache,     // same layout as kcache
+    __global const int*   blockTable, // [ceil(seqLen/blockSize)] physical block ids
+    __global float*       outbuf,     // [heads*headDim]
+    const int heads, const int headDim, const int blockSize, const int seqLen, const float scale)
+{
+    int h = get_global_id(0);
+    if (h >= heads) return;
+
+    float acc[PA_MAX_HEAD_DIM];
+    for (int d = 0; d < headDim; ++d) acc[d] = 0.0f;
+
+    float m = -INFINITY;   // running max logit
+    float l = 0.0f;        // running softmax denominator
+
+    for (int t = 0; t < seqLen; ++t) {
+        int blk = blockTable[t / blockSize];
+        int pos = t % blockSize;
+        long base = (((long)blk * blockSize + pos) * heads + h) * headDim;
+
+        float dot = 0.0f;
+        for (int d = 0; d < headDim; ++d) dot += q[h * headDim + d] * kcache[base + d];
+        float logit = dot * scale;
+
+        float new_m = fmax(m, logit);
+        float corr = exp(m - new_m);
+        float p = exp(logit - new_m);
+        l = l * corr + p;
+        for (int d = 0; d < headDim; ++d) acc[d] = acc[d] * corr + p * vcache[base + d];
+        m = new_m;
+    }
+
+    float inv = (l > 0.0f) ? (1.0f / l) : 0.0f;
+    for (int d = 0; d < headDim; ++d) outbuf[h * headDim + d] = acc[d] * inv;
+}
+";
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -318,6 +318,16 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 }
                 WriteDiag($"[OpenClBackend] GEMM kernels: {string.Join(", ", GemmKernel.GetKernelNames())}");
 
+                // Paged attention (P1). SafeMathFlags: the kernel relies on INFINITY / exp semantics
+                // that -cl-finite-math-only would optimize away.
+                var pagedAttnProgram = CompileOrLoadCached(PagedAttentionKernels.GetSource(), OpenClBuildOptions.SafeMathFlags, "Paged attention kernels");
+                _programs.Add(pagedAttnProgram);
+                foreach (var name in PagedAttentionKernels.GetKernelNames())
+                {
+                    _kernelCache[name] = new DirectOpenClKernel(_context, pagedAttnProgram, name);
+                }
+                WriteDiag($"[OpenClBackend] Paged attention kernels: {string.Join(", ", PagedAttentionKernels.GetKernelNames())}");
+
                 // Compile activation kernels with NaN-preserving math flags: the
                 // relu kernel propagates NaN by contract, which -cl-finite-math-only
                 // / -cl-fast-relaxed-math would optimize away (the compiler assumes
@@ -2623,6 +2633,43 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             {
                 output?.Dispose();
                 temp?.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Paged-attention decode for a single query token (P1): out[heads*headDim] =
+        /// softmax(scale · Q·K) · V over the sequence, reading K/V from the physical block pool
+        /// (layout [maxBlocks, blockSize, heads, headDim]) via <paramref name="blockTable"/> (an int
+        /// buffer of physical block ids). headDim &lt;= 256. Matches a standard-attention CPU oracle.
+        /// </summary>
+        public IGpuBuffer PagedAttentionDecode(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int headDim, int blockSize, int seqLen, float scale)
+        {
+            if (_context == null) throw new InvalidOperationException("OpenCL context not available");
+            var output = AllocateBuffer(heads * headDim);
+            try
+            {
+                var kernel = _kernelCache["paged_attention_decode"];
+                kernel.SetArg(0, ((DirectOpenClGpuBuffer)q).Buffer.Handle);
+                kernel.SetArg(1, ((DirectOpenClGpuBuffer)kcache).Buffer.Handle);
+                kernel.SetArg(2, ((DirectOpenClGpuBuffer)vcache).Buffer.Handle);
+                kernel.SetArg(3, ((DirectOpenClGpuBuffer)blockTable).Buffer.Handle);
+                kernel.SetArg(4, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+                kernel.SetArg(5, heads);
+                kernel.SetArg(6, headDim);
+                kernel.SetArg(7, blockSize);
+                kernel.SetArg(8, seqLen);
+                kernel.SetArg(9, scale);
+                int local = CalculateOptimalWorkGroupSize1D(heads);
+                int global = ((heads + local - 1) / local) * local;
+                kernel.Execute1D(global, local);
+                _context.Finish();
+                return output;
+            }
+            catch
+            {
+                output.Dispose();
                 throw;
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PagedAttentionOpenClTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PagedAttentionOpenClTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Correctness tests for the OpenCL paged-attention decode kernel (P1): attention that gathers K/V
+// through a block table, validated against a standard-attention CPU oracle. Skips when no OpenCL
+// device is available, unless AIDOTNET_REQUIRE_GPU_TESTS=1.
+
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class PagedAttentionOpenClTests : IDisposable
+{
+    private readonly OpenClBackend? _backend;
+    private readonly bool _ready;
+    private readonly Exception? _initException;
+
+    public PagedAttentionOpenClTests()
+    {
+        try { _backend = new OpenClBackend(); _ready = _backend.IsAvailable; }
+        catch (Exception ex) { _initException = ex; _ready = false; }
+    }
+
+    public void Dispose() => _backend?.Dispose();
+
+    private bool EnsureReady()
+    {
+        if (_ready) return true;
+        if (string.Equals(Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS"), "1", StringComparison.Ordinal))
+            throw new InvalidOperationException("GPU tests required but OpenCL was unavailable.", _initException);
+        return false;
+    }
+
+    [Theory]
+    [InlineData(4, 64, 16, 40)]
+    [InlineData(2, 128, 8, 20)]
+    [InlineData(8, 32, 32, 100)]
+    public void PagedAttentionDecode_MatchesCpuOracle(int heads, int headDim, int blockSize, int seqLen)
+    {
+        if (!EnsureReady()) return;
+        var backend = _backend!;
+        var rng = new Random(0xA77 + heads + seqLen);
+
+        int numLogicalBlocks = (seqLen + blockSize - 1) / blockSize;
+        int maxBlocks = numLogicalBlocks + 5;
+        int poolLen = maxBlocks * blockSize * heads * headDim;
+
+        var kcache = new float[poolLen];
+        var vcache = new float[poolLen];
+        for (int i = 0; i < poolLen; i++) { kcache[i] = (float)(rng.NextDouble() * 2 - 1); vcache[i] = (float)(rng.NextDouble() * 2 - 1); }
+
+        var q = new float[heads * headDim];
+        for (int i = 0; i < q.Length; i++) q[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        // Shuffled physical block ids (exercises the indirection).
+        var blockTable = new int[numLogicalBlocks];
+        var pool = new System.Collections.Generic.List<int>();
+        for (int b = 0; b < maxBlocks; b++) pool.Add(b);
+        for (int b = 0; b < numLogicalBlocks; b++) { int pick = rng.Next(pool.Count); blockTable[b] = pool[pick]; pool.RemoveAt(pick); }
+
+        float scale = 1.0f / MathF.Sqrt(headDim);
+
+        // CPU oracle: standard attention gathering K/V via the block table.
+        var expected = new float[heads * headDim];
+        for (int h = 0; h < heads; h++)
+        {
+            var logits = new float[seqLen];
+            float max = float.NegativeInfinity;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int blk = blockTable[t / blockSize], pos = t % blockSize;
+                long baseIdx = (((long)blk * blockSize + pos) * heads + h) * headDim;
+                float dot = 0f;
+                for (int d = 0; d < headDim; d++) dot += q[h * headDim + d] * kcache[baseIdx + d];
+                logits[t] = dot * scale;
+                if (logits[t] > max) max = logits[t];
+            }
+            float denom = 0f;
+            for (int t = 0; t < seqLen; t++) { logits[t] = MathF.Exp(logits[t] - max); denom += logits[t]; }
+            for (int t = 0; t < seqLen; t++)
+            {
+                int blk = blockTable[t / blockSize], pos = t % blockSize;
+                long baseIdx = (((long)blk * blockSize + pos) * heads + h) * headDim;
+                float p = logits[t] / denom;
+                for (int d = 0; d < headDim; d++) expected[h * headDim + d] += p * vcache[baseIdx + d];
+            }
+        }
+
+        var qBuf = backend.AllocateBuffer(q);
+        var kBuf = backend.AllocateBuffer(kcache);
+        var vBuf = backend.AllocateBuffer(vcache);
+        var btBuf = backend.AllocateIntBuffer(blockTable);
+        var outBuf = backend.PagedAttentionDecode(qBuf, kBuf, vBuf, btBuf, heads, headDim, blockSize, seqLen, scale);
+        var actual = backend.DownloadBuffer(outBuf);
+        qBuf.Dispose(); kBuf.Dispose(); vBuf.Dispose(); btBuf.Dispose(); outBuf.Dispose();
+
+        Assert.Equal(heads * headDim, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float e = expected[i], a = actual[i];
+            float tol = 2e-3f + 2e-3f * Math.Abs(e);
+            Assert.True(Math.Abs(e - a) <= tol, $"paged-attn mismatch at {i}: expected {e}, got {a} (tol {tol}, heads={heads}, seqLen={seqLen})");
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
First slice of **P1 (vLLM-core paged attention)**: an OpenCL decode kernel computing single-query attention that reads K/V from a physical block pool (`[maxBlocks, blockSize, heads, headDim]`) via a block table — so the KV cache need not be contiguous (the mechanism that lets vLLM pack many sequences without fragmentation).

- `PagedAttentionKernels.paged_attention_decode`: online-softmax (FlashAttention-style) single pass, one work-item per head, headDim ≤ 256. Compiled with SafeMathFlags (relies on INFINITY/exp). Block table bound as an int buffer.
- `OpenClBackend.PagedAttentionDecode` dispatch.
- `PagedAttentionOpenClTests` validates vs a standard-attention CPU oracle (K/V gathered through the block table).

**Validated on AMD gfx90c: 3/3** (varied heads/headDim/blockSize/seqLen), `AIDOTNET_REQUIRE_GPU_TESTS=1`. Contract matches the CPU `PagedKVCache` block layout.

Follow-ups: prefill (multi-query), GQA, on-device block allocator, and the other 5 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)