### PR TITLE
feat(autodiff): public ComputeGradientsFromSeed for manual-backward layer wrapping

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -489,6 +489,39 @@ public sealed class GradientTape<T> : IDisposable
         => ComputeGradients(loss, sources, createGraph, seedOverride: null);
 
     /// <summary>
+    /// Reverse pass seeded by a supplied upstream gradient at <paramref name="output"/>, instead of the
+    /// default "ones at the loss" seed. This is the entry point for wrapping a tape-recorded forward as a
+    /// classic manual-backward layer (e.g. an <c>ILayer.Backward(outputGradient)</c>): record the op(s) in
+    /// <c>Forward</c>, then in <c>Backward</c> call this with the layer's output tensor and the incoming
+    /// output-gradient to obtain, in one tape walk, the gradients for the trainable parameters AND the
+    /// layer input — no manual adjoint code required. Equivalent to seeding the backward with the single
+    /// pair (<paramref name="output"/>, <paramref name="outputGradient"/>).
+    /// </summary>
+    /// <param name="output">A tape-recorded tensor whose incoming gradient is supplied (typically the layer output).</param>
+    /// <param name="outputGradient">The upstream gradient flowing into <paramref name="output"/>; must match its shape.</param>
+    /// <param name="sources">Tensors to return gradients for (e.g. the layer parameters and its input). Null returns all reached leaves.</param>
+    /// <returns>Map from each reached source tensor to its accumulated gradient.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="output"/> or <paramref name="outputGradient"/> is null.</exception>
+    /// <exception cref="ArgumentException">The two tensors' shapes differ.</exception>
+    public Dictionary<Tensor<T>, Tensor<T>> ComputeGradientsFromSeed(
+        Tensor<T> output,
+        Tensor<T> outputGradient,
+        IReadOnlyList<Tensor<T>>? sources = null)
+    {
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (outputGradient is null) throw new ArgumentNullException(nameof(outputGradient));
+        bool sameShape = output.Shape.Length == outputGradient.Shape.Length;
+        for (int i = 0; sameShape && i < output.Shape.Length; i++)
+            if (output.Shape[i] != outputGradient.Shape[i]) sameShape = false;
+        if (!sameShape)
+            throw new ArgumentException(
+                $"outputGradient shape [{string.Join(",", outputGradient.Shape)}] must match output shape [{string.Join(",", output.Shape)}].",
+                nameof(outputGradient));
+        return ComputeGradients(output, sources, createGraph: false,
+            seedOverride: new[] { new KeyValuePair<Tensor<T>, Tensor<T>>(output, outputGradient) });
+    }
+
+    /// <summary>
     /// Backward with an optional custom gradient seed. When <paramref name="seedOverride"/>
     /// is null this is byte-identical to the public <see cref="ComputeGradients(Tensor{T},IReadOnlyList{Tensor{T}},bool)"/>
     /// (ones-at-loss seeding, compiled/graph fast paths eligible). When it is supplied, the

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeSeededBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeSeededBackwardTests.cs
@@ -1,0 +1,91 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Tests for <see cref="GradientTape{T}.ComputeGradientsFromSeed"/> — the public seeded-backward entry
+/// point that lets a tape-recorded forward be wrapped as a manual-backward layer (Forward records,
+/// Backward(outputGradient) seeds the reverse pass at the layer output).
+/// </summary>
+public class GradientTapeSeededBackwardTests
+{
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+
+    private static float At(Tensor<float> t, int i) => t.AsWritableSpan()[i];
+
+    [Fact]
+    public void ComputeGradientsFromSeed_AppliesUpstreamGradient()
+    {
+        using var tape = new GradientTape<float>();
+        var w = new Tensor<float>(new float[] { 2f, 3f, 4f }, [3]);
+        var x = new Tensor<float>(new float[] { 5f, 6f, 7f }, [3]);
+        var y = _engine.TensorMultiply(w, x);                             // y = w ⊙ x, recorded on the tape
+        var seed = new Tensor<float>(new float[] { 1f, 10f, 100f }, [3]); // upstream gradient at y
+
+        var grads = tape.ComputeGradientsFromSeed(y, seed, new[] { w, x });
+
+        // Chain rule for y = w⊙x seeded by g: dL/dw = g⊙x, dL/dx = g⊙w.
+        var gw = grads[w]; var gx = grads[x];
+        Assert.Equal(1f * 5f, At(gw, 0), 3);
+        Assert.Equal(10f * 6f, At(gw, 1), 3);
+        Assert.Equal(100f * 7f, At(gw, 2), 3);
+        Assert.Equal(1f * 2f, At(gx, 0), 3);
+        Assert.Equal(10f * 3f, At(gx, 1), 3);
+        Assert.Equal(100f * 4f, At(gx, 2), 3);
+    }
+
+    [Fact]
+    public void ComputeGradientsFromSeed_OnesSeed_MatchesDefaultSumBackward()
+    {
+        var w = new Tensor<float>(new float[] { 2f, 3f }, [2]);
+        var x = new Tensor<float>(new float[] { 5f, 6f }, [2]);
+
+        // Default backward from the scalar loss sum(y): dL/dw = x.
+        float d0, d1;
+        using (var t1 = new GradientTape<float>())
+        {
+            var y = _engine.TensorMultiply(w, x);
+            var loss = _engine.ReduceSum(y, null, false);
+            var g = t1.ComputeGradients(loss, new[] { w });
+            d0 = At(g[w], 0); d1 = At(g[w], 1);
+        }
+
+        // Seeding the reverse pass with ones at y is equivalent (d(sum(y))/dy = ones).
+        float s0, s1;
+        using (var t2 = new GradientTape<float>())
+        {
+            var y = _engine.TensorMultiply(w, x);
+            var ones = new Tensor<float>(new float[] { 1f, 1f }, [2]);
+            var g = t2.ComputeGradientsFromSeed(y, ones, new[] { w });
+            s0 = At(g[w], 0); s1 = At(g[w], 1);
+        }
+
+        Assert.Equal(d0, s0, 4);
+        Assert.Equal(d1, s1, 4);
+    }
+
+    [Fact]
+    public void ComputeGradientsFromSeed_ShapeMismatch_Throws()
+    {
+        using var tape = new GradientTape<float>();
+        var w = new Tensor<float>(new float[] { 1f, 2f }, [2]);
+        var x = new Tensor<float>(new float[] { 3f, 4f }, [2]);
+        var y = _engine.TensorMultiply(w, x);
+        var badSeed = new Tensor<float>(new float[] { 1f, 2f, 3f }, [3]);
+        Assert.Throws<ArgumentException>(() => tape.ComputeGradientsFromSeed(y, badSeed, new[] { w }));
+    }
+
+    [Fact]
+    public void ComputeGradientsFromSeed_NullArgs_Throw()
+    {
+        using var tape = new GradientTape<float>();
+        var w = new Tensor<float>(new float[] { 1f }, [1]);
+        var y = _engine.TensorMultiplyScalar(w, 2f);
+        Assert.Throws<ArgumentNullException>(() => tape.ComputeGradientsFromSeed(null!, y));
+        Assert.Throws<ArgumentNullException>(() => tape.ComputeGradientsFromSeed(y, null!));
+    }
+}


