### PR TITLE
review: paged-attention + weights buffer-capacity guards; raw E4M3 test coverage

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -2576,6 +2576,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt8));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt8));
+        GpuKernelGuards.Capacity(weightsInt8, (long)K * N, nameof(weightsInt8), nameof(DequantGemmInt8));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt8));
         return LaunchDequantGemm("dequant_gemm_int8", activations, weightsInt8, scales, M, K, N, groupSize, scaleCount);
     }
@@ -2587,6 +2588,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt4));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt4));
+        GpuKernelGuards.Capacity(weightsInt4Packed, ((long)K * N + 1) / 2, nameof(weightsInt4Packed), nameof(DequantGemmInt4));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt4));
         return LaunchDequantGemm("dequant_gemm_int4", activations, weightsInt4Packed, scales, M, K, N, groupSize, scaleCount);
     }
@@ -2598,6 +2600,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmFp8E4M3));
+        GpuKernelGuards.Capacity(weightsFp8, (long)K * N, nameof(weightsFp8), nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmFp8E4M3));
         return LaunchDequantGemm("dequant_gemm_fp8_e4m3", activations, weightsFp8, scales, M, K, N, groupSize, scaleCount);
     }
@@ -2629,6 +2632,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         if (!_kernelCache.TryGetValue("paged_attention_decode", out var kernel))
             throw new InvalidOperationException("CUDA kernel not found: paged_attention_decode");
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
         var output = AllocateBuffer(heads * headDim);
         using var _ = PushContext();
         uint grid = (uint)(((long)heads + DefaultBlockSize - 1) / DefaultBlockSize);
@@ -2651,6 +2655,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             throw new InvalidOperationException("CUDA kernel not found: paged_attention_prefill");
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
         var output = AllocateBuffer(numQueries * heads * headDim);
         using var _ = PushContext();
         int totalItems = numQueries * heads;
@@ -2673,6 +2678,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             throw new InvalidOperationException("CUDA kernel not found: paged_attention_decode_gqa");
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
         var output = AllocateBuffer(heads * headDim);
         using var _ = PushContext();
         uint grid = (uint)(((long)heads + DefaultBlockSize - 1) / DefaultBlockSize);
@@ -2694,6 +2700,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
         var output = AllocateBuffer(numQueries * heads * headDim);
         using var _ = PushContext();
         int totalItems = numQueries * heads;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelGuards.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelGuards.cs
@@ -66,5 +66,36 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
                 throw new ArgumentException(
                     $"{op}: {bufferName} holds {buffer.Size} elements but the kernel needs {requiredElements}.", bufferName);
         }
