### PR TITLE
feat(attention): optional logit soft-cap on ScaledDotProductAttention (CPU + all 6 GPU backends)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -26287,7 +26287,8 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<T> value,
         Tensor<bool>? mask,
         double? scale,
-        out Tensor<T> attentionWeights)
+        out Tensor<T> attentionWeights,
+        double softcap = 0.0)
     {
         using var _opScope = AiDotNet.Tensors.Engines.Profiling.Profiler.OpScope("ScaledDotProductAttention");
         if (query == null)
@@ -26334,6 +26335,14 @@ public partial class CpuEngine : ITensorLevelEngine
             var scores = TensorMatMul(query, kT);
             // scaled = scores * (1/sqrt(d_k))
             var scaled = TensorMultiplyScalar(scores, scaleT_local);
+            // Optional attention-logit soft-cap (Gemma-2): scaled = softcap * tanh(scaled / softcap).
+            // Recorded as primitives so the compiled plan's backward chains through them.
+            if (softcap > 0.0)
+            {
+                var invCap = numOpsLocal.FromDouble(1.0 / softcap);
+                var capT = numOpsLocal.FromDouble(softcap);
+                scaled = TensorMultiplyScalar(Tanh(TensorMultiplyScalar(scaled, invCap)), capT);
+            }
             // softmax over last axis (S_k) — Softmax records its own lazy node
             // and the backward kernel handles the per-row Jacobian.
             attentionWeights = Softmax(scaled);
@@ -26398,7 +26407,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 (Tensor<float>)(object)value,
                 mask, scaleVal,
                 batch, heads, seqQ, d_k, seqK, d_v,
-                out var weightsF);
+                out var weightsF, softcap);
             attentionWeights = (Tensor<T>)(object)weightsF;
             var resultFCast = (Tensor<T>)(object)resultF;
             DifferentiableOps.RecordIfActive("ScaledDotProductAttention", resultFCast,
@@ -26424,7 +26433,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 (Tensor<double>)(object)value,
                 mask, scaleVal,
                 batch, heads, seqQ, d_k, seqK, d_v,
-                out var weightsD);
+                out var weightsD, softcap);
             attentionWeights = (Tensor<T>)(object)weightsD;
             var resultDCast = (Tensor<T>)(object)resultD;
             DifferentiableOps.RecordIfActive("ScaledDotProductAttention", resultDCast,
@@ -26456,7 +26465,11 @@ public partial class CpuEngine : ITensorLevelEngine
                     {
                         sum = numOps.Add(sum, numOps.Multiply(queryData[qOffset + i * d_k + k], keyData[kOffset + j * d_k + k]));
                     }
-                    scoresData[sOffset + i * seqK + j] = numOps.Multiply(sum, scaleFactor);
+                    var scaledScore = numOps.Multiply(sum, scaleFactor);
+                    // Attention-logit soft-cap (Gemma-2), generic-T path.
+                    if (softcap > 0.0)
+                        scaledScore = numOps.FromDouble(softcap * Math.Tanh(Convert.ToDouble(scaledScore) / softcap));
+                    scoresData[sOffset + i * seqK + j] = scaledScore;
                 }
             }
         });
@@ -26557,7 +26570,8 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<bool>? mask,
         double scaleValue,
         int batch, int heads, int seqQ, int d_k, int seqK, int d_v,
