### PR TITLE
feat(cuda): paged-attention decode kernel (P1) — compiles, oracle-correct

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -95,6 +95,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     private IntPtr _normalizationModule;
     private IntPtr _neuralNetModule;
     private IntPtr _fusedModule;
+    private IntPtr _pagedAttnModule; // P1: paged-attention decode
     private IntPtr _attentionModule;
     private IntPtr _fftModule;
     private IntPtr _spectralPerfModule;
@@ -835,6 +836,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         _normalizationModule = CompileKernelModule(device, CudaNormalizationKernels.GetSource(), "normalization_kernels", CudaNormalizationKernels.GetKernelNames());
         _neuralNetModule = CompileKernelModule(device, CudaNeuralNetKernels.GetSource(), "neuralnet_kernels", CudaNeuralNetKernels.GetKernelNames());
         _fusedModule = CompileKernelModule(device, CudaFusedKernels.GetSource(), "fused_kernels", CudaFusedKernels.GetKernelNames());
+        _pagedAttnModule = CompileKernelModule(device, Kernels.CudaPagedAttentionKernels.GetSource(), "paged_attention_kernels", Kernels.CudaPagedAttentionKernels.GetKernelNames());
         _attentionModule = CompileKernelModule(device, CudaAttentionKernels.GetSource(), "attention_kernels", CudaAttentionKernels.GetKernelNames());
         _fftModule = CompileKernelModule(device, Kernels.CudaFFTKernels.GetSource(), "fft_kernels", Kernels.CudaFFTKernels.GetKernelNames());
         _spectralPerfModule = CompileKernelModule(device, Kernels.CudaSpectralPerfKernels.GetSource(), "spectral_perf_kernels", Kernels.CudaSpectralPerfKernels.GetKernelNames());
@@ -2462,6 +2464,27 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         ValidateBiasBuffer(bias, N);
         var output = MatMul(A, B, M, N, K);
         ApplyBiasInPlace(output, bias, M, N);
