### PR TITLE
fix(gpu): version-gate the persistent weight buffer so in-place weight loads under a GPU engine are not served stale

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -256,6 +256,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // Version tracking for invalidation
     private readonly ConcurrentDictionary<object, int> _tensorVersions = new();
 
+    // Host-tensor Version stamped onto each PERSISTENT weight/bias buffer at the moment it was uploaded.
+    // The persistent cache is keyed by the host backing array, but a weight is commonly registered at
+    // construction (with random INIT values) and then loaded IN PLACE by SetParameters — which bumps the
+    // tensor Version but shares the same backing array, so the cache key does not change. Without a version
+    // gate the reader would keep serving the stale random buffer (a real GGUF decoder loaded under the GPU
+    // engine produced pure garbage this way). GetWeightBufferPreferResident compares the tensor's current
+    // Version to this stamp and re-uploads on a mismatch, mirroring the resident _gpuBuffer version gate so
+    // an explicit InvalidatePersistentTensor is no longer required for correctness.
+    private readonly ConcurrentDictionary<object, int> _persistentWeightHostVersion = new();
+
     // Monotonic per-call counter for stochastic-op seeds (dropout, etc.). The old code seeded the
     // GPU dropout RNG from Environment.TickCount / DateTime.UtcNow.Ticks. TickCount has ~15 ms
     // resolution, so the many dropout calls a training step fires in <1 ms all got the SAME seed →
@@ -1526,6 +1536,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 if (_persistentBufferCache.TryRemove(backing, out var pe)) pe.Dispose();
                 _tensorVersions.TryRemove(backing, out _);
+                _persistentWeightHostVersion.TryRemove(backing, out _);
             }
         }
     }
@@ -2459,7 +2470,48 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (ResidentStepActive || !versionTracked || weights._gpuBufferVersion == weights.Version)
                 return new OwnedBuffer(resident, ownsBuffer: false);
         }
-        return GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role);
+        return GetOrCacheWeightBufferVersionAware(backend, weights, role);
+    }
+
+    /// <summary>
+    /// Host-array persistent weight cache, gated on the host tensor <see cref="Tensor{T}.Version"/> so an
+    /// in-place weight load performed AFTER registration is served correctly. A layer registers its weight
+    /// as a persistent buffer at construction (random init), then <c>SetParameters</c> loads the real
+    /// weights into the same backing array — bumping Version via the indexer/SetFlat/CopyFromArray paths —
+    /// but the cache key (the array) is unchanged, so a version-blind lookup would return the stale
+    /// construction-time buffer. This compares the current Version to the stamp recorded at upload and
+    /// re-uploads on a mismatch, so correctness no longer depends on the layer also calling
+    /// <see cref="InvalidatePersistentTensor{T}"/>. Raw-span writes (AsWritableSpan) that bypass the
+    /// version bump still require an explicit invalidate, per the documented Tensor mutation contract.
+    /// </summary>
+    private OwnedBuffer GetOrCacheWeightBufferVersionAware<T>(IDirectGpuBackend backend, Tensor<T> weights, PersistentTensorRole role)
+    {
+        T[] data = weights.GetDataArray();
+        int hostVersion = weights.Version;
+        lock (_persistentBufferLock)
+        {
+            bool cached = _persistentBufferCache.TryGetValue(data, out var entry);
+            if (cached
+                && _persistentWeightHostVersion.TryGetValue(data, out int stampedVersion)
+                && stampedVersion == hostVersion)
+            {
+                return new OwnedBuffer(entry!.Buffer, ownsBuffer: false);
+            }
+
+            // Not cached, or the host tensor was mutated in place since the buffer was uploaded: (re)upload
+            // the current host data and (re)stamp its version. Dispose the superseded buffer first.
+            if (cached)
+                entry!.Buffer.Dispose();
+
+            float[] floatData = DirectGpuEngine.ToFloatArray(data);
+            IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
+            backend.Synchronize();
+
+            var newEntry = new GpuBufferCacheEntry(gpuBuffer, role);
+            _persistentBufferCache[data] = newEntry;
+            _persistentWeightHostVersion[data] = hostVersion;
+            return new OwnedBuffer(gpuBuffer, ownsBuffer: false);
+        }
     }
 
     /// <summary>