-        out Tensor<float> attentionWeights)
+        out Tensor<float> attentionWeights,
+        double softcap = 0.0)
     {
         int bhCount = batch * heads;
         var qf = query.GetFlattenedData();
@@ -26582,6 +26596,9 @@ public partial class CpuEngine : ITensorLevelEngine
 
         float scaleF  = (float)scaleValue;
         float negInfF = float.NegativeInfinity;
+        bool useSoftcap = softcap > 0.0;
+        float capF = (float)softcap;
+        float invCapF = useSoftcap ? 1f / capF : 0f;
 
         // Process each batch-head slice in parallel. Each slice is two independent
         // SGEMMs separated by a softmax pass. The individual SGEMMs are sized well
@@ -26648,6 +26665,8 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int j = 0; j < seqK; j++)
                 {
                     float v = scoresData[rowOff + j] * scaleF;
+                    // Attention-logit soft-cap (Gemma-2): applied to the scaled logit before masking/softmax.
+                    if (useSoftcap) v = capF * MathF.Tanh(v * invCapF);
                     if (mask != null && !mask[b, h, i, j]) v = negInfF;
                     if (v > maxVal) maxVal = v;
                     scoresData[rowOff + j] = v;
@@ -26922,7 +26941,8 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<bool>? mask,
         double scaleValue,
         int batch, int heads, int seqQ, int d_k, int seqK, int d_v,
-        out Tensor<double> attentionWeights)
+        out Tensor<double> attentionWeights,
+        double softcap = 0.0)
     {
         int bhCount = batch * heads;
         // Use the stride-aware accessor on all three operands for consistency.
@@ -26986,6 +27006,8 @@ public partial class CpuEngine : ITensorLevelEngine
                     for (int j = 0; j < seqK; j++)
                     {
                         double v = scoresData[rowOff + j] * scaleValue;
+                        // Attention-logit soft-cap (Gemma-2): applied to the scaled logit before masking/softmax.
+                        if (softcap > 0.0) v = softcap * Math.Tanh(v / softcap);
                         if (mask != null && !mask[b, h, i, j]) v = negInfD;
                         if (v > maxVal) maxVal = v;
                         scoresData[rowOff + j] = v;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -7629,7 +7629,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
 
     public unsafe void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
     {
         using var _ = PushContext();
         if (batch <= 0 || numHeads <= 0 || seqQ <= 0 || seqK <= 0 || headDim <= 0)
@@ -7656,7 +7656,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         int causalFlag = isCausal ? 1 : 0;
         int maskMode = mask is null ? 0 : mask.Size >= weightsSize ? 2 : 1;
         int storeWeights = attentionWeights is null ? 0 : 1;
-        void** args = stackalloc void*[15];
+        void** args = stackalloc void*[16];
         args[0] = &queryPtr;
         args[1] = &keyPtr;
         args[2] = &valuePtr;
@@ -7672,6 +7672,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         args[12] = &causalFlag;
         args[13] = &maskMode;
         args[14] = &storeWeights;
+        args[15] = &softcap;
 
         int rows = checked(batch * numHeads * seqQ);
         uint grid = (uint)((rows + DefaultBlockSize - 1) / DefaultBlockSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAttentionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaAttentionKernels.cs
@@ -40,7 +40,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
     float scale,
     int isCausal,
     int maskMode,
-    int storeWeights)
+    int storeWeights,
+    float softcap)
 {
     int row = blockIdx.x * blockDim.x + threadIdx.x;
     int totalRows = batch * numHeads * seqQ;
@@ -54,12 +55,15 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
     int wOffset = row * seqK;
     int maskOffset = (maskMode == 2 ? bh * seqQ * seqK : 0) + qi * seqK;
 
+    // Attention-logit soft-cap (Gemma-2): softcap * tanh((score*scale)/softcap); softcap<=0 disables.
+    #define ATTN_LOGIT(sc) (softcap > 0.0f ? softcap * tanhf(((sc) * scale) / softcap) : (sc) * scale)
+
     float rowMax = -INFINITY;
     for (int ki = 0; ki < seqK; ki++) {
         if ((isCausal && ki > qi) || (maskMode != 0 && mask[maskOffset + ki] == 0.0f)) continue;
         float score = 0.0f;
         for (int d = 0; d < headDim; d++) score += query[qOffset + d] * key[kOffset + ki * headDim + d];
-        rowMax = fmaxf(rowMax, score * scale);
+        rowMax = fmaxf(rowMax, ATTN_LOGIT(score));
     }
 
     float denominator = 0.0f;
@@ -67,7 +71,7 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
         if ((isCausal && ki > qi) || (maskMode != 0 && mask[maskOffset + ki] == 0.0f)) continue;
         float score = 0.0f;
         for (int d = 0; d < headDim; d++) score += query[qOffset + d] * key[kOffset + ki * headDim + d];
-        denominator += expf(score * scale - rowMax);
+        denominator += expf(ATTN_LOGIT(score) - rowMax);
     }
 
     float inverseDenominator = denominator > 0.0f ? 1.0f / denominator : 0.0f;
@@ -77,7 +81,7 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
             if (!((isCausal && ki > qi) || (maskMode != 0 && mask[maskOffset + ki] == 0.0f))) {
                 float score = 0.0f;
                 for (int d = 0; d < headDim; d++) score += query[qOffset + d] * key[kOffset + ki * headDim + d];
-                weight = expf(score * scale - rowMax) * inverseDenominator;
+                weight = expf(ATTN_LOGIT(score) - rowMax) * inverseDenominator;
             }
             attentionWeights[wOffset + ki] = weight;
         }
@@ -89,11 +93,12 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
             if ((isCausal && ki > qi) || (maskMode != 0 && mask[maskOffset + ki] == 0.0f)) continue;
             float score = 0.0f;
             for (int inner = 0; inner < headDim; inner++) score += query[qOffset + inner] * key[kOffset + ki * headDim + inner];
-            float weight = expf(score * scale - rowMax) * inverseDenominator;
+            float weight = expf(ATTN_LOGIT(score) - rowMax) * inverseDenominator;
             sum += weight * value[vOffset + ki * headDim + d];
         }
         output[qOffset + d] = sum;
     }
