### PR TITLE
fix(cuda): power_scalar returned NaN for negative bases under --use_fast_math

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
@@ -876,7 +876,25 @@ extern ""C"" __global__ __launch_bounds__(256) void power_scalar(const float* __
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= size) return;
-    B[idx] = powf(A[idx], exponent);
+    float x = A[idx];
+    // This module compiles with --use_fast_math, under which powf lowers to the fast intrinsic
+    // exp2(y * log2(x)). log2 of a negative number is NaN, so powf(-2, 2) returned NaN instead of 4 —
+    // i.e. squaring any negative value produced NaN on GPU while the CPU path returned the right answer.
+    // pow(x, y) IS defined for x < 0 when y is integral, so handle that case explicitly via |x| and
+    // restore the sign from the exponent's parity. Non-integral exponents with x < 0 remain genuinely
+    // undefined and keep propagating NaN, matching the CPU/IEEE behaviour.
+    float r;
+    if (x < 0.0f && exponent == truncf(exponent))
+    {
+        float magnitude = powf(-x, exponent);
+        // Odd exponent keeps the negative sign; even exponent is positive.
+        r = (fmodf(fabsf(exponent), 2.0f) == 1.0f) ? -magnitude : magnitude;
+    }
+    else
+    {
+        r = powf(x, exponent);
+    }
+    B[idx] = r;
 }
 extern ""C"" __global__ __launch_bounds__(256) void reduce_sum(const float* __restrict__ input, float* __restrict__ output, int size)
 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipActivationKernels.cs