@@ -6678,6 +6730,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 entry.Dispose();
                 _tensorVersions.TryRemove(data, out _);
+                _persistentWeightHostVersion.TryRemove(data, out _);
                 return true;
             }
             return false;
@@ -6698,6 +6751,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
             _persistentBufferCache.Clear();
             _tensorVersions.Clear();
+            _persistentWeightHostVersion.Clear();
         }
     }
 
@@ -10756,6 +10810,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var entry = new GpuBufferCacheEntry(gpuBuffer, role);
             _persistentBufferCache.TryAdd(key, entry);
             _tensorVersions.TryAdd(key, 0);
+            // Stamp the host Version this buffer was uploaded at, so the version-aware weight reader
+            // (GetOrCacheWeightBufferVersionAware) detects a later in-place load and re-uploads.
+            _persistentWeightHostVersion[key] = tensor.Version;
         }
         catch
         {
@@ -10786,6 +10843,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 entry.Dispose();
             }
             _tensorVersions.TryRemove(key, out _);
+            _persistentWeightHostVersion.TryRemove(key, out _);
         }
     }
 
@@ -10828,12 +10886,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
             _persistentBufferCache[key] = newEntry;
             _tensorVersions[key] = newEntry.Version;
+            // Re-stamp with the host Version this fresh buffer matches, so the version-aware weight reader
+            // does not needlessly re-upload it again on the next read.
+            _persistentWeightHostVersion[key] = tensor.Version;
         }
         catch
         {
             // On failure, remove from cache - operations will fall back to CPU
             _persistentBufferCache.TryRemove(key, out _);
             _tensorVersions.TryRemove(key, out _);
+            _persistentWeightHostVersion.TryRemove(key, out _);
         }
     }
 
@@ -21984,6 +22046,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         _persistentBufferCache.Clear();
         _tensorVersions.Clear();
+        _persistentWeightHostVersion.Clear();
 
         // Dispose cached CSR GPU buffers
         foreach (var entry in _csrBufferCache.Values)

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -1258,6 +1258,48 @@ public class GpuCpuConsistencyTests
                 "after an in-place, Version-bumping weight load with no explicit InvalidatePersistentTensor.");
     }
 
+    // Training scenario for the version-aware persistent weight cache: a forward populates (warms) the
+    // persistent GPU buffer, THEN an optimizer step updates the weights in place (as a CPU-side parameter
+    // step does — DenseLayer.UpdateParameters mutates via Engine.TensorSubtractInPlace, bumping Version).
+    // The next forward must reflect the updated weights, not the warm-cached pre-step values — otherwise the
+    // model would train against frozen weights (loss goes flat). Distinct from the load-then-forward repro:
+    // here the cache is already warm and stamped BEFORE the mutation, so it exercises the re-upload-on-stale
+    // path rather than the first-upload path.
+    [SkippableFact]
+    public void FusedLinear_PersistentWeightUpdatedAfterWarmCache_ReflectsUpdate()
+    {
+        SkipIfNoDirectGpu();
+
+        const int M = 4, K = 8, N = 6;
+        var w0 = Enumerable.Range(0, K * N).Select(i => -0.5f + 0.017f * (i % 13)).ToArray();
+        var x = new Tensor<float>(
+            Enumerable.Range(0, M * K).Select(i => 0.1f * (i % 7) - 0.2f).ToArray(), new[] { M, K });
+        var bias = new Tensor<float>(new float[N], new[] { N });
+
+        using var gpu = new DirectGpuTensorEngine();
+        var w = new Tensor<float>((float[])w0.Clone(), new[] { K, N });
+        ((IEngine)gpu).RegisterPersistentTensor(w, PersistentTensorRole.Weights);
+
+        // Forward #1 warms + version-stamps the persistent buffer (mirrors a training step's forward).
+        var warm = ((IEngine)gpu).FusedLinear(x, w, bias, FusedActivationType.None);
+        _ = warm.Contiguous().AsSpan().ToArray();
+
+        // Optimizer step: update the weights in place via the Version-bumping indexer, no re-register/invalidate.
+        for (int i = 0; i < w.Length; i++) w[i] = w0[i] - 0.05f;
+
+        // Forward #2 must use the stepped weights.
+        var stepped = ((IEngine)gpu).FusedLinear(x, w, bias, FusedActivationType.None);
+
+        var expected = new CpuEngine().FusedLinear(
+            x, new Tensor<float>(w0.Select(v => v - 0.05f).ToArray(), new[] { K, N }), bias, FusedActivationType.None);
+        var g = stepped.Contiguous().AsSpan();
+        var c = expected.AsSpan();
+        for (int i = 0; i < c.Length; i++)
+            Assert.True(MathF.Abs(g[i] - c[i]) <= 1e-4f,
+                $"idx {i}: GPU={g[i]} CPU={c[i]} — a post-warm-cache weight update was not reflected on GPU " +
+                "(model would train against frozen weights).");
+    }
+
     #endregion
 
     #region TensorMatMul GPU vs CPU Consistency Tests

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
 using AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Tensors.Tests.TestHelpers;
