### PR TITLE
fix(ci): repair line-ending autofix workflow (revives release automation)

### DIFF
--- a/.github/workflows/normalize-line-endings.yml
+++ b/.github/workflows/normalize-line-endings.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Commit changes
         if: steps.renorm.outputs.has_changes == 'true'
-        run: git commit -m "chore: normalize line endings (git renormalize)"
+        run: |
+          git commit -m "chore: normalize line endings (git renormalize)"
 
       - name: Push branch
         if: steps.renorm.outputs.has_changes == 'true'

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,49 @@
+name: Lint PR Title (Conventional Commits)
+
+# Squash-merge uses the PR title as the commit subject, and release-please only reacts to
+# conventional-commit subjects. This check fails a PR whose title is not a valid conventional
+# commit, so non-conventional subjects (which silently disable release-please) can't reach main.
+# Mark this check "required" in branch protection for it to block merges.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: pr-title-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  lint-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    # release-please maintains its own PRs; don't lint those.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check conventional-commit format
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+            // Types kept in sync with release-please-config.json changelog-sections.
+            const types = ['feat','fix','perf','revert','refactor','build','ci','docs','chore','style','test'];
+            const pattern = new RegExp('^(' + types.join('|') + ')(\\([^)]+\\))?!?: .+');
+            if (pattern.test(title)) {
+              core.info(`PR title OK: ${title}`);
+              return;
+            }
+            const releasing = ['feat','fix','perf','revert','refactor','build','docs'];
+            core.setFailed(
+              `PR title is not a Conventional Commit: "${title}"\n\n` +
+              `Squash-merge uses the PR title as the commit subject, and release-please only cuts a\n` +
+              `release when it sees a conventional subject — a non-conventional title silently stops\n` +
+              `release PRs from being created.\n\n` +
+              `Use: <type>(optional-scope): <description>\n` +
+              `  Allowed types: ${types.join(', ')}\n` +
+              `  Trigger a release: ${releasing.join(', ')}  (chore/ci/style/test do not)\n` +
+              `  Examples: "feat(gpu): add paged attention", "fix(ci): repair release workflow"`
+            );


### PR DESCRIPTION
## Two failures fixed + recurrence prevention

### 1. Autofix CI failing on every push (FIX)
`.github/workflows/normalize-line-endings.yml` had an inline `run: git commit -m "chore: ..."` whose embedded `: ` made GitHub fail to parse the whole workflow (startup_failure, 0 jobs) — so it produced a failed run on every push. Fixed by switching that step to a block scalar. A valid schedule/workflow_dispatch-only workflow no longer runs on push.

### 2. release-please stopped opening a release PR (ROOT CAUSE)
Not a tool bug. The GPU-parity work merged in #801/#803 landed with non-conventional squash subjects (`GPU parity kernels: ...`, `review: ...`), so release-please correctly found nothing releasable since `v0.115.0`. This PR's commit carries `Release-As: 0.116.0`, so merging it opens the `0.116.0` release PR. (Even without that footer, the `fix:` type revives release-please.)

### 3. Recurrence prevention (NEW)
Added `.github/workflows/pr-title-lint.yml`: a blocking Conventional-Commits check on PR titles. Since squash-merge uses the PR title as the commit subject, this stops non-conventional titles (which silently disable release-please) from reaching `main`. Types are kept in sync with `release-please-config.json`. **Mark this check required in branch protection** for it to block merges.

Chose a blocking validation over an auto-rewrite: auto-guessing the type can mislabel a `feat` as `chore`, which would still skip the release — the exact failure we just hit.

Generated with Claude Code