@@ -343,7 +343,19 @@ extern ""C"" __global__ __launch_bounds__(256) void power_scalar(const float* A,
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= size) return;
-    B[idx] = powf(A[idx], exponent);
+    float x = A[idx];
+    // Fast pow implementations route through log2(x), which is invalid for a
+    // negative x even when the exponent is integral. Compute the magnitude
+    // from |x| and restore the sign for odd exponents.
+    if (x < 0.0f && exponent == truncf(exponent))
+    {
+        float magnitude = powf(-x, exponent);
+        B[idx] = (fmodf(fabsf(exponent), 2.0f) == 1.0f) ? -magnitude : magnitude;
+    }
+    else
+    {
+        B[idx] = powf(x, exponent);
+    }
 }
 
 extern ""C"" __global__ __launch_bounds__(256) void reduce_sum(const float* input, float* output, int size)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -223,7 +223,19 @@ kernel void pow_kernel(
     uint gid [[thread_position_in_grid]])
 {
     if (gid < size) {
-        B[gid] = pow(A[gid], power);
+        float x = A[gid];
+        // Metal pow is undefined for a negative base. Integral exponents are
+        // mathematically valid, so evaluate |x|^power and restore odd parity.
+        if (x < 0.0f) {
+            if (power == trunc(power)) {
+                float magnitude = pow(-x, power);
+                B[gid] = (fmod(fabs(power), 2.0f) == 1.0f) ? -magnitude : magnitude;
+            } else {
+                B[gid] = NAN;
+            }
+        } else {
+            B[gid] = pow(x, power);
+        }
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ActivationKernels.cs
@@ -485,7 +485,19 @@ __kernel void power_scalar(
     const int idx = get_global_id(0);
     if (idx >= size) return;
 
-    B[idx] = pow(A[idx], exponent);
+    const float x = A[idx];
+    // Some pow implementations route through log2(x), which is invalid for a
+    // negative x even when the exponent is integral. Compute the magnitude
+    // from |x| and restore the sign for odd exponents.
+    if (x < 0.0f && exponent == trunc(exponent))
+    {
+        const float magnitude = pow(-x, exponent);
+        B[idx] = (fmod(fabs(exponent), 2.0f) == 1.0f) ? -magnitude : magnitude;
+    }
+    else
+    {
+        B[idx] = pow(x, exponent);
+    }
 }
 
 // ===========================================================================

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
@@ -31,7 +31,21 @@ void main() {
     float v0 = uintBitsToFloat(p0), v1 = uintBitsToFloat(p1), v2 = uintBitsToFloat(p2);
     float y = 0.0;
     switch (op) {
-        case 0u: y = pow(x, v0); break;
+        case 0u: {
+            // GLSL pow is undefined for a negative base. Integral exponents
+            // are valid, so evaluate |x|^v0 and restore odd parity.
+            if (x < 0.0) {
+                if (v0 == trunc(v0)) {
+                    float magnitude = pow(-x, v0);
+                    y = (mod(abs(v0), 2.0) == 1.0) ? -magnitude : magnitude;
+                } else {
+                    y = uintBitsToFloat(0x7fc00000u);
+                }
+            } else {
+                y = pow(x, v0);
+            }
+            break;
+        }
         case 1u: y = abs(x); break;
         case 2u: y = exp(x); break;
         case 3u: y = exp2(x); break;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuKernels.cs
@@ -178,7 +178,22 @@ fn mul_scalar(@builtin(global_invocation_id) gid: vec3<u32>) {
 fn pow_scalar(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x;
     if (idx < params.size) {
-        B[idx] = pow(A[idx], params.scalar);
+        let x = A[idx];
+        let exponent = params.scalar;
+        // WGSL pow is undefined for a negative base. Integral exponents are
+        // valid, so evaluate |x|^exponent and restore odd parity.
+        if (x < 0.0) {
+            if (exponent == trunc(exponent)) {
+                let magnitude = pow(-x, exponent);
+                let abs_exponent = abs(exponent);
+                let is_odd = (abs_exponent - 2.0 * floor(abs_exponent * 0.5)) == 1.0;
+                B[idx] = select(magnitude, -magnitude, is_odd);
+            } else {
+                B[idx] = bitcast<f32>(0x7fc00000u);
+            }
+        } else {
+            B[idx] = pow(x, exponent);
+        }
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -8576,8 +8576,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <summary>
     /// Test/diagnostic hook (default <c>false</c>; <c>[ThreadStatic]</c> so it only affects the thread that
     /// sets it and never leaks into other parallel test collections). When <c>true</c>, the GPU-kernel
-    /// <c>catch</c> blocks that route conv / transpose / unfold-fold / pooling / locally-connected /
-    /// deformable / attention operations to their CPU reference RETHROW the kernel exception instead of
+    /// <c>catch</c> blocks that route selected GPU kernels, including Power, conv / transpose / unfold-fold /
+    /// pooling / locally-connected / deformable / attention operations, to their CPU reference RETHROW instead of
     /// silently falling back. Because the per-kernel fallback now lives partly inside the individual backends
     /// (Metal / Vulkan implement the conv/pool family in their own classes), the flag is a process-wide
     /// <c>static</c> so those backend <c>catch</c> blocks can honor it too
@@ -8589,7 +8589,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// would trivially pass (false green), exactly the gap that let issue #622 look "fixed" without proof.
     /// </para>
     /// <para>
-    /// Scope: this hook covers the conv/pool-family kernels exercised by the coverage suite (the methods whose
+    /// Scope: this hook covers the kernels exercised by strict GPU coverage tests (the methods whose
     /// <c>catch</c> blocks contain the rethrow, both here and in the Metal/Vulkan backends). It is a coverage
     /// aid, NOT a guarantee that every <c>catch</c> in the GPU stack rethrows; unrelated catch blocks (argument
     /// validation, capability probing, non-kernel host paths) deliberately keep their normal behavior.
@@ -17718,7 +17718,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> TensorPower<T>(Tensor<T> tensor, T exponent)
     {
         if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+        {
+            if (ThrowOnGpuKernelFallback)
+                throw new NotSupportedException($"GPU Power dispatch does not support the requested precision for {typeof(T)}.");
             return base.TensorPower(tensor, exponent);
+        }
 
         try
         {
@@ -17737,7 +17741,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 }
             }
         }
-        catch { }
+        catch
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+        }
+        if (ThrowOnGpuKernelFallback)
+            throw new InvalidOperationException("GPU Power dispatch was unavailable or returned no result.");
         return base.TensorPower(tensor, exponent);
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -424,6 +424,44 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
     [Theory] [MemberData(nameof(UnarySizes))] public void TensorExp_Gpu_Matches_Cpu(int[] s) => AssertUnary((e, a) => e.TensorExp(a), s, "TensorExp", TolTranscendental);
     [Theory] [MemberData(nameof(UnarySizes))] public void TensorDivideScalar_Gpu_Matches_Cpu(int[] s) => AssertUnary((e, a) => e.TensorDivideScalar(a, 3f), s, "TensorDivideScalar", Tol);
 
+    public static IEnumerable<object[]> NegativeBasePowerExponents() => new List<object[]>
+    {
+        new object[] { 3.0f },
+        new object[] { 4.0f },
+        new object[] { -3.0f },
+        new object[] { -4.0f },
+        new object[] { 0.5f },
+    };
+
+    // PR #827 fixed CUDA fast-math pow for negative bases. Keep every backend aligned with the CPU
+    // reference for odd, even, negative-integral, and genuinely undefined fractional exponents.
+    // Exponent 2 is intentionally absent: TensorPower optimizes x^2 to Multiply before Power is called.
+    [Theory]
+    [MemberData(nameof(NegativeBasePowerExponents))]
+    public void TensorPower_NegativeBases_GpuMatchesCpu(float exponent)
+    {
+        if (!EnsureGpuReady()) return;
+
+        var input = new Tensor<float>(new[] { -8.0f, -2.0f, -0.5f, 0.5f, 2.0f, 8.0f }, new[] { 6 });
+        float[] expected = _cpu.TensorPower(input, exponent).ToArray();
+        float[] actual = _gpu.TensorPower(input, exponent).ToArray();
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            if (float.IsNaN(expected[i]))
+            {
+                Assert.True(float.IsNaN(actual[i]),
+                    $"TensorPower exponent {exponent}: expected NaN at index {i}, got {actual[i]}");
+                continue;
+            }
+
+            double tolerance = 5e-4 * Math.Max(1.0, Math.Abs(expected[i]));
+            Assert.True(Math.Abs((double)actual[i] - expected[i]) <= tolerance,
+                $"TensorPower exponent {exponent}: expected {expected[i]} at index {i}, got {actual[i]}");
+        }
+    }
+
     [Theory]
     [MemberData(nameof(ElementwiseShapes))]
     public void TensorDivide_Gpu_Matches_Cpu(int[] shape)

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuCorrectnessTests.cs
@@ -444,7 +444,19 @@ public sealed class GpuCpuCorrectnessTests : IDisposable
 
         var input = new Tensor<float>(new[] { -8.0f, -2.0f, -0.5f, 0.5f, 2.0f, 8.0f }, new[] { 6 });
         float[] expected = _cpu.TensorPower(input, exponent).ToArray();
-        float[] actual = _gpu.TensorPower(input, exponent).ToArray();
+        float[] actual;
+        bool savedThrowOnFallback = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        try
+        {
+            // This diagnostic mode turns every TensorPower fallback into a test failure, proving that
+            // backend.Power dispatched successfully before the numerical comparison can pass.
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+            actual = _gpu.TensorPower(input, exponent).ToArray();
+        }
+        finally
+        {
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = savedThrowOnFallback;
+        }
 
         Assert.Equal(expected.Length, actual.Length);
         for (int i = 0; i < expected.Length; i++)

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PowerKernelSourceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PowerKernelSourceTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Reflection;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public sealed class PowerKernelSourceTests
+{
+    [Theory]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.CUDA.Kernels.CudaActivationKernels", "GetSource", "void power_scalar(",
+        "x < 0.0f && exponent == truncf(exponent)", "powf(-x, exponent)", "fmodf(fabsf(exponent), 2.0f) == 1.0f")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels.HipActivationKernels", "GetSource", "void power_scalar(",
+        "x < 0.0f && exponent == truncf(exponent)", "powf(-x, exponent)", "fmodf(fabsf(exponent), 2.0f) == 1.0f")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels.ActivationKernels", "GetSource", "__kernel void power_scalar(",
+        "x < 0.0f && exponent == trunc(exponent)", "pow(-x, exponent)", "fmod(fabs(exponent), 2.0f) == 1.0f")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.Metal.MetalKernels", "ElementWiseKernels", "kernel void pow_kernel(",
+        "power == trunc(power)", "pow(-x, power)", "fmod(fabs(power), 2.0f) == 1.0f")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.Vulkan.VulkanGlslKernels", "UnaryElementwise", "case 0u:",
+        "v0 == trunc(v0)", "pow(-x, v0)", "mod(abs(v0), 2.0) == 1.0")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.WebGpu.WebGpuKernels", "ScalarOpsSource", "fn pow_scalar(",
+        "exponent == trunc(exponent)", "pow(-x, exponent)", "select(magnitude, -magnitude, is_odd)")]
+    public void EveryAcceleratorPowerKernelHandlesNegativeBasesWithIntegralExponents(
+        string typeName,
+        string memberName,
+        string kernelMarker,
+        string integralGuard,
+        string magnitudeCalculation,
+        string parityCalculation)
+    {
+        string source = GetStaticString(typeName, memberName);
+        int kernelStart = source.IndexOf(kernelMarker, StringComparison.Ordinal);
+
+        Assert.True(kernelStart >= 0, $"Kernel marker not found: {typeName}.{memberName} -> {kernelMarker}");
+        string kernel = source.Substring(kernelStart, Math.Min(1200, source.Length - kernelStart));
+        Assert.Contains(integralGuard, kernel, StringComparison.Ordinal);
+        Assert.Contains(magnitudeCalculation, kernel, StringComparison.Ordinal);
+        Assert.Contains(parityCalculation, kernel, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.Metal.MetalKernels", "ElementWiseKernels", "kernel void pow_kernel(",
+        "B[gid] = NAN")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.Vulkan.VulkanGlslKernels", "UnaryElementwise", "case 0u:",
+        "uintBitsToFloat(0x7fc00000u)")]
+    [InlineData(
+        "AiDotNet.Tensors.Engines.DirectGpu.WebGpu.WebGpuKernels", "ScalarOpsSource", "fn pow_scalar(",
+        "bitcast<f32>(0x7fc00000u)")]
+    public void ShaderBackendsExplicitlyReturnNaNForNegativeBasesWithFractionalExponents(
+        string typeName,
+        string memberName,
+        string kernelMarker,
+        string nanExpression)
+    {
+        string source = GetStaticString(typeName, memberName);
+        int kernelStart = source.IndexOf(kernelMarker, StringComparison.Ordinal);
+
+        Assert.True(kernelStart >= 0, $"Kernel marker not found: {typeName}.{memberName} -> {kernelMarker}");
+        string kernel = source.Substring(kernelStart, Math.Min(1200, source.Length - kernelStart));
+        Assert.Contains(nanExpression, kernel, StringComparison.Ordinal);
+    }
+
+    private static string GetStaticString(string typeName, string memberName)
+    {
+        Type type = typeof(DirectGpuTensorEngine).Assembly.GetType(typeName)
+            ?? throw new InvalidOperationException($"Kernel source type not found: {typeName}");
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+        MethodInfo? method = type.GetMethod(memberName, flags);
+        if (method is not null)
+            return (string)(method.Invoke(null, null)
+                ?? throw new InvalidOperationException($"{memberName} returned null for {typeName}"));
+
+        PropertyInfo? property = type.GetProperty(memberName, flags);
+        if (property is not null)
+            return (string)(property.GetValue(null)
+                ?? throw new InvalidOperationException($"{memberName} returned null for {typeName}"));
+
+        FieldInfo? field = type.GetField(memberName, flags);
+        if (field is not null)
+            return (string)(field.GetValue(null)
+                ?? throw new InvalidOperationException($"{memberName} returned null for {typeName}"));
+
+        throw new InvalidOperationException($"Static string member not found: {typeName}.{memberName}");
+    }
+}


### PR DESCRIPTION
## The bug

`Power(x, y)` on GPU returned **NaN for every negative `x`**, even with integral exponents. Squaring a negative number gave NaN while the CPU path returned the correct value — silent wrong answers for any model applying `Power` to signed data.

## Cause

The activation module compiles with `--use_fast_math` (`CompileKernelModule` defaults `useFastMath: true`, and the activation module in `CudaBackend.cs` doesn't override it). Under fast math `powf` lowers to the fast intrinsic `exp2(y * log2(x))`, and `log2` of a negative is NaN.

`pow(x, y)` **is** mathematically defined for `x < 0` when `y` is integral, so this is a genuine correctness gap — not a permissible fast-math approximation.

## Fix

Handled inside the kernel rather than disabling fast math module-wide (which would slow every other activation): for `x < 0` with an integral exponent, compute `powf(-x, exponent)` and restore the sign from the exponent's parity. All other cases unchanged; a non-integral exponent over a negative base still yields NaN, matching IEEE and the CPU path.

## Why it went unnoticed

`DirectGpuCorrectnessTests` covers exactly this case (`AssertAllClose(PowCpu(a, 2.0f), ...)`) — but **the entire suite was inert**. Every test carried `[Fact(Timeout = N)]` on a *synchronous* method, which xUnit rejects outright:

```
Tests marked with Timeout are only supported for async tests
```

They failed in ~1 ms regardless of hardware, so the assertion never executed. That's fixed separately in the AiDotNet repo (converted to `async Task` + `await Task.Yield()`, keeping the `Timeout`).

## Verification (RTX 3080)

Packed as `0.117.2` and consumed by `AiDotNet.Tests`:

| Suite | Before | After |
|---|---|---|
| `DirectGpuCorrectnessTests` | 4/5 — failing `Index 1: expected 4, got NaN` | **5/5** |
| `DirectGpuTests` (14 revived) | never ran | **18 passed / 1 skipped / 0 failed** |

Builds clean on net10.0, net8.0 and net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU tensor power calculations for negative bases with integer exponents across supported accelerator backends.
  * Non-integer exponents with negative bases now consistently produce undefined/NaN results instead of unpredictable outputs.

* **Tests**
  * Added cross-backend correctness coverage comparing GPU power results with CPU calculations.
  * Added validation that accelerator kernels handle negative-base integer and fractional exponents consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->