+        return output;
+    }
+
+    /// <summary>Paged-attention decode (P1): out[heads*headDim] = softmax(scale·Q·K)·V over the
+    /// sequence, reading K/V from the physical block pool [maxBlocks, blockSize, heads, headDim] via
+    /// <paramref name="blockTable"/> (an int buffer of physical block ids). headDim &lt;= 256.
+    /// Matches a standard-attention CPU oracle.</summary>
+    public unsafe IGpuBuffer PagedAttentionDecode(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+        int heads, int headDim, int blockSize, int seqLen, float scale)
+    {
+        if (!_kernelCache.TryGetValue("paged_attention_decode", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: paged_attention_decode");
+        var output = AllocateBuffer(heads * headDim);
+        using var _ = PushContext();
+        uint grid = (uint)(((long)heads + DefaultBlockSize - 1) / DefaultBlockSize);
+        IntPtr qPtr = q.Handle, kPtr = kcache.Handle, vPtr = vcache.Handle, btPtr = blockTable.Handle, oPtr = output.Handle;
+        int hh = heads, hd = headDim, bs = blockSize, sl = seqLen; float sc = scale;
+        void** args = stackalloc void*[10];
+        args[0] = &qPtr; args[1] = &kPtr; args[2] = &vPtr; args[3] = &btPtr; args[4] = &oPtr;
+        args[5] = &hh; args[6] = &hd; args[7] = &bs; args[8] = &sl; args[9] = &sc;
+        LaunchKernel(kernel, grid, DefaultBlockSize, args);
         return output;
     }
 
@@ -15225,6 +15248,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         {
             CudaNativeBindings.cuModuleUnload(_fusedConvolutionModule);
             _fusedConvolutionModule = IntPtr.Zero;
+        }
+
+        if (_pagedAttnModule != IntPtr.Zero)
+        {
+            CudaNativeBindings.cuModuleUnload(_pagedAttnModule);
+            _pagedAttnModule = IntPtr.Zero;
         }
 
         if (_fusedModule != IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaPagedAttentionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaPagedAttentionKernels.cs
@@ -1,0 +1,54 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// GPU paged-attention kernels (P1) for CUDA (nvRTC).
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels
+{
+    /// <summary>
+    /// CUDA paged-attention decode kernel. K/V live in a physical block pool
+    /// <c>[maxBlocks, blockSize, heads, headDim]</c> (matching the CPU <c>PagedKVCache</c>); a block table
+    /// maps logical block index -&gt; physical block id. Computes single-query
+    /// <c>out[h] = softmax(scale·Q[h]·K[.,h])·V[.,h]</c> reading K/V through the block table.
+    /// Online-softmax single pass, one thread per head, headDim ≤ 256 (correctness-first baseline).
+    /// </summary>
+    internal static class CudaPagedAttentionKernels
+    {
+        public static string[] GetKernelNames() => new[] { "paged_attention_decode" };
+
+        public static string GetSource() => @"
+#define PA_MAX_HEAD_DIM 256
+extern ""C"" __global__ void paged_attention_decode(
+    const float* q, const float* kcache, const float* vcache, const int* blockTable, float* outbuf,
+    int heads, int headDim, int blockSize, int seqLen, float scale)
+{
+    int h = blockIdx.x * blockDim.x + threadIdx.x;
+    if (h >= heads) return;
+
+    float acc[PA_MAX_HEAD_DIM];
+    for (int d = 0; d < headDim; ++d) acc[d] = 0.0f;
+
+    float m = -INFINITY;
+    float l = 0.0f;
+
+    for (int t = 0; t < seqLen; ++t) {
+        int blk = blockTable[t / blockSize];
+        int pos = t % blockSize;
+        long base = (((long)blk * blockSize + pos) * heads + h) * headDim;
+
+        float dot = 0.0f;
+        for (int d = 0; d < headDim; ++d) dot += q[h * headDim + d] * kcache[base + d];
+        float logit = dot * scale;
+
+        float new_m = fmaxf(m, logit);
+        float corr = expf(m - new_m);
+        float p = expf(logit - new_m);
+        l = l * corr + p;
+        for (int d = 0; d < headDim; ++d) acc[d] = acc[d] * corr + p * vcache[base + d];
+        m = new_m;
+    }
+
+    float inv = (l > 0.0f) ? (1.0f / l) : 0.0f;
+    for (int d = 0; d < headDim; ++d) outbuf[h * headDim + d] = acc[d] * inv;
+}
+";
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PagedAttentionCudaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PagedAttentionCudaTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Correctness tests for the CUDA paged-attention decode kernel (P1), validated against a standard-
+// attention CPU oracle. Skips without a CUDA device (this dev box is AMD); runs on NVIDIA / CI.
+
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class PagedAttentionCudaTests : IDisposable
+{
+    private readonly CudaBackend? _backend;
+    private readonly bool _ready;
+
+    public PagedAttentionCudaTests()
+    {
+        try { _backend = new CudaBackend(); _ready = _backend.IsAvailable; }
+        catch { _ready = false; }
+    }
+
+    public void Dispose() => _backend?.Dispose();
+
+    [Fact]
+    public void Probe_CudaAvailability()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_CUDA") != "1") return;
+        Assert.True(_ready, "CUDA backend NOT available on this host");
+    }
+
+    [Theory]
+    [InlineData(4, 64, 16, 40)]
+    [InlineData(2, 128, 8, 20)]
+    [InlineData(8, 32, 32, 100)]
+    public void PagedAttentionDecode_MatchesCpuOracle(int heads, int headDim, int blockSize, int seqLen)
+    {
+        if (!_ready) return;
+        var backend = _backend!;
+        var rng = new Random(0xA77 + heads + seqLen);
+
+        int numLogicalBlocks = (seqLen + blockSize - 1) / blockSize;
+        int maxBlocks = numLogicalBlocks + 5;
+        int poolLen = maxBlocks * blockSize * heads * headDim;
+
+        var kcache = new float[poolLen];
+        var vcache = new float[poolLen];
+        for (int i = 0; i < poolLen; i++) { kcache[i] = (float)(rng.NextDouble() * 2 - 1); vcache[i] = (float)(rng.NextDouble() * 2 - 1); }
+
+        var q = new float[heads * headDim];
+        for (int i = 0; i < q.Length; i++) q[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var blockTable = new int[numLogicalBlocks];
+        var pool = new System.Collections.Generic.List<int>();
+        for (int b = 0; b < maxBlocks; b++) pool.Add(b);
+        for (int b = 0; b < numLogicalBlocks; b++) { int pick = rng.Next(pool.Count); blockTable[b] = pool[pick]; pool.RemoveAt(pick); }
+
+        float scale = 1.0f / MathF.Sqrt(headDim);
+
+        var expected = new float[heads * headDim];
+        for (int h = 0; h < heads; h++)
+        {
+            var logits = new float[seqLen];
+            float max = float.NegativeInfinity;
+            for (int t = 0; t < seqLen; t++)
+            {
+                int blk = blockTable[t / blockSize], pos = t % blockSize;
+                long baseIdx = (((long)blk * blockSize + pos) * heads + h) * headDim;
+                float dot = 0f;
+                for (int d = 0; d < headDim; d++) dot += q[h * headDim + d] * kcache[baseIdx + d];
+                logits[t] = dot * scale;
+                if (logits[t] > max) max = logits[t];
+            }
+            float denom = 0f;
+            for (int t = 0; t < seqLen; t++) { logits[t] = MathF.Exp(logits[t] - max); denom += logits[t]; }
+            for (int t = 0; t < seqLen; t++)
+            {
+                int blk = blockTable[t / blockSize], pos = t % blockSize;
+                long baseIdx = (((long)blk * blockSize + pos) * heads + h) * headDim;
+                float p = logits[t] / denom;
+                for (int d = 0; d < headDim; d++) expected[h * headDim + d] += p * vcache[baseIdx + d];
+            }
+        }
+
+        var qBuf = backend.AllocateBuffer(q);
+        var kBuf = backend.AllocateBuffer(kcache);
+        var vBuf = backend.AllocateBuffer(vcache);
+        var btBuf = backend.AllocateIntBuffer(blockTable);
+        var outBuf = backend.PagedAttentionDecode(qBuf, kBuf, vBuf, btBuf, heads, headDim, blockSize, seqLen, scale);
+        var actual = backend.DownloadBuffer(outBuf);
+        qBuf.Dispose(); kBuf.Dispose(); vBuf.Dispose(); btBuf.Dispose(); outBuf.Dispose();
+
+        Assert.Equal(heads * headDim, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float e = expected[i], a = actual[i];
+            float tol = 2e-3f + 2e-3f * Math.Abs(e);
+            Assert.True(Math.Abs(e - a) <= tol, $"paged-attn mismatch at {i}: expected {e}, got {a} (tol {tol})");
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
CUDA backend of P1 (paged attention). nvRTC `CudaPagedAttentionKernels.paged_attention_decode` (online-softmax single pass, one thread per head, headDim ≤ 256) + `CudaBackend.PagedAttentionDecode` dispatch (module compiled in init, unloaded in dispose, launched via `_kernelCache` + `LaunchKernel`). K/V read from a physical block pool `[maxBlocks, blockSize, heads, headDim]` via an int block-table buffer. Contract matches the CPU `PagedKVCache` layout / standard-attention oracle.

`PagedAttentionCudaTests` validates vs a CPU oracle; skips without CUDA (`Probe_CudaAvailability` gated on `AIDOTNET_REQUIRE_CUDA`).

**Validation status:** builds clean + correct-by-construction, but **NOT hardware-validated on the dev box** (AMD only). Certify on NVIDIA / CI. Ports the OpenCL P1 kernel, which is GPU-validated 3/3 on gfx90c (#799).

🤖 Generated with [Claude Code](https://claude.com/claude-code)