### PR TITLE
fix(gpu): centralize the persistent-weight version gate into the shared cache lookup (#821 follow-up)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2484,76 +2484,73 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <see cref="InvalidatePersistentTensor{T}"/>. Raw-span writes (AsWritableSpan) that bypass the
     /// version bump still require an explicit invalidate, per the documented Tensor mutation contract.
     /// </summary>
+    /// <summary>Sentinel for <see cref="GetOrCacheWeightBuffer{T}(IDirectGpuBackend,T[],PersistentTensorRole,int)"/>:
+    /// skip the host-Version staleness gate (legacy version-blind behavior for non-weight callers).</summary>
+    private const int NoHostVersionGate = -1;
+
     private OwnedBuffer GetOrCacheWeightBufferVersionAware<T>(IDirectGpuBackend backend, Tensor<T> weights, PersistentTensorRole role)
-    {
-        T[] data = weights.GetDataArray();
-        int hostVersion = weights.Version;
-        lock (_persistentBufferLock)
-        {
-            bool cached = _persistentBufferCache.TryGetValue(data, out var entry);
-            if (cached
-                && _persistentWeightHostVersion.TryGetValue(data, out int stampedVersion)
-                && stampedVersion == hostVersion)
-            {
-                return new OwnedBuffer(entry!.Buffer, ownsBuffer: false);
-            }
-
-            // Not cached, or the host tensor was mutated in place since the buffer was uploaded: (re)upload
-            // the current host data and (re)stamp its version. Dispose the superseded buffer first.
-            if (cached)
-                entry!.Buffer.Dispose();
-
-            float[] floatData = DirectGpuEngine.ToFloatArray(data);
-            IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
-            backend.Synchronize();
-
-            var newEntry = new GpuBufferCacheEntry(gpuBuffer, role);
-            _persistentBufferCache[data] = newEntry;
-            _persistentWeightHostVersion[data] = hostVersion;
-            return new OwnedBuffer(gpuBuffer, ownsBuffer: false);
-        }
-    }
+        // Thin wrapper: the version gate itself lives in the shared persistent-cache lookup below, so EVERY
+        // persistent-weight read path that passes the host Tensor.Version gets the same in-place-load
+        // protection — not just this one (CodeRabbit #821). We hold the Version at read time.
+        => GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role, weights.Version);
 
     /// <summary>
     /// Gets a GPU buffer for weight/bias tensor, auto-caching if not already persistent.
     /// Unlike GetOrAllocateBuffer, this caches the buffer in the persistent cache
     /// so subsequent calls reuse the same GPU buffer without re-uploading.
     /// Thread-safe: uses lock to coordinate with cache invalidation.
+    /// <para>
+    /// SHARED version gate: when <paramref name="hostVersion"/> is not <see cref="NoHostVersionGate"/>, a
+    /// cached buffer is served only if it was uploaded at that same host <see cref="Tensor{T}.Version"/>. An
+    /// in-place weight load (indexer / SetFlat / CopyFromArray) bumps Version WITHOUT changing the backing
+    /// array (the cache key), so a version-blind hit would keep serving the stale construction-time buffer
+    /// (a real GGUF-decoder-under-GPU garbage bug). Callers reading persistent WEIGHTS pass the tensor's
+    /// Version; version-blind callers (activations/inputs, which are not in-place-loaded) pass the sentinel.
+    /// </para>
     /// </summary>