@@ -974,6 +975,287 @@ public class GpuCpuConsistencyTests
         for (int i = 0; i < expectedData.Length; i++)
             Assert.True(MathF.Abs(expectedData[i] - actualData[i]) <= 2e-5f,
                 $"Cross-attention {name} mismatch at {i}: CPU={expectedData[i]}, GPU={actualData[i]}");
+    }
+
+    #endregion
+
+    #region GQA decoder op-composition GPU vs CPU (issue: GGUF decoder wrong on OpenCL)
+
+    // These reproduce the exact op sequence a grouped-query-attention decoder runs on the GPU (Q/K/V/O
+    // projection GEMM -> reshape to heads -> 4D permute to [B,H,S,D]) at real model shapes (SmolLM2-135M:
+    // hidden 576, 9 heads, head_dim 64). A real GGUF decoder generated garbage on OpenCL while matching
+    // llama.cpp on CPU; the existing parity tests covered ScaledDotProductAttention itself but not the ops
+    // that FEED it, so the divergence slipped through. Each op is checked independently to localize it.
+
+    [SkippableFact]
+    public void TensorPermute_4D_GqaHeadLayout_GpuMatchesCpu()
+    {
+        SkipIfNoDirectGpu();
+
+        const int b = 1, s = 5, h = 9, d = 64; // [B, S, H, D] -> [B, H, S, D]
+        var input = new Tensor<float>(
+            Enumerable.Range(0, b * s * h * d).Select(i => -0.5f + 0.001f * i).ToArray(),
+            new[] { b, s, h, d });
+
+        var cpu = new CpuEngine();
+        var expected = cpu.TensorPermute(input, new[] { 0, 2, 1, 3 });
+
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        var actual = ((IEngine)gpu).TensorPermute(input, new[] { 0, 2, 1, 3 });
+
+        Assert.Equal(new[] { b, h, s, d }, actual.Shape.ToArray());
+        // TensorPermute returns a strided view by contract; materialize both sides before comparing values
+        // (a consumer that mis-materializes the GPU view is exactly the failure being reproduced).
+        var e = expected.Contiguous().AsSpan();
+        var a = actual.Contiguous().AsSpan();
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(MathF.Abs(e[i] - a[i]) <= 1e-5f,
+                $"4D permute mismatch at {i}: CPU={e[i]}, GPU={a[i]}");
+    }
+
+    [SkippableFact]
+    public void TensorPermute_4D_OverResidentInput_GpuMatchesCpu()
+    {
+        SkipIfNoDirectGpu();
+
+        // In a real model the permute INPUT is GPU-resident (it comes from a projection GEMM), so the
+        // returned strided view is over a DEVICE buffer. A host-input permute view materializes correctly;
+        // this checks the resident case — where a wrong strided materialization would scramble the model's
+        // Q/K downstream while all host-input op checks still pass. Residency is forced with a matmul-by-
+        // identity (a real GPU op that leaves its output on the device).
+        const int b = 1, s = 5, h = 9, d = 64;
+        var input = new Tensor<float>(
+            Enumerable.Range(0, b * s * h * d).Select(i => -0.5f + 0.001f * i).ToArray(),
+            new[] { b, s, h, d });
+
+        var cpu = new CpuEngine();
+        var expected = cpu.TensorPermute(input, new[] { 0, 2, 1, 3 });
+
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        // Force the input GPU-resident: reshape to [B*S*H, D], matmul by the DxD identity (stays on device),
+        // reshape back to [B,S,H,D]. The permute then operates on a device buffer.
+        var identity = new Tensor<float>(new float[d * d], new[] { d, d });
+        for (int k = 0; k < d; k++) identity[new[] { k, k }] = 1.0f;
+        var flat = ((IEngine)gpu).Reshape(input, new[] { b * s * h, d });
+        var resident = ((IEngine)gpu).TensorMatMul(flat, identity);
+        var residentInput = ((IEngine)gpu).Reshape(resident, new[] { b, s, h, d });
+        var actual = ((IEngine)gpu).TensorPermute(residentInput, new[] { 0, 2, 1, 3 });
+
+        Assert.Equal(new[] { b, h, s, d }, actual.Shape.ToArray());
+        var e = expected.Contiguous().AsSpan();
+        var a = actual.Contiguous().AsSpan();
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(MathF.Abs(e[i] - a[i]) <= 1e-4f,
+                $"resident-input 4D permute mismatch at {i}: CPU={e[i]}, GPU={a[i]}");
+    }
+
+    [SkippableFact]
+    public void Reshape_GqaHeadSplit_GpuMatchesCpu()
+    {
+        SkipIfNoDirectGpu();
+
+        const int s = 5, hidden = 576; // [S, hidden] -> [1, S, 9, 64]
+        var input = new Tensor<float>(
+            Enumerable.Range(0, s * hidden).Select(i => -0.5f + 0.0007f * i).ToArray(),
+            new[] { s, hidden });
+
+        var cpu = new CpuEngine();
+        var expected = cpu.Reshape(input, new[] { 1, s, 9, 64 });
+
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        var actual = ((IEngine)gpu).Reshape(input, new[] { 1, s, 9, 64 });
+
+        Assert.Equal(new[] { 1, s, 9, 64 }, actual.Shape.ToArray());
+        var e = expected.AsSpan();
+        var a = actual.AsSpan();
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(MathF.Abs(e[i] - a[i]) <= 1e-5f,
+                $"reshape mismatch at {i}: CPU={e[i]}, GPU={a[i]}");
+    }
+
+    [SkippableFact]
+    public void TensorMatMul_GqaProjection_GpuMatchesCpu()
+    {
+        SkipIfNoDirectGpu();
+
+        const int rows = 5, hidden = 576; // [rows, hidden] x [hidden, hidden]
+        var input = new Tensor<float>(
+            Enumerable.Range(0, rows * hidden).Select(i => -0.3f + 0.0005f * (i % 97)).ToArray(),
+            new[] { rows, hidden });
+        var weights = new Tensor<float>(
+            Enumerable.Range(0, hidden * hidden).Select(i => -0.2f + 0.0003f * (i % 89)).ToArray(),
+            new[] { hidden, hidden });
+
+        var cpu = new CpuEngine();
+        var expected = cpu.TensorMatMul(input, weights);
+
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        var actual = ((IEngine)gpu).TensorMatMul(input, weights);
+
+        Assert.Equal(new[] { rows, hidden }, actual.Shape.ToArray());
+        var e = expected.AsSpan();
+        var a = actual.AsSpan();
+        for (int i = 0; i < e.Length; i++)
+            Assert.True(MathF.Abs(e[i] - a[i]) <= 2e-4f,
+                $"projection matmul mismatch at {i}: CPU={e[i]}, GPU={a[i]}");
+    }
+
+    // Regression guard tied to the real-GGUF-decoder GPU divergence investigation. Measures a
+    // decoder FFN-gate GEMM ([seq, hidden] x [hidden, intermediate], K=576) on GPU against a
+    // double-precision reference and pins two facts established while diagnosing why the
+    // SmolLM2-135M GPU forward flipped a near-tie first-token argmax:
+    //   1. The GPU GEMM is as accurate as the CPU fp32 GEMM vs the double reference (~6e-7 vs
+    //      ~4.5e-7 at K=576) — the GPU GEMM is NOT a precision deficit, so a build-flag change
+    //      cannot be the fix for the argmax flip.
+    //   2. The default aggressive fast-math flags do NOT degrade this GEMM: with and without
+    //      OpenClBuildOptions.PreciseMath the error is identical (the accumulation is not
+    //      reassociated by -cl-fast-relaxed-math). This documents that AIDOTNET_GPU_PRECISE_MATH
+    //      is not the lever for decoder GEMM parity, so future work looks elsewhere (accumulated
+    //      cross-layer rounding at a genuine near-tie) rather than re-chasing GEMM precision.
+    [SkippableFact]
+    public void TensorMatMul_DecoderFfnGate_GpuGemmIsAsAccurateAsCpuAndFlagInvariant()
+    {
+        SkipIfNoDirectGpu();
+
+        // SmolLM2-135M FFN gate shape: hidden=576 (K), intermediate=1536 (N), a short prefill row block.
+        const int seq = 16, hidden = 576, inter = 1536;
+        // Post-RMSNorm activations are ~O(1); gate weights ~O(0.03). Deterministic, non-trivial spread
+        // so the length-576 accumulation actually exercises rounding rather than cancelling to zero.
+        var input = new Tensor<float>(
+            Enumerable.Range(0, seq * hidden)
+                .Select(i => MathF.Sin(0.017f * ((i * 31) % 613)) * 1.1f).ToArray(),
+            new[] { seq, hidden });
+        var weights = new Tensor<float>(
+            Enumerable.Range(0, hidden * inter)
+                .Select(i => 0.031f * MathF.Cos(0.011f * ((i * 17) % 761))).ToArray(),
+            new[] { hidden, inter });
+
+        // Double-precision reference: the ground truth the fp32 GPU accumulation is graded against.
+        var reference = new double[seq * inter];
+        for (int r = 0; r < seq; r++)
+            for (int c = 0; c < inter; c++)
+            {
+                double acc = 0.0;
+                for (int k = 0; k < hidden; k++)
+                    acc += (double)input[new[] { r, k }] * weights[new[] { k, c }];
+                reference[r * inter + c] = acc;
+            }
+
+        bool savedPrecise = OpenClBuildOptions.PreciseMath;
+        bool savedThrow = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        try
+        {
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+
+            // CPU fp32 error vs the double reference — the accuracy bar the GPU must merely MATCH,
+            // not beat. If GPU is as accurate as CPU, any argmax divergence is a genuine near-tie
+            // (independent rounding), not a GPU precision deficit that a build flag can fix.
+            var cpu = new CpuEngine();
+            var cpuResult = cpu.TensorMatMul(input, weights);
+            var cpuSpan = cpuResult.AsSpan();
+            float cpuErr = 0f;
+            for (int i = 0; i < cpuSpan.Length; i++)
+            {
+                float d = MathF.Abs((float)(cpuSpan[i] - reference[i]));
+                if (d > cpuErr) cpuErr = d;
+            }
+
+            float fastErr = MaxAbsGemmError(input, weights, reference, precise: false);
+            float preciseErr = MaxAbsGemmError(input, weights, reference, precise: true);
+
+            // The GPU GEMM (default fast-math) must be as accurate as the CPU GEMM against the
+            // double reference (a small slack for independent rounding). This is the real contract:
+            // GPU is not allowed to be materially LESS accurate than CPU. It documents that the
+            // observed decoder argmax flip is NOT a fixable GPU-GEMM precision deficit.
+            Assert.True(fastErr <= cpuErr * 4f + 1e-6f,
+                $"GPU fast-math GEMM error ({fastErr}) must be within 4x of CPU fp32 error ({cpuErr}) vs double; " +
+                $"precise-math error ({preciseErr}).");
+
+            // Fact #2: fast-math and precise-math produce the SAME GEMM accuracy — the aggressive
+            // flags do not reassociate this accumulation, so AIDOTNET_GPU_PRECISE_MATH is not a
+            // lever for decoder GEMM parity. (Measured identical to 4 sig figs: both ~5.9e-7.)
+            Assert.True(MathF.Abs(fastErr - preciseErr) <= 1e-7f,
+                $"fast-math ({fastErr}) and precise-math ({preciseErr}) GEMM errors should match: " +
+                "the fast-math flags do not affect this accumulation.");
+        }
+        finally
+        {
+            OpenClBuildOptions.PreciseMath = savedPrecise;
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = savedThrow;
+        }
+    }
+
+    // Runs one GPU GEMM under the requested math mode against a double-precision reference and
+    // returns the max abs error. A fresh engine is built after setting PreciseMath because the
+    // build flags are captured at backend construction and the compiled-program cache is keyed by
+    // build options, so each mode compiles/loads its own kernel binary.
+    private static float MaxAbsGemmError(Tensor<float> input, Tensor<float> weights, double[] reference, bool precise)
+    {
+        OpenClBuildOptions.PreciseMath = precise;
+        using var gpu = new DirectGpuTensorEngine();
+        using var scope = gpu.BeginGpuScope();
+        var result = ((IEngine)gpu).TensorMatMul(input, weights);
+        var span = result.AsSpan();
+        float max = 0f;
+        for (int i = 0; i < span.Length; i++)
+        {
+            float diff = MathF.Abs((float)(span[i] - reference[i]));
+            if (diff > max) max = diff;
+        }
+        return max;
+    }
+
+    // Root-cause repro for the real-GGUF-decoder GPU garbage: a layer registers its weight tensor as a
+    // persistent GPU buffer at construction (with RANDOM init values), then loads the real pretrained
+    // weights by copying them IN PLACE into the same tensor and calling InvalidatePersistentTensor to force
+    // a GPU re-upload (exactly what DenseLayer.SetParameters does). If that refresh does not reach the buffer
+    // the fused-linear forward reads, the GPU multiplies by the stale random weights — which flipped the
+    // SmolLM2-135M first token 7042 -> 32084. This test asserts the post-load FusedLinear on GPU matches the
+    // CPU reference computed with the loaded weights.
+    [SkippableFact]
+    public void FusedLinear_PersistentWeightMutatedInPlace_UsesLoadedNotStaleWeights()
+    {
+        SkipIfNoDirectGpu();
+
+        const int M = 4, K = 8, N = 6;
+        var randomInit = Enumerable.Range(0, K * N).Select(i => -0.5f + 0.017f * (i % 13)).ToArray();
+        var loaded = Enumerable.Range(0, K * N).Select(i => 0.3f - 0.021f * (i % 11)).ToArray();
+        var x = new Tensor<float>(
+            Enumerable.Range(0, M * K).Select(i => 0.1f * (i % 7) - 0.2f).ToArray(), new[] { M, K });
+        var bias = new Tensor<float>(new float[N], new[] { N });
+
+        // CPU reference: what the forward MUST produce (input @ loadedWeights + 0).
+        var cpu = new CpuEngine();
+        var cpuOut = cpu.FusedLinear(
+            x, new Tensor<float>((float[])loaded.Clone(), new[] { K, N }), bias, FusedActivationType.None);
+
+        // No BeginGpuScope: mirrors real model construction/load/forward, which set the engine as Current
+        // but do not open a residency scope. The persistent-buffer refresh must work in this mode too.
+        using var gpu = new DirectGpuTensorEngine();
+
+        // Construction: weight tensor holds RANDOM init; register it as a persistent GPU buffer.
+        var w = new Tensor<float>((float[])randomInit.Clone(), new[] { K, N });
+        ((IEngine)gpu).RegisterPersistentTensor(w, PersistentTensorRole.Weights);
+
+        // SetParameters (GroupedQueryAttentionLayer style): load the real weights via the flat indexer,
+        // which BUMPS the tensor Version, and DO NOT call InvalidatePersistentTensor. The persistent
+        // weight-buffer cache must notice the version change and re-upload; otherwise the fused linear
+        // multiplies by the stale random buffer uploaded at registration.
+        for (int i = 0; i < loaded.Length; i++) w[i] = loaded[i];
+
+        // Forward: the fused linear must see the loaded weights, not the stale random upload.
+        var gpuOut = ((IEngine)gpu).FusedLinear(x, w, bias, FusedActivationType.None);
+
+        var g = gpuOut.Contiguous().AsSpan();
+        var c = cpuOut.AsSpan();
+        for (int i = 0; i < c.Length; i++)
+            Assert.True(MathF.Abs(g[i] - c[i]) <= 1e-4f,
+                $"idx {i}: GPU={g[i]} CPU={c[i]} — persistent weight buffer served stale random weights " +
+                "after an in-place, Version-bumping weight load with no explicit InvalidatePersistentTensor.");
     }
 
     #endregion