+
+        /// <summary>
+        /// Validates the buffer contract shared by the paged-attention decode/prefill kernels (MHA and GQA):
+        /// the query buffer, the block table, and the K/V physical pools. <paramref name="kvDim"/> is the
+        /// per-token KV head count in the pool layout (heads for MHA, kvHeads for GQA);
+        /// <paramref name="qRows"/> is 1 for decode and numQueries for prefill; <paramref name="keyLen"/> is
+        /// the number of key positions read (seqLen for decode, startPos+numQueries for prefill).
+        /// </summary>
+        /// <remarks>
+        /// Physical block ids live in the device <paramref name="blockTable"/> buffer, so validating that
+        /// each id is in-range would require a device→host read; that is intentionally left off this fast
+        /// path. These host-checkable capacity guards catch the common undersized-buffer mistakes before a
+        /// native out-of-bounds read.
+        /// </remarks>
+        public static void PagedAttentionBuffers(
+            IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int kvDim, int headDim, int blockSize, int keyLen, int qRows, string op)
+        {
+            Capacity(q, (long)qRows * heads * headDim, "q", op);
+            long logicalBlocks = ((long)keyLen + blockSize - 1) / blockSize;
+            Capacity(blockTable, logicalBlocks, "blockTable", op);
+            if (kcache is null || vcache is null)
+                throw new ArgumentNullException(kcache is null ? "kcache" : "vcache", $"{op}: K/V pools must not be null.");
+            if (kcache.Size <= 0 || kcache.Size != vcache.Size)
+                throw new ArgumentException(
+                    $"{op}: kcache/vcache must be equal-sized, non-empty K/V pools (got {kcache.Size}/{vcache.Size}).", "kcache");
+            long perBlock = (long)blockSize * kvDim * headDim;
+            if (kcache.Size % perBlock != 0)
+                throw new ArgumentException(
+                    $"{op}: K/V pool size {kcache.Size} is not a whole number of blocks (blockSize*kvDim*headDim = {perBlock}).", "kcache");
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -824,6 +824,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         int heads, int headDim, int blockSize, int seqLen, float scale)
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
         if (!_kernelCache.TryGetValue("paged_attention_decode", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: paged_attention_decode");
         var output = AllocateBuffer(heads * headDim);
@@ -844,6 +845,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
         if (!_kernelCache.TryGetValue("paged_attention_prefill", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: paged_attention_prefill");
         var output = AllocateBuffer(numQueries * heads * headDim);
@@ -865,6 +867,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
         if (!_kernelCache.TryGetValue("paged_attention_decode_gqa", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: paged_attention_decode_gqa");
         var output = AllocateBuffer(heads * headDim);
@@ -886,6 +889,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
         if (!_kernelCache.TryGetValue("paged_attention_prefill_gqa", out var kernel))
             throw new InvalidOperationException("HIP kernel not found: paged_attention_prefill_gqa");
         var output = AllocateBuffer(numQueries * heads * headDim);
@@ -955,6 +959,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt8));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt8));
+        GpuKernelGuards.Capacity(weightsInt8, (long)K * N, nameof(weightsInt8), nameof(DequantGemmInt8));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt8));
         return LaunchDequantGemm("dequant_gemm_int8", activations, weightsInt8, scales, M, K, N, groupSize, scaleCount);
     }
@@ -966,6 +971,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt4));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt4));
+        GpuKernelGuards.Capacity(weightsInt4Packed, ((long)K * N + 1) / 2, nameof(weightsInt4Packed), nameof(DequantGemmInt4));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt4));
         return LaunchDequantGemm("dequant_gemm_int4", activations, weightsInt4Packed, scales, M, K, N, groupSize, scaleCount);
     }
@@ -977,6 +983,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmFp8E4M3));
+        GpuKernelGuards.Capacity(weightsFp8, (long)K * N, nameof(weightsFp8), nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmFp8E4M3));
         return LaunchDequantGemm("dequant_gemm_fp8_e4m3", activations, weightsFp8, scales, M, K, N, groupSize, scaleCount);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.PagedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.PagedAttention.cs