-    private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, T[] data, PersistentTensorRole role)
+    private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, T[] data, PersistentTensorRole role, int hostVersion = NoHostVersionGate)
     {
         lock (_persistentBufferLock)
         {
-            // First check persistent tensor cache
-            var cached = TryGetCachedBuffer(data);
-            if (cached != null)
-                return new OwnedBuffer(cached, ownsBuffer: false);
+            // Persistent-cache lookup WITH the shared version gate.
+            if (_persistentBufferCache.TryGetValue(data, out var existing))
+            {
+                bool valid = hostVersion == NoHostVersionGate
+                    || (_persistentWeightHostVersion.TryGetValue(data, out int stamped) && stamped == hostVersion);
+                if (valid)
+                    return new OwnedBuffer(existing.Buffer, ownsBuffer: false);
 
-            // Not cached - upload and cache for future use
+                // Stale: the host tensor was mutated in place since upload. Dispose the superseded buffer and
+                // re-upload the current data below (re-stamping its Version).
+                existing.Buffer.Dispose();
+                _persistentBufferCache.TryRemove(data, out _);
+            }
+
+            // Not cached (or just invalidated) - upload and cache for future use.
             float[] floatData = DirectGpuEngine.ToFloatArray(data);
             IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
+            if (hostVersion != NoHostVersionGate)
+                backend.Synchronize();
 
-            // Add to persistent cache so future calls don't re-upload
+            // Insert via TryAdd, not a direct set: RegisterPersistentTensor adds lock-free (it does not take
+            // _persistentBufferLock), so a concurrent register could have populated this key while we uploaded.
+            // If so, dispose our buffer and alias the existing one rather than overwrite-and-leak it.
             var entry = new GpuBufferCacheEntry(gpuBuffer, role);
-            if (_persistentBufferCache.TryAdd(data, entry))
+            if (!_persistentBufferCache.TryAdd(data, entry))
             {
-                _tensorVersions.TryAdd(data, 0);
-                // Return with ownsBuffer=false since cache now owns it
-                return new OwnedBuffer(gpuBuffer, ownsBuffer: false);
-            }
-            else
-            {
-                // Another thread may have cached it; try to use that one
-                var alreadyCached = TryGetCachedBuffer(data);
-                if (alreadyCached != null)
+                // Concurrent register won the slot: alias its buffer and drop ours.
+                if (_persistentBufferCache.TryGetValue(data, out var raced))
                 {
                     gpuBuffer.Dispose();
-                    return new OwnedBuffer(alreadyCached, ownsBuffer: false);
+                    return new OwnedBuffer(raced.Buffer, ownsBuffer: false);
                 }
-
-                // Entry was removed between TryAdd and lookup; fall back to our buffer
+                // Removed again between TryAdd and lookup: keep our buffer, caller owns it.
                 return new OwnedBuffer(gpuBuffer, ownsBuffer: true);
             }
+            _tensorVersions.TryAdd(data, 0);
+            if (hostVersion != NoHostVersionGate)
+                _persistentWeightHostVersion[data] = hostVersion;
+            return new OwnedBuffer(gpuBuffer, ownsBuffer: false);
         }
     }
 
@@ -3164,7 +3161,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var cArr = src.DataVector.GetBackingArrayUnsafe();
             if (cArr is not null && src.IsContiguous && !Helpers.DeferredArrayMaterializer.IsPending(cArr))
             {
-                try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights).Buffer; }
+                try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights, src.Version).Buffer; }
                 catch { srcBuf = null; }
             }
         }
@@ -6711,7 +6708,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 $"GetOrCacheWeightsGpu only supports Weight, Bias, Statistics, AttentionCache, or Constant roles. " +
                 $"Got: {role}. Use UploadToGpu for other tensor types.", nameof(role))
         };
-        var ownedBuffer = GetOrCacheWeightBuffer(backend, tensor.GetDataArray(), persistentRole);
+        // Persistent-weight read: pass the host Version so an in-place weight load re-uploads (shared gate).
+        var ownedBuffer = GetOrCacheWeightBuffer(backend, tensor.GetDataArray(), persistentRole, tensor.Version);
 
         // Propagate ownership: if cache owns buffer, GpuTensor shouldn't dispose;
         // if we own buffer (race condition fallback), GpuTensor should take ownership

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -266,6 +266,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // an explicit InvalidatePersistentTensor is no longer required for correctness.
     private readonly ConcurrentDictionary<object, int> _persistentWeightHostVersion = new();
 