### PR DESCRIPTION
## Problem

A model built while a `DirectGpuTensorEngine` is the current engine ran its forward against **uninitialised weights**. A real SmolLM2-135M GGUF decoder loaded under the GPU engine produced pure garbage (greedy first token `7042 " Paris"` → `32084`), while loading the same model under the CPU engine and forwarding on GPU was correct — isolating the fault to weight **upload**, not compute (the GPU GEMM is as accurate as the CPU path: ~6e-7 vs ~4.5e-7 against a double reference).

## Root cause

`RegisterPersistentTensor` uploads each weight tensor to a persistent GPU buffer **at construction — with its random initial values** — keyed by the host backing array. `SetParameters` then loads the real pretrained weights **in place** (same array ⇒ same cache key) and bumps the tensor `Version` via the indexer / `SetFlat` / `CopyFromArray` paths. But `GetWeightBufferPreferResident`'s persistent-cache fallthrough was **not version-checked**, so it kept serving the stale construction-time buffer. Layers that call `InvalidatePersistentTensor` (`DenseLayer`) or replace+register a fresh tensor (`EmbeddingLayer`) escaped it; `GroupedQueryAttentionLayer.SetParameters` (in-place, no invalidate) did not.

## Fix

Make the persistent weight-buffer cache **version-aware**, mirroring the existing resident `_gpuBuffer` version gate:

- Add `_persistentWeightHostVersion` (host array → tensor `Version` at upload), stamped in `RegisterPersistentTensor` / `InvalidatePersistentTensor` and cleared on every cache remove/clear site.
- New `GetOrCacheWeightBufferVersionAware<T>(backend, tensor, role)` compares the tensor's current `Version` to the stamp and re-uploads on a mismatch.

Correctness no longer depends on a layer also calling `InvalidatePersistentTensor` — any in-place weight mutation that bumps `Version` self-heals. Raw `AsWritableSpan` writes that bypass the version bump still require an explicit invalidate, per the documented `Tensor` mutation contract.

## Tests

- `FusedLinear_PersistentWeightMutatedInPlace_UsesLoadedNotStaleWeights` — register random weights, load the real ones in place via the `Version`-bumping indexer with **no** explicit invalidate, and assert `FusedLinear` on GPU matches the CPU reference. (Fails without the fix.)
- `TensorMatMul_DecoderFfnGate_GpuGemmIsAsAccurateAsCpuAndFlagInvariant` — pins that the decoder-shape GPU GEMM is as accurate as CPU vs a double reference and is fast-math-flag invariant, documenting that this was a stale-buffer bug and **not** a GEMM-precision one.
- Plus GQA op-composition parity tests (4D permute / reshape / projection matmul) at decoder shapes.

All **64** `GpuCpuConsistencyTests` pass on OpenCL (AMD RX 5500 XT). End-to-end: the real GGUF decoder loaded under the GPU engine now produces `7042 " Paris"` at llama.cpp parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GPU operations now detect in-place weight and bias updates, preventing stale cached values from being used.
  - Improved consistency between CPU and GPU results for attention, tensor reshaping, permutation, and projection operations.
  - Improved GEMM accuracy consistency across fast-math and precise-math modes.

- **Tests**
  - Added regression coverage for updated persistent GPU weights and decoder operation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->