@@ -16,6 +16,7 @@ public sealed partial class MetalBackend
     {
         ThrowIfDisposed();
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
         var output = AllocateBuffer(heads * headDim);
         var pipeline = GetPipeline("PagedAttention", _pagedAttnLibrary, "paged_attention_decode");
         var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(heads);
@@ -45,6 +46,7 @@ public sealed partial class MetalBackend
         ThrowIfDisposed();
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
         var output = AllocateBuffer(numQueries * heads * headDim);
         var pipeline = GetPipeline("PagedAttention", _pagedAttnLibrary, "paged_attention_prefill");
         var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(numQueries * heads);
@@ -75,6 +77,7 @@ public sealed partial class MetalBackend
         ThrowIfDisposed();
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
         var output = AllocateBuffer(heads * headDim);
         var pipeline = GetPipeline("PagedAttention", _pagedAttnLibrary, "paged_attention_decode_gqa");
         var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(heads);
@@ -106,6 +109,7 @@ public sealed partial class MetalBackend
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
         var output = AllocateBuffer(numQueries * heads * headDim);
         var pipeline = GetPipeline("PagedAttention", _pagedAttnLibrary, "paged_attention_prefill_gqa");
         var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(numQueries * heads);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.QuantGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.QuantGemm.cs
@@ -13,7 +13,10 @@ public sealed partial class MetalBackend
     /// </summary>
     public IGpuBuffer DequantGemmInt(IGpuBuffer activations, IGpuBuffer weightsInt, IGpuBuffer scales,
         int M, int K, int N, int groupSize, int scaleCount)
-        => LaunchDequantGemm("dequant_gemm_int", activations, weightsInt, scales, M, K, N, groupSize, scaleCount);
+    {
+        GpuKernelGuards.Capacity(weightsInt, (long)K * N, nameof(weightsInt), nameof(DequantGemmInt));
+        return LaunchDequantGemm("dequant_gemm_int", activations, weightsInt, scales, M, K, N, groupSize, scaleCount);
+    }
 
     /// <summary>
     /// Weight-only fused dequant-GEMM for OCP FP8 E4M3 weights: C[M,N] = act[M,K] ·
@@ -22,7 +25,10 @@ public sealed partial class MetalBackend
     /// </summary>
     public IGpuBuffer DequantGemmFp8E4M3(IGpuBuffer activations, IGpuBuffer weightsFp8Raw, IGpuBuffer scales,
         int M, int K, int N, int groupSize, int scaleCount)
-        => LaunchDequantGemm("dequant_gemm_fp8", activations, weightsFp8Raw, scales, M, K, N, groupSize, scaleCount);
+    {
+        GpuKernelGuards.Capacity(weightsFp8Raw, (long)K * N, nameof(weightsFp8Raw), nameof(DequantGemmFp8E4M3));
+        return LaunchDequantGemm("dequant_gemm_fp8", activations, weightsFp8Raw, scales, M, K, N, groupSize, scaleCount);
+    }
 
     private IGpuBuffer LaunchDequantGemm(string kernelName, IGpuBuffer act, IGpuBuffer weights, IGpuBuffer scales,
         int M, int K, int N, int groupSize, int scaleCount)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -2666,6 +2666,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             if (_context == null) throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+            GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
             var output = AllocateBuffer(heads * headDim);
             try
             {
@@ -2705,6 +2706,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_context == null) throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
             if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+            GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
             var output = AllocateBuffer(numQueries * heads * headDim);
             try
             {
@@ -2742,6 +2744,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_context == null) throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
             GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+            GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
             var output = AllocateBuffer(heads * headDim);
             try
             {
@@ -2774,6 +2777,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
             GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
             if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+            GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
             var output = AllocateBuffer(numQueries * heads * headDim);
             try
             {
@@ -2881,6 +2885,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt8));
             GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt8));
+            GpuKernelGuards.Capacity(weightsInt8, (long)K * N, nameof(weightsInt8), nameof(DequantGemmInt8));
             GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt8));
 
             var output = AllocateBuffer(M * N);
@@ -2926,6 +2931,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt4));
             GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt4));
+            GpuKernelGuards.Capacity(weightsInt4Packed, ((long)K * N + 1) / 2, nameof(weightsInt4Packed), nameof(DequantGemmInt4));
             GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt4));
 
             var output = AllocateBuffer(M * N);
@@ -2971,6 +2977,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException("OpenCL context not available");
             GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmFp8E4M3));
             GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmFp8E4M3));
+            GpuKernelGuards.Capacity(weightsFp8, (long)K * N, nameof(weightsFp8), nameof(DequantGemmFp8E4M3));
             GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmFp8E4M3));
 
             var output = AllocateBuffer(M * N);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend.cs
@@ -569,6 +569,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt));
+        GpuKernelGuards.Capacity(weightsInt, (long)K * N, nameof(weightsInt), nameof(DequantGemmInt));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt));
         var result = AllocateBuffer(M * N);
         var pc = new uint[] { (uint)M, (uint)K, (uint)N, (uint)groupSize, (uint)scaleCount };