+    // Persistent weight buffers superseded by a version-gated re-upload, awaiting DEFERRED reclamation. The
+    // version-blind readers (TryGetCachedBuffer) fetch a cache buffer WITHOUT the lock or a refcount, so
+    // disposing a superseded buffer inline is a use-after-free (CodeRabbit #822): a stale read could launch
+    // GPU work on a freed allocation. Instead we evict the entry (no NEW reader can obtain it) and retire the
+    // buffer here; it is disposed only by a later drain that first issues a device backend.Synchronize() — a
+    // quiescence barrier after which no in-flight kernel references it. Guarded by _persistentBufferLock.
+    private readonly List<IGpuBuffer> _retiredWeightBuffers = new();
+
     // Monotonic per-call counter for stochastic-op seeds (dropout, etc.). The old code seeded the
     // GPU dropout RNG from Environment.TickCount / DateTime.UtcNow.Ticks. TickCount has ~15 ms
     // resolution, so the many dropout calls a training step fires in <1 ms all got the SAME seed →
@@ -2510,8 +2518,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, T[] data, PersistentTensorRole role, int hostVersion = NoHostVersionGate)
     {
+        // A synchronize is illegal inside CUDA graph capture (it aborts the capture, CUDA-900). This path is
+        // reachable during capture via TryAliasResidentOutput on a nonresident source under ResidentStepActive,
+        // so gate every backend.Synchronize() below on this (mirrors the FP16 / ones-buffer capture fail-fast).
+        bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cudaCap && cudaCap.IsStreamCapturing();
         lock (_persistentBufferLock)
         {
+            // Deferred reclamation: dispose buffers retired by EARLIER stale re-uploads. They were already
+            // evicted from the cache (no new reader can obtain them); the synchronize is a quiescence barrier
+            // draining any in-flight kernel that fetched them lock-free before eviction, so freeing them now is
+            // safe. Skipped under capture (sync illegal) — they persist to the next non-capturing drain.
+            if (!capturing && _retiredWeightBuffers.Count > 0)
+            {
+                backend.Synchronize();
+                foreach (var retired in _retiredWeightBuffers) retired.Dispose();
+                _retiredWeightBuffers.Clear();
+            }
+
             // Persistent-cache lookup WITH the shared version gate.
             if (_persistentBufferCache.TryGetValue(data, out var existing))
             {
@@ -2520,16 +2543,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 if (valid)
                     return new OwnedBuffer(existing.Buffer, ownsBuffer: false);
 
-                // Stale: the host tensor was mutated in place since upload. Dispose the superseded buffer and
-                // re-upload the current data below (re-stamping its Version).
-                existing.Buffer.Dispose();
+                // Stale: the host tensor was mutated in place since upload. Evict the entry now (no new reader
+                // can obtain it) but RETIRE the superseded buffer for deferred disposal — a lock-free
+                // TryGetCachedBuffer reader may still hold it, so freeing it inline is a use-after-free. It is
+                // reclaimed by a later drain past a synchronize barrier (above). Re-upload the current data below.
                 _persistentBufferCache.TryRemove(data, out _);
+                _retiredWeightBuffers.Add(existing.Buffer);
             }
 
             // Not cached (or just invalidated) - upload and cache for future use.
             float[] floatData = DirectGpuEngine.ToFloatArray(data);
             IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
-            if (hostVersion != NoHostVersionGate)
+            if (hostVersion != NoHostVersionGate && !capturing)
                 backend.Synchronize();
 
             // Insert via TryAdd, not a direct set: RegisterPersistentTensor adds lock-free (it does not take
@@ -6750,6 +6775,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             _persistentBufferCache.Clear();
             _tensorVersions.Clear();
             _persistentWeightHostVersion.Clear();
+            // Reclaim any buffers still awaiting deferred disposal: the whole cache is being torn down, so
+            // there is no reader to race and they would otherwise leak.
+            foreach (var retired in _retiredWeightBuffers) retired.Dispose();
+            _retiredWeightBuffers.Clear();
         }
     }
 