+    #undef ATTN_LOGIT
 }
 
 // ===========================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -6087,7 +6087,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
 
     public unsafe void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
     {
         if (batch <= 0 || numHeads <= 0 || seqQ <= 0 || seqK <= 0 || headDim <= 0)
             throw new ArgumentOutOfRangeException(nameof(batch), "Attention dimensions must be positive.");
@@ -6113,7 +6113,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         int causalFlag = isCausal ? 1 : 0;
         int maskMode = mask is null ? 0 : mask.Size >= weightsSize ? 2 : 1;
         int storeWeights = attentionWeights is null ? 0 : 1;
-        void** args = stackalloc void*[15];
+        void** args = stackalloc void*[16];
         args[0] = &queryPtr;
         args[1] = &keyPtr;
         args[2] = &valuePtr;
@@ -6129,6 +6129,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
         args[12] = &causalFlag;
         args[13] = &maskMode;
         args[14] = &storeWeights;
+        args[15] = &softcap;
 
         int rows = checked(batch * numHeads * seqQ);
         uint grid = (uint)((rows + DefaultBlockSize - 1) / DefaultBlockSize);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAttentionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipAttentionKernels.cs
@@ -45,7 +45,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
     float scale,
     int isCausal,
     int maskMode,
-    int storeWeights)
+    int storeWeights,
+    float softcap)
 {
     int row = blockIdx.x * blockDim.x + threadIdx.x;
     int totalRows = batch * numHeads * seqQ;
@@ -59,6 +60,9 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
     int wOffset = row * seqK;
     int maskOffset = (maskMode == 2 ? bh * seqQ * seqK : 0) + qi * seqK;
 
+    // Attention-logit soft-cap (Gemma-2): softcap * tanh((score*scale)/softcap); softcap<=0 disables.
+    #define ATTN_LOGIT(sc) (softcap > 0.0f ? softcap * tanhf(((sc) * scale) / softcap) : (sc) * scale)
+
     float rowMax = -INFINITY;
     for (int ki = 0; ki < seqK; ki++) {
         if ((isCausal && ki > qi) || (maskMode != 0 && mask[maskOffset + ki] == 0.0f)) continue;
@@ -66,7 +70,7 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
         for (int d = 0; d < headDim; d++) {
             score += query[qOffset + d] * key[kOffset + ki * headDim + d];
         }
-        rowMax = fmaxf(rowMax, score * scale);
+        rowMax = fmaxf(rowMax, ATTN_LOGIT(score));
     }
 
     float denominator = 0.0f;
@@ -76,7 +80,7 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
         for (int d = 0; d < headDim; d++) {
             score += query[qOffset + d] * key[kOffset + ki * headDim + d];
         }
-        denominator += expf(score * scale - rowMax);
+        denominator += expf(ATTN_LOGIT(score) - rowMax);
     }
 
     float inverseDenominator = denominator > 0.0f ? 1.0f / denominator : 0.0f;
@@ -88,7 +92,7 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
                 for (int d = 0; d < headDim; d++) {
                     score += query[qOffset + d] * key[kOffset + ki * headDim + d];
                 }
-                weight = expf(score * scale - rowMax) * inverseDenominator;
+                weight = expf(ATTN_LOGIT(score) - rowMax) * inverseDenominator;
             }
             attentionWeights[wOffset + ki] = weight;
         }
@@ -102,11 +106,12 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_dot_product_attention
             for (int inner = 0; inner < headDim; inner++) {
                 score += query[qOffset + inner] * key[kOffset + ki * headDim + inner];
             }
-            float weight = expf(score * scale - rowMax) * inverseDenominator;
+            float weight = expf(ATTN_LOGIT(score) - rowMax) * inverseDenominator;
             sum += weight * value[vOffset + ki * headDim + d];
         }
         output[qOffset + d] = sum;
     }
+    #undef ATTN_LOGIT
 }
 
 // ===========================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -1412,9 +1412,11 @@ public interface IDirectGpuBackend : IDisposable
 
     #region Attention Operations
 
+    /// <param name="softcap">Optional attention-logit soft-cap (Gemma-2): when &gt; 0, each scaled score
+    /// is passed through <c>softcap · tanh(score / softcap)</c> before the softmax. 0 disables it.</param>
     void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal);
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f);
 
     void ScaledDotProductAttentionBackward(IGpuBuffer gradOutput, IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer attentionWeights, IGpuBuffer gradQuery, IGpuBuffer gradKey, IGpuBuffer gradValue,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Attention.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Attention.cs
@@ -12,7 +12,8 @@ public sealed partial class MetalBackend
     /// </summary>
     public void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal,
+        float softcap = 0.0f)
     {
         ThrowIfDisposed();
         int outputCount = checked(batch * numHeads * seqQ * headDim);
@@ -29,7 +30,7 @@ public sealed partial class MetalBackend
         DispatchResidentMetal("attention_forward_serial", 1,
             new[] { query, key, value, outputTemporary, weightsTemporary ?? unusedWeights!, mask ?? unusedMask! },
             (uint)batch, (uint)numHeads, (uint)seqQ, (uint)seqK, (uint)headDim, unchecked((uint)SingleToInt32BitsCompat(scale)),
-            isCausal ? 1u : 0u, attentionWeights is null ? 0u : 1u, maskMode);
+            isCausal ? 1u : 0u, attentionWeights is null ? 0u : 1u, maskMode, unchecked((uint)SingleToInt32BitsCompat(softcap)));
         Copy(outputTemporary, output, outputCount);
         if (attentionWeights is not null) Copy(weightsTemporary!, attentionWeights, weightCount);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalResidentKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalResidentKernels.cs
