### PR TITLE
feat(licensing): P1 mirror — scope binding + jti/CRL revocation on signed entitlements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ scratch-opparity/
 *.pem
 private_key.pem
 tensors-entitlement.json
+
+# Python tool caches
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,10 @@ src/AiDotNet.Native.CUDA/obj/cuda-split/
 # local CLI/device state (gh)
 .local/
 scratch-opparity/
+
+# License signing PRIVATE keys / issued artifacts — NEVER commit. Generated locally by
+# tools/license-issuer/*keygen*.py (RSA entitlement signing key) and the issuers. The PUBLIC
+# key is embedded in source (SignedEntitlement.EntitlementPublicKey / Licensing/LicensePublicKey.json).
+*.pem
+private_key.pem
+tensors-entitlement.json

--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -161,6 +161,18 @@
   </ItemGroup>
 
   <!--
+    BouncyCastle.Cryptography (Org.BouncyCastle) — Ed25519 (EdDSA, RFC 8032) verification for the offline
+    `aidn2.` license-token path (AsymmetricEntitlementVerifier / Ed25519LicenseRevocation). This is the
+    Tensors runtime's FIRST BouncyCastle dependency: the rest of the runtime deliberately uses only
+    System.Security.Cryptography, but .NET ships no Ed25519 type on ANY target (net471/net8/net10), so the
+    signed-token verifier needs a portable Ed25519 implementation across all three TFMs. Version pinned to
+    2.6.2 to match the main AiDotNet SDK, so a token minted by the SDK verifies identically here. Cross-TFM
+    (net461+), 100% managed, no native/transitive deps. -->
+  <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
+  </ItemGroup>
+
+  <!--
     CPU BLAS native (#327): industry-standard pattern matching PyTorch / NumPy
     / TensorFlow — ship libopenblas alongside the managed package so consumers
     get MKL-class GEMM throughput out of the box. Without this reference,
@@ -334,6 +346,24 @@
   <ItemGroup>
     <EmbeddedResource Include="Licensing\LicenseRevocation.json" Condition="Exists('Licensing\LicenseRevocation.json')">
       <LogicalName>AiDotNet.Tensors.LicenseRevocation</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- Embedded PUBLIC Ed25519 signing key(s) (JWK OKP set) used by AsymmetricEntitlementVerifier to verify
+       `aidn2.` tokens offline. Contains the real prod-2026a public key; the private half never ships. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Licensing\LicensePublicKey.json">
+      <LogicalName>AiDotNet.Tensors.LicensePublicKey</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- Optional signed Ed25519 revocation deny-list (CRL) for `aidn2.` tokens, verified by
+       Ed25519LicenseRevocation against the embedded Ed25519 public key. Additive/fail-open: absent =>
+       nothing revoked. Injected (and refreshed) at release with the current signed CRL. Kept separate from
+       the RSA LicenseRevocation.json above (different signing key / trust root). -->
+  <ItemGroup>
+    <EmbeddedResource Include="Licensing\LicenseRevocationEd25519.json" Condition="Exists('Licensing\LicenseRevocationEd25519.json')">
+      <LogicalName>AiDotNet.Tensors.LicenseRevocationEd25519</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -328,4 +328,13 @@
     <EmbeddedResource Include="Engines\BlasManaged\Autotune\prewarm\*.prewarm.json" />
   </ItemGroup>
 
+  <!-- Optional signed revocation deny-list (CRL) for signed entitlements, verified by
+       TensorsLicenseRevocation against the embedded entitlement key. Additive/fail-open: absent =>
+       nothing revoked. Injected (and refreshed) at release with the current signed CRL. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Licensing\LicenseRevocation.json" Condition="Exists('Licensing\LicenseRevocation.json')">
+      <LogicalName>AiDotNet.Tensors.LicenseRevocation</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/AiDotNet.Tensors/Licensing/Aidn2Claims.cs
+++ b/src/AiDotNet.Tensors/Licensing/Aidn2Claims.cs
@@ -1,0 +1,110 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// The signed claim set carried by an <c>aidn2.</c> asymmetric license token — the Tensors port of the
+/// main SDK's <c>LicenseClaims</c>, parsed/serialized with <see cref="System.Text.Json"/> (Tensors does
+/// not reference Newtonsoft).
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> A license token is a small block of JSON (these fields) plus a
+/// cryptographic signature over that exact JSON. Because the signature can only be produced with the
+/// server's private key, nobody can change any field (e.g. bump <c>exp</c> or upgrade <c>tier</c>)
+/// without invalidating the signature.</para>
+/// <para>Field names are intentionally short (JWT-style) to keep tokens compact.</para>
+/// </remarks>
+internal sealed class Aidn2Claims
+{
+    /// <summary>Subject — the customer / license the token was issued to.</summary>
+    [JsonPropertyName("sub")]
+    public string? Sub { get; set; }
+
+    /// <summary>Tier: <c>community</c>, <c>pro</c>, or <c>enterprise</c>.</summary>
+    [JsonPropertyName("tier")]
+    public string? Tier { get; set; }
+
+    /// <summary>Number of licensed seats.</summary>
+    [JsonPropertyName("seats")]
+    public int Seats { get; set; }
+
+    /// <summary>Issued-at, Unix seconds (UTC).</summary>
+    [JsonPropertyName("iat")]
+    public long Iat { get; set; }
+
+    /// <summary>Expiry, Unix seconds (UTC). Bounds offline use — a leaked token self-expires.</summary>
+    [JsonPropertyName("exp")]
+    public long Exp { get; set; }
+
+    /// <summary>Key id — selects which embedded public key verifies this token (rotation).</summary>
+    [JsonPropertyName("kid")]
+    public string? Kid { get; set; }
+
+    /// <summary>
+    /// Signature algorithm identifier. Always <c>"EdDSA"</c> for aidn2 tokens (Ed25519). Recorded in the
+    /// claims so a future primitive change / rotation is unambiguous — the verifier rejects any token
+    /// whose <c>alg</c> it does not implement rather than silently assuming Ed25519.
+    /// </summary>
+    [JsonPropertyName("alg")]
+    public string? Alg { get; set; }
+
+    /// <summary>
+    /// Unique token id. The revocation deny-list (CRL) names revoked <c>jti</c> values, so a specific
+    /// leaked token can be killed before its <c>exp</c> without revoking the whole signing key.
+    /// </summary>
+    [JsonPropertyName("jti")]
+    public string? Jti { get; set; }
+
+    /// <summary>
+    /// Explicit capability grants (e.g. <c>tensors:save</c>, <c>tensors:load</c>). Authoritative for
+    /// offline capability gating: the persistence guard checks these rather than assuming any
+    /// <c>Active</c> license unlocks everything.
+    /// </summary>
+    [JsonPropertyName("caps")]
+    public string[]? Caps { get; set; }
+
+    /// <summary>
+    /// Optional machine-binding fingerprint (node-lock). When present, the verifier requires it to equal
+    /// this machine's id hash, so a leaked customer token is useless on another machine.
+    /// </summary>
+    [JsonPropertyName("mach")]
+    public string? Mach { get; set; }
+
+    /// <summary>
+    /// Optional audience/scope binding (e.g. <c>"ci"</c>, <c>"prod"</c>). When present, the verifier
+    /// requires it to equal the host's configured expected scope (<c>AIDOTNET_LICENSE_SCOPE</c>).
+    /// </summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    // Case-INSENSITIVE off (default): the token uses the exact short lowercase names above. Nulls are
+    // omitted so absent optional claims don't clutter the compact canonical JSON that gets signed.
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Serializes the claims to compact JSON. Used only by the (server/test) signer to produce the exact
+    /// bytes that appear in the token's middle segment. The verifier verifies over the raw decoded segment
+    /// bytes as received — it never re-serializes.
+    /// </summary>
+    internal string ToCanonicalJson() => JsonSerializer.Serialize(this, s_options);
+
+    /// <summary>Parses claims JSON. Returns null on malformed input.</summary>
+    internal static Aidn2Claims? TryParse(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Aidn2Claims>(json, s_options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/AsymmetricEntitlementVerifier.cs
+++ b/src/AiDotNet.Tensors/Licensing/AsymmetricEntitlementVerifier.cs
@@ -58,6 +58,13 @@ internal static class AsymmetricEntitlementVerifier
     private static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// Strict UTF-8 decoder (no BOM, throw on invalid bytes). Unlike <see cref="Encoding.UTF8"/>, which
+    /// silently replaces malformed byte sequences with U+FFFD, this fails closed so malformed claim bytes
+    /// are rejected rather than decoded into replacement characters.
+    /// </summary>
+    private static readonly UTF8Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
     /// Returns true if <paramref name="key"/> is in the asymmetric token shape:
     /// <c>aidn2.&lt;base64url&gt;.&lt;base64url&gt;</c>. Does NOT verify the signature — a cheap structural
     /// check used for routing.
@@ -196,7 +203,11 @@ internal static class AsymmetricEntitlementVerifier
         string claimsJson;
         try
         {
-            claimsJson = Encoding.UTF8.GetString(claimsBytes);
+            claimsJson = StrictUtf8.GetString(claimsBytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return EntitlementResult.Invalid("License token claims are not valid UTF-8.");
         }
         catch (ArgumentException)
         {
@@ -284,7 +295,9 @@ internal static class AsymmetricEntitlementVerifier
         }
 
         DateTimeOffset expiresAt = DateTimeOffset.FromUnixTimeSeconds(claims.Exp);
-        if (expiresAt + ClockSkew < nowUtc)
+        // Compare via subtraction rather than `expiresAt + ClockSkew` so an exp at the upper bound
+        // (MaxUnixSeconds, near DateTimeOffset.MaxValue) cannot overflow when adding the skew.
+        if (nowUtc > expiresAt && nowUtc - expiresAt > ClockSkew)
         {
             return EntitlementResult.Invalid("License token expired on " + expiresAt.UtcDateTime.ToString("u") + ".");
         }

--- a/src/AiDotNet.Tensors/Licensing/AsymmetricEntitlementVerifier.cs
+++ b/src/AiDotNet.Tensors/Licensing/AsymmetricEntitlementVerifier.cs
@@ -1,0 +1,323 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Verifies <c>aidn2.</c> asymmetric license tokens against the embedded PUBLIC signing key(s), fully
+/// offline. The Tensors port of the main SDK's <c>AsymmetricLicenseVerifier</c>, returning the shared
+/// <see cref="EntitlementResult"/> so it plugs into <see cref="PersistenceGuard"/> uniformly with the RSA
+/// <see cref="SignedEntitlement"/> path.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> A token looks like <c>aidn2.&lt;claims&gt;.&lt;signature&gt;</c>. We only
+/// check that the signature was produced by the holder of the private key (which lives on the server and
+/// never ships). Because verification uses a <b>public</b> key, an attacker who extracts it from the DLL
+/// still cannot forge a valid token.</para>
+///
+/// <para><b>Primitive:</b> Ed25519 (EdDSA over Curve25519, RFC 8032). .NET's
+/// <c>System.Security.Cryptography</c> ships no Ed25519 type on any of the Tensors target frameworks
+/// (net471/net8/net10), so verification uses the well-audited <c>BouncyCastle.Cryptography</c> library —
+/// the first BouncyCastle dependency in the otherwise-BouncyCastle-free Tensors runtime, added solely for
+/// this offline verification path.</para>
+///
+/// <para><b>Token grammar:</b> <c>aidn2.&lt;base64url(claims_json)&gt;.&lt;base64url(signature)&gt;</c>
+/// where the signature is computed over the raw UTF-8 bytes of <c>claims_json</c>. Claims carry
+/// <c>alg:"EdDSA"</c>.</para>
+///
+/// <para><b>Enforcement order (all AFTER the signature check, since the fields are signed):</b> signature
+/// → CRL revocation (kid/jti) → machine binding (<c>mach</c>) → scope binding
+/// (<c>AIDOTNET_LICENSE_SCOPE</c>) → expiry (5-min clock skew). Fails closed on every problem: only an
+/// authentic, unrevoked, correctly-bound, unexpired token yields a valid <see cref="EntitlementResult"/>.</para>
+/// </remarks>
+internal static class AsymmetricEntitlementVerifier
+{
+    /// <summary>The token version prefix for asymmetric (public-key-signed) licenses.</summary>
+    internal const string Prefix = "aidn2";
+
+    /// <summary>The signature algorithm this verifier implements. Tokens must declare this (or omit alg).</summary>
+    internal const string Algorithm = "EdDSA";
+
+    /// <summary>Ed25519 signatures are exactly 64 bytes.</summary>
+    private const int Ed25519SignatureSize = 64;
+
+    /// <summary>
+    /// Upper bound for a Unix-seconds <c>exp</c> claim (9999-12-31T23:59:59Z). Values outside
+    /// (0, MaxUnixSeconds] are rejected up front so <see cref="DateTimeOffset.FromUnixTimeSeconds"/> can
+    /// never throw.
+    /// </summary>
+    private const long MaxUnixSeconds = 253402300799L;
+
+    /// <summary>Allowed clock skew when checking expiry (kept small — expiry is the primary offline bound).</summary>
+    private static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Returns true if <paramref name="key"/> is in the asymmetric token shape:
+    /// <c>aidn2.&lt;base64url&gt;.&lt;base64url&gt;</c>. Does NOT verify the signature — a cheap structural
+    /// check used for routing.
+    /// </summary>
+    internal static bool IsAsymmetricKeyFormat(string? key)
+    {
+        if (key is null) return false;
+        var parts = key.Split('.');
+        if (parts.Length != 3 || parts[0] != Prefix || parts[1].Length == 0 || parts[2].Length == 0)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < parts[1].Length; i++)
+        {
+            if (!IsBase64UrlChar(parts[1][i])) return false;
+        }
+
+        for (int i = 0; i < parts[2].Length; i++)
+        {
+            if (!IsBase64UrlChar(parts[2][i])) return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsBase64UrlChar(char c)
+    {
+        return (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+            || (c >= '0' && c <= '9')
+            || c == '-'
+            || c == '_';
+    }
+
+    /// <summary>
+    /// Resolves an <c>aidn2.</c> token from the environment / disk and verifies it offline. Resolution
+    /// sources (first Active wins): (a) <c>AIDOTNET_LICENSE_KEY</c> when it is itself an <c>aidn2.</c>
+    /// token, then (b) the main SDK's cached offline tokens <c>~/.aidotnet/offline-*.token</c> (one token
+    /// per file). Returns the verified <see cref="EntitlementResult"/> when a token is Active, or
+    /// <see langword="null"/> when none is present or none verifies — this path is ADDITIVE and
+    /// positive-grant-only, so absence/failure simply falls through to the RSA/key/trial paths.
+    /// </summary>
+    internal static EntitlementResult? TryVerifyConfigured()
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // (a) AIDOTNET_LICENSE_KEY, only when it is an aidn2. token (a server AIDN-* / aidn. key is handled
+        // by the existing online key path — we must not mis-route it here).
+        try
+        {
+            string? envKey = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+            if (envKey is not null && IsAsymmetricKeyFormat(envKey.Trim()))
+            {
+                var r = Verify(envKey.Trim(), now);
+                if (r.IsValid) return r;
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AsymmetricEntitlementVerifier: unable to read AIDOTNET_LICENSE_KEY: " + ex.Message);
+        }
+
+        // (b) Cached offline tokens minted by a prior successful online validation in the main SDK.
+        try
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string dir = Path.Combine(home, ".aidotnet");
+            if (Directory.Exists(dir))
+            {
+                foreach (string file in Directory.EnumerateFiles(dir, "offline-*.token"))
+                {
+                    string token;
+                    try { token = File.ReadAllText(file).Trim(); }
+                    catch { continue; }
+
+                    if (!IsAsymmetricKeyFormat(token)) continue;
+                    var r = Verify(token, now);
+                    if (r.IsValid) return r;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AsymmetricEntitlementVerifier: cached offline token scan failed: " + ex.GetType().Name + ": " + ex.Message);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Verifies an <c>aidn2.</c> token fully offline: Ed25519 signature against the embedded public key
+    /// selected by <c>kid</c>, then CRL revocation, machine binding, scope binding, and expiry — all only
+    /// AFTER the signature check. Returns a valid <see cref="EntitlementResult"/> (tenant=<c>sub</c>,
+    /// expiry, signed <c>caps</c>) ONLY when the token is authentic and active; every other outcome
+    /// (bad signature, unknown kid, revoked, wrong machine, wrong scope, expired, malformed) is a
+    /// fail-closed <see cref="EntitlementResult.Invalid"/>.
+    /// </summary>
+    internal static EntitlementResult Verify(string key, DateTimeOffset nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return EntitlementResult.Invalid("License token is empty or missing.");
+        }
+
+        var parts = key.Split('.');
+        if (parts.Length != 3 || parts[0] != Prefix)
+        {
+            return EntitlementResult.Invalid("License token is not a valid aidn2 token.");
+        }
+
+        byte[] claimsBytes;
+        byte[] signature;
+        try
+        {
+            claimsBytes = Base64UrlHelper.Decode(parts[1]);
+            signature = Base64UrlHelper.Decode(parts[2]);
+        }
+        catch (FormatException)
+        {
+            return EntitlementResult.Invalid("License token encoding is malformed.");
+        }
+
+        if (claimsBytes.Length == 0 || signature.Length == 0)
+        {
+            return EntitlementResult.Invalid("License token is missing claims or signature.");
+        }
+
+        if (signature.Length != Ed25519SignatureSize)
+        {
+            return EntitlementResult.Invalid("License signature is not a valid Ed25519 signature.");
+        }
+
+        string claimsJson;
+        try
+        {
+            claimsJson = Encoding.UTF8.GetString(claimsBytes);
+        }
+        catch (ArgumentException)
+        {
+            return EntitlementResult.Invalid("License token claims are not valid UTF-8.");
+        }
+
+        Aidn2Claims? claims = Aidn2Claims.TryParse(claimsJson);
+        if (claims is null)
+        {
+            return EntitlementResult.Invalid("License token claims are malformed.");
+        }
+
+        // Reject a token that declares a signature algorithm this verifier does not implement. A missing
+        // alg is tolerated (implicitly EdDSA for aidn2); a present, mismatched alg fails closed.
+        if (claims.Alg is not null && claims.Alg.Length > 0 &&
+            !string.Equals(claims.Alg, Algorithm, StringComparison.Ordinal))
+        {
+            return EntitlementResult.Invalid("License token declares unsupported signature algorithm '" + claims.Alg + "'.");
+        }
+
+        string? kid = claims.Kid;
+        if (kid is null || kid.Length == 0)
+        {
+            return EntitlementResult.Invalid("License token does not name a signing key (kid).");
+        }
+
+        // A build that embeds no matching public key CANNOT verify a signature. Fail closed.
+        if (!TensorsLicensePublicKeyProvider.TryGetPublicKey(kid, out byte[] publicKey))
+        {
+            return EntitlementResult.Invalid(
+                "This build cannot verify the license signature: no embedded public key matches the " +
+                "token's key id (kid='" + kid + "').");
+        }
+
+        bool signatureValid;
+        try
+        {
+            var verifier = new Ed25519Signer();
+            verifier.Init(false, new Ed25519PublicKeyParameters(publicKey, 0));
+            verifier.BlockUpdate(claimsBytes, 0, claimsBytes.Length);
+            signatureValid = verifier.VerifySignature(signature);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AsymmetricEntitlementVerifier: verification error: " + ex.GetType().Name + ": " + ex.Message);
+            return EntitlementResult.Invalid("License signature verification failed.");
+        }
+
+        if (!signatureValid)
+        {
+            return EntitlementResult.Invalid("License signature verification failed.");
+        }
+
+        // Signature is authentic. Enforce the signed bindings + revocation. Fail closed on every problem.
+
+        // Revocation (CRL deny-list): a leaked token (jti) or a compromised key (kid) can be killed before
+        // exp. Absent/expired/unsigned CRL => not enforced (fail-open; token exp still bounds).
+        if (Ed25519LicenseRevocation.IsRevoked(kid, claims.Jti))
+        {
+            return EntitlementResult.Invalid("License token has been revoked.");
+        }
+
+        // Machine binding (node-lock): a token carrying `mach` is only valid on the machine whose id hash
+        // matches. Reuses the main-SDK-parity machine hash so a token minted there verifies here.
+        if (claims.Mach is { Length: > 0 } &&
+            !string.Equals(claims.Mach, TensorsMachineFingerprint.GetMachineIdHash(), StringComparison.Ordinal))
+        {
+            return EntitlementResult.Invalid("License token is bound to a different machine.");
+        }
+
+        // Scope/audience binding: a token carrying `scope` is only valid where the host declares the same
+        // expected scope (AIDOTNET_LICENSE_SCOPE). A scoped token on an unscoped host is rejected.
+        if (claims.Scope is { Length: > 0 } &&
+            !string.Equals(claims.Scope, ResolveExpectedScope(), StringComparison.Ordinal))
+        {
+            return EntitlementResult.Invalid("License token scope '" + claims.Scope + "' does not match this host's expected scope.");
+        }
+
+        // Fail CLOSED on a missing / non-positive / out-of-range exp BEFORE converting it: a malformed exp
+        // must never be treated as "non-expiring".
+        if (claims.Exp <= 0 || claims.Exp > MaxUnixSeconds)
+        {
+            return EntitlementResult.Invalid("License token has a missing or invalid expiry (exp).");
+        }
+
+        DateTimeOffset expiresAt = DateTimeOffset.FromUnixTimeSeconds(claims.Exp);
+        if (expiresAt + ClockSkew < nowUtc)
+        {
+            return EntitlementResult.Invalid("License token expired on " + expiresAt.UtcDateTime.ToString("u") + ".");
+        }
+
+        // Active. Carry the SIGNED capabilities so the guard gates on exactly what this token grants.
+        var caps = new HashSet<string>(StringComparer.Ordinal);
+        if (claims.Caps is not null)
+        {
+            foreach (var c in claims.Caps)
+            {
+                if (!string.IsNullOrWhiteSpace(c)) caps.Add(c);
+            }
+        }
+
+        string? tenant = string.IsNullOrWhiteSpace(claims.Sub) ? null : claims.Sub;
+        return EntitlementResult.Valid(tenant, expiresAt, caps);
+    }
+
+    /// <summary>
+    /// The scope this host expects a scoped license token to declare, from <c>AIDOTNET_LICENSE_SCOPE</c>
+    /// (empty when unset). A token carrying a <c>scope</c> claim is accepted only when it equals this value.
+    /// </summary>
+    private static string ResolveExpectedScope()
+    {
+        try
+        {
+            return Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE")?.Trim() ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AsymmetricEntitlementVerifier: unable to read AIDOTNET_LICENSE_SCOPE: " + ex.Message);
+            return string.Empty;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/Base64UrlHelper.cs
+++ b/src/AiDotNet.Tensors/Licensing/Base64UrlHelper.cs
@@ -1,0 +1,51 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Minimal Base64URL (RFC 4648 §5) encode/decode helper used by the asymmetric (<c>aidn2.</c>)
+/// license token path. Base64URL uses <c>'-'</c>/<c>'_'</c> instead of <c>'+'</c>/<c>'/'</c> and
+/// omits <c>'='</c> padding — the Tensors port of the main SDK's <c>Base64UrlHelper</c>.
+/// </summary>
+/// <remarks>
+/// <b>For Beginners:</b> License tokens are text that must survive being placed in URLs, environment
+/// variables, and files without special characters causing trouble. Base64URL is a text encoding that
+/// avoids the characters (<c>+</c>, <c>/</c>, <c>=</c>) that cause issues in those places. This helper
+/// converts between raw bytes and that safe text form.
+/// </remarks>
+internal static class Base64UrlHelper
+{
+    /// <summary>Encodes bytes as Base64URL (no padding). Returns an empty string for null/empty input.</summary>
+    internal static string Encode(byte[] bytes)
+    {
+        if (bytes is null || bytes.Length == 0) return string.Empty;
+        return Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Decodes a Base64URL string (with or without padding) to bytes. Throws
+    /// <see cref="FormatException"/> on malformed input.
+    /// </summary>
+    internal static byte[] Decode(string base64Url)
+    {
+        if (base64Url is null) throw new ArgumentNullException(nameof(base64Url));
+
+        string standard = base64Url
+            .Replace('-', '+')
+            .Replace('_', '/');
+
+        switch (standard.Length % 4)
+        {
+            case 2: standard += "=="; break;
+            case 3: standard += "="; break;
+            case 1: throw new FormatException("Invalid Base64URL length.");
+        }
+
+        return Convert.FromBase64String(standard);
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
@@ -40,6 +40,7 @@ internal static class Ed25519LicenseRevocation
 
     private static readonly object _lock = new();
     private static bool _embeddedLoaded;
+    private static bool _diskCacheLoaded;
     private static Crl? _embedded;   // release-embedded CRL (verified once)
     private static Crl? _fetched;    // newer CRL installed from an online refresh (verified on install)
 
@@ -82,6 +83,9 @@ internal static class Ed25519LicenseRevocation
         lock (_lock)
         {
             _embeddedLoaded = true;
+            // Also mark the disk cache as "handled" so a test's explicit CRL isn't silently overridden by a
+            // real ~/.aidotnet/revocations.crl left on the machine — tests must be deterministic.
+            _diskCacheLoaded = true;
             _embedded = null;
             _fetched = crlJson is null ? null : ParseAndVerify(crlJson, nowUtc);
         }
@@ -93,9 +97,34 @@ internal static class Ed25519LicenseRevocation
         lock (_lock)
         {
             EnsureEmbeddedLoadedNoLock();
+            EnsureDiskCacheLoadedNoLock();
             if (_embedded is null) return _fetched;
             if (_fetched is null) return _embedded;
             return _fetched.Iat >= _embedded.Iat ? _fetched : _embedded;
+        }
+    }
+
+    /// <summary>
+    /// Loads the last online-fetched CRL cached on disk (by <see cref="TensorsOnlineLicenseServices"/>) once
+    /// per process, so revocation is enforced even on a fully-offline start that never refreshes. A later live
+    /// refresh via <see cref="TryInstallFetched"/> supersedes it (newer iat wins). Fail-open on any error.
+    /// </summary>
+    private static void EnsureDiskCacheLoadedNoLock()
+    {
+        if (_diskCacheLoaded) return;
+        _diskCacheLoaded = true;
+        try
+        {
+            string? json = TensorsOnlineLicenseServices.ReadCachedCrl();
+            if (json is null) return;
+            var candidate = ParseAndVerify(json, DateTimeOffset.UtcNow);
+            if (candidate is null) return;
+            if (_fetched is null || candidate.Iat > _fetched.Iat) _fetched = candidate;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "Ed25519LicenseRevocation: failed to load cached CRL: " + ex.GetType().Name + ": " + ex.Message);
         }
     }
 

--- a/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
@@ -38,6 +38,10 @@ internal static class Ed25519LicenseRevocation
 
     private const int Ed25519SignatureSize = 64;
 
+    /// <summary>Max Unix-seconds (9999-12-31T23:59:59Z) so an out-of-range signed exp can't throw from
+    /// <see cref="DateTimeOffset.FromUnixTimeSeconds"/>.</summary>
+    private const long MaxUnixSeconds = 253402300799L;
+
     private static readonly object _lock = new();
     private static bool _embeddedLoaded;
     private static bool _diskCacheLoaded;
@@ -70,11 +74,30 @@ internal static class Ed25519LicenseRevocation
 
         lock (_lock)
         {
-            // Only move forward in time — a replayed older CRL must never shrink the deny-list.
-            if (_fetched is not null && candidate.Iat <= _fetched.Iat) return false;
+            if (_fetched is not null)
+            {
+                // A STRICTLY OLDER CRL (replay) must never shrink the deny-list.
+                if (candidate.Iat < _fetched.Iat) return false;
+                // SAME-SECOND CRL (1s iat precision): merge (union) rather than discard, so a second
+                // additive CRL issued in the same second isn't lost. Keep the later expiry.
+                if (candidate.Iat == _fetched.Iat)
+                {
+                    _fetched = Merge(_fetched, candidate);
+                    return true;
+                }
+            }
             _fetched = candidate;
             return true;
         }
+    }
+
+    private static Crl Merge(Crl a, Crl b)
+    {
+        var kids = new HashSet<string>(a.RevokedKids, StringComparer.Ordinal);
+        kids.UnionWith(b.RevokedKids);
+        var jti = new HashSet<string>(a.RevokedJti, StringComparer.Ordinal);
+        jti.UnionWith(b.RevokedJti);
+        return new Crl(a.Iat, Math.Max(a.Exp, b.Exp), kids, jti);
     }
 
     /// <summary>TEST-ONLY: sets the effective fetched CRL (from JSON) or clears both to a known state.</summary>
@@ -98,11 +121,19 @@ internal static class Ed25519LicenseRevocation
         {
             EnsureEmbeddedLoadedNoLock();
             EnsureDiskCacheLoadedNoLock();
-            if (_embedded is null) return _fetched;
-            if (_fetched is null) return _embedded;
-            return _fetched.Iat >= _embedded.Iat ? _fetched : _embedded;
+            var now = DateTimeOffset.UtcNow;
+            var emb = IsCurrentlyValid(_embedded, now) ? _embedded : null;
+            var fet = IsCurrentlyValid(_fetched, now) ? _fetched : null;
+            if (emb is null) return fet;
+            if (fet is null) return emb;
+            return fet.Iat >= emb.Iat ? fet : emb;
         }
     }
+
+    /// <summary>A CRL is currently valid when it has no expiry (exp&lt;=0) or its expiry is still in the future,
+    /// so a CRL valid when loaded does not stay authoritative past its exp. (exp is bounded at parse time.)</summary>
+    private static bool IsCurrentlyValid(Crl? c, DateTimeOffset now) =>
+        c is not null && (c.Exp <= 0 || DateTimeOffset.FromUnixTimeSeconds(c.Exp) >= now);
 
     /// <summary>
     /// Loads the last online-fetched CRL cached on disk (by <see cref="TensorsOnlineLicenseServices"/>) once
@@ -203,14 +234,21 @@ internal static class Ed25519LicenseRevocation
 
             long iat = p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number
                 ? iatEl.GetInt64() : 0;
-            long exp = p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
-                ? expEl.GetInt64() : 0;
+            long exp = 0;
+            if (p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
+                && !expEl.TryGetInt64(out exp))
+            {
+                return null; // exp is a number but not representable as int64 — reject, don't throw.
+            }
 
-            // Ignore an expired CRL: it is stale, not authoritative. Offline, the token's own exp still
-            // applies. (exp==0 => no expiry; treated as always-current.)
+            // Reject an out-of-range exp BEFORE converting (FromUnixTimeSeconds throws outside its range).
+            if (exp < 0 || exp > MaxUnixSeconds) return null;
+
+            // Ignore an already-expired CRL. The stored exp is ALSO enforced at access time in Effective(),
+            // so a CRL valid now does not stay authoritative past its expiry. (exp==0 => no expiry.)
             if (exp > 0 && DateTimeOffset.FromUnixTimeSeconds(exp) < nowUtc) return null;
 
-            return new Crl(iat, ReadStringSet(p, "rkids"), ReadStringSet(p, "rjti"));
+            return new Crl(iat, exp, ReadStringSet(p, "rkids"), ReadStringSet(p, "rjti"));
         }
         catch (Exception ex) when (ex is JsonException or ArgumentException)
         {
@@ -249,11 +287,12 @@ internal static class Ed25519LicenseRevocation
     internal sealed class Crl
     {
         internal long Iat { get; }
+        internal long Exp { get; }
         internal HashSet<string> RevokedKids { get; }
         internal HashSet<string> RevokedJti { get; }
-        internal Crl(long iat, HashSet<string> kids, HashSet<string> jti)
+        internal Crl(long iat, long exp, HashSet<string> kids, HashSet<string> jti)
         {
-            Iat = iat; RevokedKids = kids; RevokedJti = jti;
+            Iat = iat; Exp = exp; RevokedKids = kids; RevokedJti = jti;
         }
     }
 }

--- a/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
@@ -42,6 +42,11 @@ internal static class Ed25519LicenseRevocation
     /// <see cref="DateTimeOffset.FromUnixTimeSeconds"/>.</summary>
     private const long MaxUnixSeconds = 253402300799L;
 
+    /// <summary>Clock-skew tolerance for a CRL's <c>iat</c>: an <c>iat</c> more than this far in the future is
+    /// rejected (it decides CRL ordering, so a grossly future-dated value must not win), while benign clock
+    /// differences are tolerated.</summary>
+    private static readonly TimeSpan IatFutureSkew = TimeSpan.FromMinutes(5);
+
     private static readonly object _lock = new();
     private static bool _embeddedLoaded;
     private static bool _diskCacheLoaded;
@@ -126,7 +131,10 @@ internal static class Ed25519LicenseRevocation
             var fet = IsCurrentlyValid(_fetched, now) ? _fetched : null;
             if (emb is null) return fet;
             if (fet is null) return emb;
-            return fet.Iat >= emb.Iat ? fet : emb;
+            // Equal iat (1s precision): union embedded + fetched deny-lists so source/load ordering can
+            // never drop a valid revocation. Otherwise the strictly-newer CRL wins.
+            if (fet.Iat == emb.Iat) return Merge(fet, emb);
+            return fet.Iat > emb.Iat ? fet : emb;
         }
     }
 
@@ -150,7 +158,10 @@ internal static class Ed25519LicenseRevocation
             if (json is null) return;
             var candidate = ParseAndVerify(json, DateTimeOffset.UtcNow);
             if (candidate is null) return;
+            // Newer disk-cached CRL wins; an equal-iat one is unioned (same-second additive refresh) so a
+            // valid revocation is never dropped by load ordering.
             if (_fetched is null || candidate.Iat > _fetched.Iat) _fetched = candidate;
+            else if (candidate.Iat == _fetched.Iat) _fetched = Merge(_fetched, candidate);
         }
         catch (Exception ex)
         {
@@ -232,8 +243,17 @@ internal static class Ed25519LicenseRevocation
             var p = payloadDoc.RootElement;
             if (p.ValueKind != JsonValueKind.Object) return null;
 
-            long iat = p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number
-                ? iatEl.GetInt64() : 0;
+            // Validate iat BEFORE using it for CRL ordering. Require a JSON number parsed non-throwingly
+            // (GetInt64 would throw FormatException, which the outer catch does NOT cover), reject
+            // non-positive / out-of-range values, and reject a grossly future-dated iat. No zero fallback:
+            // a missing or invalid iat is a malformed CRL, not "iat 0".
+            if (!p.TryGetProperty("iat", out var iatEl) || iatEl.ValueKind != JsonValueKind.Number
+                || !iatEl.TryGetInt64(out long iat) || iat <= 0 || iat > MaxUnixSeconds)
+            {
+                return null;
+            }
+            if (DateTimeOffset.FromUnixTimeSeconds(iat) - nowUtc > IatFutureSkew) return null;
+
             long exp = 0;
             if (p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
                 && !expEl.TryGetInt64(out exp))
@@ -248,7 +268,14 @@ internal static class Ed25519LicenseRevocation
             // so a CRL valid now does not stay authoritative past its expiry. (exp==0 => no expiry.)
             if (exp > 0 && DateTimeOffset.FromUnixTimeSeconds(exp) < nowUtc) return null;
 
-            return new Crl(iat, exp, ReadStringSet(p, "rkids"), ReadStringSet(p, "rjti"));
+            // Reject malformed present revocation arrays (non-array, or non-string entries) rather than
+            // silently treating them as empty — a malformed newer CRL must not replace an older deny-list.
+            if (!TryReadStringSet(p, "rkids", out var rkids) || !TryReadStringSet(p, "rjti", out var rjti))
+            {
+                return null;
+            }
+
+            return new Crl(iat, exp, rkids, rjti);
         }
         catch (Exception ex) when (ex is JsonException or ArgumentException)
         {
@@ -256,21 +283,33 @@ internal static class Ed25519LicenseRevocation
         }
     }
 
-    private static HashSet<string> ReadStringSet(JsonElement obj, string name)
+    /// <summary>
+    /// Reads a revocation string set. An ABSENT field yields an empty set (<c>true</c>). A PRESENT field
+    /// that is not a JSON array, or that contains any non-string entry, is malformed and yields
+    /// <c>false</c> so the caller can reject the whole CRL instead of silently accepting an empty deny-list.
+    /// A present, valid empty array yields an empty set (<c>true</c>).
+    /// </summary>
+    private static bool TryReadStringSet(JsonElement obj, string name, out HashSet<string> set)
     {
-        var set = new HashSet<string>(StringComparer.Ordinal);
-        if (obj.TryGetProperty(name, out var arr) && arr.ValueKind == JsonValueKind.Array)
+        set = new HashSet<string>(StringComparer.Ordinal);
+        if (!obj.TryGetProperty(name, out var arr))
         {
-            foreach (var e in arr.EnumerateArray())
-            {
-                if (e.ValueKind == JsonValueKind.String)
-                {
-                    var v = e.GetString();
-                    if (!string.IsNullOrEmpty(v)) set.Add(v!);
-                }
-            }
+            return true; // absent field => empty set is fine.
         }
-        return set;
+        if (arr.ValueKind != JsonValueKind.Array)
+        {
+            return false; // present but not an array => malformed.
+        }
+        foreach (var e in arr.EnumerateArray())
+        {
+            if (e.ValueKind != JsonValueKind.String)
+            {
+                return false; // non-string entry => malformed.
+            }
+            var v = e.GetString();
+            if (!string.IsNullOrEmpty(v)) set.Add(v!);
+        }
+        return true;
     }
 
     private static bool TryGetString(JsonElement obj, string name, out string value)

--- a/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/Ed25519LicenseRevocation.cs
@@ -1,0 +1,230 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Offline revocation deny-list (CRL) for <c>aidn2.</c> tokens. Lets a specific leaked token (<c>jti</c>)
+/// or a compromised signing key (<c>kid</c>) be killed BEFORE its <c>exp</c>. The Tensors port of the main
+/// SDK's <c>LicenseRevocationProvider</c>, anchored to the same embedded Ed25519 public key via
+/// <see cref="TensorsLicensePublicKeyProvider"/>. Kept SEPARATE from the RSA
+/// <see cref="TensorsLicenseRevocation"/>, which anchors to the RSA entitlement key.
+/// </summary>
+/// <remarks>
+/// <para><b>Fail-open by design:</b> revocation is ADDITIVE. A build with no CRL, or a CRL that is
+/// expired / unsigned / malformed, revokes nothing — the token's own <c>exp</c> and bindings still bound
+/// it. Only a valid (signature-verified, unexpired) CRL can revoke.</para>
+///
+/// <para><b>Wire format</b> (JWS-style, sign-over-exact-bytes like aidn2):</para>
+/// <code>
+/// { "kid": "&lt;signing kid&gt;",
+///   "payload": "&lt;base64url(payload_json)&gt;",   // { "iat":.., "exp":.., "rkids":[..], "rjti":[..] }
+///   "sig": "&lt;base64url(ed25519 sig over the decoded payload bytes)&gt;" }
+/// </code>
+/// The signature is computed over the RAW bytes recovered by base64url-decoding <c>payload</c>, so there
+/// is no JSON canonicalization ambiguity (identical guarantee to <see cref="AsymmetricEntitlementVerifier"/>).
+/// </remarks>
+internal static class Ed25519LicenseRevocation
+{
+    /// <summary>Embedded manifest resource holding the release-time CRL (may be absent).</summary>
+    private const string ResourceName = "AiDotNet.Tensors.LicenseRevocationEd25519";
+
+    private const int Ed25519SignatureSize = 64;
+
+    private static readonly object _lock = new();
+    private static bool _embeddedLoaded;
+    private static Crl? _embedded;   // release-embedded CRL (verified once)
+    private static Crl? _fetched;    // newer CRL installed from an online refresh (verified on install)
+
+    /// <summary>
+    /// Returns true when a valid (signature-verified, unexpired) CRL revokes this token by its
+    /// <paramref name="kid"/> or <paramref name="jti"/>. Fails open (returns false) when no valid CRL
+    /// is present.
+    /// </summary>
+    internal static bool IsRevoked(string? kid, string? jti)
+    {
+        var crl = Effective();
+        if (crl is null) return false;
+
+        if (kid is { Length: > 0 } && crl.RevokedKids.Contains(kid)) return true;
+        if (jti is { Length: > 0 } && crl.RevokedJti.Contains(jti)) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Installs a CRL obtained from an ONLINE refresh. Verified and expiry-checked here; ignored if it
+    /// fails to verify, is expired, or is older than the one already installed. Returns true when accepted.
+    /// </summary>
+    internal static bool TryInstallFetched(string json, DateTimeOffset nowUtc)
+    {
+        var candidate = ParseAndVerify(json, nowUtc);
+        if (candidate is null) return false;
+
+        lock (_lock)
+        {
+            // Only move forward in time — a replayed older CRL must never shrink the deny-list.
+            if (_fetched is not null && candidate.Iat <= _fetched.Iat) return false;
+            _fetched = candidate;
+            return true;
+        }
+    }
+
+    /// <summary>TEST-ONLY: sets the effective fetched CRL (from JSON) or clears both to a known state.</summary>
+    internal static void OverrideForTesting(string? crlJson, DateTimeOffset nowUtc)
+    {
+        lock (_lock)
+        {
+            _embeddedLoaded = true;
+            _embedded = null;
+            _fetched = crlJson is null ? null : ParseAndVerify(crlJson, nowUtc);
+        }
+    }
+
+    /// <summary>The most recent valid CRL among the embedded and fetched copies (or null).</summary>
+    private static Crl? Effective()
+    {
+        lock (_lock)
+        {
+            EnsureEmbeddedLoadedNoLock();
+            if (_embedded is null) return _fetched;
+            if (_fetched is null) return _embedded;
+            return _fetched.Iat >= _embedded.Iat ? _fetched : _embedded;
+        }
+    }
+
+    private static void EnsureEmbeddedLoadedNoLock()
+    {
+        if (_embeddedLoaded) return;
+        _embeddedLoaded = true;
+        try
+        {
+            var assembly = typeof(Ed25519LicenseRevocation).Assembly;
+            using var stream = assembly.GetManifestResourceStream(ResourceName);
+            if (stream is null || stream.Length == 0) return;
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            _embedded = ParseAndVerify(reader.ReadToEnd(), DateTimeOffset.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "Ed25519LicenseRevocation: failed to load embedded CRL: " + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Parses a CRL envelope, verifies its Ed25519 signature against the embedded public key selected by
+    /// its <c>kid</c>, and enforces expiry. Returns null on any problem (fail-open: not enforced).
+    /// </summary>
+    internal static Crl? ParseAndVerify(string json, DateTimeOffset nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        string kid, payloadB64, sigB64;
+        try
+        {
+            using var envelope = JsonDocument.Parse(json);
+            var root = envelope.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !TryGetString(root, "kid", out kid)
+                || !TryGetString(root, "payload", out payloadB64)
+                || !TryGetString(root, "sig", out sigB64))
+            {
+                return null;
+            }
+        }
+        catch (JsonException) { return null; }
+
+        byte[] payloadBytes, sig;
+        try
+        {
+            payloadBytes = Base64UrlHelper.Decode(payloadB64);
+            sig = Base64UrlHelper.Decode(sigB64);
+        }
+        catch (FormatException) { return null; }
+
+        if (payloadBytes.Length == 0 || sig.Length != Ed25519SignatureSize) return null;
+        if (!TensorsLicensePublicKeyProvider.TryGetPublicKey(kid, out byte[] publicKey)) return null;
+
+        try
+        {
+            var verifier = new Ed25519Signer();
+            verifier.Init(false, new Ed25519PublicKeyParameters(publicKey, 0));
+            verifier.BlockUpdate(payloadBytes, 0, payloadBytes.Length);
+            if (!verifier.VerifySignature(sig)) return null;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "Ed25519LicenseRevocation: CRL signature verification error: " + ex.GetType().Name + ": " + ex.Message);
+            return null;
+        }
+
+        try
+        {
+            using var payloadDoc = JsonDocument.Parse(new ReadOnlyMemory<byte>(payloadBytes));
+            var p = payloadDoc.RootElement;
+            if (p.ValueKind != JsonValueKind.Object) return null;
+
+            long iat = p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number
+                ? iatEl.GetInt64() : 0;
+            long exp = p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
+                ? expEl.GetInt64() : 0;
+
+            // Ignore an expired CRL: it is stale, not authoritative. Offline, the token's own exp still
+            // applies. (exp==0 => no expiry; treated as always-current.)
+            if (exp > 0 && DateTimeOffset.FromUnixTimeSeconds(exp) < nowUtc) return null;
+
+            return new Crl(iat, ReadStringSet(p, "rkids"), ReadStringSet(p, "rjti"));
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static HashSet<string> ReadStringSet(JsonElement obj, string name)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        if (obj.TryGetProperty(name, out var arr) && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var e in arr.EnumerateArray())
+            {
+                if (e.ValueKind == JsonValueKind.String)
+                {
+                    var v = e.GetString();
+                    if (!string.IsNullOrEmpty(v)) set.Add(v!);
+                }
+            }
+        }
+        return set;
+    }
+
+    private static bool TryGetString(JsonElement obj, string name, out string value)
+    {
+        if (obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String)
+        {
+            value = el.GetString() ?? string.Empty;
+            return value.Length > 0;
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    internal sealed class Crl
+    {
+        internal long Iat { get; }
+        internal HashSet<string> RevokedKids { get; }
+        internal HashSet<string> RevokedJti { get; }
+        internal Crl(long iat, HashSet<string> kids, HashSet<string> jti)
+        {
+            Iat = iat; RevokedKids = kids; RevokedJti = jti;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/LicensePublicKey.json
+++ b/src/AiDotNet.Tensors/Licensing/LicensePublicKey.json
@@ -1,0 +1,1 @@
+{"keys":[{"kty":"OKP","crv":"Ed25519","kid":"prod-2026a","x":"kEaBMOkSFRV5p-GtRBbXdmxW7XT6uniKN-_1U--c2bM"}]}

--- a/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
+++ b/src/AiDotNet.Tensors/Licensing/LicenseValidator.cs
@@ -130,6 +130,19 @@ public sealed class LicenseValidator
         try
         {
             var result = ValidateOnline();
+
+            // v2 hybrid: off the hot path (background, throttled), refresh the signed CRL and — for a server
+            // AIDN-* key — mint + cache a fresh machine-bound offline aidn2 token, so this key keeps working
+            // (with correct caps, still revocable) the next time the server is unreachable. Best-effort:
+            // never blocks or throws into this result.
+            if (result.Status == LicenseKeyStatus.Active)
+            {
+                TensorsOnlineLicenseServices.RefreshInBackground(
+                    _licenseKey.ServerUrl ?? DefaultServerUrl,
+                    _licenseKey.Key,
+                    TensorsMachineFingerprint.GetMachineIdHash());
+            }
+
             return Cache(result);
         }
         catch (Exception ex)

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -180,6 +180,30 @@ public static class PersistenceGuard
         }
     }
 
+    // ─── aidn2 (Ed25519) offline-token cache ───────────────────────
+    //
+    // Additive to the RSA SignedEntitlement path: an aidn2. token is resolved from AIDOTNET_LICENSE_KEY
+    // (when it's an aidn2. token) or the main SDK's cached ~/.aidotnet/offline-*.token files, verified
+    // offline against the embedded Ed25519 public key, and — when Active — grants its SIGNED capabilities.
+    // Resolved + verified once per process (constant for a run). null == no valid aidn2 token; this path
+    // is positive-grant-only and NEVER hard-fails (absence/failure falls through to RSA/key/trial).
+    private static readonly object _aidn2Lock = new();
+    private static bool _aidn2Resolved;
+    private static EntitlementResult? _aidn2Entitlement;
+
+    private static EntitlementResult? GetCachedAidn2Entitlement()
+    {
+        lock (_aidn2Lock)
+        {
+            if (!_aidn2Resolved)
+            {
+                _aidn2Entitlement = AsymmetricEntitlementVerifier.TryVerifyConfigured();
+                _aidn2Resolved = true;
+            }
+            return _aidn2Entitlement;
+        }
+    }
+
     // Per-key "pending allowance consumed" set. The first
     // ValidationPending result for a key is allowed (lets users on a
     // flaky network bootstrap into the offline-grace window), but
@@ -259,6 +283,18 @@ public static class PersistenceGuard
         // Suppressed under InternalOperation — upstream AiDotNet
         // already enforced before delegating to us.
         if (_internalDepth.Value > 0) return;
+
+        // ── Offline, Ed25519-signed aidn2 token (machine-bound offline grant) ───
+        // ADDITIVE / positive-grant-only: a machine-bound aidn2. token (from AIDOTNET_LICENSE_KEY or a
+        // main-SDK-minted ~/.aidotnet/offline-*.token) that verifies Active offline and carries the
+        // required capability authorises the op with no network call and no trial tick. Checked BEFORE the
+        // RSA entitlement/key/trial paths so a valid offline token wins regardless of RSA placeholder
+        // state. Unlike the RSA entitlement below, a NON-granting/absent aidn2 result is NOT a hard failure
+        // — it simply falls through (a genuinely forged aidn2 token yields no grant here and, if it was in
+        // AIDOTNET_LICENSE_KEY, is then rejected by the invalid-key path exactly as before).
+        var aidn2 = GetCachedAidn2Entitlement();
+        if (aidn2 is not null && aidn2.IsValid && aidn2.HasCapability(requiredCapability))
+            return;
 
         // ── Offline, RSA-signed entitlement (strongest trust anchor) ───
         // Checked FIRST. A signed entitlement is verified with an embedded
@@ -431,6 +467,11 @@ public static class PersistenceGuard
         {
             _entitlementResolved = false;
             _entitlement = null;
+        }
+        lock (_aidn2Lock)
+        {
+            _aidn2Resolved = false;
+            _aidn2Entitlement = null;
         }
     }
 }

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -180,28 +180,42 @@ public static class PersistenceGuard
         }
     }
 
-    // ─── aidn2 (Ed25519) offline-token cache ───────────────────────
+    // ─── aidn2 (Ed25519) offline-token resolution ──────────────────
     //
-    // Additive to the RSA SignedEntitlement path: an aidn2. token is resolved from AIDOTNET_LICENSE_KEY
-    // (when it's an aidn2. token) or the main SDK's cached ~/.aidotnet/offline-*.token files, verified
-    // offline against the embedded Ed25519 public key, and — when Active — grants its SIGNED capabilities.
-    // Resolved + verified once per process (constant for a run). null == no valid aidn2 token; this path
-    // is positive-grant-only and NEVER hard-fails (absence/failure falls through to RSA/key/trial).
-    private static readonly object _aidn2Lock = new();
-    private static bool _aidn2Resolved;
-    private static EntitlementResult? _aidn2Entitlement;
-
-    private static EntitlementResult? GetCachedAidn2Entitlement()
+    // Additive to the RSA SignedEntitlement path: an aidn2. token grants its SIGNED capabilities when it
+    // verifies Active offline against the embedded Ed25519 public key. Positive-grant-only and NEVER
+    // hard-fails (absence/failure falls through to RSA/key/trial).
+    //
+    // Re-verified on EVERY enforcement (NO process-lifetime cache): a token that later expires or is revoked
+    // must stop granting, and a token freshly minted by the background refresh must start granting without a
+    // process restart. Verification is fully offline (signature + CRL + exp) and persistence ops are
+    // low-frequency, so re-verifying per op is cheap enough.
+    //
+    // Explicit active-key precedence (SetActiveLicenseKey / AsyncLocal) is honoured: when a key is explicitly
+    // selected, ONLY that exact token is eligible for the aidn2 grant — an unrelated cached disk/env token
+    // must never authorise on behalf of an explicitly-selected (possibly invalid/revoked) key. The global
+    // env/disk aidn2 sources are consulted ONLY when no key is explicitly selected.
+    private static EntitlementResult? ResolveAidn2Entitlement()
     {
-        lock (_aidn2Lock)
+        var now = DateTimeOffset.UtcNow;
+
+        if (_activeKey.Value is { } explicitKey)
         {
-            if (!_aidn2Resolved)
+            // A key was explicitly selected. Only an aidn2-format explicit token can grant here; verify
+            // EXACTLY it. A non-aidn2 explicit key is evaluated by the key path below, and an invalid/revoked
+            // explicit aidn2 token yields no grant (it must NOT be bypassed by a cached disk/env token).
+            string? k = explicitKey.Key?.Trim();
+            if (k is not null && AsymmetricEntitlementVerifier.IsAsymmetricKeyFormat(k))
             {
-                _aidn2Entitlement = AsymmetricEntitlementVerifier.TryVerifyConfigured();
-                _aidn2Resolved = true;
+                var r = AsymmetricEntitlementVerifier.Verify(k, now);
+                return r.IsValid ? r : null;
             }
-            return _aidn2Entitlement;
+            return null;
         }
+
+        // No explicit key selected → resolve from the configured env/disk sources (re-read + re-verified
+        // each call so expiry/revocation and freshly-minted tokens take effect immediately).
+        return AsymmetricEntitlementVerifier.TryVerifyConfigured();
     }
 
     // Per-key "pending allowance consumed" set. The first
@@ -292,7 +306,7 @@ public static class PersistenceGuard
         // state. Unlike the RSA entitlement below, a NON-granting/absent aidn2 result is NOT a hard failure
         // — it simply falls through (a genuinely forged aidn2 token yields no grant here and, if it was in
         // AIDOTNET_LICENSE_KEY, is then rejected by the invalid-key path exactly as before).
-        var aidn2 = GetCachedAidn2Entitlement();
+        var aidn2 = ResolveAidn2Entitlement();
         if (aidn2 is not null && aidn2.IsValid && aidn2.HasCapability(requiredCapability))
             return;
 
@@ -468,10 +482,7 @@ public static class PersistenceGuard
             _entitlementResolved = false;
             _entitlement = null;
         }
-        lock (_aidn2Lock)
-        {
-            _aidn2Resolved = false;
-            _aidn2Entitlement = null;
-        }
+        // The aidn2 path no longer caches (it re-verifies per enforcement), so there is nothing to reset
+        // here for it — a fresh env/disk/active-key resolution happens on the next EnforceCore call.
     }
 }

--- a/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
+++ b/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
@@ -220,6 +220,21 @@ public static class SignedEntitlement
                 }
             }
 
+            // Scope/audience binding (mirrors the AiDotNet aidn2 verifier): an entitlement that names a
+            // `scope` is valid only where the host declares the same expected scope
+            // (AIDOTNET_LICENSE_SCOPE) — fencing a scoped entitlement (e.g. a CI token) off from unintended
+            // contexts even if it leaks. Absent scope → unrestricted (back-compat).
+            if (TryGetString(signed, "scope", out var scope)
+                && !string.Equals(scope, ExpectedScope(), StringComparison.Ordinal))
+                return EntitlementResult.Invalid(
+                    $"Entitlement scope '{scope}' does not match this host's expected scope.");
+
+            // Revocation deny-list (CRL): a specific leaked entitlement (jti) can be killed before it
+            // expires. The signed CRL is verified with the same embedded entitlement key; absent/expired/
+            // unsigned CRL → nothing revoked (fail-open, additive). Mirrors LicenseRevocationProvider.
+            if (TryGetString(signed, "jti", out var jti) && TensorsLicenseRevocation.IsRevoked(jti))
+                return EntitlementResult.Invalid("Entitlement has been revoked.");
+
             string? tenant = TryGetString(signed, "tenant", out var t) && !string.IsNullOrWhiteSpace(t) ? t : null;
             return EntitlementResult.Valid(tenant, expires, caps);
         }