@@ -587,6 +588,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmFp8E4M3));
+        GpuKernelGuards.Capacity(weightsFp8Raw, (long)K * N, nameof(weightsFp8Raw), nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmFp8E4M3));
         var result = AllocateBuffer(M * N);
         var pc = new uint[] { (uint)M, (uint)K, (uint)N, (uint)groupSize, (uint)scaleCount };
@@ -605,6 +607,7 @@ public sealed unsafe partial class VulkanBackend
     {
         EnsureInitialized();
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
         var result = AllocateBuffer(heads * headDim);
         var pc = new uint[] { (uint)heads, (uint)headDim, (uint)blockSize, (uint)seqLen, FloatBits(scale) };
         GlslQuintOp(VulkanGlslKernels.PagedAttentionDecode, q, kcache, vcache, blockTable, result, heads, pc, (uint)(pc.Length * sizeof(uint)));
@@ -621,6 +624,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
         var result = AllocateBuffer(numQueries * heads * headDim);
         var pc = new uint[] { (uint)heads, (uint)headDim, (uint)blockSize, (uint)numQueries, (uint)startPos, FloatBits(scale) };
         GlslQuintOp(VulkanGlslKernels.PagedAttentionPrefill, q, kcache, vcache, blockTable, result, numQueries * heads, pc, (uint)(pc.Length * sizeof(uint)));
@@ -635,6 +639,7 @@ public sealed unsafe partial class VulkanBackend
         EnsureInitialized();
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
         var result = AllocateBuffer(heads * headDim);
         var pc = new uint[] { (uint)heads, (uint)kvHeads, (uint)headDim, (uint)blockSize, (uint)seqLen, FloatBits(scale) };
         GlslQuintOp(VulkanGlslKernels.PagedAttentionDecodeGqa, q, kcache, vcache, blockTable, result, heads, pc, (uint)(pc.Length * sizeof(uint)));
@@ -650,6 +655,7 @@ public sealed unsafe partial class VulkanBackend
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
         var result = AllocateBuffer(numQueries * heads * headDim);
         var pc = new uint[] { (uint)heads, (uint)kvHeads, (uint)headDim, (uint)blockSize, (uint)numQueries, (uint)startPos, FloatBits(scale) };
         GlslQuintOp(VulkanGlslKernels.PagedAttentionPrefillGqa, q, kcache, vcache, blockTable, result, numQueries * heads, pc, (uint)(pc.Length * sizeof(uint)));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend.cs
@@ -234,6 +234,7 @@ public sealed partial class WebGpuBackend
         int heads, int headDim, int blockSize, int seqLen, float scale)
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecode));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecode));
         var output = AllocateBuffer(heads * headDim);
         DispatchRecurrence("paged_attention_decode", WebGpuKernels.PagedAttentionDecodeSource, heads,
             new[] { q, kcache, vcache, blockTable, output },
@@ -250,6 +251,7 @@ public sealed partial class WebGpuBackend
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefill));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, heads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefill));
         var output = AllocateBuffer(numQueries * heads * headDim);
         DispatchRecurrence("paged_attention_prefill", WebGpuKernels.PagedAttentionPrefillSource, numQueries * heads,
             new[] { q, kcache, vcache, blockTable, output },
@@ -264,6 +266,7 @@ public sealed partial class WebGpuBackend
     {
         GpuKernelGuards.Attention(heads, headDim, blockSize, seqLen, nameof(PagedAttentionDecodeGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionDecodeGqa));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, seqLen, 1, nameof(PagedAttentionDecodeGqa));
         var output = AllocateBuffer(heads * headDim);
         DispatchRecurrence("paged_attention_decode_gqa", WebGpuKernels.PagedAttentionDecodeGqaSource, heads,
             new[] { q, kcache, vcache, blockTable, output },
@@ -279,6 +282,7 @@ public sealed partial class WebGpuBackend
         GpuKernelGuards.Attention(heads, headDim, blockSize, numQueries, nameof(PagedAttentionPrefillGqa));
         GpuKernelGuards.Gqa(heads, kvHeads, nameof(PagedAttentionPrefillGqa));
         if (startPos < 0) throw new ArgumentOutOfRangeException(nameof(startPos));
+        GpuKernelGuards.PagedAttentionBuffers(q, kcache, vcache, blockTable, heads, kvHeads, headDim, blockSize, checked(startPos + numQueries), numQueries, nameof(PagedAttentionPrefillGqa));
         var output = AllocateBuffer(numQueries * heads * headDim);
         DispatchRecurrence("paged_attention_prefill_gqa", WebGpuKernels.PagedAttentionPrefillGqaSource, numQueries * heads,
             new[] { q, kcache, vcache, blockTable, output },
@@ -336,6 +340,7 @@ public sealed partial class WebGpuBackend
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmInt));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmInt));
+        GpuKernelGuards.Capacity(weightsInt, (long)K * N, nameof(weightsInt), nameof(DequantGemmInt));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmInt));
         var output = AllocateBuffer(M * N);
         Dispatch4BufferAsync("DequantGemmInt", WebGpuKernels.DequantGemmIntSource, "dequant_gemm_int",
@@ -354,6 +359,7 @@ public sealed partial class WebGpuBackend
     {
         GpuKernelGuards.DequantGemm(M, K, N, groupSize, scaleCount, nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(activations, (long)M * K, nameof(activations), nameof(DequantGemmFp8E4M3));
+        GpuKernelGuards.Capacity(weightsFp8Raw, (long)K * N, nameof(weightsFp8Raw), nameof(DequantGemmFp8E4M3));
         GpuKernelGuards.Capacity(scales, scaleCount, nameof(scales), nameof(DequantGemmFp8E4M3));
         var output = AllocateBuffer(M * N);
         Dispatch4BufferAsync("DequantGemmFp8", WebGpuKernels.DequantGemmFp8Source, "dequant_gemm_fp8",

--- a/src/AiDotNet.Tensors/NumericOperations/Float8Types.cs
+++ b/src/AiDotNet.Tensors/NumericOperations/Float8Types.cs
@@ -65,6 +65,11 @@ public readonly struct Float8E4M3 : IEquatable<Float8E4M3>, IComparable<Float8E4
     /// <summary>NaN encoding (exp-max + mantissa-max, positive sign).</summary>
     public static Float8E4M3 NaN => new(NaNRawPos);
 
+    /// <summary>Constructs the value from its raw 8-bit encoding (inverse of <see cref="RawValue"/>).
+    /// Lets callers exercise exact encodings — e.g. exponent-zero raws like 0x01/0x81 — that
+    /// <see cref="FromFloat"/> would round away.</summary>
+    public static Float8E4M3 FromRawValue(byte raw) => new(raw);
+
     /// <summary>True iff this value encodes NaN.</summary>
     public bool IsNaN
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmMetalTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmMetalTests.cs
@@ -156,6 +156,9 @@ public sealed class QuantGemmMetalTests : IDisposable
             Float8E4M3.MaxFinite, Float8E4M3.MinFinite, Float8E4M3.Zero, Float8E4M3.FromFloat(-0f),
             Float8E4M3.FromFloat(448f), Float8E4M3.FromFloat(-448f),
             Float8E4M3.FromFloat(0.015625f), Float8E4M3.FromFloat(-0.015625f),
+            // Raw exponent-zero encodings FromFloat would round to signed zero — GPU decode must match CPU.
+            Float8E4M3.FromRawValue(0x01), Float8E4M3.FromRawValue(0x07),
+            Float8E4M3.FromRawValue(0x81), Float8E4M3.FromRawValue(0x87),
         };
         for (int b = 0; b < fp8Boundaries.Length && b < KN; b++)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmOpenClTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmOpenClTests.cs
@@ -255,6 +255,15 @@ public sealed class QuantGemmOpenClTests : IDisposable
             raws[i] = f8.RawValue;
             decoded[i] = f8.ToFloat();
         }
+        // Hardware-validate exact raw E4M3 encodings FromFloat can't produce, incl. exponent-zero raws
+        // (0x01/0x07/0x81/0x87) and the ±MaxFinite/±smallest-normal boundaries — GPU decode must match CPU.
+        byte[] rawBoundaries = { 0x01, 0x07, 0x81, 0x87, 0x7E, 0xFE, 0x08, 0x88 };
+        for (int b = 0; b < rawBoundaries.Length && b < kn; b++)
+        {
+            var f8 = Float8E4M3.FromRawValue(rawBoundaries[b]);
+            raws[b] = f8.RawValue;
+            decoded[b] = f8.ToFloat();
+        }
 
         bool perTensor = groupSize <= 0;
         int scaleCount;

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmVulkanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmVulkanTests.cs
@@ -159,6 +159,9 @@ public sealed class QuantGemmVulkanTests
             Float8E4M3.MaxFinite, Float8E4M3.MinFinite, Float8E4M3.Zero, Float8E4M3.FromFloat(-0f),
             Float8E4M3.FromFloat(448f), Float8E4M3.FromFloat(-448f),
             Float8E4M3.FromFloat(0.015625f), Float8E4M3.FromFloat(-0.015625f),
+            // Raw exponent-zero encodings FromFloat would round to signed zero — GPU decode must match CPU.
+            Float8E4M3.FromRawValue(0x01), Float8E4M3.FromRawValue(0x07),
+            Float8E4M3.FromRawValue(0x81), Float8E4M3.FromRawValue(0x87),
         };
         for (int b = 0; b < fp8Boundaries.Length && b < KN; b++)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmWebGpuTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/QuantGemmWebGpuTests.cs
@@ -160,6 +160,9 @@ public sealed class QuantGemmWebGpuTests : IDisposable
             Float8E4M3.MaxFinite, Float8E4M3.MinFinite, Float8E4M3.Zero, Float8E4M3.FromFloat(-0f),
             Float8E4M3.FromFloat(448f), Float8E4M3.FromFloat(-448f),
             Float8E4M3.FromFloat(0.015625f), Float8E4M3.FromFloat(-0.015625f),
+            // Raw exponent-zero encodings FromFloat would round to signed zero — GPU decode must match CPU.
+            Float8E4M3.FromRawValue(0x01), Float8E4M3.FromRawValue(0x07),
+            Float8E4M3.FromRawValue(0x81), Float8E4M3.FromRawValue(0x87),
         };
         for (int b = 0; b < fp8Boundaries.Length && b < KN; b++)
         {


### PR DESCRIPTION
Follow-up to the CodeRabbit round-2 comments on #801 (which was merged before these could land, so they go here).

- **PagedAttentionBuffers guard**: validates q / block-table / K-V pool capacities (and prefill checked-adds startPos+numQueries) before every paged decode/prefill MHA+GQA dispatch on all 6 backends. Per-block-id bounds require a device read, so they stay off the host fast path (documented in the guard).
- **Weights-buffer capacity guard** added to every dequant-GEMM dispatch on all 6 backends (int8: K*N, int4-packed: ceil(K*N/2), fp8/unpacked: K*N).
- **Float8E4M3.FromRawValue(byte)** to construct exact raw encodings.
- **Quant tests**: raw exponent-zero E4M3 cases (0x01/0x07/0x81/0x87) + boundaries; the OpenCL test hardware-validates them (kernel decode == CPU oracle).

Validated: OpenCL 64/64 DirectGpu tests pass; all 6 backends build clean.

Generated with Claude Code