@@ -1113,10 +1113,10 @@ kernel void attention_forward_serial(
     device float* output [[buffer(3)]], device float* weights [[buffer(4)]], device const float* mask [[buffer(5)]],
     constant uint& batch [[buffer(6)]], constant uint& heads [[buffer(7)]], constant uint& queryLength [[buffer(8)]], constant uint& keyLength [[buffer(9)]],
     constant uint& dimension [[buffer(10)]], constant uint& scaleBits [[buffer(11)]], constant uint& causal [[buffer(12)]],
-    constant uint& hasWeights [[buffer(13)]], constant uint& maskMode [[buffer(14)]],
+    constant uint& hasWeights [[buffer(13)]], constant uint& maskMode [[buffer(14)]], constant uint& softcapBits [[buffer(15)]],
     uint gid [[thread_position_in_grid]])
 {
-    if (gid != 0u) return; float scale = as_type<float>(scaleBits);
+    if (gid != 0u) return; float scale = as_type<float>(scaleBits); float softcap = as_type<float>(softcapBits);
     for (uint b = 0; b < batch; ++b) for (uint h = 0; h < heads; ++h) {
         uint queryOffset = (b * heads + h) * queryLength * dimension;
         uint keyOffset = (b * heads + h) * keyLength * dimension;
@@ -1124,11 +1124,11 @@ kernel void attention_forward_serial(
         uint maskOffset = (maskMode == 2u ? (b * heads + h) * queryLength * keyLength : 0u);
         for (uint i = 0; i < queryLength; ++i) {
             float maximum = -INFINITY;
-            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; maximum = max(maximum, score); }
+            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if (softcap > 0.0f) score = softcap * tanh(score / softcap); if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; maximum = max(maximum, score); }
             float sumExp = 0.0f;
-            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; sumExp += exp(score - maximum); }
-            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; float weight = sumExp > 0.0f ? exp(score - maximum) / sumExp : 0.0f; if (hasWeights != 0u) weights[weightOffset + i * keyLength + j] = weight; }
-            for (uint d = 0; d < dimension; ++d) { float sum = 0.0f; for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; sum += (sumExp > 0.0f ? exp(score - maximum) / sumExp : 0.0f) * value[keyOffset + j * dimension + d]; } output[queryOffset + i * dimension + d] = sum; }
+            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if (softcap > 0.0f) score = softcap * tanh(score / softcap); if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; sumExp += exp(score - maximum); }
+            for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if (softcap > 0.0f) score = softcap * tanh(score / softcap); if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; float weight = sumExp > 0.0f ? exp(score - maximum) / sumExp : 0.0f; if (hasWeights != 0u) weights[weightOffset + i * keyLength + j] = weight; }
+            for (uint d = 0; d < dimension; ++d) { float sum = 0.0f; for (uint j = 0; j < keyLength; ++j) { float score = resident_attention_dot(query, key, queryOffset + i * dimension, keyOffset + j * dimension, dimension) * scale; if (softcap > 0.0f) score = softcap * tanh(score / softcap); if ((causal != 0u && j > i) || (maskMode != 0u && mask[maskOffset + i * keyLength + j] == 0.0f)) score = -INFINITY; sum += (sumExp > 0.0f ? exp(score - maximum) / sumExp : 0.0f) * value[keyOffset + j * dimension + d]; } output[queryOffset + i * dimension + d] = sum; }
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/AttentionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/AttentionKernels.cs
@@ -58,7 +58,8 @@ __kernel void scaled_dot_product_attention(
     const float scale,
     const int isCausal,
     const int maskMode,
-    const int storeWeights)
+    const int storeWeights,
+    const float softcap)
 {
     const int row = get_global_id(0);
     if (row >= batch * numHeads * seqQ) return;
@@ -71,6 +72,9 @@ __kernel void scaled_dot_product_attention(
     const int wOffset = row * seqK;
     const int maskOffset = (maskMode == 2 ? bh * seqQ * seqK : 0) + qi * seqK;
 
+    // Attention-logit soft-cap (Gemma-2): softcap * tanh((score*scale)/softcap); softcap<=0 disables.
+    #define ATTN_LOGIT(sc) (softcap > 0.0f ? softcap * tanh(((sc) * scale) / softcap) : (sc) * scale)
+
     // Compute attention scores and find max for numerical stability
     float maxScore = NEGATIVE_INFINITY;
     for (int ki = 0; ki < seqK; ki++) {
@@ -80,7 +84,7 @@ __kernel void scaled_dot_product_attention(
         for (int d = 0; d < headDim; d++) {
             score += query[qOffset + d] * key[kOffset + ki * headDim + d];
         }
-        score *= scale;
+        score = ATTN_LOGIT(score);
         maxScore = fmax(maxScore, score);
     }
 
@@ -92,7 +96,7 @@ __kernel void scaled_dot_product_attention(
         for (int d = 0; d < headDim; d++) {
             score += query[qOffset + d] * key[kOffset + ki * headDim + d];
         }
-        score *= scale;
+        score = ATTN_LOGIT(score);
 
         sumExp += exp(score - maxScore);
     }
@@ -106,7 +110,7 @@ __kernel void scaled_dot_product_attention(
                 for (int inner = 0; inner < headDim; inner++) {
                     score += query[qOffset + inner] * key[kOffset + ki * headDim + inner];
                 }
-                weight = exp(score * scale - maxScore) * invSum;
+                weight = exp(ATTN_LOGIT(score) - maxScore) * invSum;
             }
             attentionWeights[wOffset + ki] = weight;
         }
@@ -120,11 +124,12 @@ __kernel void scaled_dot_product_attention(
             for (int inner = 0; inner < headDim; inner++) {
                 score += query[qOffset + inner] * key[kOffset + ki * headDim + inner];
             }
-            float weight = exp(score * scale - maxScore) * invSum;
+            float weight = exp(ATTN_LOGIT(score) - maxScore) * invSum;
             val += weight * value[vOffset + ki * headDim + d];
         }
         output[qOffset + d] = val;
     }
+    #undef ATTN_LOGIT
 }
 
 // ===========================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -8332,7 +8332,7 @@ KERNEL VARIANTS (A/B testing):
 
         public void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
             IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-            int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+            int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
         {
             if (batch <= 0 || numHeads <= 0 || seqQ <= 0 || seqK <= 0 || headDim <= 0)
                 throw new ArgumentOutOfRangeException(nameof(batch), "Attention dimensions must be positive.");
@@ -8364,6 +8364,7 @@ KERNEL VARIANTS (A/B testing):
             k.SetArg(arg++, isCausal ? 1 : 0);
             k.SetArg(arg++, maskMode);
             k.SetArg(arg++, attentionWeights != null ? 1 : 0);
+            k.SetArg(arg++, softcap);
 
             int rows = checked(batch * numHeads * seqQ);
             k.Execute1D(rows, Math.Min(256, rows));

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend3.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend3.cs
@@ -14,14 +14,14 @@ public sealed unsafe partial class VulkanBackend
 
     public void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
         => AttentionForwardCore(query, key, value, output, attentionWeights, mask,
-            batch, numHeads, numHeads, seqQ, seqK, headDim, scale, isCausal);
+            batch, numHeads, numHeads, seqQ, seqK, headDim, scale, isCausal, softcap: softcap);
 
     private void AttentionForwardCore(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
         int batch, int queryHeads, int kvHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal,
-        int maskBatchStride = 0)
+        int maskBatchStride = 0, float softcap = 0.0f)
     {
         if (queryHeads <= 0 || kvHeads <= 0 || queryHeads % kvHeads != 0)
             throw new ArgumentException("queryHeads must be a positive multiple of kvHeads.");
@@ -42,7 +42,7 @@ public sealed unsafe partial class VulkanBackend
                 {
                     (uint)batch, (uint)queryHeads, (uint)kvHeads, (uint)seqQ, (uint)seqK, (uint)headDim,
                     FloatBits(scale), isCausal ? 1u : 0u, attentionWeights is null ? 0u : 1u, maskMode,
-                    effectiveMaskBatchStride
+                    effectiveMaskBatchStride, FloatBits(softcap)
                 });
         }
         finally

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
@@ -402,14 +402,16 @@ layout(set = 0, binding = 4) writeonly buffer Weights { float weightData[]; };
 layout(set = 0, binding = 5) readonly buffer Mask { float maskData[]; };
 layout(push_constant) uniform Params {
     uint batch; uint queryHeads; uint kvHeads; uint seqQ; uint seqK; uint headDim;
-    float scale; uint causal; uint writeWeights; uint maskMode; uint maskBatchStride;
+    float scale; uint causal; uint writeWeights; uint maskMode; uint maskBatchStride; float softcap;
 };
 float attentionScore(uint batchIndex, uint queryHead, uint kvHead, uint queryIndex, uint keyIndex) {
     uint queryOffset = ((batchIndex * queryHeads + queryHead) * seqQ + queryIndex) * headDim;
     uint keyOffset = ((batchIndex * kvHeads + kvHead) * seqK + keyIndex) * headDim;
     float score = 0.0;
     for (uint d0 = 0u; d0 < headDim; ++d0) score += queryData[queryOffset + d0] * keyData[keyOffset + d0];
-    return score * scale;
+    float logit = score * scale;
+    // Attention-logit soft-cap (Gemma-2): softcap * tanh(logit / softcap); softcap<=0 disables.
+    return softcap > 0.0 ? softcap * tanh(logit / softcap) : logit;
 }
 bool attentionMasked(uint batchIndex, uint queryHead, uint queryIndex, uint keyIndex) {
     if (maskMode == 0u) return false;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend3.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend3.cs
@@ -32,7 +32,7 @@ public sealed partial class WebGpuBackend
     private static float[] MakeAttentionParams(
         int batch, int numQHeads, int numKVHeads, int seqQ, int seqK, int headDim,
         int queriesPerKV, float scale, bool isCausal, bool hasBias, int biasBatchStride,
-        bool flag0, bool flag1 = false, int booleanMaskMode = 0)
+        bool flag0, bool flag1 = false, int booleanMaskMode = 0, float softcap = 0f)
     {
         return new float[]
         {
@@ -50,7 +50,7 @@ public sealed partial class WebGpuBackend
             BitConverter.Int32BitsToSingle(flag0 ? 1 : 0),
             BitConverter.Int32BitsToSingle(flag1 ? 1 : 0),
             BitConverter.Int32BitsToSingle(booleanMaskMode),
-            0, 0
+            softcap, 0
         };
     }
 
