### PR TITLE
fix(cpu): bound Tanh/Sigmoid SIMD backward by logical length (fixes OOB / AccessViolation)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -40321,7 +40321,10 @@ public partial class CpuEngine : ITensorLevelEngine
 #else
             var resultArr = new float[length];
 #endif
-            SigmoidBackwardFloat(gF, oF, resultArr);
+            // Bound by the LOGICAL length — gF/oF can be pool-over-allocated (longer than the tensor's
+            // logical Length) while resultArr is sized to `length`; iterating to grad.Length would write
+            // past resultArr (unchecked AVX store -> AccessViolation). See TanhBackward for the mechanism.
+            SigmoidBackwardFloat(gF, oF, resultArr, length);
             return (Tensor<T>)(object)TensorAllocator.Rent<T>(gradOutput._shape, (Vector<T>)(object)Vector<float>.FromMemory(resultArr));
         }
 
@@ -40353,9 +40356,13 @@ public partial class CpuEngine : ITensorLevelEngine
         return TensorAllocator.Rent<T>(gradOutput._shape, result);
     }
 
-    private static unsafe void SigmoidBackwardFloat(float[] grad, float[] sigmoid, float[] result)
+    private static unsafe void SigmoidBackwardFloat(float[] grad, float[] sigmoid, float[] result, int length)
     {
-        int length = grad.Length;
+        // Clamp to the shortest array — grad/sigmoid may be pool-over-allocated (longer than `length`);
+        // result is sized to the logical length. Never read/write past any buffer.
+        if (length > result.Length) length = result.Length;
+        if (length > grad.Length) length = grad.Length;
+        if (length > sigmoid.Length) length = sigmoid.Length;
         int i = 0;
 #if NET5_0_OR_GREATER
         if (System.Runtime.Intrinsics.X86.Avx2.IsSupported && length >= 32)
@@ -40409,7 +40416,12 @@ public partial class CpuEngine : ITensorLevelEngine
 #else
             var resultArr = new float[length];
 #endif
-            TanhBackwardFloat(gF, oF, resultArr);
+            // Bound by the LOGICAL length: gF/oF come from GetFlattenedData/GetDataArray, which
+            // can hand back a pool-OVER-ALLOCATED backing array (physically longer than the tensor's
+            // logical Length — see VectorBase.GetDataArray returning the full segment.Array at offset 0).
+            // resultArr is sized to `length`, so iterating to grad.Length would write past it (the
+            // AVX store has no bounds check -> AccessViolation). Pass the logical length explicitly.
+            TanhBackwardFloat(gF, oF, resultArr, length);
             return (Tensor<T>)(object)TensorAllocator.Rent<T>(gradOutput._shape, (Vector<T>)(object)Vector<float>.FromMemory(resultArr));
         }
 
@@ -40441,9 +40453,14 @@ public partial class CpuEngine : ITensorLevelEngine
         return TensorAllocator.Rent<T>(gradOutput._shape, result);
     }
 
