### PR TITLE
feat: document and release the native ANN kernel stack (0.118.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A high-performance .NET tensor library with hand-written AVX2/AVX-512 SIMD kerne
 - **JIT-Compiled Kernels**: Runtime x86-64 machine code generation for size-specialized operations
 - **BLIS-Style GEMM**: Tiled matrix multiply with FMA micro-kernel, cache-aware panel packing
 - **GPU Acceleration**: Optional CUDA, HIP/ROCm, OpenCL, Metal, Vulkan, and WebGPU support via separate packages, with CPU-vs-GPU op-parity validated across every backend (#775)
+- **Native ANN Index**: Dependency-free approximate-nearest-neighbour search (Flat / IVF / PQ / IVFPQ) via `AnnIndex`, with fused `IAnnBackend` GPU kernels across all seven backends — no FAISS / MKL dependency (#824)
 - **Multi-Target**: Supports .NET 10.0 and .NET Framework 4.7.1
 - **Generic Math**: Works with any numeric type via `INumericOperations<T>` interface
 


### PR DESCRIPTION
Triggers the 0.118.0 release-please release for the native fused ANN kernels merged in #824. The #824 squash-merge commit was not conventional-commit formatted, so release-please detected no releasable change and cut no release PR. This feat commit (with a Release-As: 0.118.0 footer) forces the 0.118.0 release that the main AiDotNet repo NativeAnn vector index (PR #1899) depends on.

Also adds the native ANN index to the README feature list.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for native approximate-nearest-neighbor indexing, including Flat, IVF, PQ, and IVFPQ support.
  * Noted GPU-accelerated indexing and operation without FAISS or MKL dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->