@@ -58,7 +58,7 @@ public sealed partial class WebGpuBackend
         IGpuBuffer query, IGpuBuffer key, IGpuBuffer value, IGpuBuffer output,
         IGpuBuffer? attentionWeights, IGpuBuffer? softmaxStats, IGpuBuffer? attentionBias,
         int batch, int numQHeads, int numKVHeads, int seqQ, int seqK, int headDim,
-        float scale, bool isCausal, int biasBatchStride, int booleanMaskMode = 0)
+        float scale, bool isCausal, int biasBatchStride, int booleanMaskMode = 0, float softcap = 0f)
     {
         if (numKVHeads <= 0 || numQHeads <= 0 || numQHeads % numKVHeads != 0)
             throw new ArgumentException("The number of query heads must be divisible by the number of KV heads.");
@@ -94,7 +94,7 @@ public sealed partial class WebGpuBackend
 
         var uniforms = MakeAttentionParams(batch, numQHeads, numKVHeads, seqQ, seqK, headDim,
             queriesPerKV, scale, isCausal, attentionBias is not null, biasBatchStride,
-            attentionWeights is not null, softmaxStats is not null, booleanMaskMode);
+            attentionWeights is not null, softmaxStats is not null, booleanMaskMode, softcap);
         IGpuBuffer dummy = SharedDummyBuffer;
         DispatchNBufferAsync("AttentionResident", WebGpuKernels.AttentionSource, "attention_forward_resident",
             new[]
@@ -161,7 +161,8 @@ public sealed partial class WebGpuBackend
     }
     public void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal,
