### PR TITLE
feat(gpu): expose paged-attention kernels via IPagedAttentionBackend capability interface

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IPagedAttentionBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IPagedAttentionBackend.cs
@@ -1,0 +1,53 @@
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    /// <summary>
+    /// Capability interface for GPU backends that provide paged-attention kernels (vLLM-style paged KV
+    /// cache decode/prefill). Implemented by the OpenCL, CUDA, HIP, and Metal backends; backends without
+    /// paged-attention support (e.g. Vulkan, WebGPU) simply do not implement it.
+    /// </summary>
+    /// <remarks>
+    /// Consumers obtain a backend from <see cref="DirectGpuTensorEngine.GetBackend"/> and test for this
+    /// capability: <c>if (engine.GetBackend() is IPagedAttentionBackend paged) { ... }</c>. This exposes the
+    /// existing per-backend kernels (previously public only on the concrete backend types) through a stable,
+    /// backend-agnostic surface so higher layers (e.g. an inference/serving engine) can run paged attention
+    /// on the resident <see cref="DevicePagedKVCache"/> without depending on a specific backend type.
+    /// </remarks>
+    public interface IPagedAttentionBackend
+    {
+        /// <summary>Single-query paged-attention decode: attends one query per head over the paged KV cache.</summary>
+        IGpuBuffer PagedAttentionDecode(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int headDim, int blockSize, int seqLen, float scale);
+
+        /// <summary>Multi-query paged-attention prefill: attends <paramref name="numQueries"/> queries (causal).</summary>
+        IGpuBuffer PagedAttentionPrefill(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int headDim, int blockSize, int numQueries, int startPos, float scale);
+
+        /// <summary>Grouped-query variant of <see cref="PagedAttentionDecode"/> (kvHeads &lt; heads).</summary>
+        IGpuBuffer PagedAttentionDecodeGqa(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int kvHeads, int headDim, int blockSize, int seqLen, float scale);
+
+        /// <summary>Grouped-query variant of <see cref="PagedAttentionPrefill"/> (kvHeads &lt; heads).</summary>
+        IGpuBuffer PagedAttentionPrefillGqa(IGpuBuffer q, IGpuBuffer kcache, IGpuBuffer vcache, IGpuBuffer blockTable,
+            int heads, int kvHeads, int headDim, int blockSize, int numQueries, int startPos, float scale);
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    public sealed partial class OpenClBackend : DirectGpu.IPagedAttentionBackend { }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA
+{
+    public sealed partial class CudaBackend : DirectGpu.IPagedAttentionBackend { }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP
+{
+    public sealed partial class HipBackend : DirectGpu.IPagedAttentionBackend { }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    public sealed partial class MetalBackend : DirectGpu.IPagedAttentionBackend { }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DevicePagedKVCacheOpenClTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DevicePagedKVCacheOpenClTests.cs
@@ -121,6 +121,52 @@ public sealed class DevicePagedKVCacheOpenClTests : IDisposable
     }
 
     [Fact]
+    public void Backend_ExposesPagedAttentionCapability_AndInterfacePathMatchesOracle()
+    {
+        // The capability interface (IPagedAttentionBackend) is how higher layers (e.g. an inference/serving
+        // engine) consume paged attention without depending on a concrete backend type. Verify the backend
+        // advertises it and that dispatching through the interface produces the same result as the oracle.
+        if (!EnsureReady()) return;
+        var backend = _backend!;
+        Assert.True(backend is IPagedAttentionBackend, "OpenClBackend must expose IPagedAttentionBackend.");
+        var paged = (IPagedAttentionBackend)backend;
+
+        const int heads = 2, headDim = 32, blockSize = 8, seqLen = 20;
+        int stride = heads * headDim;
+        var rng = new Random(123);
+        var k = new float[seqLen * stride];
+        var v = new float[seqLen * stride];
+        for (int i = 0; i < k.Length; i++) { k[i] = (float)(rng.NextDouble() * 2 - 1); v[i] = (float)(rng.NextDouble() * 2 - 1); }
+        var q = new float[stride];
+        for (int i = 0; i < q.Length; i++) q[i] = (float)(rng.NextDouble() * 2 - 1);
+        float scale = 1.0f / MathF.Sqrt(headDim);
+
+        using var cache = new DevicePagedKVCache(backend, (seqLen + blockSize - 1) / blockSize + 2, blockSize, heads, headDim);
+        cache.Append(1, k, v);
+
+        float[] actual;
+        IGpuBuffer? qBuf = null, btBuf = null, outBuf = null;
+        try
+        {
+            qBuf = backend.AllocateBuffer(q);
+            btBuf = cache.GetBlockTableBuffer(1);
+            outBuf = paged.PagedAttentionDecode(qBuf, cache.KeyBlocks, cache.ValueBlocks, btBuf,
+                heads, headDim, blockSize, cache.GetLength(1), scale);
+            actual = backend.DownloadBuffer(outBuf);
+        }
+        finally { qBuf?.Dispose(); btBuf?.Dispose(); outBuf?.Dispose(); }
+
+        var expected = AttnOracle(q, k, v, heads, headDim, seqLen, scale);
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            float tol = 2e-3f + 2e-3f * Math.Abs(expected[i]);
+            Assert.True(Math.Abs(expected[i] - actual[i]) <= tol,
+                $"interface-path decode mismatch at {i}: expected {expected[i]}, got {actual[i]}");
+        }
+    }
+
+    [Fact]
     public void Free_ReturnsBlocksToPool_AndReuses()
     {
         if (!EnsureReady()) return;


### PR DESCRIPTION
Exposes the existing GPU paged-attention kernels (PagedAttentionDecode/Prefill + GQA variants) through a backend-agnostic capability interface `IPagedAttentionBackend`, so the serving/inference layer can invoke them via `DirectGpuTensorEngine.GetBackend() is IPagedAttentionBackend` without depending on a concrete backend type.

**Why:** the kernels were public only on the concrete backends (OpenCL/CUDA/HIP/Metal). `GetBackend()` returns `IDirectGpuBackend`, which doesn't declare them, so higher layers had no way to call them. Adding to `IDirectGpuBackend` would break backends without paged support (Vulkan/WebGPU) — hence a capability interface only the four supporting backends implement (their existing methods satisfy it unchanged).

**Unblocks:** GPU-accelerated paged attention in the AiDotNet serving engine (paired with the already-public `DevicePagedKVCache`).

**Test:** verifies OpenClBackend advertises the capability and that a decode dispatched through the interface matches the standard-attention CPU oracle on a real OpenCL GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)