@@ -241,6 +256,16 @@ public static class SignedEntitlement
     }
 
     /// <summary>
+    /// The scope this host expects a scoped entitlement to declare, from the <c>AIDOTNET_LICENSE_SCOPE</c>
+    /// environment variable (empty when unset). A scoped entitlement is accepted only when it matches.
+    /// </summary>
+    private static string ExpectedScope()
+    {
+        try { return Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE")?.Trim() ?? string.Empty; }
+        catch { return string.Empty; }
+    }
+
+    /// <summary>
     /// Imports the embedded <c>{modulusBase64}:{exponentBase64}</c> public key.
     /// Uses <see cref="RSA.ImportParameters"/> (RSAParameters) so it works on
     /// net471 and net10.0 alike — <see cref="RSA.ImportRSAPublicKey(System.ReadOnlySpan{byte}, out int)"/>
@@ -256,6 +281,27 @@ public static class SignedEntitlement
         var rsa = RSA.Create();
         rsa.ImportParameters(new RSAParameters { Modulus = modulus, Exponent = exponent });
         return rsa;
+    }
+
+    /// <summary>
+    /// Verifies an RSA-SHA256 (PKCS#1 v1.5) signature over <paramref name="data"/> using the embedded
+    /// entitlement public key. Returns false when this build ships the placeholder key (not configured)
+    /// or on any error. Used by <see cref="TensorsLicenseRevocation"/> so the CRL is anchored to the same
+    /// trust root as the entitlement itself.
+    /// </summary>
+    internal static bool VerifyWithEntitlementKey(byte[] data, byte[] signature)
+    {
+        string pubKey = ResolvePublicKey();
+        if (string.Equals(pubKey, PublicKeyPlaceholderMarker, StringComparison.Ordinal)) return false;
+        try
+        {
+            using var rsa = ImportPublicKey(pubKey);
+            return rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
+        catch
+        {
+            return false;
+        }
     }
 }
 