+        float softcap = 0.0f)
     {
         int sharedMaskSize = CheckedAttentionSize(nameof(mask), seqQ, seqK);
         int fullMaskSize = CheckedAttentionSize(nameof(mask), batch, numHeads, seqQ, seqK);
@@ -170,7 +171,7 @@ public sealed partial class WebGpuBackend
         int maskMode = mask is null ? 0 : mask.Size >= fullMaskSize ? 2 : 1;
         int maskBatchStride = maskMode == 2 ? checked(numHeads * seqQ * seqK) : 0;
         AttentionForwardResident(query, key, value, output, attentionWeights, null, mask,
-            batch, numHeads, numHeads, seqQ, seqK, headDim, scale, isCausal, maskBatchStride, maskMode);
+            batch, numHeads, numHeads, seqQ, seqK, headDim, scale, isCausal, maskBatchStride, maskMode, softcap);
     }
 
     public void ScaledDotProductAttentionBackward(IGpuBuffer gradOutput, IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -4586,7 +4586,7 @@ struct AttentionForwardParams {
     store_weights: u32,
     store_stats: u32,
     boolean_mask_mode: u32,
-    _pad2: u32,
+    softcap: f32,
     _pad3: u32,
 }
 @group(0) @binding(7) var<uniform> attention_params: AttentionForwardParams;
@@ -4615,6 +4615,9 @@ fn attention_forward_score(b: u32, q_head: u32, kv_head: u32, q_pos: u32, k_pos:
     }
 
     var score = dot * attention_params.scale;
+    if (attention_params.softcap > 0.0) {
+        score = attention_params.softcap * tanh(score / attention_params.softcap);
+    }
     if (attention_params.has_bias != 0u && attention_params.boolean_mask_mode == 0u) {
         var bias_base: u32 = 0u;
         if (attention_params.bias_batch_stride != 0u) {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5359,13 +5359,14 @@ public partial class DirectGpuTensorEngine
 
     /// <inheritdoc/>
     Tensor<T> IEngine.ScaledDotProductAttention<T>(Tensor<T> query, Tensor<T> key, Tensor<T> value,
-        Tensor<bool>? mask, double? scale, out Tensor<T> attentionWeights)
+        Tensor<bool>? mask, double? scale, out Tensor<T> attentionWeights, double softcap)
     {
         // GPU SDPA kernel: [batch, numHeads, seqQ/seqK, headDim]. Tape/graph,
-        // non-float, or unequal Q/K/V feature depths defer to the base implementation.
-        if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
+        // non-float, unequal Q/K/V feature depths, or an attention-logit soft-cap (Gemma-2, GPU kernel
+        // has no softcap) defer to the base (CPU) implementation, which applies the softcap.
+        if (softcap > 0.0 || IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || query.Rank != 4 || key.Rank != 4 || value.Rank != 4 || !TryGetBackend(out var backend))
-            return base.ScaledDotProductAttention(query, key, value, mask, scale, out attentionWeights);
+            return base.ScaledDotProductAttention(query, key, value, mask, scale, out attentionWeights, softcap);
         try
         {
             int batch = query.Shape._dims[0], numHeads = query.Shape._dims[1];

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5362,9 +5362,9 @@ public partial class DirectGpuTensorEngine
         Tensor<bool>? mask, double? scale, out Tensor<T> attentionWeights, double softcap)
     {
         // GPU SDPA kernel: [batch, numHeads, seqQ/seqK, headDim]. Tape/graph,
-        // non-float, unequal Q/K/V feature depths, or an attention-logit soft-cap (Gemma-2, GPU kernel
-        // has no softcap) defer to the base (CPU) implementation, which applies the softcap.
-        if (softcap > 0.0 || IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
+        // non-float, or unequal Q/K/V feature depths defer to the base (CPU) implementation. The
+        // attention-logit soft-cap (Gemma-2) is threaded into every backend kernel below.
+        if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || query.Rank != 4 || key.Rank != 4 || value.Rank != 4 || !TryGetBackend(out var backend))
             return base.ScaledDotProductAttention(query, key, value, mask, scale, out attentionWeights, softcap);
         try
@@ -5388,7 +5388,7 @@ public partial class DirectGpuTensorEngine
             using var outB = AllocateOutputBuffer(backend, outLen);
             using var awB = AllocateOutputBuffer(backend, awLen);
             backend.ScaledDotProductAttention(qB.Buffer, kB.Buffer, vB.Buffer, outB.Buffer, awB.Buffer, maskB?.Buffer,
-                batch, numHeads, seqQ, seqK, headDim, sc, false);
+                batch, numHeads, seqQ, seqK, headDim, sc, false, (float)softcap);
             var result = DeferTensorResult<T>(backend, outB.Buffer, outLen,
                 new[] { batch, numHeads, seqQ, headDim });
             attentionWeights = DeferTensorResult<T>(backend, awB.Buffer, awLen,

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -873,9 +873,9 @@ public class DelegatingGpuBackend : IDirectGpuBackend
     /// <inheritdoc/>
     public virtual void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
         => Inner.ScaledDotProductAttention(query, key, value, output, attentionWeights, mask,
-            batch, numHeads, seqQ, seqK, headDim, scale, isCausal);
+            batch, numHeads, seqQ, seqK, headDim, scale, isCausal, softcap);
 
     /// <inheritdoc/>
     public virtual void ScaledDotProductAttentionBackward(IGpuBuffer gradOutput, IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,

--- a/src/AiDotNet.Tensors/Engines/Gpu/RecordingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/RecordingGpuBackend.cs
@@ -682,7 +682,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
     /// <inheritdoc/>
     public override void ScaledDotProductAttention(IGpuBuffer query, IGpuBuffer key, IGpuBuffer value,
         IGpuBuffer output, IGpuBuffer? attentionWeights, IGpuBuffer? mask,
-        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal)
+        int batch, int numHeads, int seqQ, int seqK, int headDim, float scale, bool isCausal, float softcap = 0.0f)
     {
         var inputs = new List<IGpuBuffer> { query, key, value };
         if (mask != null) inputs.Add(mask);
@@ -695,7 +695,7 @@ public class RecordingGpuBackend : DelegatingGpuBackend
             inputs.ToArray(),
             outputs.ToArray(),
             () => Inner.ScaledDotProductAttention(query, key, value, output, attentionWeights, mask,
-                batch, numHeads, seqQ, seqK, headDim, scale, isCausal),
+                batch, numHeads, seqQ, seqK, headDim, scale, isCausal, softcap),
             new Dictionary<string, object>
             {
                 ["batch"] = batch,
@@ -704,7 +704,8 @@ public class RecordingGpuBackend : DelegatingGpuBackend
                 ["seqK"] = seqK,
                 ["headDim"] = headDim,
                 ["scale"] = scale,
-                ["isCausal"] = isCausal
+                ["isCausal"] = isCausal,
+                ["softcap"] = softcap
             });
     }
 

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4184,13 +4184,17 @@ public interface IEngine
     /// <item><description>Combined: Element-wise AND of causal and padding masks</description></item>
     /// </list>
     /// </remarks>
+    /// <param name="softcap">Optional attention-logit soft-cap (Gemma-2): when &gt; 0, the scaled scores
+    /// are passed through <c>softcap · tanh(scores / softcap)</c> before the softmax, bounding them to
+    /// <c>(-softcap, softcap)</c>. 0 (the default) disables it.</param>
     Tensor<T> ScaledDotProductAttention<T>(
         Tensor<T> query,
         Tensor<T> key,
         Tensor<T> value,
         Tensor<bool>? mask,
         double? scale,
-        out Tensor<T> attentionWeights);
+        out Tensor<T> attentionWeights,
+        double softcap = 0.0);
 
     /// <summary>
     /// Fused multi-head attention forward (inference only): Q/K/V projection +

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchMatMulAndAttentionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchMatMulAndAttentionTests.cs
@@ -283,4 +283,36 @@ public class BatchMatMulAndAttentionTests
         bool allSame = data.All(x => Math.Abs(x - first) < 1e-8f);
         Assert.False(allSame, $"{name} is uniform - all {data.Length} elements equal {first}");
     }