### PR DESCRIPTION
## What

Adds `GradientTape<T>.ComputeGradientsFromSeed(output, outputGradient, sources)` — a public entry point to run the reverse pass seeded by a supplied upstream gradient at `output`, instead of the default "ones at the loss" seed.

## Why

The tape already supported seeding the backward with an arbitrary gradient (the `internal` `seedOverride` path used by the mixed-precision bridge), but it was not reachable publicly. That capability is exactly what a classic **manual-backward layer** needs to wrap a tape-recorded forward:

- `Forward`: run the op(s) with a tape active (they auto-record).
- `Backward(outputGradient)`: call `ComputeGradientsFromSeed(output, outputGradient, [params, input])` to obtain the parameter **and** input gradients in a single tape walk — no hand-written adjoint code.

This lets a tape-native operator be packaged as an `ILayer`/`LayerBase` (`Backward(outputGradient)` contract) without re-implementing autodiff by hand.

## How

Thin, validated wrapper over the existing internal seeded backward. Null + shape guards; no change to any existing path (the default `ComputeGradients` is untouched).

## Tests

`GradientTapeSeededBackwardTests` (4): correct seeded chain-rule for `y = w⊙x`; equivalence with the default `sum(y)` backward when seeded with ones; shape-mismatch and null-arg guards. Green on **net10.0** and **net471**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)