--- a/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
+++ b/src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs
@@ -61,10 +61,16 @@ public static class SignedEntitlement
     /// Embedded RSA public key as <c>{modulusBase64}:{exponentBase64}</c>
     /// (RSAParameters form — chosen over PKCS#1 DER so import works on both
     /// net471 and net10.0 with no BouncyCastle dependency in the runtime
-    /// assembly). Replace for production per build/LicenseValidator/README.md;
-    /// the PRIVATE key never ships.
+    /// assembly). The PRIVATE half never ships; it lives with the operator and
+    /// signs per-tenant entitlements via tools/license-issuer/rsa_entitlement_issuer.py.
+    /// This is the real production RSA-2048 entitlement key (kid-less; a single
+    /// trust root for offline air-gapped entitlements) — replacing it ACTIVATES
+    /// the offline entitlement path (a configured but invalid token now hard-fails
+    /// rather than falling through). It is a SEPARATE trust root from the Ed25519
+    /// aidn2 key embedded for AsymmetricEntitlementVerifier.
     /// </summary>
-    public const string EntitlementPublicKey = PublicKeyPlaceholderMarker;
+    public const string EntitlementPublicKey =
+        "tmsQ6ZHZxje8vKPbaUV0FG+JBERML+M1rvV5rfudnRVC+NWYBpcIFOLE45lOvTbQRI9c36RzCGwOtQQGYw1hQNhDLjiNYinuC9R1IRH0dSl/WO8cskz2Gx8Fec38AdtJMWvs22dSlw0nKgbFKB6H4zA2+W8/vBv079Ea+65+3clxFxkX2aixIG8rToD8F2K8ZoHb4t3AMRHthfUJ7EcWD8E3JEQoMtYPE7aHfpfbXmOBqrJwpURU2dw4nOIyf0pgANnCZxcNQ6FRdD78u6LK5cFI4Ye0GFI6//qexNk8N2nTy0xLiK725mJzFIguHKyF66J8hHJlxTF0gDfOunkVNQ==:AQAB";
 
     /// <summary>Test-only override of the embedded key (see the build-time validator's identical hook).</summary>
     internal static string? s_overridePublicKey;