+
+    [Fact]
+    public void ScaledDotProductAttention_Softcap_CapsLogitsBeforeSoftmax()
+    {
+        // One query attending to two keys with large-magnitude scores: Q·K^T = [10, -10] (scale = 1).
+        var Q = new Tensor<float>(new float[] { 10f }, new[] { 1, 1, 1, 1 });
+        var K = new Tensor<float>(new float[] { 1f, -1f }, new[] { 1, 1, 2, 1 });
+        var V = new Tensor<float>(new float[] { 3f, 7f }, new[] { 1, 1, 2, 1 });
+
+        // softcap = 2: logits become 2·tanh([5, -5]) before softmax, bounding them to (-2, 2).
+        const double cap = 2.0;
+        _engine.ScaledDotProductAttention(Q, K, V, null, scale: 1.0, out var wCapped, softcap: cap);
+
+        double t0 = cap * Math.Tanh(10.0 / cap);
+        double t1 = cap * Math.Tanh(-10.0 / cap);
+        double m = Math.Max(t0, t1);
+        double e0 = Math.Exp(t0 - m), e1 = Math.Exp(t1 - m), sum = e0 + e1;
+        Assert.Equal(e0 / sum, wCapped[0, 0, 0, 0], 4);
+        Assert.Equal(e1 / sum, wCapped[0, 0, 0, 1], 4);
+
+        // Without softcap the distribution is far more peaked (~[1, 0]); softcap moves probability mass
+        // toward the low-scoring key (capped ~0.018 vs plain ~2e-9 here).
+        _engine.ScaledDotProductAttention(Q, K, V, null, scale: 1.0, out var wPlain);
+        Assert.True(wPlain[0, 0, 0, 1] < 1e-3f, $"plain low-score weight should be tiny (was {wPlain[0, 0, 0, 1]})");
+        Assert.True(wCapped[0, 0, 0, 1] > 100f * wPlain[0, 0, 0, 1],
+            $"softcap should raise the low-score weight (capped={wCapped[0, 0, 0, 1]}, plain={wPlain[0, 0, 0, 1]})");
+
+        // Default softcap (0) must be byte-identical to the plain call (regression guard).
+        _engine.ScaledDotProductAttention(Q, K, V, null, scale: 1.0, out var wDefault, softcap: 0.0);
+        Assert.Equal(wPlain[0, 0, 0, 0], wDefault[0, 0, 0, 0], 6);
+        Assert.Equal(wPlain[0, 0, 0, 1], wDefault[0, 0, 0, 1], 6);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -865,6 +865,48 @@ public class GpuCpuConsistencyTests
     }
 
     [SkippableFact]