@@ -22045,6 +22074,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         _persistentBufferCache.Clear();
         _tensorVersions.Clear();
         _persistentWeightHostVersion.Clear();
+        // Reclaim buffers awaiting deferred disposal (engine teardown — no reader to race).
+        foreach (var retired in _retiredWeightBuffers) retired.Dispose();
+        _retiredWeightBuffers.Clear();
 
         // Dispose cached CSR GPU buffers
         foreach (var entry in _csrBufferCache.Values)

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -1135,13 +1135,17 @@ public class GpuCpuConsistencyTests
             new[] { hidden, inter });
 
         // Double-precision reference: the ground truth the fp32 GPU accumulation is graded against.
+        // Index the contiguous backing spans directly — the [r,k] indexer would allocate a throwaway
+        // int[] per element (~28M arrays across the triple loop).
         var reference = new double[seq * inter];
+        var inputSpan = input.AsSpan();
+        var weightSpan = weights.AsSpan();
         for (int r = 0; r < seq; r++)
             for (int c = 0; c < inter; c++)
             {
                 double acc = 0.0;
                 for (int k = 0; k < hidden; k++)
-                    acc += (double)input[new[] { r, k }] * weights[new[] { k, c }];
+                    acc += (double)inputSpan[r * hidden + k] * weightSpan[k * inter + c];
                 reference[r * inter + c] = acc;
             }
 


### PR DESCRIPTION
Resolves the two unresolved CodeRabbit review comments on the merged PR #821.

## Comment 1 (Major) — push the version gate into the shared persistent-cache lookup

#821 added a host-`Version` staleness gate so an in-place weight load (e.g. a GGUF decode under a GPU engine) re-uploads instead of serving the stale construction-time buffer. But the gate lived only in `GetOrCacheWeightBufferVersionAware`, which just one read path (`GetWeightBufferPreferResident`) used. The other persistent-weight readers still went through the version-blind `GetOrCacheWeightBuffer` and could serve a stale buffer after an in-place load.

- Pushed the gate down into the shared `GetOrCacheWeightBuffer<T>` via an optional `hostVersion` parameter. `NoHostVersionGate` (sentinel `-1`) preserves the legacy version-blind behavior for activation/input callers (which are never in-place-loaded).
- `GetOrCacheWeightBufferVersionAware` is now a thin wrapper that forwards `weights.Version`.
- The two remaining weight read sites now pass the tensor's `Version`: the resident-`src` persistent upload path, and `GetOrCacheWeightsGpu`.
- **Race-safety preserved:** `RegisterPersistentTensor` adds to the cache lock-free (it does not take `_persistentBufferLock`), so the upload path keeps the `TryAdd` + alias-existing fallback rather than a direct set that would overwrite-and-leak a concurrently-registered buffer.

## Comment 2 (Trivial) — reference loop allocation in `DecoderFfnGate` test

The double-precision reference indexed the tensors via `[r,k]`/`[k,c]`, allocating a throwaway `int[]` per element (~28M arrays across the triple loop). It now indexes the contiguous backing spans directly.

## Verification (RTX 3080)

- `FusedLinear_PersistentWeightMutatedInPlace_UsesLoadedNotStaleWeights`, `FusedLinear_PersistentWeightUpdatedAfterWarmCache_ReflectsUpdate`, `TensorMatMul_DecoderFfnGate_...` — all pass.
- Broader DirectGpu suite (`GpuCpuConsistencyTests`, `FusedOptimizerWeightCoherenceTests`, `MatrixMultiplyResidencyTests`, `InvalidateActivationCacheEntryLifetimeTests`): **72 passed / 0 failed / 2 skipped**.
- Builds clean on net10.0, net8.0, net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU weight caching to detect in-place weight changes and re-upload updated data instead of using stale buffers.
  * Improved cache handling during concurrent registrations to prevent incorrect buffer reuse and resource leaks.

* **Tests**
  * Updated GPU-versus-CPU matrix multiplication validation to use direct tensor data access while preserving existing accuracy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->