--- a/src/AiDotNet.Tensors/Licensing/TensorsLicensePublicKeyProvider.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsLicensePublicKeyProvider.cs
@@ -166,21 +166,18 @@ internal static class TensorsLicensePublicKeyProvider
         {
             if (entry.ValueKind != JsonValueKind.Object) continue;
 
+            string? kty = GetString(entry, "kty");
             string? kid = GetString(entry, "kid");
             string? x = GetString(entry, "x");
             string? crv = GetString(entry, "crv");
 
-            if (kid is null || kid.Length == 0 || x is null || x.Length == 0)
+            // Enforce the COMPLETE Ed25519 JWK type contract: kty MUST be "OKP" and crv MUST be "Ed25519"
+            // (both present and exact), in addition to a non-empty kid and x. A missing/incorrect kty or crv
+            // is rejected so an entry of an unknown/unsupported key type can never be trusted as Ed25519.
+            if (kid is null || kid.Length == 0 || x is null || x.Length == 0
+                || !string.Equals(kty, "OKP", StringComparison.Ordinal)
+                || !string.Equals(crv, "Ed25519", StringComparison.Ordinal))
             {
-                continue;
-            }
-
-            // Only Ed25519 OKP keys are accepted. A missing crv is tolerated for brevity but a present,
-            // non-Ed25519 crv is rejected so a future curve cannot be silently treated as Ed25519.
-            if (crv is not null && crv.Length > 0 && !string.Equals(crv, "Ed25519", StringComparison.Ordinal))
-            {
-                System.Diagnostics.Trace.TraceWarning(
-                    "TensorsLicensePublicKeyProvider: skipping key '" + kid + "' with unsupported crv '" + crv + "'.");
                 continue;
             }
 

--- a/src/AiDotNet.Tensors/Licensing/TensorsLicensePublicKeyProvider.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsLicensePublicKeyProvider.cs
@@ -1,0 +1,222 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Provides the PUBLIC license-signing key(s) embedded as a resource in official builds. Used to verify
+/// <c>aidn2.</c> asymmetric (Ed25519 / EdDSA) license tokens offline — the Tensors port of the main SDK's
+/// <c>LicensePublicKeyProvider</c>, parsed with <see cref="System.Text.Json"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> The <c>aidn2.</c> license format is signed on the AiDotNet license server
+/// with a <b>private</b> key that never leaves the server. Every published DLL only embeds the matching
+/// <b>public</b> key. A public key can verify a signature but cannot create one, so extracting it from the
+/// DLL gives an attacker nothing — they still cannot forge a license without the private key.</para>
+///
+/// <para>The embedded resource <c>AiDotNet.Tensors.LicensePublicKey</c> is a small JSON document listing
+/// one or more Ed25519 public keys, each tagged with a <c>kid</c> (key id). A token names the <c>kid</c>
+/// it was signed with, so the signing key can be <b>rotated</b> without invalidating already-issued
+/// licenses that reference an older, still-trusted key.</para>
+///
+/// <para>Resource schema (JWK OKP — RFC 8037; an Ed25519 public key is the 32-byte <c>x</c> value):</para>
+/// <code>
+/// { "keys": [ { "kty": "OKP", "crv": "Ed25519", "kid": "prod-2026a", "x": "&lt;base64url 32-byte pubkey&gt;" } ] }
+/// </code>
+/// </remarks>
+internal static class TensorsLicensePublicKeyProvider
+{
+    private const string ResourceName = "AiDotNet.Tensors.LicensePublicKey";
+
+    /// <summary>Ed25519 raw public keys are exactly 32 bytes.</summary>
+    internal const int Ed25519PublicKeySize = 32;
+
+    // kid -> raw 32-byte Ed25519 public key.
+    private static Dictionary<string, byte[]>? _cachedKeys;
+    private static bool _loaded;
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// TEST-ONLY: overrides the embedded public key set so tests can inject an ephemeral test keypair's
+    /// public half and exercise the real signature-verification path. Pass <see langword="null"/> to
+    /// simulate a dev/fork build (no embedded public key) and assert fail-closed offline behaviour.
+    /// </summary>
+    internal static void OverrideForTesting(IReadOnlyDictionary<string, byte[]>? keys)
+    {
+        lock (_lock)
+        {
+            _cachedKeys = keys is { Count: > 0 } ? CloneAll(keys) : null;
+            _loaded = true;
+        }
+    }
+
+    /// <summary>
+    /// Snapshots the currently-effective public key set (for scoped test overrides), or null if none.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, byte[]>? CurrentSnapshot()
+    {
+        lock (_lock)
+        {
+            EnsureLoadedNoLock();
+            return _cachedKeys is { Count: > 0 } ? CloneAll(_cachedKeys) : null;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether this build embeds at least one license public key (i.e. it can verify <c>aidn2.</c>
+    /// tokens offline).
+    /// </summary>
+    internal static bool HasAnyKey
+    {
+        get
+        {
+            lock (_lock)
+            {
+                EnsureLoadedNoLock();
+                return _cachedKeys is { Count: > 0 };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the raw 32-byte Ed25519 public key for a given <c>kid</c>. Returns false if this build
+    /// embeds no matching key.
+    /// </summary>
+    internal static bool TryGetPublicKey(string kid, out byte[] publicKey)
+    {
+        publicKey = Array.Empty<byte>();
+        if (string.IsNullOrEmpty(kid)) return false;
+
+        lock (_lock)
+        {
+            EnsureLoadedNoLock();
+            if (_cachedKeys is not null && _cachedKeys.TryGetValue(kid, out var found))
+            {
+                publicKey = (byte[])found.Clone();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void EnsureLoadedNoLock()
+    {
+        if (_loaded) return;
+
+        try
+        {
+            var assembly = typeof(TensorsLicensePublicKeyProvider).Assembly;
+            using var stream = assembly.GetManifestResourceStream(ResourceName);
+            if (stream is null || stream.Length == 0)
+            {
+                _cachedKeys = null;
+                return;
+            }
+
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            _cachedKeys = Parse(reader.ReadToEnd());
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsLicensePublicKeyProvider: failed to load public key(s): " + ex.GetType().Name + ": " + ex.Message);
+            _cachedKeys = null;
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    /// <summary>
+    /// Parses the JWK OKP public-key manifest. Returns null when no usable Ed25519 key is present.
+    /// Non-Ed25519 / malformed / wrong-length entries are skipped (fail closed).
+    /// </summary>
+    internal static Dictionary<string, byte[]>? Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        JsonElement root;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            // Clone so the element survives disposal of the JsonDocument.
+            root = doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("keys", out var keysEl)
+            || keysEl.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in keysEl.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object) continue;
+
+            string? kid = GetString(entry, "kid");
+            string? x = GetString(entry, "x");
+            string? crv = GetString(entry, "crv");
+
+            if (kid is null || kid.Length == 0 || x is null || x.Length == 0)
+            {
+                continue;
+            }
+
+            // Only Ed25519 OKP keys are accepted. A missing crv is tolerated for brevity but a present,
+            // non-Ed25519 crv is rejected so a future curve cannot be silently treated as Ed25519.
+            if (crv is not null && crv.Length > 0 && !string.Equals(crv, "Ed25519", StringComparison.Ordinal))
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "TensorsLicensePublicKeyProvider: skipping key '" + kid + "' with unsupported crv '" + crv + "'.");
+                continue;
+            }
+
+            try
+            {
+                byte[] pub = Base64UrlHelper.Decode(x);
+                if (pub.Length != Ed25519PublicKeySize)
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        "TensorsLicensePublicKeyProvider: skipping key '" + kid + "' with wrong Ed25519 length " + pub.Length + ".");
+                    continue;
+                }
+
+                result[kid] = pub;
+            }
+            catch (FormatException ex)
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "TensorsLicensePublicKeyProvider: skipping malformed key '" + kid + "': " + ex.Message);
+            }
+        }
+
+        return result.Count > 0 ? result : null;
+    }
+
+    private static string? GetString(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String ? el.GetString() : null;
+
+    private static Dictionary<string, byte[]> CloneAll(IReadOnlyDictionary<string, byte[]> src)
+    {
+        var copy = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var kvp in src)
+        {
+            copy[kvp.Key] = kvp.Value is null ? Array.Empty<byte>() : (byte[])kvp.Value.Clone();
+        }
+
+        return copy;
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/TensorsLicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsLicenseRevocation.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Offline revocation deny-list (CRL) for signed entitlements. Lets a specific leaked entitlement
+/// (<c>jti</c>) be killed BEFORE it expires. The Tensors analogue of AiDotNet's
+/// <c>LicenseRevocationProvider</c>, anchored to the same RSA entitlement key via
+/// <see cref="SignedEntitlement.VerifyWithEntitlementKey"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>Fail-open by design:</b> revocation is ADDITIVE. No CRL, or a CRL that is expired /
+/// unsigned / malformed (including any build that still ships the placeholder entitlement key, so the
+/// signature can't be checked), revokes nothing — the entitlement's own expiry still bounds it.</para>
+///
+/// <para><b>Wire format</b> (same envelope as the entitlement — RSA-SHA256 over the raw payload bytes):</para>
+/// <code>
+/// { "payload":  "&lt;base64(payload_json)&gt;",   // { "iat":.., "exp":.., "rjti":[..] }  exp/iat = Unix seconds
+///   "signature":"&lt;base64(RSA-SHA256 over the decoded payload bytes)&gt;" }
+/// </code>
+/// </remarks>
+internal static class TensorsLicenseRevocation
+{
+    /// <summary>Embedded manifest resource holding the release-time signed CRL (may be absent).</summary>
+    private const string ResourceName = "AiDotNet.Tensors.LicenseRevocation";
+
+    private static readonly object _lock = new();
+    private static bool _embeddedLoaded;
+    private static Crl? _embedded;
+    private static Crl? _fetched;
+
+    /// <summary>
+    /// True when a valid (signature-verified, unexpired) CRL revokes the entitlement identified by
+    /// <paramref name="jti"/>. Fails open (false) when no valid CRL is present.
+    /// </summary>
+    internal static bool IsRevoked(string? jti)
+    {
+        if (string.IsNullOrEmpty(jti)) return false;
+        var crl = Effective();
+        return crl is not null && crl.RevokedJti.Contains(jti!);
+    }
+
+    /// <summary>
+    /// Installs a CRL from an ONLINE refresh; verified and expiry-checked here, ignored if it fails to
+    /// verify, is expired, or is not newer than the one already installed. Returns true when accepted.
+    /// </summary>
+    internal static bool TryInstallFetched(string json, DateTimeOffset nowUtc)
+    {
+        var candidate = ParseAndVerify(json, nowUtc);
+        if (candidate is null) return false;
+        lock (_lock)
+        {
+            if (_fetched is not null && candidate.Iat <= _fetched.Iat) return false;
+            _fetched = candidate;
+            return true;
+        }
+    }
+
+    /// <summary>TEST-ONLY: set the effective fetched CRL (from JSON) or clear both to a known state.</summary>
+    internal static void OverrideForTesting(string? crlJson, DateTimeOffset nowUtc)
+    {
+        lock (_lock)
+        {
+            _embeddedLoaded = true;
+            _embedded = null;
+            _fetched = crlJson is null ? null : ParseAndVerify(crlJson, nowUtc);
+        }
+    }
+
+    private static Crl? Effective()
+    {
+        lock (_lock)
+        {
+            EnsureEmbeddedLoadedNoLock();
+            if (_embedded is null) return _fetched;
+            if (_fetched is null) return _embedded;
+            return _fetched.Iat >= _embedded.Iat ? _fetched : _embedded;
+        }
+    }
+
+    private static void EnsureEmbeddedLoadedNoLock()
+    {
+        if (_embeddedLoaded) return;
+        _embeddedLoaded = true;
+        try
+        {
+            var assembly = typeof(TensorsLicenseRevocation).Assembly;
+            using var stream = assembly.GetManifestResourceStream(ResourceName);
+            if (stream is null || stream.Length == 0) return;
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            _embedded = ParseAndVerify(reader.ReadToEnd(), DateTimeOffset.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsLicenseRevocation: failed to load embedded CRL: " + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Parses a CRL envelope, verifies its RSA signature against the embedded entitlement key, and
+    /// enforces expiry. Returns null on any problem (fail-open).
+    /// </summary>
+    internal static Crl? ParseAndVerify(string json, DateTimeOffset nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        string payloadB64, sigB64;
+        try
+        {
+            using var envelope = JsonDocument.Parse(json);
+            var root = envelope.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !TryGetString(root, "payload", out payloadB64)
+                || !TryGetString(root, "signature", out sigB64))
+                return null;
+        }
+        catch (JsonException) { return null; }
+
+        byte[] payloadBytes, sig;
+        try
+        {
+            payloadBytes = Convert.FromBase64String(payloadB64);
+            sig = Convert.FromBase64String(sigB64);
+        }
+        catch (FormatException) { return null; }
+
+        if (payloadBytes.Length == 0 || sig.Length == 0) return null;
+        if (!SignedEntitlement.VerifyWithEntitlementKey(payloadBytes, sig)) return null;
+
+        try
+        {
+            using var payloadDoc = JsonDocument.Parse(new ReadOnlyMemory<byte>(payloadBytes));
+            var p = payloadDoc.RootElement;
+            if (p.ValueKind != JsonValueKind.Object) return null;
+
+            long iat = p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number
+                ? iatEl.GetInt64() : 0;
+            long exp = p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
+                ? expEl.GetInt64() : 0;
+
+            // Ignore a stale (expired) CRL — client should refetch; entitlement expiry still applies.
+            if (exp > 0 && DateTimeOffset.FromUnixTimeSeconds(exp) < nowUtc) return null;
+
+            var rjti = new HashSet<string>(StringComparer.Ordinal);
+            if (p.TryGetProperty("rjti", out var rjtiEl) && rjtiEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var e in rjtiEl.EnumerateArray())
+                {
+                    if (e.ValueKind == JsonValueKind.String)
+                    {
+                        var v = e.GetString();
+                        if (!string.IsNullOrEmpty(v)) rjti.Add(v!);
+                    }
+                }
+            }
+
+            return new Crl(iat, rjti);
+        }
+        catch (JsonException) { return null; }
+    }
+
+    private static bool TryGetString(JsonElement obj, string name, out string value)
+    {
+        if (obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String)
+        {
+            value = el.GetString() ?? string.Empty;
+            return value.Length > 0;
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    internal sealed class Crl
+    {
+        internal long Iat { get; }
+        internal HashSet<string> RevokedJti { get; }
+        internal Crl(long iat, HashSet<string> rjti) { Iat = iat; RevokedJti = rjti; }
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/TensorsLicenseRevocation.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsLicenseRevocation.cs
@@ -28,6 +28,10 @@ internal static class TensorsLicenseRevocation
     /// <summary>Embedded manifest resource holding the release-time signed CRL (may be absent).</summary>
     private const string ResourceName = "AiDotNet.Tensors.LicenseRevocation";
 
+    /// <summary>Max Unix-seconds (9999-12-31T23:59:59Z) so an out-of-range signed exp can't throw from
+    /// <see cref="DateTimeOffset.FromUnixTimeSeconds"/>.</summary>
+    private const long MaxUnixSeconds = 253402300799L;
+
     private static readonly object _lock = new();
     private static bool _embeddedLoaded;
     private static Crl? _embedded;
@@ -54,10 +58,28 @@ internal static class TensorsLicenseRevocation
         if (candidate is null) return false;
         lock (_lock)
         {
-            if (_fetched is not null && candidate.Iat <= _fetched.Iat) return false;
+            if (_fetched is not null)
+            {
+                // A STRICTLY OLDER CRL (replay) must never shrink the deny-list.
+                if (candidate.Iat < _fetched.Iat) return false;
+                // SAME-SECOND CRL (iat is 1s-precision Unix seconds): a later signed refresh with additional
+                // revoked JTIs can share the same iat, so UNION rather than discard, keeping the later expiry.
+                if (candidate.Iat == _fetched.Iat)
+                {
+                    _fetched = Merge(_fetched, candidate);
+                    return true;
+                }
+            }
             _fetched = candidate;
             return true;
         }
+    }
+
+    private static Crl Merge(Crl a, Crl b)
+    {
+        var jti = new HashSet<string>(a.RevokedJti, StringComparer.Ordinal);
+        jti.UnionWith(b.RevokedJti);
+        return new Crl(a.Iat, Math.Max(a.Exp, b.Exp), jti);
     }
 
     /// <summary>TEST-ONLY: set the effective fetched CRL (from JSON) or clear both to a known state.</summary>
@@ -76,11 +98,23 @@ internal static class TensorsLicenseRevocation
         lock (_lock)
         {
             EnsureEmbeddedLoadedNoLock();
-            if (_embedded is null) return _fetched;
-            if (_fetched is null) return _embedded;
-            return _fetched.Iat >= _embedded.Iat ? _fetched : _embedded;
+            var now = DateTimeOffset.UtcNow;
+            // Exclude a CRL whose exp has passed since it was installed — its stored expiry is enforced at
+            // ACCESS time (not just at parse), so a CRL cannot deny valid entitlements forever (fail-open).
+            var emb = IsCurrentlyValid(_embedded, now) ? _embedded : null;
+            var fet = IsCurrentlyValid(_fetched, now) ? _fetched : null;
+            if (emb is null) return fet;
+            if (fet is null) return emb;
+            // Equal iat (1s precision): union both deny-lists so load ordering can't drop a revocation.
+            if (fet.Iat == emb.Iat) return Merge(fet, emb);
+            return fet.Iat > emb.Iat ? fet : emb;
         }
     }
+
+    /// <summary>A CRL remains valid only until its (always-present, positive) exp passes, so a CRL valid
+    /// when installed does not stay authoritative past its expiry.</summary>
+    private static bool IsCurrentlyValid(Crl? c, DateTimeOffset now) =>
+        c is not null && DateTimeOffset.FromUnixTimeSeconds(c.Exp) >= now;
 
     private static void EnsureEmbeddedLoadedNoLock()
     {
@@ -138,13 +172,22 @@ internal static class TensorsLicenseRevocation
             var p = payloadDoc.RootElement;
             if (p.ValueKind != JsonValueKind.Object) return null;
 
-            long iat = p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number
-                ? iatEl.GetInt64() : 0;
-            long exp = p.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
-                ? expEl.GetInt64() : 0;
+            // iat orders CRLs; parse non-throwingly (GetInt64 would throw FormatException, uncaught here).
+            long iat = 0;
+            if (p.TryGetProperty("iat", out var iatEl) && iatEl.ValueKind == JsonValueKind.Number)
+            {
+                iatEl.TryGetInt64(out iat);
+            }
 
-            // Ignore a stale (expired) CRL — client should refetch; entitlement expiry still applies.
-            if (exp > 0 && DateTimeOffset.FromUnixTimeSeconds(exp) < nowUtc) return null;
+            // exp MUST be present, a positive number, and strictly later than nowUtc. A missing / zero /
+            // negative / non-representable exp is rejected so a CRL cannot deny valid entitlements forever;
+            // the stored exp is ALSO enforced at access time in Effective().
+            if (!p.TryGetProperty("exp", out var expEl) || expEl.ValueKind != JsonValueKind.Number
+                || !expEl.TryGetInt64(out long exp) || exp <= 0 || exp > MaxUnixSeconds
+                || DateTimeOffset.FromUnixTimeSeconds(exp) <= nowUtc)
+            {
+                return null;
+            }
 
             var rjti = new HashSet<string>(StringComparer.Ordinal);
             if (p.TryGetProperty("rjti", out var rjtiEl) && rjtiEl.ValueKind == JsonValueKind.Array)
@@ -159,7 +202,7 @@ internal static class TensorsLicenseRevocation
                 }
             }
 
-            return new Crl(iat, rjti);
+            return new Crl(iat, exp, rjti);
         }
         catch (JsonException) { return null; }
     }
@@ -178,7 +221,8 @@ internal static class TensorsLicenseRevocation
     internal sealed class Crl
     {
         internal long Iat { get; }
+        internal long Exp { get; }
         internal HashSet<string> RevokedJti { get; }
-        internal Crl(long iat, HashSet<string> rjti) { Iat = iat; RevokedJti = rjti; }
+        internal Crl(long iat, long exp, HashSet<string> rjti) { Iat = iat; Exp = exp; RevokedJti = rjti; }
     }
 }

--- a/src/AiDotNet.Tensors/Licensing/TensorsMachineFingerprint.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsMachineFingerprint.cs
@@ -138,12 +138,19 @@ internal static class TensorsMachineFingerprint
                 return null;
             }
 
-            string output = process.StandardOutput.ReadToEnd();
+            // Drain stdout asynchronously so a hung ioreg cannot block us indefinitely on ReadToEnd() before
+            // the timeout is ever consulted. The background read keeps the pipe from filling; we then bound
+            // the total wait with WaitForExit(5000) and kill the process (returning null) if it overruns.
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             if (!process.WaitForExit(5000))
             {
                 try { process.Kill(); } catch { /* best effort */ }
                 return null;
             }
+
+            string output;
+            try { output = outputTask.GetAwaiter().GetResult(); }
+            catch { return null; }
 
             const string marker = "\"IOPlatformUUID\" = \"";
             int start = output.IndexOf(marker, StringComparison.Ordinal);

--- a/src/AiDotNet.Tensors/Licensing/TensorsMachineFingerprint.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsMachineFingerprint.cs
@@ -1,0 +1,198 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Deterministic machine identifier used to enforce the node-lock (<c>mach</c>) binding on <c>aidn2.</c>
+/// license tokens. This is a byte-for-byte port of the main SDK's <c>MachineFingerprint.GetMachineId</c> +
+/// <c>LicenseValidator.GetMachineIdHash</c>, so a token minted by the main SDK (whose <c>mach</c> claim is
+/// the main SDK's <see cref="GetMachineIdHash"/>) verifies here on the SAME physical machine — offline
+/// parity is the whole point of node-locking.
+/// </summary>
+/// <remarks>
+/// <para><b>Platform strategies (must match the main SDK exactly):</b></para>
+/// <list type="bullet">
+/// <item><description>Windows: reads <c>MachineGuid</c> from the registry (net10.0+; net471 uses the fallback)</description></item>
+/// <item><description>Linux: reads <c>/etc/machine-id</c></description></item>
+/// <item><description>macOS: runs <c>ioreg</c> for <c>IOPlatformUUID</c></description></item>
+/// <item><description>Fallback: <c>hostname|username|OSDescription</c></description></item>
+/// </list>
+/// <para>The raw platform id is SHA-256 hex-encoded to form the machine id, then re-hashed under the
+/// <c>"license-validation:"</c> salt to form the machine id HASH the <c>mach</c> claim carries. The salt
+/// and the two-step hashing must remain identical to the main SDK or node-locked tokens stop verifying.</para>
+/// </remarks>
+internal static class TensorsMachineFingerprint
+{
+    /// <summary>
+    /// Returns the SHA-256 machine-id hash the <c>mach</c> claim is compared against. Equivalent to the
+    /// main SDK's <c>LicenseValidator.GetMachineIdHash()</c>:
+    /// <c>SHA256hex("license-validation:" + GetMachineId())</c>.
+    /// </summary>
+    internal static string GetMachineIdHash()
+    {
+        string rawId = GetMachineId();
+        return HashToHex("license-validation:" + rawId);
+    }
+
+    /// <summary>
+    /// Returns a deterministic, hex-encoded SHA-256 fingerprint for the current machine. Equivalent to the
+    /// main SDK's <c>MachineFingerprint.GetMachineId()</c>.
+    /// </summary>
+    internal static string GetMachineId()
+    {
+        string? raw = GetPlatformMachineId();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            raw = GetFallbackId();
+        }
+
+        return HashToHex(raw ?? "unknown");
+    }
+
+    private static string? GetPlatformMachineId()
+    {
+#if NET471
+        // .NET Framework — use fallback (registry APIs differ; keep it simple), matching the main SDK.
+        return null;
+#else
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return ReadWindowsMachineGuid();
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return ReadLinuxMachineId();
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return ReadMacOsPlatformUuid();
+        }
+
+        return null;
+#endif
+    }
+
+#if !NET471
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private static string? ReadWindowsMachineGuid()
+    {
+        try
+        {
+            using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                @"SOFTWARE\Microsoft\Cryptography");
+            return key?.GetValue("MachineGuid") as string;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("linux")]
+    private static string? ReadLinuxMachineId()
+    {
+        try
+        {
+            const string path = "/etc/machine-id";
+            if (File.Exists(path))
+            {
+                string content = File.ReadAllText(path).Trim();
+                if (content.Length > 0)
+                {
+                    return content;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore
+        }
+
+        return null;
+    }
+
+    private static string? ReadMacOsPlatformUuid()
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "ioreg",
+                Arguments = "-rd1 -c IOPlatformExpertDevice",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = System.Diagnostics.Process.Start(psi);
+            if (process is null)
+            {
+                return null;
+            }
+
+            string output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(5000))
+            {
+                try { process.Kill(); } catch { /* best effort */ }
+                return null;
+            }
+
+            const string marker = "\"IOPlatformUUID\" = \"";
+            int start = output.IndexOf(marker, StringComparison.Ordinal);
+            if (start >= 0)
+            {
+                start += marker.Length;
+                int end = output.IndexOf('"', start);
+                if (end > start)
+                {
+                    return output.Substring(start, end - start);
+                }
+            }
+        }
+        catch
+        {
+            // Ignore
+        }
+
+        return null;
+    }
+#endif
+
+    private static string GetFallbackId()
+    {
+        string hostname;
+        string username;
+        try { hostname = Environment.MachineName; } catch { hostname = "unknown"; }
+        try { username = Environment.UserName; } catch { username = "unknown"; }
+        string os = RuntimeInformation.OSDescription ?? "unknown";
+        return $"{hostname}|{username}|{os}";
+    }
+
+    private static string HashToHex(string input)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(input);
+
+#if NET471
+        using var sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(bytes);
+#else
+        byte[] hash = SHA256.HashData(bytes);
+#endif
+
+        var sb = new StringBuilder(hash.Length * 2);
+        for (int i = 0; i < hash.Length; i++)
+        {
+            sb.Append(hash[i].ToString("x2"));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/TensorsOnlineLicenseServices.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsOnlineLicenseServices.cs
@@ -1,0 +1,414 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+#if !NET471
+using System.Net.Http;
+#endif
+
+namespace AiDotNet.Tensors.Licensing;
+
+/// <summary>
+/// Client glue for the v2 hybrid online→offline licensing model in a STANDALONE Tensors app (used without the
+/// main <c>AiDotNet</c> SDK): fetches the signed revocation list (CRL) and mints/caches short-lived offline
+/// <c>aidn2</c> tokens off a SUCCESSFUL online validation, so an <c>AIDN-*</c> server key keeps working —
+/// with the correct capabilities and while staying revocable — after the machine goes offline. The Tensors
+/// port of the main SDK's <c>OnlineLicenseServices</c>, using <c>System.Text.Json</c> (no Newtonsoft) and the
+/// Tensors verifiers (<see cref="AsymmetricEntitlementVerifier"/>, <see cref="Ed25519LicenseRevocation"/>).
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> An <c>AIDN-*</c> key normally must phone home to the license server on every
+/// run. That breaks air-gapped / offline use. This helper closes the gap: right after a successful online
+/// check, it (a) downloads the signed revocation list so leaked keys can be denied even offline, and (b) asks
+/// the server for a short-lived, machine-locked offline token and caches it. Next time the server is
+/// unreachable, the SDK verifies that cached token locally (against the embedded public key) instead of
+/// failing — until the token expires and a fresh online check is needed.</para>
+///
+/// <para><b>Shared cache with the main SDK:</b> the CRL is cached to <c>~/.aidotnet/revocations.crl</c> and
+/// offline tokens to <c>~/.aidotnet/offline-&lt;hash&gt;.token</c> using the SAME per-key filename scheme the
+/// main SDK's <c>OnlineLicenseServices</c> uses (<c>offline-</c> + first 8 bytes of
+/// <c>SHA256("license-cache:" + key)</c> hex + <c>.token</c>), so the two packages never collide and either
+/// can consume the other's cached token / CRL.</para>
+///
+/// <para><b>Fail-open / best-effort:</b> every network + disk operation here is wrapped so a failure NEVER
+/// breaks or blocks the validation that triggered it. The refresh runs on a background thread/task (off the
+/// hot path) and is throttled so it doesn't hit the network on every validation. The offline fallback only
+/// ever GRANTS when a genuinely signature-valid, unexpired, machine-matched token is present — it can't
+/// weaken security, only preserve availability.</para>
+/// </remarks>
+internal static class TensorsOnlineLicenseServices
+{
+    /// <summary>Minimum spacing between background refreshes (per machine, tracked by cache-file mtime), so a
+    /// tight validate loop doesn't hammer the endpoints. Well inside the offline token's exp so it stays fresh.</summary>
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(12);
+
+    private static readonly object FileLock = new();
+    private static string? _cacheDirOverrideForTests;
+
+#if !NET471
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(10) };
+#endif
+
+    private static string CacheDir => _cacheDirOverrideForTests ?? Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aidotnet");
+
+    private static string CrlPath => Path.Combine(CacheDir, "revocations.crl");
+
+    // One cache file per key (keyed by a short hash of the key, never the plaintext key) so multiple keys on
+    // one machine don't clobber each other's offline tokens. IDENTICAL scheme to the main SDK's
+    // OnlineLicenseServices.TokenPath so either package consumes the other's token.
+    private static string TokenPath(string licenseKey) =>
+        Path.Combine(CacheDir, "offline-" + ShortHash(licenseKey) + ".token");
+
+    /// <summary>TEST-ONLY: redirects the cache directory so tests don't touch the real user profile.</summary>
+    internal static IDisposable OverrideCacheDirForTesting(string dir)
+    {
+        var previous = _cacheDirOverrideForTests;
+        _cacheDirOverrideForTests = dir;
+        return new CacheDirScope(previous);
+    }
+
+    /// <summary>TEST-ONLY: writes an offline token to the same per-key cache path <see cref="RefreshCore"/> uses.</summary>
+    internal static void CacheOfflineTokenForTesting(string licenseKey, string token) =>
+        WriteAtomic(TokenPath(licenseKey), token);
+
+    /// <summary>TEST-ONLY: writes a CRL to the same cache path a background refresh would.</summary>
+    internal static void CacheCrlForTesting(string crl) => WriteAtomic(CrlPath, crl);
+
+    // ───────────────────────── refresh (background, off the hot path) ─────────────────────────
+
+    /// <summary>
+    /// Fire-and-forget refresh triggered after a successful ONLINE validation: pulls the latest signed CRL and
+    /// (for a server <c>AIDN-*</c> key) mints + caches a fresh offline token. Never blocks the caller and never
+    /// throws. Throttled by <see cref="RefreshInterval"/>.
+    /// </summary>
+    internal static void RefreshInBackground(string validateUrl, string licenseKey, string machineIdHash)
+    {
+        if (!ShouldRefresh())
+        {
+            return;
+        }
+
+        try
+        {
+#if NET471
+            var thread = new System.Threading.Thread(() => RefreshCore(validateUrl, licenseKey, machineIdHash))
+            {
+                IsBackground = true,
+                Name = "aidotnet-tensors-license-refresh"
+            };
+            thread.Start();
+#else
+            _ = System.Threading.Tasks.Task.Run(() => RefreshCore(validateUrl, licenseKey, machineIdHash));
+#endif
+        }
+        catch (Exception ex)
+        {
+            // Even scheduling the work is best-effort — a thread-pool/thread failure must not surface.
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsOnlineLicenseServices: failed to schedule refresh: " + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    private static void RefreshCore(string validateUrl, string licenseKey, string machineIdHash)
+    {
+        // CRL first: cheapest, benefits every key type (revocation enforcement offline).
+        try
+        {
+            string? crlUrl = DeriveFunctionUrl(validateUrl, "get-revocations");
+            if (crlUrl is not null)
+            {
+                string? crl = HttpGet(crlUrl);
+                if (!string.IsNullOrWhiteSpace(crl) &&
+                    Ed25519LicenseRevocation.TryInstallFetched(crl!, DateTimeOffset.UtcNow))
+                {
+                    WriteAtomic(CrlPath, crl!);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsOnlineLicenseServices: CRL refresh failed: " + ex.GetType().Name + ": " + ex.Message);
+        }
+
+        // Offline token: only meaningful for a server AIDN-* key (aidn./aidn2. keys already verify offline).
+        try
+        {
+            if (LicenseValidator.IsServerValidatedKeyFormat(licenseKey))
+            {
+                string? issueUrl = DeriveFunctionUrl(validateUrl, "issue-license");
+                if (issueUrl is not null)
+                {
+                    var payload = new Dictionary<string, string?>
+                    {
+                        ["license_key"] = licenseKey,
+                        ["machine_id_hash"] = machineIdHash,
+                        // A standalone Tensors app wants the tensors capability set on the minted token, so it
+                        // tags the issue request with its own package name (the main SDK sends "AiDotNet").
+                        ["package"] = "AiDotNet.Tensors",
+                    };
+                    string body = JsonSerializer.Serialize(payload);
+                    string? resp = HttpPost(issueUrl, body);
+                    string? token = ExtractOfflineToken(resp);
+                    // Only cache a token that actually verifies against THIS build's embedded public key — a
+                    // token we can't verify is useless offline, and caching it would just fail later.
+                    if (token is not null &&
+                        AsymmetricEntitlementVerifier.Verify(token, DateTimeOffset.UtcNow).IsValid)
+                    {
+                        WriteAtomic(TokenPath(licenseKey), token);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsOnlineLicenseServices: offline-token issue failed: " + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    // ───────────────────────── offline consumption ─────────────────────────
+
+    /// <summary>
+    /// Offline fallback used when the license server is unreachable: returns the cached offline <c>aidn2</c>
+    /// token's verified <see cref="EntitlementResult"/> if one exists and verifies (IsValid) against the
+    /// embedded public key on THIS machine, else null. Because it delegates to
+    /// <see cref="AsymmetricEntitlementVerifier"/>, all v2 bindings (signature, exp, machine-lock, CRL
+    /// revocation) are enforced — a leaked or expired cached token yields a non-valid result and is ignored.
+    /// Reads the per-key file from the (test-overridable) cache directory.
+    /// </summary>
+    internal static EntitlementResult? TryValidateCachedOfflineToken(string licenseKey)
+    {
+        try
+        {
+            string path = TokenPath(licenseKey);
+            string token;
+            lock (FileLock)
+            {
+                if (!File.Exists(path))
+                {
+                    return null;
+                }
+
+                token = File.ReadAllText(path).Trim();
+            }
+
+            if (!AsymmetricEntitlementVerifier.IsAsymmetricKeyFormat(token))
+            {
+                return null;
+            }
+
+            var result = AsymmetricEntitlementVerifier.Verify(token, DateTimeOffset.UtcNow);
+            return result.IsValid ? result : null;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsOnlineLicenseServices: cached offline token read failed: " + ex.GetType().Name + ": " + ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>Reads the last-fetched CRL from disk (or null). Used by <see cref="Ed25519LicenseRevocation"/>
+    /// to enforce the most recent online revocation list even on a fully offline start.</summary>
+    internal static string? ReadCachedCrl()
+    {
+        try
+        {
+            lock (FileLock)
+            {
+                return File.Exists(CrlPath) ? File.ReadAllText(CrlPath) : null;
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "TensorsOnlineLicenseServices: cached CRL read failed: " + ex.GetType().Name + ": " + ex.Message);
+            return null;
+        }
+    }
+
+    // ───────────────────────── helpers ─────────────────────────
+
+    /// <summary>
+    /// Derives a sibling edge-function URL (e.g. get-revocations, issue-license) from the validate-license URL
+    /// by swapping the trailing function segment. Returns null when the URL isn't the expected
+    /// <c>…/validate-license</c> shape (e.g. a custom test stub), so callers simply skip the feature.
+    /// </summary>
+    internal static string? DeriveFunctionUrl(string validateUrl, string functionName)
+    {
+        if (string.IsNullOrEmpty(validateUrl))
+        {
+            return null;
+        }
+
+        const string marker = "/validate-license";
+        int i = validateUrl.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (i < 0)
+        {
+            return null;
+        }
+
+        // Preserve anything after the segment (e.g. a query string) though normally there is none.
+        string tail = validateUrl.Substring(i + marker.Length);
+        return validateUrl.Substring(0, i) + "/" + functionName + tail;
+    }
+
+    private static string? ExtractOfflineToken(string? responseJson)
+    {
+        if (string.IsNullOrWhiteSpace(responseJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(responseJson!);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            bool valid = root.TryGetProperty("valid", out var v)
+                && (v.ValueKind == JsonValueKind.True
+                    || (v.ValueKind == JsonValueKind.String && bool.TryParse(v.GetString(), out var b) && b));
+            if (!valid)
+            {
+                return null;
+            }
+
+            if (root.TryGetProperty("offline_token", out var t) && t.ValueKind == JsonValueKind.String)
+            {
+                string? token = t.GetString();
+                return string.IsNullOrWhiteSpace(token) ? null : token;
+            }
+
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>True when no cache file exists yet or the freshest one is older than <see cref="RefreshInterval"/>.</summary>
+    private static bool ShouldRefresh()
+    {
+        try
+        {
+            DateTime newest = DateTime.MinValue;
+            lock (FileLock)
+            {
+                if (Directory.Exists(CacheDir))
+                {
+                    if (File.Exists(CrlPath))
+                    {
+                        newest = File.GetLastWriteTimeUtc(CrlPath);
+                    }
+
+                    foreach (string f in Directory.EnumerateFiles(CacheDir, "offline-*.token"))
+                    {
+                        DateTime t = File.GetLastWriteTimeUtc(f);
+                        if (t > newest)
+                        {
+                            newest = t;
+                        }
+                    }
+                }
+            }
+
+            return DateTime.UtcNow - newest >= RefreshInterval;
+        }
+        catch
+        {
+            // If we can't tell how fresh the cache is, err toward refreshing (still throttled by the fact that
+            // it only runs after a successful online validation).
+            return true;
+        }
+    }
+
+    private static void WriteAtomic(string path, string content)
+    {
+        lock (FileLock)
+        {
+            string? dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            // Write to a temp file then move, so a concurrent reader never sees a half-written file.
+            string tmp = path + ".tmp";
+            File.WriteAllText(tmp, content);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            File.Move(tmp, path);
+        }
+    }
+
+    private static string ShortHash(string value)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("license-cache:" + value);
+#if NET471
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        byte[] hash = sha.ComputeHash(bytes);
+#else
+        byte[] hash = System.Security.Cryptography.SHA256.HashData(bytes);
+#endif
+        var sb = new StringBuilder(16);
+        for (int i = 0; i < 8; i++)
+        {
+            sb.Append(hash[i].ToString("x2"));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string? HttpGet(string url)
+    {
+#if NET471
+        using var client = new System.Net.WebClient();
+        return client.DownloadString(url);
+#else
+        using var resp = Http.GetAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
+        return resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#endif
+    }
+
+    private static string? HttpPost(string url, string json)
+    {
+#if NET471
+        using var client = new System.Net.WebClient();
+        client.Headers[System.Net.HttpRequestHeader.ContentType] = "application/json";
+        try
+        {
+            return client.UploadString(url, "POST", json);
+        }
+        catch (System.Net.WebException ex) when (ex.Response is System.Net.HttpWebResponse http)
+        {
+            // A 403 (e.g. invalid_key) still carries a JSON body we want to inspect/ignore cleanly.
+            using var reader = new System.IO.StreamReader(http.GetResponseStream()!);
+            return reader.ReadToEnd();
+        }
+#else
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = Http.PostAsync(url, content).ConfigureAwait(false).GetAwaiter().GetResult();
+        return resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+#endif
+    }
+
+    private sealed class CacheDirScope : IDisposable
+    {
+        private readonly string? _previous;
+        public CacheDirScope(string? previous) => _previous = previous;
+        public void Dispose() => _cacheDirOverrideForTests = _previous;
+    }
+}

--- a/src/AiDotNet.Tensors/Licensing/TensorsOnlineLicenseServices.cs
+++ b/src/AiDotNet.Tensors/Licensing/TensorsOnlineLicenseServices.cs
@@ -50,6 +50,10 @@ internal static class TensorsOnlineLicenseServices
 
 #if !NET471
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(10) };
+#else
+    /// <summary>Explicit HTTP timeout for the net471 <see cref="System.Net.HttpWebRequest"/> path (WebClient
+    /// has none), matching the modern <see cref="HttpClient"/> 10-second budget.</summary>
+    private const int Net471TimeoutMs = 10_000;
 #endif
 
     private static string CacheDir => _cacheDirOverrideForTests ?? Path.Combine(
@@ -87,7 +91,10 @@ internal static class TensorsOnlineLicenseServices
     /// </summary>
     internal static void RefreshInBackground(string validateUrl, string licenseKey, string machineIdHash)
     {
-        if (!ShouldRefresh())
+        // Throttle the CRL and this key's offline token INDEPENDENTLY: a fresh CRL must not suppress minting
+        // a missing token for this key, and a fresh token (for this or any other key) must not suppress the
+        // CRL refresh. Skip scheduling only when BOTH relevant artifacts are already fresh.
+        if (!ShouldRefreshCrl() && !ShouldRefreshToken(licenseKey))
         {
             return;
         }
@@ -115,17 +122,21 @@ internal static class TensorsOnlineLicenseServices
 
     private static void RefreshCore(string validateUrl, string licenseKey, string machineIdHash)
     {
-        // CRL first: cheapest, benefits every key type (revocation enforcement offline).
+        // CRL first: cheapest, benefits every key type (revocation enforcement offline). Guarded by its OWN
+        // freshness so a fresh offline token never suppresses a needed CRL refresh.
         try
         {
-            string? crlUrl = DeriveFunctionUrl(validateUrl, "get-revocations");
-            if (crlUrl is not null)
+            if (ShouldRefreshCrl())
             {
-                string? crl = HttpGet(crlUrl);
-                if (!string.IsNullOrWhiteSpace(crl) &&
-                    Ed25519LicenseRevocation.TryInstallFetched(crl!, DateTimeOffset.UtcNow))
+                string? crlUrl = DeriveFunctionUrl(validateUrl, "get-revocations");
+                if (crlUrl is not null)
                 {
-                    WriteAtomic(CrlPath, crl!);
+                    string? crl = HttpGet(crlUrl);
+                    if (!string.IsNullOrWhiteSpace(crl) &&
+                        Ed25519LicenseRevocation.TryInstallFetched(crl!, DateTimeOffset.UtcNow))
+                    {
+                        WriteAtomic(CrlPath, crl!);
+                    }
                 }
             }
         }
@@ -136,9 +147,11 @@ internal static class TensorsOnlineLicenseServices
         }
 
         // Offline token: only meaningful for a server AIDN-* key (aidn./aidn2. keys already verify offline).
+        // Guarded by THIS key's own token freshness so a fresh CRL (or another key's token) never suppresses
+        // minting a missing token for this key.
         try
         {
-            if (LicenseValidator.IsServerValidatedKeyFormat(licenseKey))
+            if (ShouldRefreshToken(licenseKey))
             {
                 string? issueUrl = DeriveFunctionUrl(validateUrl, "issue-license");
                 if (issueUrl is not null)
@@ -296,38 +309,35 @@ internal static class TensorsOnlineLicenseServices
         }
     }
 
-    /// <summary>True when no cache file exists yet or the freshest one is older than <see cref="RefreshInterval"/>.</summary>
-    private static bool ShouldRefresh()
+    /// <summary>True when the CRL cache is missing or older than <see cref="RefreshInterval"/>.</summary>
+    private static bool ShouldRefreshCrl() => IsArtifactStale(CrlPath);
+
+    /// <summary>True when <paramref name="licenseKey"/> is a server <c>AIDN-*</c> key (the only kind for which
+    /// an offline token is minted) AND that key's own cached token is missing or older than
+    /// <see cref="RefreshInterval"/>. Only THIS key's token file is consulted, so another key's fresh token
+    /// can never suppress this key's refresh.</summary>
+    private static bool ShouldRefreshToken(string licenseKey) =>
+        LicenseValidator.IsServerValidatedKeyFormat(licenseKey) && IsArtifactStale(TokenPath(licenseKey));
+
+    /// <summary>True when a specific cache artifact is missing or older than <see cref="RefreshInterval"/>.</summary>
+    private static bool IsArtifactStale(string path)
     {
         try
         {
-            DateTime newest = DateTime.MinValue;
             lock (FileLock)
             {
-                if (Directory.Exists(CacheDir))
+                if (!File.Exists(path))
                 {
-                    if (File.Exists(CrlPath))
-                    {
-                        newest = File.GetLastWriteTimeUtc(CrlPath);
-                    }
-
-                    foreach (string f in Directory.EnumerateFiles(CacheDir, "offline-*.token"))
-                    {
-                        DateTime t = File.GetLastWriteTimeUtc(f);
-                        if (t > newest)
-                        {
-                            newest = t;
-                        }
-                    }
+                    return true;
                 }
-            }
 
-            return DateTime.UtcNow - newest >= RefreshInterval;
+                return DateTime.UtcNow - File.GetLastWriteTimeUtc(path) >= RefreshInterval;
+            }
         }
         catch
         {
-            // If we can't tell how fresh the cache is, err toward refreshing (still throttled by the fact that
-            // it only runs after a successful online validation).
+            // If we can't tell how fresh the artifact is, err toward refreshing (still throttled by the fact
+            // that a refresh only runs after a successful online validation).
             return true;
         }
     }
@@ -342,15 +352,35 @@ internal static class TensorsOnlineLicenseServices
                 Directory.CreateDirectory(dir);
             }
 
-            // Write to a temp file then move, so a concurrent reader never sees a half-written file.
-            string tmp = path + ".tmp";
-            File.WriteAllText(tmp, content);
-            if (File.Exists(path))
+            // Uniquely named temp file in the SAME directory (same volume, so the swap is a rename), then a
+            // SINGLE atomic replace — never delete the destination first. This closes both the missing-file
+            // window a concurrent reader could hit and the fixed-"*.tmp"-name race with the main SDK / another
+            // process.
+            string tmp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+            try
             {
-                File.Delete(path);
+                File.WriteAllText(tmp, content);
+#if NET471
+                // .NET Framework has no File.Move overwrite overload. File.Replace is an atomic swap but
+                // requires the destination to already exist; fall back to a plain Move when it does not (a
+                // best-effort equivalent, matching the modern overwrite Move).
+                if (File.Exists(path))
+                {
+                    File.Replace(tmp, path, destinationBackupFileName: null);
+                }
+                else
+                {
+                    File.Move(tmp, path);
+                }
+#else
+                File.Move(tmp, path, overwrite: true);
+#endif
             }
-
-            File.Move(tmp, path);
+            finally
+            {
+                // Clean up the temp file if the replace didn't consume it (e.g. an exception mid-write).
+                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best effort */ }
+            }
         }
     }
 
@@ -375,8 +405,16 @@ internal static class TensorsOnlineLicenseServices
     private static string? HttpGet(string url)
     {
 #if NET471
-        using var client = new System.Net.WebClient();
-        return client.DownloadString(url);
+        // WebClient has NO default timeout, so a hung endpoint could pin a background thread far beyond the
+        // documented refresh budget. Use HttpWebRequest with an explicit 10s timeout (matching the modern
+        // HttpClient path).
+        var req = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(url);
+        req.Method = "GET";
+        req.Timeout = Net471TimeoutMs;
+        req.ReadWriteTimeout = Net471TimeoutMs;
+        using var resp = (System.Net.HttpWebResponse)req.GetResponse();
+        using var reader = new System.IO.StreamReader(resp.GetResponseStream()!);
+        return reader.ReadToEnd();
 #else
         using var resp = Http.GetAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
         return resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -386,11 +424,25 @@ internal static class TensorsOnlineLicenseServices
     private static string? HttpPost(string url, string json)
     {
 #if NET471
-        using var client = new System.Net.WebClient();
-        client.Headers[System.Net.HttpRequestHeader.ContentType] = "application/json";
+        // Same reasoning as HttpGet: enforce an explicit 10s timeout that WebClient.UploadString lacks.
+        var req = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(url);
+        req.Method = "POST";
+        req.ContentType = "application/json";
+        req.Timeout = Net471TimeoutMs;
+        req.ReadWriteTimeout = Net471TimeoutMs;
+
+        byte[] payload = Encoding.UTF8.GetBytes(json);
+        req.ContentLength = payload.Length;
+        using (var reqStream = req.GetRequestStream())
+        {
+            reqStream.Write(payload, 0, payload.Length);
+        }
+
         try
         {
-            return client.UploadString(url, "POST", json);
+            using var resp = (System.Net.HttpWebResponse)req.GetResponse();
+            using var reader = new System.IO.StreamReader(resp.GetResponseStream()!);
+            return reader.ReadToEnd();
         }
         catch (System.Net.WebException ex) when (ex.Response is System.Net.HttpWebResponse http)
         {

--- a/tests/AiDotNet.Tensors.Tests/Licensing/Aidn2TestSupport.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/Aidn2TestSupport.cs
@@ -1,0 +1,154 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Test support for the offline aidn2 (Ed25519) license-token path: an ephemeral test keypair whose PUBLIC
+// half is injected into TensorsLicensePublicKeyProvider and whose PRIVATE half signs real test tokens/CRLs,
+// so tests exercise the genuine cryptographic verification path.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Tensors.Licensing;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+using Org.BouncyCastle.Security;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Produces REAL Ed25519-signed <c>aidn2.</c> tokens (and signed CRLs) against an ephemeral test keypair,
+/// and injects that keypair's public half into <see cref="TensorsLicensePublicKeyProvider"/> so
+/// <see cref="AsymmetricEntitlementVerifier"/> verifies them offline. Nothing here is a real signing key —
+/// the keypair is regenerated per test process and never committed. Mirrors the main SDK's
+/// <c>LicenseTestSupport</c>.
+/// </summary>
+internal static class Aidn2TestSupport
+{
+    /// <summary>Fixed key-id for the ephemeral test signing keypair (distinct from the real prod-2026a kid).</summary>
+    internal const string TestKid = "test-kid-2026a";
+
+    private static readonly AsymmetricCipherKeyPair TestKeyPair = CreateEd25519KeyPair();
+
+    private static AsymmetricCipherKeyPair CreateEd25519KeyPair()
+    {
+        var generator = new Ed25519KeyPairGenerator();
+        generator.Init(new Ed25519KeyGenerationParameters(new SecureRandom()));
+        return generator.GenerateKeyPair();
+    }
+
+    /// <summary>The raw 32-byte Ed25519 PUBLIC key of the ephemeral test signing keypair.</summary>
+    internal static byte[] TestPublicKey =>
+        ((Ed25519PublicKeyParameters)TestKeyPair.Public).GetEncoded();
+
+    /// <summary>The default embedded public-key set for tests: { TestKid → test public key }.</summary>
+    internal static Dictionary<string, byte[]> DefaultTestKeySet() =>
+        new(StringComparer.Ordinal) { [TestKid] = TestPublicKey };
+
+    /// <summary>A fresh, unrelated Ed25519 PRIVATE key — signs a token whose signature will NOT verify.</summary>
+    internal static AsymmetricKeyParameter CreateForeignSigningKey() =>
+        CreateEd25519KeyPair().Private;
+
+    /// <summary>
+    /// Produces a valid <c>aidn2.{base64url(claims)}.{base64url(sig)}</c> token signed with the ephemeral
+    /// test PRIVATE key — exactly what <see cref="AsymmetricEntitlementVerifier.Verify"/> verifies. The
+    /// claims are signed over the EXACT bytes that are then base64url-encoded into the token, so the
+    /// verifier (which verifies over the raw decoded segment) always sees the signed bytes.
+    /// </summary>
+    internal static string SignedTokenV2(
+        string sub = "test-customer",
+        string tier = "pro",
+        int seats = 5,
+        DateTimeOffset? iat = null,
+        DateTimeOffset? exp = null,
+        string kid = null,
+        string alg = "EdDSA",
+        AsymmetricKeyParameter signingKey = null,
+        string jti = null,
+        string[] caps = null,
+        string mach = null,
+        string scope = null)
+    {
+        var claims = new Aidn2Claims
+        {
+            Sub = sub,
+            Tier = tier,
+            Seats = seats,
+            Iat = (iat ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds(),
+            Exp = (exp ?? DateTimeOffset.UtcNow.AddDays(30)).ToUnixTimeSeconds(),
+            Kid = kid ?? TestKid,
+            Alg = alg,
+            Jti = jti,
+            Caps = caps,
+            Mach = mach,
+            Scope = scope,
+        };
+
+        byte[] claimsBytes = Encoding.UTF8.GetBytes(claims.ToCanonicalJson());
+        var signer = new Ed25519Signer();
+        signer.Init(true, signingKey ?? TestKeyPair.Private);
+        signer.BlockUpdate(claimsBytes, 0, claimsBytes.Length);
+        byte[] sig = signer.GenerateSignature();
+
+        return AsymmetricEntitlementVerifier.Prefix + "." +
+               Base64UrlEncode(claimsBytes) + "." +
+               Base64UrlEncode(sig);
+    }
+
+    /// <summary>
+    /// Produces a signed CRL in the format <see cref="Ed25519LicenseRevocation.ParseAndVerify"/> verifies:
+    /// <c>{ kid, payload:base64url({iat,exp,rkids,rjti}), sig:base64url(Ed25519 over payload) }</c>.
+    /// </summary>
+    internal static string SignedCrlV2(
+        string[] revokedJti = null,
+        string[] revokedKids = null,
+        DateTimeOffset? exp = null,
+        string kid = null,
+        AsymmetricKeyParameter signingKey = null)
+    {
+        var payload = new
+        {
+            iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            exp = (exp ?? DateTimeOffset.UtcNow.AddDays(1)).ToUnixTimeSeconds(),
+            rkids = revokedKids ?? Array.Empty<string>(),
+            rjti = revokedJti ?? Array.Empty<string>(),
+        };
+        byte[] payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload));
+        var signer = new Ed25519Signer();
+        signer.Init(true, signingKey ?? TestKeyPair.Private);
+        signer.BlockUpdate(payloadBytes, 0, payloadBytes.Length);
+        byte[] sig = signer.GenerateSignature();
+
+        var envelope = new
+        {
+            kid = kid ?? TestKid,
+            payload = Base64UrlEncode(payloadBytes),
+            sig = Base64UrlEncode(sig),
+        };
+        return JsonSerializer.Serialize(envelope);
+    }
+
+    /// <summary>
+    /// Scopes the embedded license public-key set to <paramref name="keys"/> for the duration of a test,
+    /// restoring the previous set on dispose. Pass <see langword="null"/> to simulate a dev/fork build with
+    /// NO embedded public key and assert fail-closed behaviour.
+    /// </summary>
+    internal static IDisposable WithPublicKeys(IReadOnlyDictionary<string, byte[]> keys)
+    {
+        var previous = TensorsLicensePublicKeyProvider.CurrentSnapshot();
+        TensorsLicensePublicKeyProvider.OverrideForTesting(keys);
+        return new RestorePublicKeys(previous);
+    }
+
+    private sealed class RestorePublicKeys : IDisposable
+    {
+        private readonly IReadOnlyDictionary<string, byte[]> _previous;
+        public RestorePublicKeys(IReadOnlyDictionary<string, byte[]> previous) => _previous = previous;
+        public void Dispose() => TensorsLicensePublicKeyProvider.OverrideForTesting(_previous);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+}

--- a/tests/AiDotNet.Tensors.Tests/Licensing/AsymmetricEntitlementVerifierTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/AsymmetricEntitlementVerifierTests.cs
@@ -1,0 +1,279 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for the offline aidn2 (Ed25519) license-token verification path and its PersistenceGuard wiring.
+
+#nullable disable
+
+using System;
+using AiDotNet.Tensors.Licensing;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Verifies the offline <c>aidn2.</c> (Ed25519) path against the real <see cref="AsymmetricEntitlementVerifier"/>
+/// with a fixture-injected test public key: a valid machine-bound token → Active with its signed caps;
+/// different-machine, expired, unknown-kid / no-embedded-key, forged, revoked, and scope-mismatch tokens →
+/// rejected (fail closed); and a valid token wired through <see cref="PersistenceGuard"/> authorises a
+/// persistence op. Serial via the shared PersistenceGuard collection — these mutate process-wide static
+/// state (the embedded public-key override, the CRL override, env vars, the guard's aidn2 cache), all
+/// restored in finally.
+/// </summary>
+[Collection("PersistenceGuard")]
+public class AsymmetricEntitlementVerifierTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    // ───────────── valid machine-bound token ─────────────
+
+    [Fact]
+    public void Verify_ValidMachineBoundToken_IsActive_WithCaps()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            string token = Aidn2TestSupport.SignedTokenV2(
+                mach: TensorsMachineFingerprint.GetMachineIdHash(),
+                caps: new[] { "tensors:save", "tensors:load" });
+
+            var r = AsymmetricEntitlementVerifier.Verify(token, Now);
+
+            Assert.True(r.IsValid, r.Message);
+            Assert.True(r.HasCapability("tensors:save"));
+            Assert.True(r.HasCapability("tensors:load"));
+            Assert.False(r.HasCapability("tensors:admin"));
+            Assert.Equal("test-customer", r.Tenant);
+        }
+    }
+
+    [Fact]
+    public void Verify_NoMachineClaim_IsActive_Anywhere()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            // A token WITHOUT a mach claim is unbound and valid on any machine.
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(caps: new[] { "tensors:save" }), Now);
+            Assert.True(r.IsValid, r.Message);
+        }
+    }
+
+    // ───────────── machine binding ─────────────
+
+    [Fact]
+    public void Verify_DifferentMachine_Rejected()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(mach: "not-this-machine-hash", caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+            Assert.Contains("machine", r.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // ───────────── expiry ─────────────
+
+    [Fact]
+    public void Verify_Expired_Rejected()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            // Expired well beyond the 5-minute clock skew.
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(exp: Now.AddHours(-1), caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+            Assert.Contains("expired", r.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // ───────────── unknown kid / no embedded key ─────────────
+
+    [Fact]
+    public void Verify_UnknownKid_Rejected()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            // Signed with the test key but declaring a kid the build doesn't embed → cannot verify.
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(kid: "unknown-kid-9999", caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+            Assert.Contains("kid", r.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void Verify_NoEmbeddedKey_DevBuild_Rejected()
+    {
+        // Simulate a dev/fork build with NO embedded public key: even a structurally valid token fails closed.
+        using (Aidn2TestSupport.WithPublicKeys(null))
+        {
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+        }
+    }
+
+    [Fact]
+    public void Verify_ForgedWithForeignKey_Rejected()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            // Signed by an unrelated private key; verified against the embedded test public key → bad sig.
+            var forged = Aidn2TestSupport.SignedTokenV2(
+                signingKey: Aidn2TestSupport.CreateForeignSigningKey(), caps: new[] { "tensors:save" });
+            var r = AsymmetricEntitlementVerifier.Verify(forged, Now);
+            Assert.False(r.IsValid);
+            Assert.Contains("signature", r.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // ───────────── scope binding ─────────────
+
+    [Fact]
+    public void Verify_Scope_AcceptedWhenHostScopeMatches()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        using (new ScopeEnv("ci"))
+        {
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(scope: "ci", caps: new[] { "tensors:save" }), Now);
+            Assert.True(r.IsValid, r.Message);
+        }
+    }
+
+    [Fact]
+    public void Verify_Scope_RejectedWhenHostScopeDiffers()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        using (new ScopeEnv("prod"))
+        {
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(scope: "ci", caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+            Assert.Contains("scope", r.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void Verify_Scope_RejectedWhenHostScopeUnset()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        using (new ScopeEnv(null))
+        {
+            var r = AsymmetricEntitlementVerifier.Verify(
+                Aidn2TestSupport.SignedTokenV2(scope: "ci", caps: new[] { "tensors:save" }), Now);
+            Assert.False(r.IsValid);
+        }
+    }
+
+    // ───────────── CRL revocation ─────────────
+
+    [Fact]
+    public void Verify_RevokedJti_Rejected()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            try
+            {
+                Ed25519LicenseRevocation.OverrideForTesting(
+                    Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "leaked-token-1" }), Now);
+
+                var r = AsymmetricEntitlementVerifier.Verify(
+                    Aidn2TestSupport.SignedTokenV2(jti: "leaked-token-1", caps: new[] { "tensors:save" }), Now);
+                Assert.False(r.IsValid);
+                Assert.Contains("revoked", r.Message, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                Ed25519LicenseRevocation.OverrideForTesting(null, Now);
+            }
+        }
+    }
+
+    [Fact]
+    public void Verify_NonRevokedJti_IsActive()
+    {
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            try
+            {
+                Ed25519LicenseRevocation.OverrideForTesting(
+                    Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "some-other-token" }), Now);
+
+                var r = AsymmetricEntitlementVerifier.Verify(
+                    Aidn2TestSupport.SignedTokenV2(jti: "my-token", caps: new[] { "tensors:save" }), Now);
+                Assert.True(r.IsValid, r.Message);
+            }
+            finally
+            {
+                Ed25519LicenseRevocation.OverrideForTesting(null, Now);
+            }
+        }
+    }
+
+    // ───────────── PersistenceGuard wiring ─────────────
+
+    [Fact]
+    public void PersistenceGuard_ValidAidn2TokenInEnv_AuthorisesWithNoKeyOrTrial()
+    {
+        var savedKeyEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY",
+                    Aidn2TestSupport.SignedTokenV2(
+                        mach: TensorsMachineFingerprint.GetMachineIdHash(),
+                        caps: new[] { "tensors:save", "tensors:load" }));
+                PersistenceGuard.ClearValidatorCacheForTesting(); // force re-resolve of the aidn2 token
+
+                // No RSA entitlement, no server key, no trial override — the aidn2 token alone authorises.
+                PersistenceGuard.EnforceBeforeSave();
+                PersistenceGuard.EnforceBeforeLoad();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY", savedKeyEnv);
+                PersistenceGuard.ClearValidatorCacheForTesting();
+            }
+        }
+    }
+
+    [Fact]
+    public void PersistenceGuard_Aidn2TokenMissingCapability_DoesNotAuthorise_FallsThroughToKeyPath()
+    {
+        var savedKeyEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            try
+            {
+                // Token grants only load — save is not granted by aidn2, so the guard falls through. With
+                // AIDOTNET_LICENSE_KEY set to an aidn2 token (not a valid server-key format), the key path
+                // then rejects it → LicenseRequiredException (positive-grant-only aidn2 never hard-fails
+                // itself, but it also doesn't mask the existing key-path behaviour).
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY",
+                    Aidn2TestSupport.SignedTokenV2(
+                        mach: TensorsMachineFingerprint.GetMachineIdHash(),
+                        caps: new[] { "tensors:load" }));
+                PersistenceGuard.ClearValidatorCacheForTesting();
+
+                Assert.Throws<LicenseRequiredException>(() => PersistenceGuard.EnforceBeforeSave());
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY", savedKeyEnv);
+                PersistenceGuard.ClearValidatorCacheForTesting();
+            }
+        }
+    }
+
+    private sealed class ScopeEnv : IDisposable
+    {
+        private readonly string _previous;
+        public ScopeEnv(string value)
+        {
+            _previous = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE");
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE", value);
+        }
+        public void Dispose() => Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE", _previous);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Licensing/AsymmetricEntitlementVerifierTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/AsymmetricEntitlementVerifierTests.cs
@@ -242,10 +242,16 @@ public class AsymmetricEntitlementVerifierTests
     public void PersistenceGuard_Aidn2TokenMissingCapability_DoesNotAuthorise_FallsThroughToKeyPath()
     {
         var savedKeyEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+        // A pre-existing RSA entitlement token in AIDOTNET_LICENSE_TOKEN could grant 'tensors:save' after the
+        // aidn2 result declines it, masking the key-path fall-through this test asserts. Clear it for the
+        // duration and restore it in finally.
+        var savedTokenEnv = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
         using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
         {
             try
             {
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", null);
+
                 // Token grants only load — save is not granted by aidn2, so the guard falls through. With
                 // AIDOTNET_LICENSE_KEY set to an aidn2 token (not a valid server-key format), the key path
                 // then rejects it → LicenseRequiredException (positive-grant-only aidn2 never hard-fails
@@ -261,6 +267,7 @@ public class AsymmetricEntitlementVerifierTests
             finally
             {
                 Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY", savedKeyEnv);
+                Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", savedTokenEnv);
                 PersistenceGuard.ClearValidatorCacheForTesting();
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
@@ -152,16 +152,25 @@ public class SignedEntitlementTests
     {
         // Even with a token present in the env, the placeholder key makes the
         // feature inert (returns null → guard falls through to key/trial path).
+        // Production now embeds a REAL entitlement key, so this test explicitly
+        // pins the placeholder via the override to exercise the inert-build path
+        // (rather than relying on the default embedded key still being the placeholder).
         var saved = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN");
+        var savedKey = SignedEntitlement.s_overridePublicKey;
         var (rsa, _) = NewKeypair();
         using (rsa)
         try
         {
+            SignedEntitlement.s_overridePublicKey = SignedEntitlement.PublicKeyPlaceholderMarker;
             Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN",
                 SignToken(rsa, SignedEntitlement.Marker, "2099-12-31", new[] { "tensors:save" }));
             Assert.Null(SignedEntitlement.TryVerifyConfigured()); // placeholder → inert
         }
-        finally { Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", saved); }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_TOKEN", saved);
+            SignedEntitlement.s_overridePublicKey = savedKey;
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/SignedEntitlementTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -35,9 +36,35 @@ public class SignedEntitlementTests
         return (rsa, embedded);
     }
 
-    private static string SignToken(RSA rsa, string marker, string expires, string[] capabilities)
+    private static string SignToken(RSA rsa, string marker, string expires, string[] capabilities,
+        string scope = null, string jti = null)
     {
-        var payload = new { marker, tenant = "ACME Corp.", expires, capabilities };
+        // Dictionary (not an anonymous type) so optional scope/jti claims can be included conditionally; the
+        // RSA signature is computed over the EXACT serialized bytes, so claim order/shape doesn't matter.
+        var payload = new Dictionary<string, object>
+        {
+            ["marker"] = marker,
+            ["tenant"] = "ACME Corp.",
+            ["expires"] = expires,
+            ["capabilities"] = capabilities,
+        };
+        if (scope != null) payload["scope"] = scope;
+        if (jti != null) payload["jti"] = jti;
+
+        var payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload));
+        var sig = rsa.SignData(payloadBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var envelope = new
+        {
+            payload = Convert.ToBase64String(payloadBytes),
+            signature = Convert.ToBase64String(sig),
+        };
+        return JsonSerializer.Serialize(envelope);
+    }
+
+    /// <summary>Signs an RSA CRL envelope (same key/format as the entitlement) revoking <paramref name="rjti"/>.</summary>
+    private static string SignCrl(RSA rsa, string[] rjti, DateTimeOffset iat, DateTimeOffset exp)
+    {
+        var payload = new { iat = iat.ToUnixTimeSeconds(), exp = exp.ToUnixTimeSeconds(), rjti };
         var payloadBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload));
         var sig = rsa.SignData(payloadBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         var envelope = new
@@ -224,6 +251,109 @@ public class SignedEntitlementTests
         }
     }
 
+    // ───────────── RSA scope binding (mirrors the aidn2 scope tests) ─────────────
+
+    [Fact]
+    public void Verify_Scope_AcceptedWhenHostScopeMatches()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        using (new ScopeEnv("ci"))
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31",
+                new[] { "tensors:save" }, scope: "ci");
+            var r = SignedEntitlement.Verify(token);
+            Assert.True(r.IsValid, r.Message);
+        });
+    }
+
+    [Fact]
+    public void Verify_Scope_RejectedWhenHostScopeDiffers()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        using (new ScopeEnv("prod"))
+        WithEmbeddedKey(embedded, () =>
+        {
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31",
+                new[] { "tensors:save" }, scope: "ci");
+            var r = SignedEntitlement.Verify(token);
+            Assert.False(r.IsValid);
+            Assert.Contains("scope", r.Message, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    [Fact]
+    public void Verify_Scope_RejectedWhenHostScopeUnset()
+    {
+        var (rsa, embedded) = NewKeypair();
+        using (rsa)
+        using (new ScopeEnv(null))
+        WithEmbeddedKey(embedded, () =>
+        {
+            // A scoped entitlement on an unscoped host is rejected (scope "" != "ci").
+            string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31",
+                new[] { "tensors:save" }, scope: "ci");
+            var r = SignedEntitlement.Verify(token);
+            Assert.False(r.IsValid);
+        });
+    }
+
+    // ───────────── RSA revocation (mirrors the aidn2 CRL tests) ─────────────
+
+    [Fact]
+    public void Verify_RevokedJti_Rejected()
+    {
+        var (rsa, embedded) = NewKeypair();
+        var now = DateTimeOffset.UtcNow;
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            try
+            {
+                // A CRL signed by the SAME entitlement key (unexpired) revokes this jti.
+                TensorsLicenseRevocation.OverrideForTesting(
+                    SignCrl(rsa, new[] { "leaked-ent-1" }, now, now.AddDays(1)), now);
+
+                string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31",
+                    new[] { "tensors:save" }, jti: "leaked-ent-1");
+                var r = SignedEntitlement.Verify(token);
+                Assert.False(r.IsValid);
+                Assert.Contains("revoked", r.Message, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                TensorsLicenseRevocation.OverrideForTesting(null, now);
+            }
+        });
+    }
+
+    [Fact]
+    public void Verify_NonRevokedJti_IsValid()
+    {
+        var (rsa, embedded) = NewKeypair();
+        var now = DateTimeOffset.UtcNow;
+        using (rsa)
+        WithEmbeddedKey(embedded, () =>
+        {
+            try
+            {
+                TensorsLicenseRevocation.OverrideForTesting(
+                    SignCrl(rsa, new[] { "some-other-ent" }, now, now.AddDays(1)), now);
+
+                string token = SignToken(rsa, SignedEntitlement.Marker, "2099-12-31",
+                    new[] { "tensors:save" }, jti: "my-ent");
+                var r = SignedEntitlement.Verify(token);
+                Assert.True(r.IsValid, r.Message);
+            }
+            finally
+            {
+                TensorsLicenseRevocation.OverrideForTesting(null, now);
+            }
+        });
+    }
+
     [Fact]
     public void PersistenceGuard_InvalidEntitlementPresent_Throws_DoesNotFallThroughToTrial()
     {
@@ -250,5 +380,17 @@ public class SignedEntitlementTests
             SignedEntitlement.s_overridePublicKey = savedKey;
             PersistenceGuard.ClearValidatorCacheForTesting();
         }
+    }
+
+    /// <summary>Sets AIDOTNET_LICENSE_SCOPE for the scope tests, restoring the prior value on dispose.</summary>
+    private sealed class ScopeEnv : IDisposable
+    {
+        private readonly string _previous;
+        public ScopeEnv(string value)
+        {
+            _previous = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE");
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE", value);
+        }
+        public void Dispose() => Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_SCOPE", _previous);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Licensing/TensorsOnlineLicenseServicesTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/TensorsOnlineLicenseServicesTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Tests for the auto-offline client glue (TensorsOnlineLicenseServices): sibling-URL derivation, the shared
+// per-key offline-token cache filename scheme, cached-token read → verified EntitlementResult, and CRL disk
+// round-trip. All disk I/O is redirected to a temp dir via OverrideCacheDirForTesting so the real user
+// profile is never touched.
+
+#nullable disable
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using AiDotNet.Tensors.Licensing;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Licensing;
+
+/// <summary>
+/// Exercises <see cref="TensorsOnlineLicenseServices"/> — the standalone-Tensors auto-offline glue that
+/// mints/caches offline <c>aidn2</c> tokens and the signed CRL off a successful online validation. Serial via
+/// the shared PersistenceGuard collection because these mutate process-wide static state (the cache-dir
+/// override and the injected public-key set), all restored in <c>finally</c>/<c>using</c>.
+/// </summary>
+[Collection("PersistenceGuard")]
+public class TensorsOnlineLicenseServicesTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    private const string ValidateUrl =
+        "https://yfkqwpgjahoamlgckjib.supabase.co/functions/v1/validate-license";
+
+    // An AIDN-* server-validated key (the only key type for which an offline token is minted).
+    private const string ServerKey = "AIDN-PROD-PRO-abcdef12";
+
+    // ───────────── sibling-URL derivation ─────────────
+
+    [Fact]
+    public void DeriveFunctionUrl_SwapsTrailingSegment()
+    {
+        Assert.Equal(
+            "https://yfkqwpgjahoamlgckjib.supabase.co/functions/v1/get-revocations",
+            TensorsOnlineLicenseServices.DeriveFunctionUrl(ValidateUrl, "get-revocations"));
+
+        Assert.Equal(
+            "https://yfkqwpgjahoamlgckjib.supabase.co/functions/v1/issue-license",
+            TensorsOnlineLicenseServices.DeriveFunctionUrl(ValidateUrl, "issue-license"));
+    }
+
+    [Fact]
+    public void DeriveFunctionUrl_PreservesQueryTail()
+    {
+        Assert.Equal(
+            "https://host/functions/v1/get-revocations?x=1",
+            TensorsOnlineLicenseServices.DeriveFunctionUrl(
+                "https://host/functions/v1/validate-license?x=1", "get-revocations"));
+    }
+
+    [Fact]
+    public void DeriveFunctionUrl_NonMatchingUrl_ReturnsNull()
+    {
+        Assert.Null(TensorsOnlineLicenseServices.DeriveFunctionUrl("https://host/custom-stub", "get-revocations"));
+        Assert.Null(TensorsOnlineLicenseServices.DeriveFunctionUrl("", "get-revocations"));
+    }
+
+    // ───────────── shared per-key cache filename scheme (byte-for-byte with the main SDK) ─────────────
+
+    [Fact]
+    public void CachedTokenFilename_MatchesMainSdkPerKeyScheme()
+    {
+        using var dir = new TempCacheDir();
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            TensorsOnlineLicenseServices.CacheOfflineTokenForTesting(ServerKey, "aidn2.x.y");
+
+            // Independently reproduce the main SDK's scheme: "offline-" + first 8 bytes of
+            // SHA256("license-cache:" + key) as lowercase hex + ".token".
+            string expected = "offline-" + MainSdkShortHash(ServerKey) + ".token";
+            Assert.True(File.Exists(Path.Combine(dir.Path, expected)),
+                "expected cache file '" + expected + "' was not written");
+        }
+    }
+
+    // ───────────── cached-token read → verified EntitlementResult with caps ─────────────
+
+    [Fact]
+    public void TryValidateCachedOfflineToken_ReadsSharedScheme_ReturnsActiveWithCaps()
+    {
+        using var dir = new TempCacheDir();
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            // Mint a REAL machine-bound aidn2 token (verifies against the injected test public key on THIS
+            // machine) and cache it under the per-key filename the refresh path uses.
+            string token = Aidn2TestSupport.SignedTokenV2(
+                mach: TensorsMachineFingerprint.GetMachineIdHash(),
+                caps: new[] { "tensors:save", "tensors:load" });
+            TensorsOnlineLicenseServices.CacheOfflineTokenForTesting(ServerKey, token);
+
+            var r = TensorsOnlineLicenseServices.TryValidateCachedOfflineToken(ServerKey);
+
+            Assert.NotNull(r);
+            Assert.True(r.IsValid, r.Message);
+            Assert.True(r.HasCapability("tensors:save"));
+            Assert.True(r.HasCapability("tensors:load"));
+            Assert.False(r.HasCapability("tensors:admin"));
+        }
+    }
+
+    [Fact]
+    public void TryValidateCachedOfflineToken_DifferentMachine_ReturnsNull()
+    {
+        using var dir = new TempCacheDir();
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            // A token bound to a DIFFERENT machine must never grant here (fail closed).
+            string token = Aidn2TestSupport.SignedTokenV2(
+                mach: "not-this-machine-hash", caps: new[] { "tensors:save" });
+            TensorsOnlineLicenseServices.CacheOfflineTokenForTesting(ServerKey, token);
+
+            Assert.Null(TensorsOnlineLicenseServices.TryValidateCachedOfflineToken(ServerKey));
+        }
+    }
+
+    [Fact]
+    public void TryValidateCachedOfflineToken_NoFile_ReturnsNull()
+    {
+        using var dir = new TempCacheDir();
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            Assert.Null(TensorsOnlineLicenseServices.TryValidateCachedOfflineToken("AIDN-PROD-PRO-deadbeef"));
+        }
+    }
+
+    // ───────────── CRL disk round-trip ─────────────
+
+    [Fact]
+    public void CrlDiskRoundTrip_WriteThenRead_ReturnsSameBytes()
+    {
+        using var dir = new TempCacheDir();
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            string crl = Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "leaked-token-1" });
+            TensorsOnlineLicenseServices.CacheCrlForTesting(crl);
+
+            Assert.True(File.Exists(Path.Combine(dir.Path, "revocations.crl")));
+            Assert.Equal(crl, TensorsOnlineLicenseServices.ReadCachedCrl());
+        }
+    }
+
+    [Fact]
+    public void ReadCachedCrl_NoFile_ReturnsNull()
+    {
+        using var dir = new TempCacheDir();
+        using (TensorsOnlineLicenseServices.OverrideCacheDirForTesting(dir.Path))
+        {
+            Assert.Null(TensorsOnlineLicenseServices.ReadCachedCrl());
+        }
+    }
+
+    [Fact]
+    public void CachedCrl_IsSignatureVerified_AndInstallable()
+    {
+        // The cached CRL round-trips AND is a genuine signature-verified CRL that TryInstallFetched accepts.
+        using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
+        {
+            string crl = Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "leaked-token-1" });
+            Assert.True(Ed25519LicenseRevocation.TryInstallFetched(crl, Now));
+            // Reset shared static state so this test doesn't leak a fetched CRL into others.
+            Ed25519LicenseRevocation.OverrideForTesting(null, Now);
+        }
+    }
+
+    // ───────────── helpers ─────────────
+
+    /// <summary>Independent reproduction of the main SDK's OnlineLicenseServices.ShortHash.</summary>
+    private static string MainSdkShortHash(string value)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("license-cache:" + value);
+        using var sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(bytes);
+        var sb = new StringBuilder(16);
+        for (int i = 0; i < 8; i++)
+        {
+            sb.Append(hash[i].ToString("x2"));
+        }
+
+        return sb.ToString();
+    }
+
+    private sealed class TempCacheDir : IDisposable
+    {
+        public string Path { get; }
+
+        public TempCacheDir()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "aidn-tensors-online-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Licensing/TensorsOnlineLicenseServicesTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/TensorsOnlineLicenseServicesTests.cs
@@ -164,10 +164,17 @@ public class TensorsOnlineLicenseServicesTests
         // The cached CRL round-trips AND is a genuine signature-verified CRL that TryInstallFetched accepts.
         using (Aidn2TestSupport.WithPublicKeys(Aidn2TestSupport.DefaultTestKeySet()))
         {
-            string crl = Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "leaked-token-1" });
-            Assert.True(Ed25519LicenseRevocation.TryInstallFetched(crl, Now));
-            // Reset shared static state so this test doesn't leak a fetched CRL into others.
-            Ed25519LicenseRevocation.OverrideForTesting(null, Now);
+            try
+            {
+                string crl = Aidn2TestSupport.SignedCrlV2(revokedJti: new[] { "leaked-token-1" });
+                Assert.True(Ed25519LicenseRevocation.TryInstallFetched(crl, Now));
+            }
+            finally
+            {
+                // Reset shared static state so this test doesn't leak a fetched CRL into others, even if the
+                // installation/assertion above throws.
+                Ed25519LicenseRevocation.OverrideForTesting(null, Now);
+            }
         }
     }
 