+    public void ScaledDotProductAttention_LogitSoftcap_MatchesCpu()
+    {
+        SkipIfNoDirectGpu();
+
+        // Gemma-2 attention-logit soft-cap: the GPU kernel must apply softcap*tanh(scaledScore/softcap)
+        // before the softmax, byte-for-byte consistent with the CPU path. Large scores + a small cap
+        // make the softcap the dominant term (an uncapped run would diverge wildly here).
+        const int batch = 2, heads = 2, seqQ = 2, seqK = 3, dimension = 3;
+        const double scale = 1.5;
+        const double softcap = 2.0;
+        var query = new Tensor<float>(
+            Enumerable.Range(0, batch * heads * seqQ * dimension).Select(i => -0.9f + 0.17f * i).ToArray(),
+            new[] { batch, heads, seqQ, dimension });
+        var key = new Tensor<float>(
+            Enumerable.Range(0, batch * heads * seqK * dimension).Select(i => 1.3f - 0.11f * i).ToArray(),
+            new[] { batch, heads, seqK, dimension });
+        var value = new Tensor<float>(
+            Enumerable.Range(0, batch * heads * seqK * dimension).Select(i => -0.4f + 0.09f * i).ToArray(),
+            new[] { batch, heads, seqK, dimension });
+
+        var cpu = new CpuEngine();
+        var expected = cpu.ScaledDotProductAttention(query, key, value, null, scale, out var expectedWeights, softcap);
+
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        var actual = ((IEngine)gpu).ScaledDotProductAttention(
+            query, key, value, null, scale, out var actualWeights, softcap);
+
+        var expectedData = expected.AsSpan();
+        var actualData = actual.AsSpan();
+        for (int i = 0; i < expectedData.Length; i++)
+            Assert.True(MathF.Abs(expectedData[i] - actualData[i]) <= 2e-5f,
+                $"Soft-capped attention output mismatch at {i}: CPU={expectedData[i]}, GPU={actualData[i]}");
+
+        var expectedWeightData = expectedWeights.AsSpan();
+        var actualWeightData = actualWeights.AsSpan();
+        for (int i = 0; i < expectedWeightData.Length; i++)
+            Assert.True(MathF.Abs(expectedWeightData[i] - actualWeightData[i]) <= 2e-5f,
+                $"Soft-capped attention weight mismatch at {i}: CPU={expectedWeightData[i]}, GPU={actualWeightData[i]}");
+    }
+
+    [SkippableFact]
     public void ScaledDotProductAttention_FullBooleanMaskStaysResidentAndMatchesCpu()
     {
         SkipIfNoDirectGpu();


### PR DESCRIPTION
## Summary

Adds an optional attention-logit **soft-cap** to `ScaledDotProductAttention` — the Gemma-2 cap that bounds each scaled QKᵀ score to `(-softcap, softcap)` **before** the softmax:

```
logit = softcap > 0 ? softcap * tanh((QKᵀ · scale) / softcap) : QKᵀ · scale
```

The parameter defaults to `0` (disabled), so every existing caller is byte-identical. It is implemented in **all six backends, including the CPU backend** — no CPU-deferral shortcut.

## Where it's implemented

| Backend | Implementation |
|---|---|
| **CPU** | All 4 paths: GraphMode primitive-decomp, float BLAS fast path, double SIMD fast path, generic-T scalar |
| **CUDA / HIP** | Kernel gains trailing `float softcap`; `ATTN_LOGIT` macro applies `softcap*tanhf(logit/softcap)`; backend packs it as the last launch arg (`args[15]`) |
| **OpenCL** | Kernel `const float softcap` + `ATTN_LOGIT` macro (`tanh`); backend `SetArg` |
| **Vulkan** | `float softcap` in the attention push-constant; `attentionScore` helper caps the logit; backend appends `FloatBits(softcap)` to the common uniform array |
| **WebGpu** | `softcap: f32` in `AttentionForwardParams`; `attention_forward_score` caps after scale; threaded through `MakeAttentionParams` / `AttentionForwardResident` |
| **Metal** | `attention_forward_serial` takes a `softcapBits` buffer(15); caps each scaled score; backend packs `SingleToInt32BitsCompat(softcap)` |

`IDirectGpuBackend` and the `DelegatingGpuBackend` / `RecordingGpuBackend` wrappers gain the optional `softcap` parameter, and `DirectGpuTensorEngine` now **passes softcap through to the backend kernel instead of falling back to the CPU base**.

## Validation

- Builds clean across all TFMs (net10.0 / net8.0 / net471).
- New `GpuCpuConsistencyTests.ScaledDotProductAttention_LogitSoftcap_MatchesCpu` runs soft-capped attention on the **OpenCL backend on real hardware** and matches the CPU path within `2e-5` (chosen so the cap dominates — an uncapped run would diverge wildly).
- CPU soft-cap unit test asserts the output equals `softmax(cap*tanh(scaled))` exactly, redistributes mass off the peak, and `softcap=0` == the uncapped call.
- Existing SDPA/attention suites stay green: CPU double/generic fast paths, OpenCL flash-decode + paged (20 tests).
- CUDA/HIP/Vulkan/WebGpu/Metal kernel param orders verified against their arg-packing (those backends are not runtime-testable on the dev box).

## Downstream

Inert in AiDotNet until the Tensors package pin is bumped. The AiDotNet-side Gemma-2 wiring (GQA layer soft-cap param → `Engine.ScaledDotProductAttention(…, softcap)`, `Gemma2ModelBuilder` passing `attn_logit_softcapping`, `HuggingFaceConfig` parsing it) is a follow-up after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