-    private static unsafe void TanhBackwardFloat(float[] grad, float[] tanh, float[] result)
+    private static unsafe void TanhBackwardFloat(float[] grad, float[] tanh, float[] result, int length)
     {
-        int length = grad.Length;
+        // Clamp to the shortest array so no read/write can exceed any buffer, even if a caller
+        // passes a `length` larger than one of the arrays (over-allocated pool backings mean
+        // grad/tanh may be LONGER than `length`, never shorter — but the clamp is O(1) insurance).
+        if (length > result.Length) length = result.Length;
+        if (length > grad.Length) length = grad.Length;
+        if (length > tanh.Length) length = tanh.Length;
         int i = 0;
 #if NET5_0_OR_GREATER
         if (System.Runtime.Intrinsics.X86.Avx2.IsSupported && length >= 32)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ActivationBackwardOverAllocatedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ActivationBackwardOverAllocatedTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Regression: the SIMD Tanh/Sigmoid backward kernels iterated to grad.Length (the PHYSICAL
+// backing-array length) while writing into a result buffer sized to the tensor's LOGICAL length.
+// Under a GradientTape the activation's forward output is POOL-allocated, and the pool hands back a
+// backing array rounded UP to a bucket size — physically longer than the logical Length, yet with
+// _storage.Length == Length so GetFlattenedData returns that oversized array. The unchecked AVX
+// store in the backward kernel then wrote PAST the logical-sized result buffer -> AccessViolation.
+//
+// Discovered via the HRE standard-transformer block (attention intermediates cycle the pool, then
+// the wide 4E Tanh FFN backward crashes). This test reproduces that shape/pressure through the tape
+// so it faults deterministically if the bound regresses; the fix bounds the kernels by the logical
+// length. Verified to CRASH with the bound reverted and PASS with it in place.
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public class ActivationBackwardOverAllocatedTests
+{
+    // One attention-then-FFN block, matching the HRE standard-transformer arm that surfaced the bug:
+    // 3D permute / batched-matmul / softmax intermediates cycle the tape's buffer pool, then a wide
+    // [B*S, 4E] activation backward runs against a pool-over-allocated forward output.
+    private static void RunBlock(IEngine e, System.Func<Tensor<float>, Tensor<float>> act,
+        Tensor<float> h, Tensor<float> wq, Tensor<float> wk, Tensor<float> wv, Tensor<float> wo,
+        Tensor<float> w1, Tensor<float> w2, int B, int S, int E)
+    {
+        var h2 = e.Reshape<float>(h, new[] { B * S, E });
+        Tensor<float> Proj(Tensor<float> w) => e.Reshape<float>(e.TensorMatMul<float>(h2, w), new[] { B, S, E });
+        var q = Proj(wq); var k = Proj(wk); var v = Proj(wv);
+        var kT = e.TensorPermute<float>(k, new[] { 0, 2, 1 });
+        var scores = e.TensorMultiplyScalar<float>(e.BatchMatMul<float>(q, kT), 1f / (float)Math.Sqrt(E));
+        var ctx = e.BatchMatMul<float>(e.Softmax<float>(scores, 2), v);
+        var att = e.Reshape<float>(e.TensorMatMul<float>(e.Reshape<float>(ctx, new[] { B * S, E }), wo), new[] { B, S, E });
+        var a = e.Reshape<float>(e.TensorAdd<float>(h, att), new[] { B * S, E });
+        // wide FFN: [B*S,E]@[E,4E] -> activation -> @[4E,E]  (the activation whose backward crashed)
+        var hid = act(e.TensorMatMul<float>(a, w1));
+        var f = e.TensorMatMul<float>(hid, w2);
+        var outT = e.TensorAdd<float>(a, f);
+        var loss = e.ReduceSum<float>(e.TensorMultiply<float>(outT, outT), null, false);
+        // backward over all params — runs the activation backward against the pooled forward output.
+        // Do NOT dispose the tape here; the caller's `using` owns its lifetime.
+        var tape = GradientTape<float>.Current;
+        _ = tape!.ComputeGradients(loss, new[] { h, wq, wk, wv, wo, w1, w2 });
+    }
+
+    private static Tensor<float> Rand(Random r, int[] shape)
+    {
+        int n = 1; foreach (var d in shape) n *= d;
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(r.NextDouble() * 2 - 1);
+        return new Tensor<float>(a, shape);
+    }
+
+    [Theory]
+    [InlineData("tanh")]
+    [InlineData("sigmoid")]
+    public void ActivationBackward_WideFfnUnderPoolPressure_NoOob(string kind)
+    {
+        var e = new CpuEngine();
+        int B = 256, S = 6, E = 64, H = 4 * E;
+        var r = new Random(3);
+        System.Func<Tensor<float>, Tensor<float>> act = kind == "tanh"
+            ? (t => e.Tanh<float>(t))
+            : (t => e.Sigmoid<float>(t));
+
+        // Several fresh-tape steps so the buffer pool warms up and starts handing back
+        // rounded-up (over-allocated) buckets — the condition the crash needed.
+        for (int step = 0; step < 6; step++)
+        {
+            using (new GradientTape<float>())
+            {
+                var h = Rand(r, new[] { B, S, E });
+                var wq = Rand(r, new[] { E, E }); var wk = Rand(r, new[] { E, E });
+                var wv = Rand(r, new[] { E, E }); var wo = Rand(r, new[] { E, E });
+                var w1 = Rand(r, new[] { E, H }); var w2 = Rand(r, new[] { H, E });
+                RunBlock(e, act, h, wq, wk, wv, wo, w1, w2, B, S, E);
+            }
+        }
+        // Reaching here without an AccessViolation is the assertion (pre-fix: hard crash in the
+        // activation backward). Sanity-check the engine is still usable afterward.
+        var probe = e.Tanh<float>(new Tensor<float>(new float[] { 0f }, new[] { 1, 1 })).ToArray();
+        Assert.Equal(0f, probe[0], 3);
+    }
+}


### PR DESCRIPTION
## Problem

The CPU SIMD **Tanh/Sigmoid backward** kernels (`TanhBackwardFloat` / `SigmoidBackwardFloat`) iterated to `grad.Length` — the **physical** backing-array length — while writing into a result buffer allocated to the tensor's **logical** `Length`.

When an activation's forward output is pool-allocated with a **rounded-up backing** (bucketed pools hand back an array larger than the logical length; `GetFlattenedData` then returns the full `segment.Array` at offset 0), the two lengths diverge. The unchecked AVX `Store(rp + i)` then wrote **past the logical result buffer** → heap corruption / hard `AccessViolationException` (uncatchable, aborts the process).

## How it showed up

A standard pre-LN transformer block: the 3D attention path (`TensorPermute` → `BatchMatMul` → `Softmax(axis=2)` → `BatchMatMul`) cycles the tape's buffer pool, so the subsequent **wide 4E Tanh FFN**'s forward output lands on an over-allocated bucket. Its backward then crashes. The narrow-FFN / zero-param-attention path never triggered it (exact-fit backing), which is why it looked size/shape-specific.

## Fix

Pass the **logical length** into the kernels and clamp to the shortest of `{result, grad, activation}` so no read/write can exceed any buffer:

```csharp
if (length > result.Length)     length = result.Length;
if (length > grad.Length)       length = grad.Length;
if (length > activation.Length) length = activation.Length;
```

Byte-identical in the normal exact-fit path (all three equal `length`); the clamp only affects the over-allocated case. `SoftmaxBackwardFloat` already takes explicit `outerSize`/`axisSize`, so it was unaffected; the double SIMD paths already passed the logical length.

## Verification

- **New regression test** `ActivationBackwardOverAllocatedTests` — an attention → wide-FFN → backward under tape pool pressure, for both Tanh and Sigmoid. Proven to have teeth: **crashes with `AccessViolation` when the bound is reverted, passes with the fix**.
- **442** existing autodiff/gradient-correctness/pooled-backward tests: **green** (no regression).
- **End-to-end**: the standard-transformer training arm that previously hard-crashed now trains (val 0.27 vs 0.12 majority baseline) — correct gradients, not just non-crashing.