--- a/tools/license-issuer/rsa_entitlement_issuer.py
+++ b/tools/license-issuer/rsa_entitlement_issuer.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Tensors entitlement issuer — mints an offline, RSA-signed entitlement file for one tenant.
+
+Output envelope (must match src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs):
+    { "payload": "<base64(canonical payload JSON)>",
+      "signature": "<base64(RSA-2048 PKCS#1 v1.5 SHA-256 over the RAW payload bytes)>" }
+Signed payload:
+    { "marker": "AiDotNet-Tensors-Entitlement-v1", "tenant": "...", "expires": "YYYY-MM-DD",
+      "capabilities": ["tensors:save", ...], "scope"?: "...", "jti"?: "..." }
+
+The signature is computed over the RAW bytes that base64-decoding `payload` yields — exactly what the
+runtime re-verifies — so JSON field order/whitespace is irrelevant. Only `payload` is signed; every
+privilege field is read from it, never from the envelope.
+
+Deliver the resulting JSON to the tenant to install as ~/.aidotnet/tensors-entitlement.json (or point
+AIDOTNET_LICENSE_TOKEN at it). It verifies fully OFFLINE against the embedded RSA public key.
+
+Requires: pip install cryptography
+"""
+import argparse
+import base64
+import datetime as dt
+import json
+import sys
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+MARKER = "AiDotNet-Tensors-Entitlement-v1"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Mint a signed Tensors entitlement.")
+    ap.add_argument("--private-key-pem", required=True, help="RSA private key PEM from rsa_keygen.py")
+    ap.add_argument("--tenant", required=True, help="tenant / customer name (recorded in the signed payload)")
+    ap.add_argument("--caps", default="tensors:save,tensors:load,model:save,model:load",
+                    help="comma-separated capabilities")
+    ap.add_argument("--days", type=int, default=365, help="validity in days (omit --days 0 for perpetual)")
+    ap.add_argument("--scope", default=None, help="optional audience binding; host must set AIDOTNET_LICENSE_SCOPE to match")
+    ap.add_argument("--jti", default=None, help="optional token id for CRL revocation")
+    ap.add_argument("--out", default="tensors-entitlement.json", help="output path")
+    args = ap.parse_args()
+
+    with open(args.private_key_pem, "rb") as f:
+        priv = serialization.load_pem_private_key(f.read(), password=None)
+    if not isinstance(priv, RSAPrivateKey):
+        print("ERROR: provided PEM is not an RSA private key", file=sys.stderr)
+        return 2
+
+    payload = {
+        "marker": MARKER,
+        "tenant": args.tenant,
+        "capabilities": [c.strip() for c in args.caps.split(",") if c.strip()],
+    }
+    if args.days > 0:
+        exp = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=args.days)
+        payload["expires"] = exp.strftime("%Y-%m-%d")
+    if args.scope:
+        payload["scope"] = args.scope
+    if args.jti:
+        payload["jti"] = args.jti
+
+    payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    signature = priv.sign(payload_bytes, padding.PKCS1v15(), hashes.SHA256())
+
+    # Self-verify (fail closed) before writing anything.
+    priv.public_key().verify(signature, payload_bytes, padding.PKCS1v15(), hashes.SHA256())
+
+    envelope = {
+        "payload": base64.b64encode(payload_bytes).decode("ascii"),
+        "signature": base64.b64encode(signature).decode("ascii"),
+    }
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(envelope, f, separators=(",", ":"))
+
+    print("=== Tensors entitlement issued ===")
+    print(f"tenant:       {args.tenant}")
+    print(f"capabilities: {payload['capabilities']}")
+    print(f"expires:      {payload.get('expires', 'perpetual')}")
+    if args.scope:
+        print(f"scope:        {args.scope}")
+    if args.jti:
+        print(f"jti:          {args.jti}")
+    print(f"\nwrote -> {args.out}  (deliver to the tenant; install as ~/.aidotnet/tensors-entitlement.json)")
+    print("self-verify: OK (RSA-SHA256 signature valid over the exact payload bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/license-issuer/rsa_entitlement_issuer.py
+++ b/tools/license-issuer/rsa_entitlement_issuer.py
@@ -37,16 +37,26 @@ def main() -> int:
     ap.add_argument("--tenant", required=True, help="tenant / customer name (recorded in the signed payload)")
     ap.add_argument("--caps", default="tensors:save,tensors:load,model:save,model:load",
                     help="comma-separated capabilities")
-    ap.add_argument("--days", type=int, default=365, help="validity in days (omit --days 0 for perpetual)")
+    ap.add_argument("--days", type=int, default=365,
+                    help="validity in days (use 0 for a perpetual token; omitting the option defaults to 365)")
     ap.add_argument("--scope", default=None, help="optional audience binding; host must set AIDOTNET_LICENSE_SCOPE to match")
     ap.add_argument("--jti", default=None, help="optional token id for CRL revocation")
     ap.add_argument("--out", default="tensors-entitlement.json", help="output path")
     args = ap.parse_args()
 
+    # Reject negative validity: a negative --days would silently omit `expires` and mint a PERPETUAL token.
+    # A perpetual token is requested EXPLICITLY with --days 0, never by a negative value.
+    if args.days < 0:
+        ap.error("--days must be non-negative (use 0 for a perpetual token)")
+
     with open(args.private_key_pem, "rb") as f:
         priv = serialization.load_pem_private_key(f.read(), password=None)
     if not isinstance(priv, RSAPrivateKey):
         print("ERROR: provided PEM is not an RSA private key", file=sys.stderr)
+        return 2
+    # Reject a weak externally-supplied key — the documented trust root is RSA-2048.
+    if priv.key_size < 2048:
+        print(f"ERROR: RSA private key is only {priv.key_size} bits; the minimum is 2048", file=sys.stderr)
         return 2
 
     payload = {

--- a/tools/license-issuer/rsa_keygen.py
+++ b/tools/license-issuer/rsa_keygen.py
@@ -35,9 +35,13 @@ def i2b(n: int) -> bytes:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Generate a Tensors entitlement RSA signing keypair.")
-    ap.add_argument("--bits", type=int, default=2048, help="RSA key size (default 2048)")
+    ap.add_argument("--bits", type=int, default=2048, help="RSA key size (default 2048; minimum 2048)")
     ap.add_argument("--out-dir", default=".", help="where to write private_key.pem (default: cwd)")
     args = ap.parse_args()
+
+    # Enforce the documented RSA-2048 trust-root minimum — a weaker key must never be minted.
+    if args.bits < 2048:
+        ap.error("--bits must be at least 2048 (RSA-2048 is the documented trust-root minimum)")
 
     priv = rsa.generate_private_key(public_exponent=65537, key_size=args.bits)
     nums = priv.public_key().public_numbers()
@@ -48,7 +52,15 @@ def main() -> int:
 
     os.makedirs(args.out_dir, exist_ok=True)
     priv_path = os.path.join(args.out_dir, "private_key.pem")
-    with open(priv_path, "wb") as f:
+    # Create the private key file owner-readable/writable ONLY (0600) so a leaked copy can't be world-read.
+    # os.open honours the mode on creation; fchmod additionally forces 0600 on an existing file. Both are
+    # effectively no-ops on Windows (which lacks POSIX permission bits / fchmod), so this is safe there.
+    fd = os.open(priv_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        try:
+            os.fchmod(f.fileno(), 0o600)
+        except (AttributeError, OSError):
+            pass  # Windows / platforms without fchmod — best effort.
         f.write(priv.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,

--- a/tools/license-issuer/rsa_keygen.py
+++ b/tools/license-issuer/rsa_keygen.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Tensors entitlement RSA signing keypair bootstrap.
+
+Generates ONE RSA-2048 keypair and prints everything needed to activate AiDotNet.Tensors' offline
+entitlement path (SignedEntitlement). RUN THIS ON YOUR OWN MACHINE — the private key is written to a local
+PEM and never leaves your terminal; do not paste it into chat, commit it, or store it unencrypted.
+
+Why RSA (not the Ed25519/aidn2 key): the Tensors runtime verifies entitlements with .NET's BUILT-IN
+System.Security.Cryptography.RSA, so it works on net471 + net8 + net10 with NO extra crypto dependency
+(no BouncyCastle) — a deliberate design choice for the low-level Tensors package. This is a SEPARATE trust
+root from the main SDK's Ed25519 aidn2 key.
+
+Emits:
+  1. EntitlementPublicKey  — "{modulusBase64}:{exponentBase64}" (RSAParameters form). Paste it in place of
+     the SignedEntitlement.PublicKeyPlaceholderMarker in
+     src/AiDotNet.Tensors/Licensing/SignedEntitlement.cs (public — safe to commit). This ACTIVATES the
+     feature (until then it's inert and every entitlement falls through to the online/trial path).
+  2. private_key.pem       — RSA private key. Keep it in your signing secret store; sign per-tenant
+     entitlements with rsa_entitlement_issuer.py. NEVER commit.
+
+Requires: pip install cryptography
+"""
+import argparse
+import base64
+import os
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def i2b(n: int) -> bytes:
+    return n.to_bytes((n.bit_length() + 7) // 8, "big")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate a Tensors entitlement RSA signing keypair.")
+    ap.add_argument("--bits", type=int, default=2048, help="RSA key size (default 2048)")
+    ap.add_argument("--out-dir", default=".", help="where to write private_key.pem (default: cwd)")
+    args = ap.parse_args()
+
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=args.bits)
+    nums = priv.public_key().public_numbers()
+
+    mod_b64 = base64.b64encode(i2b(nums.n)).decode("ascii")
+    exp_b64 = base64.b64encode(i2b(nums.e)).decode("ascii")
+    embed = f"{mod_b64}:{exp_b64}"
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    priv_path = os.path.join(args.out_dir, "private_key.pem")
+    with open(priv_path, "wb") as f:
+        f.write(priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ))
+
+    print("=== Tensors entitlement RSA keypair ===")
+    print(f"key size: {args.bits} bits\n")
+    print("--- 1. EntitlementPublicKey (PUBLIC — commit) ---")
+    print("Replace SignedEntitlement.EntitlementPublicKey (currently the placeholder) with:\n")
+    print(f'    public const string EntitlementPublicKey = "{embed}";\n')
+    print(f"--- 2. private key -> {priv_path}  (SECRET — never commit) ---")
+    print("Sign per-tenant entitlements with:")
+    print(f"    python rsa_entitlement_issuer.py --private-key-pem {priv_path} --tenant \"ACME Corp\" \\")
+    print("        --caps tensors:save,tensors:load,model:save,model:load --days 365")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Mirrors the AiDotNet v2 aidn2 P1 hardening (ooples/AiDotNet#1891) on the Tensors side, adapted to the Tensors **RSA signed-entitlement** model.

## Context
Tensors' `PersistenceGuard` is **already capability-authoritative** (checks `HasCapability(requiredCapability)` on both the offline entitlement and online paths; throws on `Active && !cap`), so — unlike AiDotNet — it had no "any Active unlocks everything" gap. The remaining P1 parity is **binding + revocation** on the offline entitlement.

## Changes
- **`SignedEntitlement.Verify`**: after signature/marker/expiry, enforce **scope binding** (payload `scope` must equal `AIDOTNET_LICENSE_SCOPE`) and **jti revocation**.
- **`TensorsLicenseRevocation`** (new): signed CRL (embedded + online-fetched), RSA-verified against the embedded entitlement key via `SignedEntitlement.VerifyWithEntitlementKey`, expiry-checked, **fail-open** (absent/expired/unsigned ⇒ nothing revoked). `IsRevoked(jti)`.
- **csproj**: embed optional `Licensing/LicenseRevocation.json` ⇒ `AiDotNet.Tensors.LicenseRevocation`.

## Deferred
Machine (node-lock) binding — Tensors has no machine-id fingerprint yet (only `MachineName` for telemetry). To add alongside a proper fingerprint. The RSA entitlement/CRL keys remain the existing placeholders until Ooples embeds the real keys.

Builds clean (net10.0). See the design doc in ooples/AiDotNet#1891 (`docs/licensing/v2-licensing-design.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline license validation for signed tokens, including capability and expiry checks.
  * Added support for machine-bound and scope-specific entitlements.
  * Added offline license caching for continued validation without network access.
  * Added automatic background refresh of licenses and revocation data after successful online validation.

* **Security**
  * Added revocation checks for invalidated licenses and improved signature verification.
  * Added safeguards against malformed, expired, forged, or incorrectly scoped licenses.

* **Tests**
  * Expanded coverage for offline validation, caching, machine binding, scopes, and revocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->