### PR TITLE
feat: add direct PTX fused-kernel blueprint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           --collect:"XPlat Code Coverage" \
           --results-directory ./coverage \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
-          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]AiDotNet.Tensors.Engines.DirectGpu.*,[*]AiDotNet.Tensors.Engines.Cu*,[*]AiDotNet.Tensors.Engines.ClBlast*,[*]AiDotNet.Tensors.Engines.OpenCl*,[*]AiDotNet.Tensors.Engines.Simd.*,[*]AiDotNet.Tensors.Engines.BlasManaged.*"
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*]AiDotNet.Tensors.Engines.DirectGpu.*,[*]AiDotNet.Tensors.Engines.DirectGpuTensorEngine*,[*]AiDotNet.Tensors.Engines.Cu*,[*]AiDotNet.Tensors.Engines.ClBlast*,[*]AiDotNet.Tensors.Engines.OpenCl*,[*]AiDotNet.Tensors.Engines.Simd.*,[*]AiDotNet.Tensors.Engines.BlasManaged.*"
 
     # If --blame-hang-timeout (a test made no progress for 300s) or --blame-crash (test host
     # native-crashed, e.g. a CUDA-finalizer 0xC0000005) fired, the hang/crash dump + the

--- a/docs/research/2026-07-20-fused-attention-championship-blueprint.md
+++ b/docs/research/2026-07-20-fused-attention-championship-blueprint.md
@@ -1,0 +1,478 @@
+# Direct-PTX online-attention kernel blueprint
+
+Date: 2026-07-20; productionization pass 2026-07-21
+Baseline: `b386d35` plus the working-tree experiment described here
+
+## Verdict
+
+The forward-inference experiment is implemented end to end for NVIDIA SM80+
+and the declared shape family:
+
+```text
+FP16 Q/K/V, dense BHSD, S in {16,32,64,128}, D=64
+  -> scaled attention, unmasked or causal
+  -> optional head-local LayerNorm(D=64) + affine + tanh-GELU
+  -> FP32 BHSD output
+```
+
+The final wide benchmark is GPU-only. It compares the direct PTX kernel with
+the current AiDotNet CUDA/NVRTC implementation, a direct cuBLAS Tensor Core
+composition, and PyTorch SDPA with its exposed Flash and Math backends forced
+one at a time. Intel MKL and OpenBLAS are deliberately absent: they are CPU
+BLAS libraries, not NVIDIA GPU kernels. The NVIDIA analogue for this
+experiment is cuBLAS.
+
+On the RTX 3080 used here, the fused direct-PTX path wins steady-state median
+in every tested attention-plus-epilogue cell from decode through saturation.
+The attention-only path wins every cell in the representative capture below,
+but its saturated unmasked BH512 result is a 1% near tie and has reversed in
+repeated one-launch host captures on this display GPU. The fused experiment
+therefore clears the competition gate; the attention-only saturation case
+remains an optimization lane rather than a robust universal win. These claims
+apply only to this GPU, dtype, shape family, and semantic contract—not other
+GPUs, dimensions, dropout, arbitrary masks, or backward.
+
+## Apples-to-apples contracts
+
+Two lanes are reported separately.
+
+| Lane | Required result | FLOP accounting |
+|---|---|---:|
+| Attention | FP16 Q/K/V -> FP32 `softmax(QK^T * scale + mask)V` | `4 * BH * S^2 * D` |
+| Attention + epilogue | The same FP32 attention, then row-wise LayerNorm over D=64, affine, and tanh-GELU | Attention FLOPs only, labeled effective TFLOPS |
+
+All steady-state rows use resident GPU inputs and outputs. Setup, allocation,
+host/device copies, module JIT, and PyTorch/AiDotNet construction are outside
+the timed region. Each invocation includes its framework or Driver-API launch
+and a completion synchronization. PyTorch SDPA's native FP16 result is
+converted to FP32 inside the timed action. TorchSharp 0.106 does not expose
+GELU's approximation selector, so the PyTorch epilogue spells out the same
+tanh-GELU equation with PyTorch GPU tensor operations.
+
+The inference PTX specialization does not emit log-sum-exp statistics. The
+production AiDotNet inference route uses the API-compatible specialization,
+which does emit the existing API's FP32 statistics. The current AiDotNet benchmark
+therefore performs a small additional documented side effect. No public
+PyTorch SDPA API in this package returns matching LSE output.
+
+`TFLOPS` counts the two attention matrix products. It does not invent FLOPs
+for softmax, mask predicates, normalization, or activation. `B/call` is
+managed allocation on the calling thread. `tmp MiB` is known intermediate
+VRAM, excluding inputs and final outputs.
+
+## Exact championship cell
+
+System: NVIDIA GeForce RTX 3080, SM 8.6, driver 610.47, Windows display GPU.
+Shape: `[BH=128,S=128,D=64]`, FP16 Q/K/V, FP32 output.
+Samples: 101 after 30 warmups. CUDA-event device samples average ten launches;
+end-to-end samples are one synchronized invocation each.
+
+```text
+Mode      Method                              median us     p95 us     p99 us    mean us    TFLOPS   B/call  tmp MiB    max err  regs  local B
+-----------------------------------------------------------------------------------------------------------------------------------------------
+unmasked  Direct PTX attention [device]           33.69      34.82      79.67      35.51    15.936        0    0.000  7.081e-6     66        0
+unmasked  Direct PTX attention [E2E]              46.10      50.50     251.10      51.69    11.646        0    0.000  7.081e-6     66        0
+unmasked  cuBLAS+PTX softmax [device]             51.30      80.28      93.90      54.39    10.465        0   12.000  1.052e-5    n/a      n/a
+unmasked  cuBLAS+PTX softmax [E2E]                69.60     118.20     153.70      78.93     7.714        0   12.000  1.052e-5    n/a      n/a
+unmasked  Direct PTX + LN + GELU [device]         38.60      66.05      89.91      41.23    13.907        0    0.000  5.491e-4     66        0
+unmasked  Direct PTX + LN + GELU [E2E]            52.90      63.70     308.50      62.78    10.149        0    0.000  5.491e-4     66        0
+unmasked  AiDotNet NVRTC attention [E2E]        1175.30    1578.20    1788.40    1261.20     0.457        0    0.062   2.980e-8    n/a      n/a
+unmasked  AiDotNet NVRTC + LN + GELU [E2E]      1259.90    1614.70    2068.30    1321.81     0.426       40    8.188   5.603e-6    n/a      n/a
+unmasked  PyTorch Flash-SDPA FP32 [E2E]           64.10     132.20     138.80      72.38     8.376       96      n/a   1.214e-5    n/a      n/a
+unmasked  PyTorch Flash + LN + GELU [E2E]        406.00    1681.90    2115.90     811.50     1.322      704      n/a   9.871e-4    n/a      n/a
+causal    Direct PTX attention [device]           25.60      53.04      59.90      28.84    20.972        0    0.000  2.855e-5     80        0
+causal    Direct PTX attention [E2E]              39.80     129.40     326.60      64.62    13.489        0    0.000  2.855e-5     80        0
+causal    cuBLAS+PTX softmax [device]             51.51      96.15     157.49      61.22    10.423        0   12.000  3.869e-5    n/a      n/a
+causal    cuBLAS+PTX softmax [E2E]                71.30     242.60     293.70     104.13     7.530        0   12.000  3.869e-5    n/a      n/a
+causal    Direct PTX + LN + GELU [device]         26.73      36.76      46.80      28.25    20.088        0    0.000  5.491e-4     80        0
+causal    Direct PTX + LN + GELU [E2E]            41.20      43.70      45.40      41.42    13.031        0    0.000  5.491e-4     80        0
+causal    AiDotNet NVRTC attention [E2E]         912.30    1137.60    1527.30     943.25     0.588        0    0.062   2.980e-8    n/a      n/a
+causal    AiDotNet NVRTC + LN + GELU [E2E]      1025.10    1280.00    1529.30    1061.36     0.524       40    8.188   5.722e-6    n/a      n/a
+causal    PyTorch Flash-SDPA FP32 [E2E]          102.30     119.50     131.60     102.53     5.248       96      n/a   6.071e-5    n/a      n/a
+causal    PyTorch Flash + LN + GELU [E2E]        371.50    1598.10    1794.40     766.39     1.445      704      n/a   1.247e-3    n/a      n/a
+```
+
+The direct kernel's device median is 1.52x faster than the decomposed cuBLAS
+floor unmasked and 2.01x faster causal. Its synchronized attention median is
+1.39x/2.57x faster than forced PyTorch Flash-SDPA. The fused median is
+7.67x/9.02x faster than PyTorch's equivalent tanh-GELU composition and
+23.82x/24.88x faster than current AiDotNet.
+
+The RTX 3080 is also driving the desktop. Occasional Windows GPU scheduling
+outliers are visible in host p99 (for example, the unmasked direct-attention
+E2E row), while its CUDA-event p99 remains below the cuBLAS device p99. Tail
+values are reported rather than removed.
+
+## Wide shape matrix
+
+The matrix covers six occupancy regimes, both mask modes, and both semantic
+lanes. The following is the compact championship view from a representative
+serialized capture; `best competitor` is the lowest median among cuBLAS composition,
+current AiDotNet, forced PyTorch Flash-SDPA, and forced PyTorch Math-SDPA.
+
+| Shape | Mode | Lane | Direct median us | Direct p95 | Direct p99 | Direct TFLOPS | Best competitor | Competitor median us | Speedup |
+|---|---|---|---:|---:|---:|---:|---|---:|---:|
+| BH12 S16 | plain | attention | 21.40 | 41.95 | 44.25 | 0.037 | cuBLAS+PTX | 42.50 | 1.99x |
+| BH12 S16 | causal | attention | 17.80 | 19.35 | 21.70 | 0.044 | cuBLAS+PTX | 45.50 | 2.56x |
+| BH12 S32 | plain | attention | 19.20 | 35.40 | 44.10 | 0.164 | cuBLAS+PTX | 43.50 | 2.27x |
+| BH12 S32 | causal | attention | 17.80 | 33.65 | 41.85 | 0.177 | PyTorch Math | 52.10 | 2.93x |
+| BH12 S64 | plain | attention | 21.20 | 40.20 | 73.40 | 0.594 | cuBLAS+PTX | 49.40 | 2.33x |
+| BH12 S64 | causal | attention | 20.20 | 39.70 | 45.60 | 0.623 | PyTorch Math | 52.00 | 2.57x |
+| BH12 S128 | plain | attention | 35.40 | 56.15 | 97.15 | 1.422 | cuBLAS+PTX | 48.00 | 1.36x |
+| BH12 S128 | causal | attention | 27.70 | 48.75 | 107.45 | 1.817 | cuBLAS+PTX | 46.80 | 1.69x |
+| BH128 S128 | plain | attention | 48.00 | 51.80 | 54.75 | 11.185 | PyTorch Math | 65.20 | 1.36x |
+| BH128 S128 | causal | attention | 39.00 | 56.70 | 79.65 | 13.766 | PyTorch Flash | 64.20 | 1.65x |
+| BH512 S128 | plain | attention | 130.60 | 133.40 | 138.05 | 16.443 | PyTorch Flash | 132.10 | 1.01x |
+| BH512 S128 | causal | attention | 91.40 | 262.80 | 350.90 | 23.495 | PyTorch Math | 118.00 | 1.29x |
+| BH12 S16 | plain | attn+epi | 18.50 | 31.05 | 39.75 | 0.043 | AiDotNet NVRTC | 55.80 | 3.02x |
+| BH12 S16 | causal | attn+epi | 22.40 | 48.90 | 66.55 | 0.035 | AiDotNet NVRTC | 55.30 | 2.47x |
+| BH12 S32 | plain | attn+epi | 18.90 | 39.05 | 40.50 | 0.166 | AiDotNet NVRTC | 82.60 | 4.37x |
+| BH12 S32 | causal | attn+epi | 23.00 | 49.70 | 57.60 | 0.137 | AiDotNet NVRTC | 80.90 | 3.52x |
+| BH12 S64 | plain | attn+epi | 21.50 | 38.05 | 45.30 | 0.585 | AiDotNet NVRTC | 129.20 | 6.01x |
+| BH12 S64 | causal | attn+epi | 20.80 | 41.55 | 44.30 | 0.605 | AiDotNet NVRTC | 132.90 | 6.39x |
+| BH12 S128 | plain | attn+epi | 32.10 | 32.85 | 35.20 | 1.568 | AiDotNet NVRTC | 238.90 | 7.44x |
+| BH12 S128 | causal | attn+epi | 35.40 | 69.50 | 163.15 | 1.422 | AiDotNet NVRTC | 241.70 | 6.83x |
+| BH128 S128 | plain | attn+epi | 52.40 | 56.55 | 59.65 | 10.246 | PyTorch Math | 304.60 | 5.81x |
+| BH128 S128 | causal | attn+epi | 39.00 | 40.10 | 43.70 | 13.766 | PyTorch Math | 275.20 | 7.06x |
+| BH512 S128 | plain | attn+epi | 135.70 | 182.35 | 320.05 | 15.825 | PyTorch Math | 804.70 | 5.93x |
+| BH512 S128 | causal | attn+epi | 103.00 | 114.25 | 255.30 | 20.849 | PyTorch Flash | 809.50 | 7.86x |
+
+The executable prints every competitor row with median, p95, p99, mean,
+effective TFLOPS, managed allocation, and known temporary VRAM. The table
+above is intentionally a compact winner view; it does not replace the raw TUI.
+Repeated 101-sample, one-launch host captures under desktop load occasionally
+reverse the closest attention-only cells because scheduler phase changes by
+more than their margin. They did not erase the fused lane's 2.47x--7.86x
+median advantage. Use the CUDA-event championship cell for raw device work,
+and an otherwise idle GPU for release-gate host distributions.
+
+## Kernel dataflow
+
+```text
+dense aligned FP16 BHSD Q/K/V in global memory
+                     |
+                     v
+          cp.async 16-byte transactions
+                     |
+                     v
+  warp-private Q tiles + CTA-shared double-buffered K/V tiles
+                     |
+                     v
+       mma.sync.m16n8k16 QK fragments in FP32 registers
+                     |
+                     v
+ compile-time causal mask + online max/sum recurrence
+ (fully masked future tiles are skipped by each causal warp)
+                     |
+                     v
+       mma.sync.m16n8k16 PV; 16x64 output stays in registers
+                     |
+                     +--> optional row LayerNorm + affine + tanh-GELU
+                     |
+                     v
+              one final FP32 output store
+```
+
+For S=128, all eight 16-row query warps for one head share a CTA. The K/V tile
+is fetched once per CTA, double buffered, and reused by all eight warps. The
+first online tile omits a provably useless zero-accumulator rescale; later row
+rescaling is predicated on the running maximum actually changing.
+
+"Avoid VRAM traffic" means avoiding intermediate global-memory traffic. Q,
+K, V must be read from global memory and the final output must be committed.
+The kernel never materializes an SxS score or probability tensor in global or
+shared memory. Its online max, sum, score fragments, and 16x64 output fragment
+remain in registers. The inference specialization writes only the output; the
+API-compatible inference specialization additionally writes the required LSE stats.
+
+## Runtime and feature gate
+
+The custom path uses `nvcuda.dll` Driver API calls directly:
+
+```text
+C# shape/fusion specialization -> emitted PTX
+  -> cuModuleLoadDataEx (driver JIT PTX to GPU-specific SASS)
+  -> cuModuleGetFunction
+  -> cuLaunchKernel on AiDotNet's existing stream/context
+```
+
+It does not use CUDA Runtime, NVRTC, cuBLAS, or cuDNN for the custom kernel.
+It cannot bypass the NVIDIA driver: the driver owns context creation, PTX JIT,
+memory, stream submission, and execution. PTX is a virtual ISA close to the
+hardware, not a hand-encoded SASS binary.
+
+Production integration is fail-closed:
+
+- The default is off. Set `AIDOTNET_DIRECT_PTX_ATTENTION=1` to opt in.
+- SM < 8.0, unsupported shape/dtype/layout, bias, active autodiff tape, stream
+  capture, JIT failure, or launch failure falls back to the existing path.
+- The runtime borrows the existing `CudaBackend` context and stream, so
+  resident AiDotNet buffers require no copy or context bridge.
+- Modules are cached by BH, S, mask, fusion signature, scale bits, and epsilon
+  bits, and unloaded before the backend destroys its context/stream.
+- The kernel cache and launches use the backend's existing dispatch locks.
+- Stream capture stays on the established resident NVRTC path because lazy
+  PTX JIT and eager scratch allocation are not capture safe. A later graph API
+  should prewarm the specialization and provide stable output buffers first.
+
+## Canonical physical-layout policy
+
+Stride checks should not exist inside a machine-code hot loop. They cannot be
+eliminated from an ergonomic public tensor API altogether: someone must prove
+that the pointer satisfies the kernel contract. The correct boundary is one
+dispatch-time proof followed by a stride-free capability token.
+
+The implemented token is `DirectPtxTensorView`:
+
+- dense row-major `[batch,head,sequence,dimension]` (`BHSD`);
+- zero logical storage offset and exact logical backing extent at the tensor
+  boundary;
+- FP16 physical Q/K/V and FP32 output/stats/gamma/beta;
+- at least 16-byte device-pointer alignment;
+- sufficient byte extent and dtype-compatible extent;
+- no stride fields and no shape fields passed to PTX.
+
+Shape, offsets, trip counts, mask mode, scale, and fusion choices are baked
+into the PTX specialization. Public `Tensor<float>` input is currently
+resolved to persistent/resident FP16 storage once at the dispatch boundary.
+The longer-term tensor design should preserve logical views for usability but
+attach an immutable physical-layout proof (`layout id`, dtype, alignment,
+storage generation, extent) to resident allocations. View/transpose changes
+invalidate the proof. A compiled plan can then propagate the proof without
+rechecking every invocation; unsupported views are materialized once or sent
+to a general fallback.
+
+## Zero-spill proof
+
+Module admission calls `cuFuncGetAttribute` after the driver has JIT-compiled
+PTX to the installed GPU. If `CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES` is nonzero,
+`GetFunction` rejects the specialization and AiDotNet falls back. It is not a
+benchmark-only assertion.
+
+The final S=128 functions on this RTX 3080 report:
+
+| Specialization | Registers/thread | Static shared | Local bytes/thread |
+|---|---:|---:|---:|
+| Unmasked | 66 | 25,088 bytes | 0 |
+| Causal | 80 | 25,088 bytes | 0 |
+
+`local bytes/thread = 0` is direct runtime evidence that this JIT result has
+no local stack or register-spill allocation. Tests carry the value through
+the borrowed production runtime and assert zero. Structural tests also assert
+the expected `cp.async`, `mma.sync`, online tiling, absence of score/probability
+pointers, and absence of stride parameters.
+
+`ptxas`, `nvdisasm`, and `cuobjdump` are not installed on this machine, so the
+report does not claim a separately inspected SASS listing. Nsight Compute
+2025.4.1 was installed as a user-local portable tool and successfully attached
+to the deterministic target, but the driver returned `ERR_NVGPUCTRPERM` because
+performance-counter access is disabled for this Windows user. No executed
+hardware-counter result is claimed until that OS/driver permission is enabled
+and the checked-in profile command is rerun. PerfView is useful for managed
+host allocation and scheduling, but it cannot prove GPU spills, tensor-pipe
+use, shared-bank conflicts, or DRAM transactions. The Driver-API local-memory
+attribute remains the available zero-spill admission proof for this capture.
+
+## Edge-case dispatch table
+
+| Condition | Direct PTX behavior |
+|---|---|
+| S = 16, 32, 64, or 128; D=64 | Shape-specialized kernel |
+| Other S or D | Existing CUDA fallback; no semantic padding |
+| Unmasked / causal | Separate compile-time specializations |
+| Arbitrary attention bias or padding mask | Fallback |
+| Dropout | Fallback |
+| FP16 physical Q/K/V, FP32 output | Accepted |
+| Noncontiguous, sparse, nonzero-offset, or aliased larger logical view | Materialize/general fallback; never enter stride-free PTX |
+| Misaligned or undersized device pointer | Capability-token rejection and fallback |
+| Active autodiff tape / backward | Existing recorded implementation |
+| CUDA graph capture | Backend direct launch is allowed only after explicit prewarm; the high-level route retains its resident NVRTC fallback because FP16 scratch/output materialization is not capture-safe yet |
+| Non-Ampere architecture | Gate disabled until a separately tuned Ada/Hopper/Blackwell family exists |
+| Driver JIT reports local bytes | Module rejected and fallback |
+| Causal future K/V tile | Compute skipped per owning query warp |
+| Inference output-only | No score, probability, or LSE global store |
+| Training-forward / backward | Existing recorded CUDA implementation; direct PTX is inference-only |
+
+## Reusable kernel assembly line
+
+Each future low-level kernel should be delivered as one repeatable unit:
+
+1. Freeze the semantic contract: layouts, physical dtypes, accumulation,
+   outputs, approximation, masking, and exact FLOP accounting.
+2. Add a scalar oracle before writing PTX.
+3. Define a canonical physical-layout capability token. Validate once at the
+   dispatch boundary; never put stride or dtype branches in the hot loop.
+4. Select explicit shape buckets and a correct general fallback. Never pad a
+   mask-sensitive operation merely to enter a fast bucket.
+5. Write a memory ledger for inputs, register state, shared tiles, optional
+   outputs, and forbidden global intermediates.
+6. Emit architecture/fusion/shape-specialized PTX and cache it by every bit
+   that can change code generation.
+7. Pipeline global-to-shared movement asynchronously, reuse shared tiles
+   across warps, and keep recurrence/output state in registers.
+8. Fuse epilogues only when their semantic axis and approximation are exact.
+   Here LayerNorm is per `[B,H,S]` row over D=64, with shared D64 gamma/beta.
+9. Query registers, shared memory, and local bytes from the compiled function.
+   Reject spills as a runtime admission rule.
+10. Validate every supported bucket, mask, and fusion signature, including
+    layout rejection and fallback behavior.
+11. Benchmark only semantic and hardware peers: current AiDotNet GPU,
+    NVIDIA vendor composition, and framework GPU primitives with backends
+    forced where the API permits. Keep CPU libraries in a separate study.
+12. Report median, p95, p99, mean, effective throughput, managed allocation,
+    known temporary VRAM, numerical error, registers, local bytes, and JIT
+    setup separately.
+13. Promote behind an opt-in gate only after the declared cell wins; retain a
+    safe fallback and expand one shape/fusion cell at a time.
+
+The reusable code layers are:
+
+- `DirectPtxRuntime`: Driver API, owned/borrowed context, JIT, module, launch,
+  events, allocation, and zero-local-memory admission.
+- `DirectPtxFeatureGate` / `DirectPtxTensorView`: opt-in and physical contract.
+- `DirectPtxKernelBlueprint`: logical/physical ABI, architecture family,
+  semantic manifest, resource budget, PTX identity, and profiler evidence.
+- `DirectPtxKernelCache` / `DirectPtxAttentionAutotuner`: bounded LRU modules,
+  persisted device-specific winners, and prewarm-only graph capture.
+- `PtxOnlineFusedAttention128x64Kernel`: shape emitter, async online dataflow,
+  causal specialization, optional LSE, and fused epilogue.
+- `CudaBackend.DirectPtx`: production cache, existing stream/context, audit,
+  fallback, and teardown.
+- `DirectPtxWmmaTests`: structural, scalar-oracle, layout, gate, borrowed-
+  context, feature-route, and zero-spill tests.
+- `DirectPtxGpuMatrixExperiment`: NVIDIA-only wide competitor harness.
+
+## Productionization pass: all seven improvements
+
+The experiment has now been extracted into a reusable system rather than
+copied into another one-off emitter.
+
+| Improvement | Implemented result | Remaining evidence boundary |
+|---|---|---|
+| Formal layout ABI | Logical and physical extents, layout identity, dtype, alignment, access, padding, byte offset, and allocation extent are validated once in `DirectPtxTensorContract`; the PTX has no stride path | Packed QKV and paged KV have ABI identities but no kernel yet |
+| Autotuned dispatch | Attention tries valid query-warp variants, persists the winner through the existing autotune cache, keys it by GPU UUID/SM/driver and semantics, and bounds loaded modules with an LRU | A clean production release run still requires three independent captures |
+| Stronger spill proof | Runtime admission enforces register/shared/local budgets and records PTX SHA-256, JIT attributes, occupancy, GPU fingerprint, and log; an Nsight CSV parser and deterministic profile target enforce executed spill/local counters | Nsight attached, but `ERR_NVGPUCTRPERM` blocks counter access until enabled by the host administrator |
+| Hardened performance gate | Policy requires >=1.10x median, bounded p95, zero hot managed/device temporary bytes, numerical tolerance, zero local bytes, and three independent runs | Windows display scheduling can hold an otherwise fast candidate |
+| Expanded correctness | Explicit eligibility reasons cover dtype, non-square Q/KV, D, GQA/MQA, mask, dropout, phase/backward, ragged and paged requests; unsupported cells fail closed | Those semantics remain implementation work, not silently advertised support |
+| Real second fusion | `residual + RMSNorm(D=64)` is one warp-owned reduction/fusion using the same ABI, audit, gate, cache, graph-prewarm, tests, and benchmark framework | QKV projection/RoPE remains the next tensor-core fusion |
+| Architecture families | Ampere, Ada, Hopper, and Blackwell are distinct dispatch domains | Only Ampere SM86 was executed here; other families deliberately reject rather than inherit Ampere tuning |
+
+### Physical layout rule
+
+AiDotNet tensors are not globally forced contiguous. Views remain legal for
+general operations. A direct kernel instead requires an immutable capability:
+
+```text
+logical tensor/view
+  -> graph-boundary materialize or existing canonical resident allocation
+  -> DirectPtxTensorContract validation
+     (layout + logical/physical extent + dtype + offset + alignment + access)
+  -> stride-free pointer capability
+  -> specialized PTX
+```
+
+This supports future padding, packed QKV, ragged offsets, and paged KV as
+different physical ABIs rather than runtime stride branches.
+
+### Second-blueprint result
+
+RTX 3080, FP32 resident inputs/output, fused `RMSNorm(input + residual)` over
+D=64, 101 synchronized samples after 30 warmups:
+
+```text
+Rows  Method                       median us  p95 us  p99 us  GB/s    B/call  tmp MiB  max err    regs  local B
+32    Direct PTX fused                 17.50    25.10   34.40    1.43       0    0.000  4.768e-7   18       0
+32    AiDotNet add + RMSNorm           20.30    44.60   53.90    1.23      56    0.008  4.768e-7
+256   Direct PTX fused                 18.00    21.20   28.30   10.99       0    0.000  4.768e-7   18       0
+256   AiDotNet add + RMSNorm           20.70    50.30   61.30    9.56      56    0.062  4.768e-7
+2048  Direct PTX fused                 19.10    51.00   60.60   82.79       0    0.000  7.153e-7   18       0
+2048  AiDotNet add + RMSNorm           24.40    42.20   74.90   64.81      56    0.500  7.153e-7
+8192  Direct PTX fused                 21.50    43.80   45.50  294.16       0    0.000  5.960e-7   18       0
+8192  AiDotNet add + RMSNorm           43.90    68.80  257.50  144.07      56    2.000  7.153e-7
+```
+
+Every median clears the 10% threshold (1.15x--2.04x). The diagnostic gate
+passes rows 32, 256, and 8192. Rows 2048 is correctly held because its p95
+exceeded the allowed competitor tail by 4.58 us on this capture. Production
+promotion additionally requires three clean independent runs.
+
+### Strong GPU competitors
+
+The in-process suite still includes current AiDotNet CUDA, direct cuBLAS
+composition, and forced TorchSharp Flash/Math SDPA. The new external harness
+adds explicitly forced PyTorch cuDNN, Flash, Efficient, and Math SDPA, each in
+eager and `torch.compile(max-autotune)` form, plus the official
+`flash-attn` package when installed. It reports CUDA-event median/p95/p99/mean,
+effective TFLOPS, and peak device allocation.
+
+The external matrix was subsequently executed in an isolated Python 3.12
+environment with PyTorch 2.12.1+cu130 on the same RTX 3080. The Windows wheel
+does not contain PyTorch Flash-SDPA, and the third-party `flash-attn` package is
+not installed, so those lanes report explicit skips. cuDNN, Efficient, and Math
+were forced independently; no candidate was allowed to silently fall back.
+The best eager external median for the two largest shapes is shown below. Peak
+bytes include the candidate output allocation and are not directly comparable
+to the direct kernel's `temporary VRAM` column.
+
+| Shape | Mode | Lane | Forced backend | Median us | P95 us | P99 us | Mean us | TFLOPS | Peak bytes | Max error |
+|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+| BH128 S128 | plain | attention | cuDNN | 196.61 | 381.95 | 577.54 | 231.98 | 2.731 | 6,291,456 | 3.052e-5 |
+| BH128 S128 | causal | attention | cuDNN | 161.76 | 330.75 | 485.38 | 189.69 | 3.319 | 6,291,456 | 1.221e-4 |
+| BH128 S128 | plain | attn+epi | cuDNN | 399.36 | 594.94 | 677.89 | 431.90 | 1.344 | 20,971,520 | 2.632e-3 |
+| BH128 S128 | causal | attn+epi | cuDNN | 393.22 | 494.78 | 728.06 | 407.97 | 1.365 | 20,971,520 | 2.451e-3 |
+| BH512 S128 | plain | attention | Efficient | 160.77 | 297.98 | 345.09 | 191.96 | 13.358 | 25,165,824 | 3.052e-5 |
+| BH512 S128 | causal | attention | Efficient | 94.21 | 332.80 | 438.27 | 124.45 | 22.795 | 25,165,824 | 1.221e-4 |
+| BH512 S128 | plain | attn+epi | Efficient | 886.78 | 1,180.67 | 1,576.96 | 927.18 | 2.422 | 83,886,080 | 2.528e-3 |
+| BH512 S128 | causal | attn+epi | Efficient | 904.19 | 1,482.75 | 1,938.43 | 1,001.07 | 2.375 | 83,886,080 | 2.614e-3 |
+
+`torch.compile(max-autotune)` correctly remains an unavailable lane on this
+Windows installation because the official wheel has no working Triton
+installation. The harness records that failure rather than relabeling eager
+execution as compiled execution.
+
+### Resource evidence workflow
+
+The runtime JIT audit remains a mandatory first gate. Release profiling adds:
+
+```powershell
+tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1 `
+  -Target attention -OutputCsv attention-ncu.csv
+
+tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1 `
+  -Target residual-rmsnorm -OutputCsv residual-rmsnorm-ncu.csv
+```
+
+The script profiles a deterministic kernel target and fails unless executed
+register-spill instructions, local loads, local stores, and local spill
+requests are all zero. PerfView remains appropriate for managed allocation
+and ETW; it is not accepted as GPU spill evidence.
+
+## Reproduction
+
+```powershell
+dotnet build tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj -c Release
+
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj `
+  -c Release -f net10.0 --filter DirectPtxWmmaTests
+
+dotnet run --project tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj `
+  -c Release --no-build -- --direct-ptx-online-attention
+
+dotnet run --project tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj `
+  -c Release --no-build -- --direct-ptx-gpu-matrix
+
+dotnet run --project tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj `
+  -c Release --no-build -- --direct-ptx-residual-rmsnorm
+
+dotnet run --project tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj `
+  -c Release --no-build -- --direct-ptx-external-gpu-baselines
+
+$env:AIDOTNET_DIRECT_PTX_ATTENTION='1'
+$env:AIDOTNET_DIRECT_PTX_RESIDUAL_RMSNORM='1'
+# Or enable all admitted direct kernels:
+$env:AIDOTNET_DIRECT_PTX='1'
+```
+
+Run on an otherwise idle system. The exact values are hardware, driver,
+clock, thermal, and scheduler dependent; the contract and pass/fail process
+are the reusable artifacts.

--- a/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
@@ -669,6 +669,7 @@ public static class CuBlasNative
             CudaResult.NoDevice => "No CUDA device available",
             CudaResult.InvalidDevice => "Invalid device",
             CudaResult.InvalidContext => "Invalid context",
+            CudaResult.InvalidPtx => "Invalid PTX (JIT compilation failed)",
             CudaResult.LaunchFailed => "Kernel launch failed",
             CudaResult.NotReady => "Operation not ready (async operation still in progress)",
             _ => $"Unknown CUDA error ({(int)result})"

--- a/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
@@ -55,6 +55,7 @@ public enum CudaResult
     NotMapped = 211,
     NotMappedAsArray = 212,
     NotMappedAsPointer = 213,
+    InvalidPtx = 218,
     LaunchFailed = 719,
     NotReady = 600,
     Unknown = 999
@@ -589,6 +590,26 @@ public static class CuBlasNative
         IntPtr B, int Btype, int ldb,
         IntPtr beta,
         IntPtr C, int Ctype, int ldc,
+        int computeType,
+        int algo);
+
+    /// <summary>
+    /// Mixed-precision strided-batched GEMM. This is the closest cuBLAS
+    /// comparison for a packed batch of attention heads because it performs
+    /// the entire Q*K^T fanout with one host launch.
+    /// </summary>
+    [DllImport(CublasLibrary, EntryPoint = "cublasGemmStridedBatchedEx")]
+    public static extern CublasStatus cublasGemmStridedBatchedEx(
+        IntPtr handle,
+        CublasOperation transa,
+        CublasOperation transb,
+        int m, int n, int k,
+        IntPtr alpha,
+        IntPtr A, int Atype, int lda, long strideA,
+        IntPtr B, int Btype, int ldb, long strideB,
+        IntPtr beta,
+        IntPtr C, int Ctype, int ldc, long strideC,
+        int batchCount,
         int computeType,
         int algo);
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.DirectPtx.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.DirectPtx.cs
@@ -1,0 +1,486 @@
+#if NET5_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+
+public sealed partial class CudaBackend
+{
+    private readonly object _directPtxLock = new();
+    private readonly DirectPtxKernelCache<DirectPtxAttentionKey, PtxOnlineFusedAttention128x64Kernel>
+        _directPtxAttentionKernels = new(DirectPtxFeatureGate.CacheCapacity);
+    private readonly DirectPtxPlanCache<DirectPtxAttentionPlanKey, int>
+        _directPtxAttentionPlans = new(DirectPtxFeatureGate.CacheCapacity);
+    private readonly DirectPtxKernelCache<DirectPtxResidualRmsNormKey, PtxFusedResidualRmsNormD64Kernel>
+        _directPtxResidualRmsNormKernels = new(Math.Max(4, DirectPtxFeatureGate.CacheCapacity / 2));
+    private DirectPtxRuntime? _directPtxRuntime;
+
+    /// <summary>The last opt-in direct-PTX initialization/launch failure, if fallback was required.</summary>
+    internal string? DirectPtxLastError { get; private set; }
+    internal long DirectPtxAttentionDispatchCount =>
+        System.Threading.Interlocked.Read(ref _directPtxAttentionDispatchCount);
+    private long _directPtxAttentionDispatchCount;
+    private long _directPtxResidualRmsNormDispatchCount;
+    internal int DirectPtxCachedKernelCount
+    {
+        get { lock (_directPtxLock) return _directPtxAttentionKernels.Count; }
+    }
+
+    internal bool IsDirectPtxAttentionEnabled =>
+        DirectPtxFeatureGate.IsAttentionEnabled && IsAvailable &&
+        DirectPtxArchitecture.HasValidatedOnlineAttention(
+            DirectPtxArchitecture.Classify(_ccMajor, _ccMinor));
+
+    internal bool IsDirectPtxResidualRmsNormEnabled =>
+        DirectPtxFeatureGate.IsResidualRmsNormEnabled && IsAvailable &&
+        DirectPtxArchitecture.Classify(_ccMajor, _ccMinor) == DirectPtxArchitectureFamily.Ampere;
+
+    internal long DirectPtxResidualRmsNormDispatchCount =>
+        System.Threading.Interlocked.Read(ref _directPtxResidualRmsNormDispatchCount);
+
+    /// <summary>
+    /// Attempts the canonical FP16-BHSD S in {16,32,64,128}, D=64 online attention
+    /// specialization. All layout and extent checks happen here; the emitted
+    /// PTX has no dtype, shape, stride, or storage-offset branches.
+    /// </summary>
+    internal bool TryDirectPtxOnlineAttention(
+        IGpuBuffer queryHalf,
+        IGpuBuffer keyHalf,
+        IGpuBuffer valueHalf,
+        IGpuBuffer outputFloat,
+        IGpuBuffer softmaxStatsFloat,
+        int batchHeads,
+        float scale,
+        bool isCausal,
+        int sequenceLength = PtxOnlineFusedAttention128x64Kernel.DefaultSequenceLength)
+    {
+        return TryDirectPtxOnlineAttentionCore(
+            queryHalf, keyHalf, valueHalf,
+            gammaFloat: null, betaFloat: null,
+            outputFloat, softmaxStatsFloat,
+            batchHeads, scale, isCausal,
+            fuseLayerNormGelu: false, epsilon: 1e-5f, sequenceLength);
+    }
+
+    /// <summary>
+    /// Same online attention dataflow with a head-local LayerNorm(D=64),
+    /// affine transform, and tanh-GELU fused before the single output store.
+    /// </summary>
+    internal bool TryDirectPtxOnlineAttentionLayerNormGelu(
+        IGpuBuffer queryHalf,
+        IGpuBuffer keyHalf,
+        IGpuBuffer valueHalf,
+        IGpuBuffer gammaFloat,
+        IGpuBuffer betaFloat,
+        IGpuBuffer outputFloat,
+        IGpuBuffer softmaxStatsFloat,
+        int batchHeads,
+        float scale,
+        bool isCausal,
+        float epsilon = 1e-5f,
+        int sequenceLength = PtxOnlineFusedAttention128x64Kernel.DefaultSequenceLength)
+    {
+        return TryDirectPtxOnlineAttentionCore(
+            queryHalf, keyHalf, valueHalf,
+            gammaFloat, betaFloat,
+            outputFloat, softmaxStatsFloat,
+            batchHeads, scale, isCausal,
+            fuseLayerNormGelu: true, epsilon, sequenceLength);
+    }
+
+    private bool TryDirectPtxOnlineAttentionCore(
+        IGpuBuffer queryHalf,
+        IGpuBuffer keyHalf,
+        IGpuBuffer valueHalf,
+        IGpuBuffer? gammaFloat,
+        IGpuBuffer? betaFloat,
+        IGpuBuffer outputFloat,
+        IGpuBuffer softmaxStatsFloat,
+        int batchHeads,
+        float scale,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float epsilon,
+        int sequenceLength)
+    {
+        if (!IsDirectPtxAttentionEnabled || batchHeads <= 0)
+            return false;
+
+        DirectPtxEligibilityResult eligibility = DirectPtxAttentionEligibility.Evaluate(
+            new DirectPtxAttentionRequest(
+                DirectPtxArchitecture.Classify(_ccMajor, _ccMinor),
+                DirectPtxPhysicalType.Float16,
+                DirectPtxPhysicalLayout.Bhsd,
+                Batch: 1,
+                QueryHeads: batchHeads,
+                KeyValueHeads: batchHeads,
+                QuerySequence: sequenceLength,
+                KeyValueSequence: sequenceLength,
+                HeadDimension: PtxOnlineFusedAttention128x64Kernel.HeadDimension,
+                Mask: isCausal ? DirectPtxAttentionMaskKind.CausalTopLeft : DirectPtxAttentionMaskKind.None,
+                Phase: DirectPtxAttentionPhase.Inference,
+                DropoutProbability: 0,
+                IsRagged: false,
+                UsesPagedKv: false));
+        if (!eligibility.IsEligible)
+        {
+            DirectPtxLastError = eligibility.Reason;
+            return false;
+        }
+
+        try
+        {
+            bool capturing = IsStreamCapturing();
+            // Establish this backend's context once on the calling thread.
+            // DirectPtxRuntime detects it and skips redundant push/pop pairs.
+            EnsureContextCurrent();
+            lock (_directPtxLock)
+            {
+                var planKey = new DirectPtxAttentionPlanKey(
+                    batchHeads, sequenceLength, isCausal, fuseLayerNormGelu,
+                    true,
+                    BitConverter.SingleToInt32Bits(scale),
+                    BitConverter.SingleToInt32Bits(epsilon));
+
+                // Capture may launch only an already-loaded in-memory plan. No
+                // disk lookup, module JIT, event allocation, or autotune occurs
+                // while the stream is recording.
+                if (capturing && (!_directPtxAttentionPlans.TryGetValue(planKey, out int captureWarps) ||
+                    !_directPtxAttentionKernels.TryGetValue(
+                        DirectPtxAttentionKey.FromPlan(planKey, captureWarps), out _)))
+                {
+                    DirectPtxLastError = "Direct PTX attention must be prewarmed before CUDA graph capture.";
+                    return false;
+                }
+
+                _directPtxRuntime ??= new DirectPtxRuntime(_cudaContext, _stream);
+
+                if (!_directPtxAttentionPlans.TryGetValue(planKey, out int selectedWarps))
+                {
+                    bool persisted = DirectPtxAttentionAutotuner.TryLoad(
+                        _directPtxRuntime, batchHeads, sequenceLength, isCausal,
+                        fuseLayerNormGelu, emitStats: true, scale, epsilon, out selectedWarps);
+                    int[] candidates = DirectPtxAttentionAutotuner.Candidates(sequenceLength);
+                    if (!persisted) selectedWarps = candidates[0];
+
+                    if (!persisted && DirectPtxFeatureGate.IsAutotuneEnabled && candidates.Length > 1)
+                    {
+                        double bestMilliseconds = double.PositiveInfinity;
+                        int bestWarps = selectedWarps;
+                        lock (GpuDispatchLock)
+                        {
+                            foreach (int candidate in candidates)
+                            {
+                                PtxOnlineFusedAttention128x64Kernel candidateKernel = GetOrCreateAttentionKernel(
+                                    planKey, candidate, scale, epsilon);
+                                float milliseconds = _directPtxRuntime.MeasureKernelMilliseconds(
+                                    () => LaunchAttentionKernel(
+                                        candidateKernel, queryHalf, keyHalf, valueHalf,
+                                        gammaFloat, betaFloat, outputFloat, softmaxStatsFloat),
+                                    warmup: 3, iterations: 12);
+                                if (milliseconds < bestMilliseconds)
+                                {
+                                    bestMilliseconds = milliseconds;
+                                    bestWarps = candidate;
+                                }
+                            }
+                        }
+                        selectedWarps = bestWarps;
+                        PtxOnlineFusedAttention128x64Kernel winner = GetOrCreateAttentionKernel(
+                            planKey, selectedWarps, scale, epsilon);
+                        DirectPtxAttentionAutotuner.Store(
+                            _directPtxRuntime, batchHeads, sequenceLength, isCausal,
+                            fuseLayerNormGelu, emitStats: true, scale, epsilon,
+                            selectedWarps, bestMilliseconds,
+                            winner.AttentionTflops((float)bestMilliseconds));
+                    }
+                    _directPtxAttentionPlans.Set(planKey, selectedWarps);
+                }
+
+                PtxOnlineFusedAttention128x64Kernel kernel = GetOrCreateAttentionKernel(
+                    planKey, selectedWarps, scale, epsilon);
+                lock (GpuDispatchLock)
+                    LaunchAttentionKernel(
+                        kernel, queryHalf, keyHalf, valueHalf,
+                        gammaFloat, betaFloat, outputFloat, softmaxStatsFloat);
+            }
+            System.Threading.Interlocked.Increment(ref _directPtxAttentionDispatchCount);
+            DirectPtxLastError = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // This is an experimental opt-in path. A bad shape/capability/JIT
+            // must preserve the existing CUDA implementation as the fallback.
+            DirectPtxLastError = $"{ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+
+    private PtxOnlineFusedAttention128x64Kernel GetOrCreateAttentionKernel(
+        DirectPtxAttentionPlanKey plan,
+        int warpsPerBlock,
+        float scale,
+        float epsilon)
+    {
+        DirectPtxAttentionKey key = DirectPtxAttentionKey.FromPlan(plan, warpsPerBlock);
+        return _directPtxAttentionKernels.GetOrAdd(key, () =>
+            new PtxOnlineFusedAttention128x64Kernel(
+                _directPtxRuntime!, plan.BatchHeads, plan.IsCausal,
+                plan.FuseLayerNormGelu, scale, epsilon, plan.SequenceLength,
+                plan.EmitSoftmaxStats, warpsPerBlock));
+    }
+
+    private static void LaunchAttentionKernel(
+        PtxOnlineFusedAttention128x64Kernel kernel,
+        IGpuBuffer queryHalf,
+        IGpuBuffer keyHalf,
+        IGpuBuffer valueHalf,
+        IGpuBuffer? gammaFloat,
+        IGpuBuffer? betaFloat,
+        IGpuBuffer outputFloat,
+        IGpuBuffer softmaxStatsFloat)
+    {
+        DirectPtxTensorView gamma = default;
+        DirectPtxTensorView beta = default;
+        if (kernel.FuseLayerNormGelu)
+        {
+            gamma = DirectPtxTensorView.Create(gammaFloat!, kernel.Blueprint.Tensors[3]);
+            beta = DirectPtxTensorView.Create(betaFloat!, kernel.Blueprint.Tensors[4]);
+        }
+        kernel.Launch(
+            DirectPtxTensorView.Create(queryHalf, kernel.Blueprint.Tensors[0]),
+            DirectPtxTensorView.Create(keyHalf, kernel.Blueprint.Tensors[1]),
+            DirectPtxTensorView.Create(valueHalf, kernel.Blueprint.Tensors[2]),
+            gamma,
+            beta,
+            DirectPtxTensorView.Create(outputFloat, kernel.Blueprint.Tensors[5]),
+            DirectPtxTensorView.Create(softmaxStatsFloat, kernel.Blueprint.Tensors[6]));
+    }
+
+    /// <summary>
+    /// Loads a persisted/default specialization outside capture. Stable caller-
+    /// owned buffers may subsequently launch it while a CUDA graph is recording.
+    /// Autotuning itself requires representative buffers and occurs on first use.
+    /// </summary>
+    internal bool PrewarmDirectPtxAttention(
+        int batchHeads,
+        int sequenceLength,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float scale,
+        float epsilon = 1e-5f)
+    {
+        if (!IsDirectPtxAttentionEnabled || IsStreamCapturing()) return false;
+        try
+        {
+            EnsureContextCurrent();
+            lock (_directPtxLock)
+            {
+                _directPtxRuntime ??= new DirectPtxRuntime(_cudaContext, _stream);
+                var plan = new DirectPtxAttentionPlanKey(
+                    batchHeads, sequenceLength, isCausal, fuseLayerNormGelu, true,
+                    BitConverter.SingleToInt32Bits(scale), BitConverter.SingleToInt32Bits(epsilon));
+                if (!_directPtxAttentionPlans.TryGetValue(plan, out int warps))
+                {
+                    if (!DirectPtxAttentionAutotuner.TryLoad(
+                        _directPtxRuntime, batchHeads, sequenceLength, isCausal,
+                        fuseLayerNormGelu, true, scale, epsilon, out warps))
+                        warps = DirectPtxAttentionAutotuner.Candidates(sequenceLength)[0];
+                    _directPtxAttentionPlans.Set(plan, warps);
+                }
+                _ = GetOrCreateAttentionKernel(plan, warps, scale, epsilon);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            DirectPtxLastError = $"{ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Fuses a transformer residual addition and D=64 RMSNorm. Inputs, gamma,
+    /// output, and saved RMS are FP32 canonical row-major allocations.
+    /// </summary>
+    internal bool TryDirectPtxFusedResidualRmsNorm(
+        IGpuBuffer input,
+        IGpuBuffer residual,
+        IGpuBuffer gamma,
+        IGpuBuffer output,
+        IGpuBuffer savedRms,
+        int rows,
+        float epsilon = 1e-5f)
+    {
+        if (!IsDirectPtxResidualRmsNormEnabled || rows <= 0) return false;
+        try
+        {
+            bool capturing = IsStreamCapturing();
+            EnsureContextCurrent();
+            lock (_directPtxLock)
+            {
+                var key = new DirectPtxResidualRmsNormKey(
+                    rows, BitConverter.SingleToInt32Bits(epsilon));
+                if (capturing && !_directPtxResidualRmsNormKernels.TryGetValue(key, out _))
+                {
+                    DirectPtxLastError = "Direct PTX residual RMSNorm must be prewarmed before CUDA graph capture.";
+                    return false;
+                }
+
+                _directPtxRuntime ??= new DirectPtxRuntime(_cudaContext, _stream);
+                PtxFusedResidualRmsNormD64Kernel kernel =
+                    _directPtxResidualRmsNormKernels.GetOrAdd(key, () =>
+                        new PtxFusedResidualRmsNormD64Kernel(_directPtxRuntime, rows, epsilon));
+                lock (GpuDispatchLock)
+                {
+                    kernel.Launch(
+                        DirectPtxTensorView.Create(input, kernel.Blueprint.Tensors[0]),
+                        DirectPtxTensorView.Create(residual, kernel.Blueprint.Tensors[1]),
+                        DirectPtxTensorView.Create(gamma, kernel.Blueprint.Tensors[2]),
+                        DirectPtxTensorView.Create(output, kernel.Blueprint.Tensors[3]),
+                        DirectPtxTensorView.Create(savedRms, kernel.Blueprint.Tensors[4]));
+                }
+            }
+            System.Threading.Interlocked.Increment(ref _directPtxResidualRmsNormDispatchCount);
+            DirectPtxLastError = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DirectPtxLastError = $"{ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+
+    internal bool PrewarmDirectPtxFusedResidualRmsNorm(int rows, float epsilon = 1e-5f)
+    {
+        if (!IsDirectPtxResidualRmsNormEnabled || IsStreamCapturing()) return false;
+        try
+        {
+            EnsureContextCurrent();
+            lock (_directPtxLock)
+            {
+                _directPtxRuntime ??= new DirectPtxRuntime(_cudaContext, _stream);
+                var key = new DirectPtxResidualRmsNormKey(rows, BitConverter.SingleToInt32Bits(epsilon));
+                _ = _directPtxResidualRmsNormKernels.GetOrAdd(key, () =>
+                    new PtxFusedResidualRmsNormD64Kernel(_directPtxRuntime, rows, epsilon));
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            DirectPtxLastError = $"{ex.GetType().Name}: {ex.Message}";
+            return false;
+        }
+    }
+
+    internal bool TryGetDirectPtxResidualRmsNormAudit(
+        int rows,
+        float epsilon,
+        out DirectPtxKernelAudit audit)
+    {
+        lock (_directPtxLock)
+        {
+            var key = new DirectPtxResidualRmsNormKey(rows, BitConverter.SingleToInt32Bits(epsilon));
+            if (_directPtxResidualRmsNormKernels.TryGetValue(key, out var kernel))
+            {
+                audit = kernel.Audit;
+                return true;
+            }
+        }
+        audit = null!;
+        return false;
+    }
+
+    internal bool TryGetDirectPtxAttentionAudit(
+        int batchHeads,
+        float scale,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float epsilon,
+        int sequenceLength,
+        out DirectPtxFunctionInfo info,
+        out string jitInfoLog)
+    {
+        lock (_directPtxLock)
+        {
+            var plan = new DirectPtxAttentionPlanKey(
+                batchHeads, sequenceLength, isCausal, fuseLayerNormGelu,
+                true,
+                BitConverter.SingleToInt32Bits(scale),
+                BitConverter.SingleToInt32Bits(epsilon));
+            if (_directPtxAttentionPlans.TryGetValue(plan, out int warps) &&
+                _directPtxAttentionKernels.TryGetValue(
+                    DirectPtxAttentionKey.FromPlan(plan, warps), out var kernel))
+            {
+                info = kernel.FunctionInfo;
+                jitInfoLog = kernel.JitInfoLog;
+                return true;
+            }
+        }
+        info = default;
+        jitInfoLog = string.Empty;
+        return false;
+    }
+
+    internal bool TryGetDirectPtxAttentionKernelAudit(
+        int batchHeads,
+        float scale,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float epsilon,
+        int sequenceLength,
+        out DirectPtxKernelAudit audit)
+    {
+        lock (_directPtxLock)
+        {
+            var plan = new DirectPtxAttentionPlanKey(
+                batchHeads, sequenceLength, isCausal, fuseLayerNormGelu, true,
+                BitConverter.SingleToInt32Bits(scale), BitConverter.SingleToInt32Bits(epsilon));
+            if (_directPtxAttentionPlans.TryGetValue(plan, out int warps) &&
+                _directPtxAttentionKernels.TryGetValue(
+                    DirectPtxAttentionKey.FromPlan(plan, warps), out var kernel))
+            {
+                audit = kernel.Audit;
+                return true;
+            }
+        }
+        audit = null!;
+        return false;
+    }
+
+    private void DisposeDirectPtxRuntime()
+    {
+        lock (_directPtxLock)
+        {
+            _directPtxAttentionKernels.Dispose();
+            _directPtxAttentionPlans.Clear();
+            _directPtxResidualRmsNormKernels.Dispose();
+            _directPtxRuntime?.Dispose();
+            _directPtxRuntime = null;
+        }
+    }
+
+    private readonly record struct DirectPtxAttentionPlanKey(
+        int BatchHeads,
+        int SequenceLength,
+        bool IsCausal,
+        bool FuseLayerNormGelu,
+        bool EmitSoftmaxStats,
+        int ScaleBits,
+        int EpsilonBits);
+
+    private readonly record struct DirectPtxAttentionKey(
+        DirectPtxAttentionPlanKey Plan,
+        int WarpsPerBlock)
+    {
+        internal static DirectPtxAttentionKey FromPlan(
+            DirectPtxAttentionPlanKey plan,
+            int warpsPerBlock) => new(plan, warpsPerBlock);
+    }
+
+    private readonly record struct DirectPtxResidualRmsNormKey(int Rows, int EpsilonBits);
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -15572,6 +15572,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         // finalizer-fatal 0xC0000005 path this method's teardown guards exist to prevent.
         DrainDeferredFrees(blockOldest: true);
 
+        // Direct-PTX modules borrow this backend's context and stream. Unload
+        // them while both handles are still alive, before pool/stream teardown.
+#if NET5_0_OR_GREATER
+        DisposeDirectPtxRuntime();
+#endif
+
         _pinnedPool.Dispose();
         _bufferPool.Dispose();
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -21,6 +21,27 @@ public enum CudaDeviceAttribute
     CooperativeLaunch = 95
 }
 
+/// <summary>
+/// CUDA function attributes returned by <c>cuFuncGetAttribute</c>.
+/// These values are part of the CUDA Driver API ABI.
+/// </summary>
+internal enum CudaFunctionAttribute
+{
+    MaxThreadsPerBlock = 0,
+    SharedSizeBytes = 1,
+    ConstSizeBytes = 2,
+    LocalSizeBytes = 3,
+    NumRegisters = 4,
+    PtxVersion = 5,
+    BinaryVersion = 6
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct CudaDeviceUuid
+{
+    internal fixed byte Bytes[16];
+}
+
 internal static class CudaNativeBindings
 {
 #if WINDOWS
@@ -86,14 +107,29 @@ internal static class CudaNativeBindings
     [DllImport(CudaLibrary, EntryPoint = "cuDeviceTotalMem_v2")]
     public static extern CudaResult cuDeviceTotalMem(out ulong bytes, int device);
 
+    [DllImport(CudaLibrary, EntryPoint = "cuDeviceGetUuid_v2")]
+    internal static extern CudaResult cuDeviceGetUuidV2(out CudaDeviceUuid uuid, int device);
+
     [DllImport(CudaLibrary, EntryPoint = "cuModuleLoadData")]
     public static extern CudaResult cuModuleLoadData(out IntPtr module, IntPtr image);
+
+    [DllImport(CudaLibrary, EntryPoint = "cuModuleLoadDataEx")]
+    public static extern CudaResult cuModuleLoadDataEx(
+        out IntPtr module,
+        IntPtr image,
+        uint numOptions,
+        [In] int[] options,
+        [In] IntPtr[] optionValues);
 
     [DllImport(CudaLibrary, EntryPoint = "cuModuleUnload")]
     public static extern CudaResult cuModuleUnload(IntPtr module);
 
     [DllImport(CudaLibrary, EntryPoint = "cuModuleGetFunction")]
     public static extern CudaResult cuModuleGetFunction(out IntPtr function, IntPtr module, string name);
+
+    [DllImport(CudaLibrary, EntryPoint = "cuFuncGetAttribute")]
+    public static extern CudaResult cuFuncGetAttribute(
+        out int value, CudaFunctionAttribute attribute, IntPtr function);
 
     [DllImport(CudaLibrary, EntryPoint = "cuLaunchKernel")]
     public static extern CudaResult cuLaunchKernel(
@@ -294,6 +330,9 @@ internal static class CudaNativeBindings
 
     [DllImport(CudaLibrary, EntryPoint = "cuCtxGetCurrent")]
     public static extern CudaResult cuCtxGetCurrent(out IntPtr ctx);
+
+    [DllImport(CudaLibrary, EntryPoint = "cuCtxGetDevice")]
+    public static extern CudaResult cuCtxGetDevice(out int device);
 
     [DllImport(CudaLibrary, EntryPoint = "cuCtxPushCurrent_v2")]
     public static extern CudaResult cuCtxPushCurrent(IntPtr ctx);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionAutotuner.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionAutotuner.cs
@@ -1,0 +1,102 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using AiDotNet.Tensors.Helpers.Autotune;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+internal static class DirectPtxAttentionAutotuner
+{
+    private const string VariantPrefix = "query-warps-";
+
+    internal static int[] Candidates(int sequenceLength) => sequenceLength switch
+    {
+        16 => [1],
+        32 => [2, 1],
+        64 => [4, 2],
+        128 => [8, 4],
+        _ => throw new ArgumentOutOfRangeException(nameof(sequenceLength))
+    };
+
+    internal static bool TryLoad(
+        DirectPtxRuntime runtime,
+        int batchHeads,
+        int sequenceLength,
+        bool isCausal,
+        bool fused,
+        bool emitStats,
+        float scale,
+        float epsilon,
+        out int warps)
+    {
+        KernelChoice? choice = AutotuneCache.Lookup(
+            KernelId(runtime), Shape(batchHeads, sequenceLength, isCausal, fused, emitStats, scale, epsilon));
+        if (choice?.Variant?.StartsWith(VariantPrefix, StringComparison.Ordinal) == true &&
+            int.TryParse(choice.Variant.AsSpan(VariantPrefix.Length), NumberStyles.None,
+                CultureInfo.InvariantCulture, out int parsed) &&
+            Array.IndexOf(Candidates(sequenceLength), parsed) >= 0)
+        {
+            warps = parsed;
+            return true;
+        }
+        warps = 0;
+        return false;
+    }
+
+    internal static void Store(
+        DirectPtxRuntime runtime,
+        int batchHeads,
+        int sequenceLength,
+        bool isCausal,
+        bool fused,
+        bool emitStats,
+        float scale,
+        float epsilon,
+        int warps,
+        double milliseconds,
+        double tflops)
+    {
+        try
+        {
+            AutotuneCache.Store(
+                KernelId(runtime),
+                Shape(batchHeads, sequenceLength, isCausal, fused, emitStats, scale, epsilon),
+                new KernelChoice
+                {
+                    Variant = VariantPrefix + warps.ToString(CultureInfo.InvariantCulture),
+                    Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["QueryTileRows"] = PtxOnlineFusedAttention128x64Kernel.QueryTileRows.ToString(CultureInfo.InvariantCulture),
+                        ["KeyTileRows"] = PtxOnlineFusedAttention128x64Kernel.KeyTileRows.ToString(CultureInfo.InvariantCulture),
+                        ["WarpsPerBlock"] = warps.ToString(CultureInfo.InvariantCulture),
+                        ["GpuFingerprint"] = runtime.DeviceFingerprint
+                    },
+                    MeasuredTimeMs = milliseconds,
+                    MeasuredGflops = tflops * 1000.0,
+                    RecordedAtUtc = DateTime.UtcNow
+                });
+        }
+        catch
+        {
+            // Persistence is advisory. A read-only home directory must not
+            // disable a numerically valid in-memory winner.
+        }
+    }
+
+    private static KernelId KernelId(DirectPtxRuntime runtime) =>
+        new("direct-ptx-sdpa", $"online-attention-v2-{runtime.DeviceFingerprint}");
+
+    private static ShapeProfile Shape(
+        int batchHeads,
+        int sequenceLength,
+        bool isCausal,
+        bool fused,
+        bool emitStats,
+        float scale,
+        float epsilon) =>
+        new(batchHeads, sequenceLength, PtxOnlineFusedAttention128x64Kernel.HeadDimension,
+            isCausal ? 1 : 0, fused ? 1 : 0, emitStats ? 1 : 0,
+            BitConverter.SingleToInt32Bits(scale), BitConverter.SingleToInt32Bits(epsilon));
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionEligibility.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionEligibility.cs
@@ -61,7 +61,7 @@ internal static class DirectPtxAttentionEligibility
             return DirectPtxEligibilityResult.Reject("gqa-mqa-not-implemented");
         if (request.QuerySequence != request.KeyValueSequence)
             return DirectPtxEligibilityResult.Reject("non-square-attention-not-implemented");
-        if (request.QuerySequence is not (16 or 32 or 64 or 128))
+        if (!PtxOnlineFusedAttention128x64Kernel.IsSupportedSequenceLength(request.QuerySequence))
             return DirectPtxEligibilityResult.Reject("sequence-bucket-not-implemented");
         if (request.HeadDimension != PtxOnlineFusedAttention128x64Kernel.HeadDimension)
             return DirectPtxEligibilityResult.Reject("head-dimension-not-64");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionEligibility.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxAttentionEligibility.cs
@@ -1,0 +1,81 @@
+#if NET5_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+internal enum DirectPtxAttentionMaskKind
+{
+    None,
+    CausalTopLeft,
+    AdditiveBias,
+    Padding,
+    SlidingWindow,
+    BlockSparse
+}
+
+internal enum DirectPtxAttentionPhase
+{
+    Inference,
+    TrainingForward,
+    Backward
+}
+
+internal readonly record struct DirectPtxAttentionRequest(
+    DirectPtxArchitectureFamily Architecture,
+    DirectPtxPhysicalType InputType,
+    DirectPtxPhysicalLayout Layout,
+    int Batch,
+    int QueryHeads,
+    int KeyValueHeads,
+    int QuerySequence,
+    int KeyValueSequence,
+    int HeadDimension,
+    DirectPtxAttentionMaskKind Mask,
+    DirectPtxAttentionPhase Phase,
+    float DropoutProbability,
+    bool IsRagged,
+    bool UsesPagedKv);
+
+internal readonly record struct DirectPtxEligibilityResult(bool IsEligible, string Reason)
+{
+    internal static DirectPtxEligibilityResult Eligible => new(true, "eligible");
+    internal static DirectPtxEligibilityResult Reject(string reason) => new(false, reason);
+}
+
+/// <summary>
+/// Single source of truth for the checked-in specialization's semantic domain.
+/// Unsupported requests are explicit fallback decisions, never latent stride
+/// or shape branches in PTX.
+/// </summary>
+internal static class DirectPtxAttentionEligibility
+{
+    internal static DirectPtxEligibilityResult Evaluate(in DirectPtxAttentionRequest request)
+    {
+        if (!DirectPtxArchitecture.HasValidatedOnlineAttention(request.Architecture))
+            return DirectPtxEligibilityResult.Reject("architecture-family-not-validated");
+        if (request.InputType != DirectPtxPhysicalType.Float16)
+            return DirectPtxEligibilityResult.Reject("dtype-not-fp16");
+        if (request.Layout != DirectPtxPhysicalLayout.Bhsd)
+            return DirectPtxEligibilityResult.Reject("layout-not-dense-bhsd");
+        if (request.Batch <= 0 || request.QueryHeads <= 0 || request.KeyValueHeads <= 0)
+            return DirectPtxEligibilityResult.Reject("invalid-batch-or-head-count");
+        if (request.QueryHeads != request.KeyValueHeads)
+            return DirectPtxEligibilityResult.Reject("gqa-mqa-not-implemented");
+        if (request.QuerySequence != request.KeyValueSequence)
+            return DirectPtxEligibilityResult.Reject("non-square-attention-not-implemented");
+        if (request.QuerySequence is not (16 or 32 or 64 or 128))
+            return DirectPtxEligibilityResult.Reject("sequence-bucket-not-implemented");
+        if (request.HeadDimension != PtxOnlineFusedAttention128x64Kernel.HeadDimension)
+            return DirectPtxEligibilityResult.Reject("head-dimension-not-64");
+        if (request.Mask is not (DirectPtxAttentionMaskKind.None or DirectPtxAttentionMaskKind.CausalTopLeft))
+            return DirectPtxEligibilityResult.Reject("mask-kind-not-implemented");
+        if (request.Phase != DirectPtxAttentionPhase.Inference)
+            return DirectPtxEligibilityResult.Reject("training-or-backward-not-implemented");
+        if (request.DropoutProbability != 0)
+            return DirectPtxEligibilityResult.Reject("dropout-not-implemented");
+        if (request.IsRagged)
+            return DirectPtxEligibilityResult.Reject("ragged-layout-not-implemented");
+        if (request.UsesPagedKv)
+            return DirectPtxEligibilityResult.Reject("paged-kv-not-implemented");
+        return DirectPtxEligibilityResult.Eligible;
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxFeatureGate.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxFeatureGate.cs
@@ -1,0 +1,207 @@
+#if NET5_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Opt-in gate for hand-emitted PTX kernels. The gate is deliberately off by
+/// default until a specialization passes its correctness, no-spill, and
+/// championship benchmarks on a supported SM.
+/// </summary>
+internal static class DirectPtxFeatureGate
+{
+    internal const string MasterEnvironmentVariable = "AIDOTNET_DIRECT_PTX";
+    internal const string EnvironmentVariable = "AIDOTNET_DIRECT_PTX_ATTENTION";
+    internal const string ResidualRmsNormEnvironmentVariable = "AIDOTNET_DIRECT_PTX_RESIDUAL_RMSNORM";
+    internal const string AutotuneEnvironmentVariable = "AIDOTNET_DIRECT_PTX_AUTOTUNE";
+    internal const string CacheCapacityEnvironmentVariable = "AIDOTNET_DIRECT_PTX_CACHE_CAPACITY";
+
+    /// <summary>Test-only override. Null restores environment-based behavior.</summary>
+    internal static bool? TestOverride { get; set; }
+
+    internal static bool IsEnabled => IsAttentionEnabled;
+
+    internal static bool IsAttentionEnabled => TestOverride ??
+        (string.Equals(Environment.GetEnvironmentVariable(MasterEnvironmentVariable), "1", StringComparison.Ordinal) ||
+         string.Equals(Environment.GetEnvironmentVariable(EnvironmentVariable), "1", StringComparison.Ordinal));
+
+    internal static bool IsResidualRmsNormEnabled => TestOverride ??
+        (string.Equals(Environment.GetEnvironmentVariable(MasterEnvironmentVariable), "1", StringComparison.Ordinal) ||
+         string.Equals(Environment.GetEnvironmentVariable(ResidualRmsNormEnvironmentVariable), "1", StringComparison.Ordinal));
+
+    internal static bool IsAutotuneEnabled =>
+        !string.Equals(Environment.GetEnvironmentVariable(AutotuneEnvironmentVariable), "0", StringComparison.Ordinal);
+
+    internal static int CacheCapacity
+    {
+        get
+        {
+            string? text = Environment.GetEnvironmentVariable(CacheCapacityEnvironmentVariable);
+            return int.TryParse(text, out int value) && value is >= 4 and <= 256 ? value : 32;
+        }
+    }
+}
+
+internal enum DirectPtxPhysicalType
+{
+    Float16,
+    BFloat16,
+    Float32,
+    Int32
+}
+
+internal enum DirectPtxPhysicalLayout
+{
+    /// <summary>Dense row-major [batch, head, sequence, dimension].</summary>
+    Bhsd,
+    /// <summary>Dense row-major [row, feature].</summary>
+    RowMajor2D,
+    /// <summary>Dense [row, qkv, head, feature] projection output.</summary>
+    PackedQkv,
+    /// <summary>One-dimensional canonical vector.</summary>
+    Vector,
+    /// <summary>Block table plus packed pages for decode attention.</summary>
+    PagedKv
+}
+
+/// <summary>
+/// Capability token for an already-validated device allocation. It contains
+/// no strides: construction proves that the pointer obeys the specialization's
+/// canonical physical layout, dtype, byte extent, and alignment.
+/// </summary>
+internal readonly struct DirectPtxTensorView
+{
+    internal IntPtr Pointer { get; }
+    internal nuint ByteLength { get; }
+    internal nuint AllocationByteLength { get; }
+    internal DirectPtxPhysicalType PhysicalType { get; }
+    internal DirectPtxPhysicalLayout Layout { get; }
+    internal DirectPtxExtent LogicalExtent { get; }
+    internal DirectPtxExtent PhysicalExtent { get; }
+    internal DirectPtxTensorAccess Access { get; }
+
+    private DirectPtxTensorView(
+        IntPtr pointer,
+        nuint byteLength,
+        nuint allocationByteLength,
+        DirectPtxPhysicalType physicalType,
+        DirectPtxPhysicalLayout layout,
+        DirectPtxExtent logicalExtent,
+        DirectPtxExtent physicalExtent,
+        DirectPtxTensorAccess access)
+    {
+        Pointer = pointer;
+        ByteLength = byteLength;
+        AllocationByteLength = allocationByteLength;
+        PhysicalType = physicalType;
+        Layout = layout;
+        LogicalExtent = logicalExtent;
+        PhysicalExtent = physicalExtent;
+        Access = access;
+    }
+
+    internal static DirectPtxTensorView Create(
+        IGpuBuffer buffer,
+        DirectPtxTensorContract contract,
+        nuint byteOffset = 0)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if (buffer.Handle == IntPtr.Zero)
+            throw new ArgumentException("The GPU buffer has no device pointer.", nameof(buffer));
+        nuint allocationBytes = checked((nuint)buffer.SizeInBytes);
+        nuint end = checked(byteOffset + contract.RequiredBytes);
+        if (end > allocationBytes ||
+            (contract.ExtentMode == DirectPtxExtentMode.Exact && end != allocationBytes))
+            throw new ArgumentException(
+                $"Tensor '{contract.Name}' requires {contract.RequiredBytes} bytes at offset {byteOffset}; allocation has {allocationBytes}.",
+                nameof(buffer));
+        nuint pointerValue = checked((nuint)buffer.Handle + byteOffset);
+        if ((pointerValue & (nuint)(contract.AlignmentBytes - 1)) != 0)
+            throw new ArgumentException(
+                $"Tensor '{contract.Name}' is not {contract.AlignmentBytes}-byte aligned.", nameof(buffer));
+        if (byteOffset % (nuint)contract.ElementBytes != 0 || allocationBytes % (nuint)contract.ElementBytes != 0)
+            throw new ArgumentException(
+                $"Tensor '{contract.Name}' extent/offset is incompatible with {contract.PhysicalType}.", nameof(buffer));
+
+        return new DirectPtxTensorView(
+            (IntPtr)pointerValue,
+            contract.RequiredBytes,
+            allocationBytes,
+            contract.PhysicalType,
+            contract.Layout,
+            contract.LogicalExtent,
+            contract.PhysicalExtent,
+            contract.Access);
+    }
+
+    internal static DirectPtxTensorView CreateBhsd(
+        IGpuBuffer buffer,
+        DirectPtxPhysicalType physicalType,
+        nuint requiredBytes,
+        int requiredAlignment = 16)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if (buffer.Handle == IntPtr.Zero)
+            throw new ArgumentException("The GPU buffer has no device pointer.", nameof(buffer));
+        if (requiredBytes == 0 || checked((nuint)buffer.SizeInBytes) < requiredBytes)
+            throw new ArgumentException(
+                $"The GPU buffer has {buffer.SizeInBytes} bytes; the canonical BHSD view requires {requiredBytes}.",
+                nameof(buffer));
+        if (requiredAlignment <= 0 || (requiredAlignment & (requiredAlignment - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(requiredAlignment), "Alignment must be a power of two.");
+        if (((nuint)buffer.Handle & (nuint)(requiredAlignment - 1)) != 0)
+            throw new ArgumentException(
+                $"The GPU pointer is not {requiredAlignment}-byte aligned.", nameof(buffer));
+
+        long elementBytes = physicalType is DirectPtxPhysicalType.Float16 or DirectPtxPhysicalType.BFloat16 ? 2L : 4L;
+        if (buffer.SizeInBytes % elementBytes != 0)
+            throw new ArgumentException("The buffer byte extent is incompatible with its physical dtype.", nameof(buffer));
+
+        int elements = checked((int)(requiredBytes / (nuint)elementBytes));
+        return new DirectPtxTensorView(
+            buffer.Handle, requiredBytes, checked((nuint)buffer.SizeInBytes), physicalType,
+            DirectPtxPhysicalLayout.Bhsd, new DirectPtxExtent(elements),
+            new DirectPtxExtent(elements), DirectPtxTensorAccess.ReadWrite);
+    }
+
+    internal static DirectPtxTensorView CreateOwned(
+        DirectPtxBuffer buffer,
+        DirectPtxPhysicalType physicalType,
+        nuint requiredBytes)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if (buffer.Pointer == IntPtr.Zero || buffer.ByteLength < requiredBytes)
+            throw new ArgumentException("The direct PTX buffer is smaller than the canonical BHSD view.", nameof(buffer));
+        if (((nuint)buffer.Pointer & 15u) != 0)
+            throw new ArgumentException("The direct PTX buffer is not 16-byte aligned.", nameof(buffer));
+        int elementBytes = physicalType is DirectPtxPhysicalType.Float16 or DirectPtxPhysicalType.BFloat16 ? 2 : 4;
+        int elements = checked((int)(requiredBytes / (nuint)elementBytes));
+        return new DirectPtxTensorView(
+            buffer.Pointer, requiredBytes, buffer.ByteLength, physicalType,
+            DirectPtxPhysicalLayout.Bhsd, new DirectPtxExtent(elements),
+            new DirectPtxExtent(elements), DirectPtxTensorAccess.ReadWrite);
+    }
+
+    internal static DirectPtxTensorView CreateOwned(
+        DirectPtxBuffer buffer,
+        DirectPtxTensorContract contract,
+        nuint byteOffset = 0)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        nuint end = checked(byteOffset + contract.RequiredBytes);
+        if (buffer.Pointer == IntPtr.Zero || end > buffer.ByteLength ||
+            (contract.ExtentMode == DirectPtxExtentMode.Exact && end != buffer.ByteLength))
+            throw new ArgumentException(
+                $"The direct PTX buffer does not satisfy tensor ABI '{contract.Name}'.", nameof(buffer));
+        nuint pointer = checked((nuint)buffer.Pointer + byteOffset);
+        if ((pointer & (nuint)(contract.AlignmentBytes - 1)) != 0)
+            throw new ArgumentException(
+                $"Tensor '{contract.Name}' is not {contract.AlignmentBytes}-byte aligned.", nameof(buffer));
+        return new DirectPtxTensorView(
+            (IntPtr)pointer, contract.RequiredBytes, buffer.ByteLength,
+            contract.PhysicalType, contract.Layout, contract.LogicalExtent,
+            contract.PhysicalExtent, contract.Access);
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelBlueprint.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelBlueprint.cs
@@ -1,0 +1,304 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>Hardware families are deliberately separate tuning domains.</summary>
+internal enum DirectPtxArchitectureFamily
+{
+    Unsupported,
+    Ampere,
+    Ada,
+    Hopper,
+    Blackwell
+}
+
+internal static class DirectPtxArchitecture
+{
+    internal static DirectPtxArchitectureFamily Classify(int major, int minor) => (major, minor) switch
+    {
+        (8, 9) => DirectPtxArchitectureFamily.Ada,
+        (8, _) => DirectPtxArchitectureFamily.Ampere,
+        (9, _) => DirectPtxArchitectureFamily.Hopper,
+        (>= 10, _) => DirectPtxArchitectureFamily.Blackwell,
+        _ => DirectPtxArchitectureFamily.Unsupported
+    };
+
+    /// <summary>
+    /// The checked-in asynchronous attention implementation is an Ampere
+    /// specialization. Other families must supply and benchmark their own
+    /// implementation instead of silently inheriting Ampere's tuning.
+    /// </summary>
+    internal static bool HasValidatedOnlineAttention(DirectPtxArchitectureFamily family) =>
+        family == DirectPtxArchitectureFamily.Ampere;
+}
+
+internal enum DirectPtxExtentMode
+{
+    AtLeast,
+    Exact
+}
+
+[Flags]
+internal enum DirectPtxTensorAccess
+{
+    Read = 1,
+    Write = 2,
+    ReadWrite = Read | Write
+}
+
+/// <summary>A fixed-size rank-four extent that does not allocate on hot paths.</summary>
+internal readonly record struct DirectPtxExtent
+{
+    internal int Rank { get; }
+    internal int D0 { get; }
+    internal int D1 { get; }
+    internal int D2 { get; }
+    internal int D3 { get; }
+
+    internal DirectPtxExtent(int d0)
+        : this(1, d0, 1, 1, 1) { }
+
+    internal DirectPtxExtent(int d0, int d1)
+        : this(2, d0, d1, 1, 1) { }
+
+    internal DirectPtxExtent(int d0, int d1, int d2, int d3)
+        : this(4, d0, d1, d2, d3) { }
+
+    private DirectPtxExtent(int rank, int d0, int d1, int d2, int d3)
+    {
+        if (rank is < 1 or > 4) throw new ArgumentOutOfRangeException(nameof(rank));
+        if (d0 <= 0 || d1 <= 0 || d2 <= 0 || d3 <= 0)
+            throw new ArgumentOutOfRangeException(nameof(d0), "Physical extents must be positive.");
+        Rank = rank;
+        D0 = d0;
+        D1 = d1;
+        D2 = d2;
+        D3 = d3;
+    }
+
+    internal long ElementCount => checked((long)D0 * D1 * D2 * D3);
+
+    public override string ToString() => Rank switch
+    {
+        1 => $"[{D0}]",
+        2 => $"[{D0},{D1}]",
+        3 => $"[{D0},{D1},{D2}]",
+        _ => $"[{D0},{D1},{D2},{D3}]"
+    };
+}
+
+/// <summary>
+/// Immutable physical ABI for one kernel argument. Logical and physical
+/// extents are separate so later padded, packed, ragged, and paged layouts do
+/// not need to reintroduce dynamic strides inside the kernel.
+/// </summary>
+internal readonly record struct DirectPtxTensorContract
+{
+    internal string Name { get; }
+    internal DirectPtxPhysicalType PhysicalType { get; }
+    internal DirectPtxPhysicalLayout Layout { get; }
+    internal DirectPtxExtent LogicalExtent { get; }
+    internal DirectPtxExtent PhysicalExtent { get; }
+    internal int AlignmentBytes { get; }
+    internal DirectPtxTensorAccess Access { get; }
+    internal DirectPtxExtentMode ExtentMode { get; }
+
+    internal DirectPtxTensorContract(
+        string name,
+        DirectPtxPhysicalType physicalType,
+        DirectPtxPhysicalLayout layout,
+        DirectPtxExtent logicalExtent,
+        DirectPtxExtent physicalExtent,
+        int alignmentBytes,
+        DirectPtxTensorAccess access,
+        DirectPtxExtentMode extentMode = DirectPtxExtentMode.AtLeast)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("A tensor ABI name is required.", nameof(name));
+        if (alignmentBytes <= 0 || (alignmentBytes & (alignmentBytes - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(alignmentBytes), "Alignment must be a power of two.");
+        if (physicalExtent.ElementCount < logicalExtent.ElementCount)
+            throw new ArgumentException("Physical extent cannot be smaller than logical extent.", nameof(physicalExtent));
+        Name = name;
+        PhysicalType = physicalType;
+        Layout = layout;
+        LogicalExtent = logicalExtent;
+        PhysicalExtent = physicalExtent;
+        AlignmentBytes = alignmentBytes;
+        Access = access;
+        ExtentMode = extentMode;
+    }
+
+    internal nuint RequiredBytes => checked((nuint)PhysicalExtent.ElementCount * (nuint)ElementBytes);
+    internal int ElementBytes => PhysicalType switch
+    {
+        DirectPtxPhysicalType.Float16 or DirectPtxPhysicalType.BFloat16 => 2,
+        DirectPtxPhysicalType.Float32 => 4,
+        DirectPtxPhysicalType.Int32 => 4,
+        _ => throw new ArgumentOutOfRangeException(nameof(PhysicalType))
+    };
+}
+
+internal readonly record struct DirectPtxResourceBudget(
+    int MaxRegistersPerThread,
+    int MaxStaticSharedBytes,
+    int MaxLocalBytesPerThread,
+    int MinBlocksPerMultiprocessor)
+{
+    internal void Validate(
+        string kernelName,
+        DirectPtxFunctionInfo info,
+        int blockThreads,
+        int activeBlocksPerMultiprocessor)
+    {
+        if (info.LocalBytesPerThread > MaxLocalBytesPerThread)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{kernelName}' has {info.LocalBytesPerThread} local bytes/thread; budget is {MaxLocalBytesPerThread}.");
+        if (info.RegistersPerThread > MaxRegistersPerThread)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{kernelName}' uses {info.RegistersPerThread} registers/thread; budget is {MaxRegistersPerThread}.");
+        if (info.StaticSharedBytes > MaxStaticSharedBytes)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{kernelName}' uses {info.StaticSharedBytes} static shared bytes; budget is {MaxStaticSharedBytes}.");
+        if (blockThreads > info.MaxThreadsPerBlock)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{kernelName}' requests {blockThreads} threads but the JIT limit is {info.MaxThreadsPerBlock}.");
+        if (activeBlocksPerMultiprocessor < MinBlocksPerMultiprocessor)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{kernelName}' admits only {activeBlocksPerMultiprocessor} blocks/SM; budget requires {MinBlocksPerMultiprocessor}.");
+    }
+}
+
+/// <summary>Versioned, inspectable contract shipped with every direct kernel.</summary>
+internal sealed record DirectPtxKernelBlueprint(
+    string Operation,
+    int Version,
+    DirectPtxArchitectureFamily Architecture,
+    string Variant,
+    IReadOnlyList<DirectPtxTensorContract> Tensors,
+    DirectPtxResourceBudget ResourceBudget,
+    IReadOnlyDictionary<string, string> Semantics)
+{
+    internal string Id => $"{Operation}-v{Version}-{Architecture}-{Variant}";
+}
+
+/// <summary>JIT resource report plus a content identity for the exact PTX.</summary>
+internal sealed record DirectPtxKernelAudit(
+    string BlueprintId,
+    string DeviceFingerprint,
+    string PtxSha256,
+    DirectPtxFunctionInfo Function,
+    int BlockThreads,
+    int ActiveBlocksPerMultiprocessor,
+    string JitInfoLog,
+    DateTime RecordedAtUtc)
+{
+    internal static DirectPtxKernelAudit Create(
+        DirectPtxKernelBlueprint blueprint,
+        string deviceFingerprint,
+        string ptx,
+        DirectPtxFunctionInfo function,
+        int blockThreads,
+        int activeBlocksPerMultiprocessor,
+        string jitInfoLog)
+    {
+        using SHA256 sha = SHA256.Create();
+        string hash = Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(ptx))).ToLowerInvariant();
+        return new DirectPtxKernelAudit(
+            blueprint.Id, deviceFingerprint, hash, function, blockThreads,
+            activeBlocksPerMultiprocessor, jitInfoLog, DateTime.UtcNow);
+    }
+
+    internal string ToJson() => JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+}
+
+/// <summary>
+/// Optional Nsight Compute evidence. Driver-reported local size remains the
+/// runtime gate; release evidence additionally requires executed spill and
+/// local-memory counters to be zero.
+/// </summary>
+internal sealed record DirectPtxProfilerEvidence(
+    long RegisterSpillInstructions,
+    long LocalLoadInstructions,
+    long LocalStoreInstructions,
+    long LocalSpillRequests,
+    int ObservedMetricGroups,
+    string Source)
+{
+    internal bool ProvesZeroExecutedSpills =>
+        ObservedMetricGroups == 4 &&
+        RegisterSpillInstructions == 0 && LocalLoadInstructions == 0 &&
+        LocalStoreInstructions == 0 && LocalSpillRequests == 0;
+
+    internal static DirectPtxProfilerEvidence FromNcuCsv(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var values = new Dictionary<string, long>(StringComparer.Ordinal);
+        foreach (string line in File.ReadLines(path))
+        {
+            if (!line.Contains("sass__", StringComparison.Ordinal) &&
+                !line.Contains("derived__local_spilling_requests", StringComparison.Ordinal))
+                continue;
+            string[] cells = ParseCsvLine(line);
+            for (int i = 0; i < cells.Length; i++)
+            {
+                string metric = cells[i].Trim();
+                if (!IsSpillMetric(metric)) continue;
+                for (int valueIndex = cells.Length - 1; valueIndex > i; valueIndex--)
+                {
+                    string normalized = cells[valueIndex].Trim().Replace(",", string.Empty, StringComparison.Ordinal);
+                    if (long.TryParse(normalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))
+                    {
+                        values[metric] = checked(values.GetValueOrDefault(metric) + value);
+                        break;
+                    }
+                }
+            }
+        }
+
+        long Get(params string[] names) => names.Sum(name => values.GetValueOrDefault(name));
+        int observedGroups = 0;
+        if (values.ContainsKey("sass__inst_executed_register_spilling") ||
+            values.ContainsKey("sass__inst_executed_register_spilling_mem_local")) observedGroups++;
+        if (values.ContainsKey("sass__inst_executed_local_loads")) observedGroups++;
+        if (values.ContainsKey("sass__inst_executed_local_stores")) observedGroups++;
+        if (values.ContainsKey("derived__local_spilling_requests")) observedGroups++;
+        return new DirectPtxProfilerEvidence(
+            Get("sass__inst_executed_register_spilling", "sass__inst_executed_register_spilling_mem_local"),
+            Get("sass__inst_executed_local_loads"),
+            Get("sass__inst_executed_local_stores"),
+            Get("derived__local_spilling_requests"),
+            observedGroups,
+            Path.GetFullPath(path));
+    }
+
+    private static bool IsSpillMetric(string value) => value is
+        "sass__inst_executed_register_spilling" or
+        "sass__inst_executed_register_spilling_mem_local" or
+        "sass__inst_executed_local_loads" or
+        "sass__inst_executed_local_stores" or
+        "derived__local_spilling_requests";
+
+    private static string[] ParseCsvLine(string line)
+    {
+        var result = new List<string>();
+        var value = new StringBuilder();
+        bool quoted = false;
+        foreach (char c in line)
+        {
+            if (c == '"') quoted = !quoted;
+            else if (c == ',' && !quoted) { result.Add(value.ToString()); value.Clear(); }
+            else value.Append(c);
+        }
+        result.Add(value.ToString());
+        return result.ToArray();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelBlueprint.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelBlueprint.cs
@@ -228,14 +228,13 @@ internal sealed record DirectPtxProfilerEvidence(
     long RegisterSpillInstructions,
     long LocalLoadInstructions,
     long LocalStoreInstructions,
-    long LocalSpillRequests,
     int ObservedMetricGroups,
     string Source)
 {
     internal bool ProvesZeroExecutedSpills =>
-        ObservedMetricGroups == 4 &&
+        ObservedMetricGroups == 3 &&
         RegisterSpillInstructions == 0 && LocalLoadInstructions == 0 &&
-        LocalStoreInstructions == 0 && LocalSpillRequests == 0;
+        LocalStoreInstructions == 0;
 
     internal static DirectPtxProfilerEvidence FromNcuCsv(string path)
     {
@@ -243,8 +242,7 @@ internal sealed record DirectPtxProfilerEvidence(
         var values = new Dictionary<string, long>(StringComparer.Ordinal);
         foreach (string line in File.ReadLines(path))
         {
-            if (!line.Contains("sass__", StringComparison.Ordinal) &&
-                !line.Contains("derived__local_spilling_requests", StringComparison.Ordinal))
+            if (!line.Contains("sass__", StringComparison.Ordinal))
                 continue;
             string[] cells = ParseCsvLine(line);
             for (int i = 0; i < cells.Length; i++)
@@ -269,12 +267,10 @@ internal sealed record DirectPtxProfilerEvidence(
             values.ContainsKey("sass__inst_executed_register_spilling_mem_local")) observedGroups++;
         if (values.ContainsKey("sass__inst_executed_local_loads")) observedGroups++;
         if (values.ContainsKey("sass__inst_executed_local_stores")) observedGroups++;
-        if (values.ContainsKey("derived__local_spilling_requests")) observedGroups++;
         return new DirectPtxProfilerEvidence(
             Get("sass__inst_executed_register_spilling", "sass__inst_executed_register_spilling_mem_local"),
             Get("sass__inst_executed_local_loads"),
             Get("sass__inst_executed_local_stores"),
-            Get("derived__local_spilling_requests"),
             observedGroups,
             Path.GetFullPath(path));
     }
@@ -283,8 +279,7 @@ internal sealed record DirectPtxProfilerEvidence(
         "sass__inst_executed_register_spilling" or
         "sass__inst_executed_register_spilling_mem_local" or
         "sass__inst_executed_local_loads" or
-        "sass__inst_executed_local_stores" or
-        "derived__local_spilling_requests";
+        "sass__inst_executed_local_stores";
 
     private static string[] ParseCsvLine(string line)
     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelCache.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxKernelCache.cs
@@ -1,0 +1,125 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Small deterministic LRU for loaded modules. Callers serialize lookup,
+/// launch, and eviction so an executing module can never be unloaded.
+/// </summary>
+internal sealed class DirectPtxKernelCache<TKey, TKernel> : IDisposable
+    where TKey : notnull
+    where TKernel : class, IDisposable
+{
+    private readonly int _capacity;
+    private readonly Dictionary<TKey, LinkedListNode<Entry>> _entries = new();
+    private readonly LinkedList<Entry> _lru = new();
+
+    private sealed record Entry(TKey Key, TKernel Kernel);
+
+    internal DirectPtxKernelCache(int capacity)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+        _capacity = capacity;
+    }
+
+    internal int Count => _entries.Count;
+    internal int Capacity => _capacity;
+
+    internal bool TryGetValue(TKey key, out TKernel kernel)
+    {
+        if (_entries.TryGetValue(key, out LinkedListNode<Entry>? node))
+        {
+            _lru.Remove(node);
+            _lru.AddFirst(node);
+            kernel = node.Value.Kernel;
+            return true;
+        }
+        kernel = null!;
+        return false;
+    }
+
+    internal TKernel GetOrAdd(TKey key, Func<TKernel> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        if (TryGetValue(key, out TKernel existing)) return existing;
+
+        TKernel created = factory();
+        var node = new LinkedListNode<Entry>(new Entry(key, created));
+        _entries.Add(key, node);
+        _lru.AddFirst(node);
+        Trim();
+        return created;
+    }
+
+    private void Trim()
+    {
+        while (_entries.Count > _capacity)
+        {
+            LinkedListNode<Entry> victim = _lru.Last!;
+            _lru.RemoveLast();
+            _entries.Remove(victim.Value.Key);
+            victim.Value.Kernel.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (Entry entry in _lru) entry.Kernel.Dispose();
+        _entries.Clear();
+        _lru.Clear();
+    }
+}
+
+/// <summary>Bounded LRU for small immutable dispatch-plan values.</summary>
+internal sealed class DirectPtxPlanCache<TKey, TValue> where TKey : notnull
+{
+    private readonly int _capacity;
+    private readonly Dictionary<TKey, LinkedListNode<(TKey Key, TValue Value)>> _entries = new();
+    private readonly LinkedList<(TKey Key, TValue Value)> _lru = new();
+
+    internal DirectPtxPlanCache(int capacity)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+        _capacity = capacity;
+    }
+
+    internal bool TryGetValue(TKey key, out TValue value)
+    {
+        if (_entries.TryGetValue(key, out var node))
+        {
+            _lru.Remove(node);
+            _lru.AddFirst(node);
+            value = node.Value.Value;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    internal void Set(TKey key, TValue value)
+    {
+        if (_entries.TryGetValue(key, out var existing))
+        {
+            existing.Value = (key, value);
+            _lru.Remove(existing);
+            _lru.AddFirst(existing);
+            return;
+        }
+        var node = new LinkedListNode<(TKey Key, TValue Value)>((key, value));
+        _entries.Add(key, node);
+        _lru.AddFirst(node);
+        if (_entries.Count <= _capacity) return;
+        LinkedListNode<(TKey Key, TValue Value)> victim = _lru.Last!;
+        _lru.RemoveLast();
+        _entries.Remove(victim.Value.Key);
+    }
+
+    internal void Clear()
+    {
+        _entries.Clear();
+        _lru.Clear();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxReleaseGate.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxReleaseGate.cs
@@ -1,0 +1,61 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+internal readonly record struct DirectPtxPerformanceEvidence(
+    double MedianMicroseconds,
+    double P95Microseconds,
+    long ManagedBytesPerCall,
+    long TemporaryDeviceBytes,
+    double MaxAbsoluteError,
+    int LocalBytesPerThread,
+    int IndependentRuns);
+
+internal readonly record struct DirectPtxReleaseGatePolicy(
+    double MinimumMedianSpeedup,
+    double MaximumP95RegressionFraction,
+    long MaximumManagedBytesPerCall,
+    long MaximumTemporaryDeviceBytes,
+    double MaximumAbsoluteError,
+    int RequiredIndependentRuns)
+{
+    internal static DirectPtxReleaseGatePolicy ProductionDefault => new(
+        MinimumMedianSpeedup: 1.10,
+        MaximumP95RegressionFraction: 0.10,
+        MaximumManagedBytesPerCall: 0,
+        MaximumTemporaryDeviceBytes: 0,
+        MaximumAbsoluteError: 5e-5,
+        RequiredIndependentRuns: 3);
+
+    internal DirectPtxReleaseDecision Evaluate(
+        in DirectPtxPerformanceEvidence candidate,
+        in DirectPtxPerformanceEvidence bestCompetitor)
+    {
+        var failures = new List<string>();
+        double speedup = bestCompetitor.MedianMicroseconds / candidate.MedianMicroseconds;
+        if (!double.IsFinite(speedup) || speedup < MinimumMedianSpeedup)
+            failures.Add($"median-speedup={speedup:F3}x<{MinimumMedianSpeedup:F3}x");
+        double p95Limit = bestCompetitor.P95Microseconds * (1.0 + MaximumP95RegressionFraction);
+        if (candidate.P95Microseconds > p95Limit)
+            failures.Add($"p95={candidate.P95Microseconds:F3}us>{p95Limit:F3}us");
+        if (candidate.ManagedBytesPerCall > MaximumManagedBytesPerCall)
+            failures.Add($"managed-bytes={candidate.ManagedBytesPerCall}>{MaximumManagedBytesPerCall}");
+        if (candidate.TemporaryDeviceBytes > MaximumTemporaryDeviceBytes)
+            failures.Add($"temporary-device-bytes={candidate.TemporaryDeviceBytes}>{MaximumTemporaryDeviceBytes}");
+        if (candidate.MaxAbsoluteError > MaximumAbsoluteError)
+            failures.Add($"max-error={candidate.MaxAbsoluteError:G6}>{MaximumAbsoluteError:G6}");
+        if (candidate.LocalBytesPerThread != 0)
+            failures.Add($"local-bytes/thread={candidate.LocalBytesPerThread}");
+        if (candidate.IndependentRuns < RequiredIndependentRuns)
+            failures.Add($"independent-runs={candidate.IndependentRuns}<{RequiredIndependentRuns}");
+        return new DirectPtxReleaseDecision(failures.Count == 0, speedup, failures);
+    }
+}
+
+internal sealed record DirectPtxReleaseDecision(
+    bool Passed,
+    double MedianSpeedup,
+    IReadOnlyList<string> Failures);
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxRuntime.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxRuntime.cs
@@ -1,0 +1,489 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Runtime.InteropServices;
+using System.Globalization;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Minimal CUDA Driver-API runtime for loading and launching hand-emitted PTX.
+/// It deliberately has no dependency on cudart, NVRTC, cuBLAS, or cuDNN.
+/// </summary>
+internal sealed class DirectPtxRuntime : IDisposable
+{
+    [ThreadStatic] private static IntPtr s_scopedContext;
+    [ThreadStatic] private static int s_scopeDepth;
+    private IntPtr _context;
+    private readonly IntPtr _stream;
+    private readonly bool _ownsContext;
+    private bool _disposed;
+
+    internal int DeviceOrdinal { get; }
+    internal string DeviceName { get; }
+    internal int ComputeCapabilityMajor { get; }
+    internal int ComputeCapabilityMinor { get; }
+    internal DirectPtxArchitectureFamily ArchitectureFamily { get; }
+    internal string DeviceUuid { get; }
+    internal int DriverVersion { get; }
+    internal string DeviceFingerprint { get; }
+    internal IntPtr Stream => _stream;
+
+    internal static bool IsAvailable => CudaNativeBindings.IsAvailable;
+
+    internal DirectPtxRuntime(int deviceOrdinal = 0)
+    {
+        Check(CuBlasNative.cuInit(0), "cuInit");
+        Check(CuBlasNative.cuDeviceGet(out int device, deviceOrdinal), "cuDeviceGet");
+
+        var name = new StringBuilder(256);
+        Check(CuBlasNative.cuDeviceGetName(name, name.Capacity, device), "cuDeviceGetName");
+        Check(CuBlasNative.cuDeviceGetAttribute(
+            out int major, (int)CudaDeviceAttribute.ComputeCapabilityMajor, device),
+            "cuDeviceGetAttribute(ComputeCapabilityMajor)");
+        Check(CuBlasNative.cuDeviceGetAttribute(
+            out int minor, (int)CudaDeviceAttribute.ComputeCapabilityMinor, device),
+            "cuDeviceGetAttribute(ComputeCapabilityMinor)");
+
+        Check(CuBlasNative.cuCtxCreate(out _context, 0, device), "cuCtxCreate");
+        // cuCtxCreate makes the context current. Detach it so every operation
+        // below has an explicit, balanced push/pop boundary.
+        Check(CuBlasNative.cuCtxPopCurrent(out IntPtr popped), "cuCtxPopCurrent");
+        if (popped != _context)
+        {
+            CuBlasNative.cuCtxDestroy(_context);
+            _context = IntPtr.Zero;
+            throw new InvalidOperationException("CUDA returned a different context from cuCtxPopCurrent.");
+        }
+
+        _stream = IntPtr.Zero;
+        _ownsContext = true;
+        DeviceOrdinal = deviceOrdinal;
+        DeviceName = name.ToString();
+        ComputeCapabilityMajor = major;
+        ComputeCapabilityMinor = minor;
+        ArchitectureFamily = DirectPtxArchitecture.Classify(major, minor);
+        DeviceUuid = QueryDeviceUuid(device);
+        DriverVersion = CudaNativeBindings.DriverVersion;
+        DeviceFingerprint = BuildDeviceFingerprint(DeviceUuid, major, minor, DriverVersion);
+    }
+
+    /// <summary>
+    /// Creates a non-owning PTX runtime over an existing CUDA context and
+    /// stream. Production kernels use this path so resident AiDotNet buffers,
+    /// generated modules, events, and launches all share one ordering domain.
+    /// </summary>
+    internal DirectPtxRuntime(IntPtr borrowedContext, IntPtr borrowedStream)
+    {
+        if (borrowedContext == IntPtr.Zero)
+            throw new ArgumentException("A borrowed CUDA context cannot be null.", nameof(borrowedContext));
+
+        _context = borrowedContext;
+        _stream = borrowedStream;
+        _ownsContext = false;
+
+        using var _ = Enter();
+        Check(CudaNativeBindings.cuCtxGetDevice(out int device), "cuCtxGetDevice");
+        var name = new StringBuilder(256);
+        Check(CuBlasNative.cuDeviceGetName(name, name.Capacity, device), "cuDeviceGetName");
+        Check(CuBlasNative.cuDeviceGetAttribute(
+            out int major, (int)CudaDeviceAttribute.ComputeCapabilityMajor, device),
+            "cuDeviceGetAttribute(ComputeCapabilityMajor)");
+        Check(CuBlasNative.cuDeviceGetAttribute(
+            out int minor, (int)CudaDeviceAttribute.ComputeCapabilityMinor, device),
+            "cuDeviceGetAttribute(ComputeCapabilityMinor)");
+
+        DeviceOrdinal = device;
+        DeviceName = name.ToString();
+        ComputeCapabilityMajor = major;
+        ComputeCapabilityMinor = minor;
+        ArchitectureFamily = DirectPtxArchitecture.Classify(major, minor);
+        DeviceUuid = QueryDeviceUuid(device);
+        DriverVersion = CudaNativeBindings.DriverVersion;
+        DeviceFingerprint = BuildDeviceFingerprint(DeviceUuid, major, minor, DriverVersion);
+    }
+
+    private static unsafe string QueryDeviceUuid(int device)
+    {
+        try
+        {
+            if (CudaNativeBindings.cuDeviceGetUuidV2(out CudaDeviceUuid uuid, device) != CudaResult.Success)
+                return $"ordinal-{device}";
+            Span<byte> bytes = stackalloc byte[16];
+            for (int i = 0; i < bytes.Length; i++) bytes[i] = uuid.Bytes[i];
+            return Convert.ToHexString(bytes).ToLowerInvariant();
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return $"ordinal-{device}";
+        }
+    }
+
+    private static string BuildDeviceFingerprint(string uuid, int major, int minor, int driverVersion) =>
+        $"gpu-{uuid}-sm{major}{minor}-drv{driverVersion.ToString(CultureInfo.InvariantCulture)}";
+
+    internal ContextScope Enter()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return new ContextScope(_context);
+    }
+
+    internal DirectPtxBuffer AllocateBytes(nuint bytes)
+    {
+        if (bytes == 0) throw new ArgumentOutOfRangeException(nameof(bytes));
+        using var _ = Enter();
+        Check(CudaNativeBindings.cuMemAlloc(out IntPtr pointer, checked((ulong)bytes)), "cuMemAlloc");
+        return new DirectPtxBuffer(this, pointer, bytes);
+    }
+
+    internal DirectPtxModule LoadModule(string ptx)
+    {
+        if (string.IsNullOrWhiteSpace(ptx)) throw new ArgumentException("PTX cannot be empty.", nameof(ptx));
+        using var _ = Enter();
+        IntPtr text = Marshal.StringToHGlobalAnsi(ptx);
+        const int logBytes = 16 * 1024;
+        IntPtr errorLog = Marshal.AllocHGlobal(logBytes);
+        IntPtr infoLog = Marshal.AllocHGlobal(logBytes);
+        try
+        {
+            unsafe
+            {
+                new Span<byte>((void*)errorLog, logBytes).Clear();
+                new Span<byte>((void*)infoLog, logBytes).Clear();
+            }
+            // CUjit_option values: INFO_LOG_BUFFER=3, INFO_LOG_SIZE=4,
+            // ERROR_LOG_BUFFER=5, ERROR_LOG_SIZE=6. Size values are passed
+            // by value through the void* option slot per the Driver API ABI.
+            int[] options = [3, 4, 5, 6];
+            IntPtr[] values = [infoLog, (IntPtr)logBytes, errorLog, (IntPtr)logBytes];
+            CudaResult result = CudaNativeBindings.cuModuleLoadDataEx(
+                out IntPtr module, text, (uint)options.Length, options, values);
+            if (result != CudaResult.Success)
+            {
+                string error = Marshal.PtrToStringAnsi(errorLog) ?? string.Empty;
+                string info = Marshal.PtrToStringAnsi(infoLog) ?? string.Empty;
+                throw new InvalidOperationException(
+                    $"cuModuleLoadDataEx(PTX) failed with CUDA driver status {(int)result} ({result}).\n" +
+                    $"JIT error log:\n{error}\nJIT info log:\n{info}");
+            }
+            string jitInfo = Marshal.PtrToStringAnsi(infoLog) ?? string.Empty;
+            return new DirectPtxModule(this, module, jitInfo);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(errorLog);
+            Marshal.FreeHGlobal(infoLog);
+            Marshal.FreeHGlobal(text);
+        }
+    }
+
+    internal void Synchronize()
+    {
+        using var _ = Enter();
+        if (_stream != IntPtr.Zero)
+            Check(CudaNativeBindings.cuStreamSynchronize(_stream), "cuStreamSynchronize");
+        else
+            Check(CuBlasNative.cuCtxSynchronize(), "cuCtxSynchronize");
+    }
+
+    internal float MeasureKernelMilliseconds(Action launch, int warmup, int iterations)
+    {
+        ArgumentNullException.ThrowIfNull(launch);
+        if (warmup < 0) throw new ArgumentOutOfRangeException(nameof(warmup));
+        if (iterations <= 0) throw new ArgumentOutOfRangeException(nameof(iterations));
+
+        for (int i = 0; i < warmup; i++) launch();
+        Synchronize();
+
+        using var _ = Enter();
+        Check(CudaNativeBindings.cuEventCreate(out IntPtr start, CudaNativeBindings.CU_EVENT_DEFAULT), "cuEventCreate(start)");
+        Check(CudaNativeBindings.cuEventCreate(out IntPtr stop, CudaNativeBindings.CU_EVENT_DEFAULT), "cuEventCreate(stop)");
+        try
+        {
+            Check(CudaNativeBindings.cuEventRecord(start, _stream), "cuEventRecord(start)");
+            for (int i = 0; i < iterations; i++) launch();
+            Check(CudaNativeBindings.cuEventRecord(stop, _stream), "cuEventRecord(stop)");
+            Check(CudaNativeBindings.cuEventSynchronize(stop), "cuEventSynchronize(stop)");
+            Check(CudaNativeBindings.cuEventElapsedTime(out float elapsed, start, stop), "cuEventElapsedTime");
+            return elapsed / iterations;
+        }
+        finally
+        {
+            CudaNativeBindings.cuEventDestroy(start);
+            CudaNativeBindings.cuEventDestroy(stop);
+        }
+    }
+
+    /// <summary>
+    /// Returns a distribution of CUDA-event device times. Each sample is an
+    /// average of a small back-to-back launch group, which keeps event-record
+    /// overhead from dominating kernels in the 10-microsecond range while
+    /// still exposing run-to-run p95/p99 variation.
+    /// </summary>
+    internal float[] MeasureKernelSamples(
+        Action launch, int warmup, int samples, int launchesPerSample)
+    {
+        ArgumentNullException.ThrowIfNull(launch);
+        if (warmup < 0) throw new ArgumentOutOfRangeException(nameof(warmup));
+        if (samples <= 0) throw new ArgumentOutOfRangeException(nameof(samples));
+        if (launchesPerSample <= 0) throw new ArgumentOutOfRangeException(nameof(launchesPerSample));
+
+        for (int i = 0; i < warmup; i++) launch();
+        Synchronize();
+
+        var starts = new IntPtr[samples];
+        var stops = new IntPtr[samples];
+        var result = new float[samples];
+        using var _ = Enter();
+        try
+        {
+            for (int i = 0; i < samples; i++)
+            {
+                Check(CudaNativeBindings.cuEventCreate(out starts[i], CudaNativeBindings.CU_EVENT_DEFAULT),
+                    "cuEventCreate(sample start)");
+                Check(CudaNativeBindings.cuEventCreate(out stops[i], CudaNativeBindings.CU_EVENT_DEFAULT),
+                    "cuEventCreate(sample stop)");
+            }
+
+            for (int sample = 0; sample < samples; sample++)
+            {
+                Check(CudaNativeBindings.cuEventRecord(starts[sample], _stream), "cuEventRecord(sample start)");
+                for (int launchIndex = 0; launchIndex < launchesPerSample; launchIndex++) launch();
+                Check(CudaNativeBindings.cuEventRecord(stops[sample], _stream), "cuEventRecord(sample stop)");
+            }
+
+            Check(CudaNativeBindings.cuEventSynchronize(stops[^1]), "cuEventSynchronize(samples)");
+            for (int sample = 0; sample < samples; sample++)
+            {
+                Check(CudaNativeBindings.cuEventElapsedTime(
+                    out float elapsed, starts[sample], stops[sample]), "cuEventElapsedTime(sample)");
+                result[sample] = elapsed / launchesPerSample;
+            }
+            return result;
+        }
+        finally
+        {
+            for (int i = 0; i < samples; i++)
+            {
+                if (starts[i] != IntPtr.Zero) CudaNativeBindings.cuEventDestroy(starts[i]);
+                if (stops[i] != IntPtr.Zero) CudaNativeBindings.cuEventDestroy(stops[i]);
+            }
+        }
+    }
+
+    internal static void Check(CudaResult result, string operation)
+    {
+        if (result != CudaResult.Success)
+            throw new InvalidOperationException($"{operation} failed with CUDA driver status {(int)result} ({result}).");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_ownsContext && _context != IntPtr.Zero)
+        {
+            CuBlasNative.cuCtxDestroy(_context);
+        }
+        _context = IntPtr.Zero;
+    }
+
+    internal readonly struct ContextScope : IDisposable
+    {
+        private readonly bool _pushed;
+        private readonly bool _enteredNewContext;
+        private readonly IntPtr _previousTrackedContext;
+        private readonly int _previousTrackedDepth;
+
+        internal ContextScope(IntPtr context)
+        {
+            _previousTrackedContext = s_scopedContext;
+            _previousTrackedDepth = s_scopeDepth;
+            if (s_scopedContext == context && s_scopeDepth > 0)
+            {
+                s_scopeDepth++;
+                _pushed = false;
+                _enteredNewContext = false;
+                return;
+            }
+
+            Check(CudaNativeBindings.cuCtxGetCurrent(out IntPtr current), "cuCtxGetCurrent");
+            if (current == context)
+            {
+                _pushed = false;
+            }
+            else
+            {
+                Check(CuBlasNative.cuCtxPushCurrent(context), "cuCtxPushCurrent");
+                _pushed = true;
+            }
+            s_scopedContext = context;
+            s_scopeDepth = 1;
+            _enteredNewContext = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_enteredNewContext)
+            {
+                s_scopeDepth--;
+                return;
+            }
+
+            s_scopedContext = _previousTrackedContext;
+            s_scopeDepth = _previousTrackedDepth;
+            if (_pushed)
+                Check(CuBlasNative.cuCtxPopCurrent(out _), "cuCtxPopCurrent");
+        }
+    }
+}
+
+internal sealed class DirectPtxBuffer : IDisposable
+{
+    private readonly DirectPtxRuntime _runtime;
+    private IntPtr _pointer;
+
+    internal IntPtr Pointer => _pointer;
+    internal nuint ByteLength { get; }
+
+    internal DirectPtxBuffer(DirectPtxRuntime runtime, IntPtr pointer, nuint byteLength)
+    {
+        _runtime = runtime;
+        _pointer = pointer;
+        ByteLength = byteLength;
+    }
+
+    internal unsafe void Upload<T>(ReadOnlySpan<T> source) where T : unmanaged
+    {
+        nuint bytes = checked((nuint)source.Length * (nuint)sizeof(T));
+        if (bytes > ByteLength) throw new ArgumentException("Source is larger than the device buffer.", nameof(source));
+        using var _ = _runtime.Enter();
+        fixed (T* pSource = source)
+            DirectPtxRuntime.Check(
+                CudaNativeBindings.cuMemcpyHtoD(_pointer, (IntPtr)pSource, checked((ulong)bytes)),
+                "cuMemcpyHtoD");
+    }
+
+    internal unsafe void Download<T>(Span<T> destination) where T : unmanaged
+    {
+        nuint bytes = checked((nuint)destination.Length * (nuint)sizeof(T));
+        if (bytes > ByteLength) throw new ArgumentException("Destination is larger than the device buffer.", nameof(destination));
+        using var _ = _runtime.Enter();
+        fixed (T* pDestination = destination)
+            DirectPtxRuntime.Check(
+                CudaNativeBindings.cuMemcpyDtoH((IntPtr)pDestination, _pointer, checked((ulong)bytes)),
+                "cuMemcpyDtoH");
+    }
+
+    public void Dispose()
+    {
+        if (_pointer == IntPtr.Zero) return;
+        using var _ = _runtime.Enter();
+        DirectPtxRuntime.Check(CudaNativeBindings.cuMemFree(_pointer), "cuMemFree");
+        _pointer = IntPtr.Zero;
+    }
+}
+
+internal sealed class DirectPtxModule : IDisposable
+{
+    private readonly DirectPtxRuntime _runtime;
+    private IntPtr _module;
+    internal string JitInfoLog { get; }
+
+    internal DirectPtxModule(DirectPtxRuntime runtime, IntPtr module, string jitInfoLog)
+    {
+        _runtime = runtime;
+        _module = module;
+        JitInfoLog = jitInfoLog;
+    }
+
+    internal IntPtr GetFunction(string name)
+        => GetFunction(name, out _);
+
+    internal IntPtr GetFunction(string name, out DirectPtxFunctionInfo info)
+    {
+        using var _ = _runtime.Enter();
+        DirectPtxRuntime.Check(
+            CudaNativeBindings.cuModuleGetFunction(out IntPtr function, _module, name),
+            $"cuModuleGetFunction({name})");
+        info = DirectPtxFunctionInfo.Query(function);
+        if (info.LocalBytesPerThread != 0)
+            throw new InvalidOperationException(
+                $"Direct PTX kernel '{name}' was rejected: CUDA JIT allocated " +
+                $"{info.LocalBytesPerThread} local bytes/thread (register spill or local stack). " +
+                "The direct-kernel contract requires zero local memory.");
+        return function;
+    }
+
+    internal unsafe void Launch(
+        IntPtr function,
+        uint gridX, uint gridY, uint gridZ,
+        uint blockX, uint blockY, uint blockZ,
+        uint sharedMemoryBytes,
+        void** arguments)
+    {
+        using var _ = _runtime.Enter();
+        DirectPtxRuntime.Check(
+            CudaNativeBindings.cuLaunchKernel(
+                function,
+                gridX, gridY, gridZ,
+                blockX, blockY, blockZ,
+                sharedMemoryBytes,
+                _runtime.Stream,
+                (IntPtr)arguments,
+                IntPtr.Zero),
+            "cuLaunchKernel(PTX)");
+    }
+
+    internal int GetActiveBlocksPerMultiprocessor(
+        IntPtr function,
+        int blockThreads,
+        nuint dynamicSharedBytes = 0)
+    {
+        using var _ = _runtime.Enter();
+        DirectPtxRuntime.Check(
+            CudaNativeBindings.cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+                out int blocks, function, blockThreads, checked((nint)dynamicSharedBytes), 0),
+            "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags");
+        return blocks;
+    }
+
+    public void Dispose()
+    {
+        if (_module == IntPtr.Zero) return;
+        using var _ = _runtime.Enter();
+        DirectPtxRuntime.Check(CudaNativeBindings.cuModuleUnload(_module), "cuModuleUnload");
+        _module = IntPtr.Zero;
+    }
+}
+
+internal readonly record struct DirectPtxFunctionInfo(
+    int MaxThreadsPerBlock,
+    int StaticSharedBytes,
+    int ConstBytes,
+    int LocalBytesPerThread,
+    int RegistersPerThread,
+    int PtxVersion,
+    int BinaryVersion)
+{
+    internal static DirectPtxFunctionInfo Query(IntPtr function)
+    {
+        static int Get(IntPtr f, CudaFunctionAttribute attribute)
+        {
+            DirectPtxRuntime.Check(
+                CudaNativeBindings.cuFuncGetAttribute(out int value, attribute, f),
+                $"cuFuncGetAttribute({attribute})");
+            return value;
+        }
+
+        return new DirectPtxFunctionInfo(
+            Get(function, CudaFunctionAttribute.MaxThreadsPerBlock),
+            Get(function, CudaFunctionAttribute.SharedSizeBytes),
+            Get(function, CudaFunctionAttribute.ConstSizeBytes),
+            Get(function, CudaFunctionAttribute.LocalSizeBytes),
+            Get(function, CudaFunctionAttribute.NumRegisters),
+            Get(function, CudaFunctionAttribute.PtxVersion),
+            Get(function, CudaFunctionAttribute.BinaryVersion));
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxAttentionSoftmax32Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxAttentionSoftmax32Kernel.cs
@@ -32,7 +32,7 @@ internal sealed class PtxAttentionSoftmax32Kernel : IDisposable
     {
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         if (batchHeads <= 0 || batchHeads > 65535) throw new ArgumentOutOfRangeException(nameof(batchHeads));
-        if (sequenceLength is not (16 or 32 or 64 or 128))
+        if (!PtxOnlineFusedAttention128x64Kernel.IsSupportedSequenceLength(sequenceLength))
             throw new ArgumentOutOfRangeException(nameof(sequenceLength));
 
         BatchHeads = batchHeads;
@@ -71,7 +71,7 @@ internal sealed class PtxAttentionSoftmax32Kernel : IDisposable
         int ccMajor, int ccMinor, bool isCausal,
         int sequenceLength = DefaultSequenceLength)
     {
-        if (sequenceLength is not (16 or 32 or 64 or 128))
+        if (!PtxOnlineFusedAttention128x64Kernel.IsSupportedSequenceLength(sequenceLength))
             throw new ArgumentOutOfRangeException(nameof(sequenceLength));
         int valuesPerLane = (sequenceLength + 31) / 32;
         var ptx = new StringBuilder(16 * 1024);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxAttentionSoftmax32Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxAttentionSoftmax32Kernel.cs
@@ -1,0 +1,158 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Warp-per-row softmax used to construct a strong, decomposed cuBLAS
+/// attention baseline for S in {16,32,64,128}. Input is FP32 and output is FP16.
+/// </summary>
+internal sealed class PtxAttentionSoftmax32Kernel : IDisposable
+{
+    internal const string EntryPoint = "aidotnet_attention_softmax_32";
+    internal const int DefaultSequenceLength = 32;
+
+    private readonly DirectPtxRuntime _runtime;
+    private readonly DirectPtxModule _module;
+    private readonly IntPtr _function;
+
+    internal int BatchHeads { get; }
+    internal int SequenceLength { get; }
+    internal bool IsCausal { get; }
+    internal nuint ScoreBytes => checked(
+        (nuint)BatchHeads * (nuint)SequenceLength * (nuint)SequenceLength * sizeof(float));
+    internal nuint ProbabilityBytes => checked(
+        (nuint)BatchHeads * (nuint)SequenceLength * (nuint)SequenceLength * sizeof(ushort));
+    internal string Ptx { get; }
+
+    internal PtxAttentionSoftmax32Kernel(
+        DirectPtxRuntime runtime, int batchHeads, bool isCausal,
+        int sequenceLength = DefaultSequenceLength)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        if (batchHeads <= 0 || batchHeads > 65535) throw new ArgumentOutOfRangeException(nameof(batchHeads));
+        if (sequenceLength is not (16 or 32 or 64 or 128))
+            throw new ArgumentOutOfRangeException(nameof(sequenceLength));
+
+        BatchHeads = batchHeads;
+        SequenceLength = sequenceLength;
+        IsCausal = isCausal;
+        Ptx = EmitPtx(
+            runtime.ComputeCapabilityMajor, runtime.ComputeCapabilityMinor,
+            isCausal, sequenceLength);
+        _module = runtime.LoadModule(Ptx);
+        _function = _module.GetFunction(EntryPoint);
+    }
+
+    internal unsafe void Launch(DirectPtxBuffer scores, DirectPtxBuffer probabilities)
+    {
+        ArgumentNullException.ThrowIfNull(scores);
+        ArgumentNullException.ThrowIfNull(probabilities);
+        if (scores.ByteLength < ScoreBytes || probabilities.ByteLength < ProbabilityBytes)
+            throw new ArgumentException("A softmax buffer is smaller than the specialized shape.");
+
+        IntPtr scorePointer = scores.Pointer;
+        IntPtr probabilityPointer = probabilities.Pointer;
+        void** args = stackalloc void*[2];
+        args[0] = &scorePointer;
+        args[1] = &probabilityPointer;
+        _module.Launch(
+            _function,
+            checked((uint)((BatchHeads * SequenceLength + 3) / 4)), 1, 1,
+            128, 1, 1,
+            0,
+            args);
+    }
+
+    public void Dispose() => _module.Dispose();
+
+    internal static string EmitPtx(
+        int ccMajor, int ccMinor, bool isCausal,
+        int sequenceLength = DefaultSequenceLength)
+    {
+        if (sequenceLength is not (16 or 32 or 64 or 128))
+            throw new ArgumentOutOfRangeException(nameof(sequenceLength));
+        int valuesPerLane = (sequenceLength + 31) / 32;
+        var ptx = new StringBuilder(16 * 1024);
+        ptx.AppendLine(".version 7.1");
+        ptx.AppendLine($".target sm_{ccMajor}{ccMinor}");
+        ptx.AppendLine(".address_size 64");
+        ptx.AppendLine();
+        ptx.AppendLine($".visible .entry {EntryPoint}(");
+        ptx.AppendLine("    .param .u64 score_ptr,");
+        ptx.AppendLine("    .param .u64 probability_ptr");
+        ptx.AppendLine(")");
+        ptx.AppendLine("{");
+        ptx.AppendLine("    .reg .b16 %h<4>;");
+        ptx.AppendLine("    .reg .b32 %r<20>;");
+        ptx.AppendLine("    .reg .b64 %rd<12>;");
+        ptx.AppendLine("    .reg .f32 %f<20>;");
+        ptx.AppendLine("    .reg .pred %p<4>;");
+        ptx.AppendLine("    ld.param.u64 %rd0, [score_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd1, [probability_ptr];");
+        ptx.AppendLine("    mov.u32 %r0, %tid.x;");
+        ptx.AppendLine("    mov.u32 %r1, %ctaid.x;");
+        ptx.AppendLine("    shr.u32 %r2, %r0, 5;");
+        ptx.AppendLine("    and.b32 %r3, %r0, 31;");
+        ptx.AppendLine("    mad.lo.u32 %r4, %r1, 4, %r2;"); // row
+        if (isCausal)
+            ptx.AppendLine($"    rem.u32 %r6, %r4, {sequenceLength};");
+        ptx.AppendLine("    mov.f32 %f8, 0fFF800000;");
+        for (int i = 0; i < valuesPerLane; i++)
+        {
+            int columnOffset = i * 32;
+            ptx.AppendLine($"    add.u32 %r5, %r3, {columnOffset};");
+            ptx.AppendLine($"    setp.lt.u32 %p0, %r5, {sequenceLength};");
+            ptx.AppendLine($"    mad.lo.u32 %r7, %r4, {sequenceLength}, %r5;");
+            ptx.AppendLine("    mul.wide.u32 %rd2, %r7, 4;");
+            ptx.AppendLine("    add.u64 %rd3, %rd0, %rd2;");
+            ptx.AppendLine($"    @%p0 ld.global.f32 %f{i}, [%rd3];");
+            ptx.AppendLine($"    @!%p0 mov.f32 %f{i}, 0fFF800000;");
+            if (isCausal)
+            {
+                ptx.AppendLine("    setp.gt.u32 %p1, %r5, %r6;");
+                ptx.AppendLine($"    @%p1 mov.f32 %f{i}, 0fFF800000;");
+            }
+            ptx.AppendLine($"    max.f32 %f8, %f8, %f{i};");
+        }
+        EmitShuffleReduction(ptx, "max.f32", "%f8");
+        ptx.AppendLine("    mov.f32 %f9, 0f00000000;");
+        for (int i = 0; i < valuesPerLane; i++)
+        {
+            ptx.AppendLine($"    sub.rn.f32 %f{i}, %f{i}, %f8;");
+            ptx.AppendLine($"    mul.rn.f32 %f{i}, %f{i}, 0f3FB8AA3B;");
+            ptx.AppendLine($"    ex2.approx.f32 %f{i}, %f{i};");
+            ptx.AppendLine($"    add.rn.f32 %f9, %f9, %f{i};");
+        }
+        EmitShuffleReduction(ptx, "add.rn.f32", "%f9");
+        ptx.AppendLine("    rcp.approx.f32 %f10, %f9;");
+        for (int i = 0; i < valuesPerLane; i++)
+        {
+            int columnOffset = i * 32;
+            ptx.AppendLine($"    add.u32 %r5, %r3, {columnOffset};");
+            ptx.AppendLine($"    setp.lt.u32 %p0, %r5, {sequenceLength};");
+            ptx.AppendLine($"    mul.rn.f32 %f{i}, %f{i}, %f10;");
+            ptx.AppendLine($"    cvt.rn.f16.f32 %h0, %f{i};");
+            ptx.AppendLine($"    mad.lo.u32 %r7, %r4, {sequenceLength}, %r5;");
+            ptx.AppendLine("    mul.wide.u32 %rd4, %r7, 2;");
+            ptx.AppendLine("    add.u64 %rd5, %rd1, %rd4;");
+            ptx.AppendLine("    @%p0 st.global.u16 [%rd5], %h0;");
+        }
+        ptx.AppendLine("    ret;");
+        ptx.AppendLine("}");
+        return ptx.ToString();
+    }
+
+    private static void EmitShuffleReduction(StringBuilder ptx, string operation, string accumulator)
+    {
+        foreach (int delta in new[] { 16, 8, 4, 2, 1 })
+        {
+            ptx.AppendLine($"    mov.b32 %r18, {accumulator};");
+            ptx.AppendLine($"    shfl.sync.bfly.b32 %r19, %r18, {delta}, 31, 0xffffffff;");
+            ptx.AppendLine("    mov.b32 %f18, %r19;");
+            ptx.AppendLine($"    {operation} {accumulator}, {accumulator}, %f18;");
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxFusedResidualRmsNormD64Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxFusedResidualRmsNormD64Kernel.cs
@@ -1,0 +1,244 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Real transformer boundary: residual addition followed by RMSNorm over D=64.
+/// Each warp owns one row, reads both inputs exactly once, keeps the reduction
+/// in registers, and writes only the normalized result plus one RMS scalar.
+/// </summary>
+internal sealed class PtxFusedResidualRmsNormD64Kernel : IDisposable
+{
+    internal const string EntryPoint = "aidotnet_fused_residual_rmsnorm_d64";
+    internal const int Dimension = 64;
+
+    private readonly DirectPtxModule _module;
+    private readonly IntPtr _function;
+
+    internal int Rows { get; }
+    internal float Epsilon { get; }
+    internal int WarpsPerBlock { get; }
+    internal string Ptx { get; }
+    internal DirectPtxFunctionInfo FunctionInfo { get; }
+    internal DirectPtxKernelBlueprint Blueprint { get; }
+    internal DirectPtxKernelAudit Audit { get; }
+    internal string JitInfoLog => _module.JitInfoLog;
+
+    internal nuint InputBytes => checked((nuint)Rows * Dimension * sizeof(float));
+    internal nuint OutputBytes => InputBytes;
+    internal const nuint GammaBytes = Dimension * sizeof(float);
+    internal nuint RmsBytes => checked((nuint)Rows * sizeof(float));
+
+    internal PtxFusedResidualRmsNormD64Kernel(
+        DirectPtxRuntime runtime,
+        int rows,
+        float epsilon = 1e-5f,
+        int warpsPerBlock = 4)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        if (rows <= 0 || rows > 65535) throw new ArgumentOutOfRangeException(nameof(rows));
+        if (!float.IsFinite(epsilon) || epsilon <= 0) throw new ArgumentOutOfRangeException(nameof(epsilon));
+        if (warpsPerBlock is not (1 or 2 or 4 or 8))
+            throw new ArgumentOutOfRangeException(nameof(warpsPerBlock));
+        if (runtime.ArchitectureFamily != DirectPtxArchitectureFamily.Ampere)
+            throw new NotSupportedException(
+                $"Residual RMSNorm has no validated {runtime.ArchitectureFamily} specialization.");
+
+        Rows = rows;
+        Epsilon = epsilon;
+        WarpsPerBlock = warpsPerBlock;
+        Blueprint = CreateBlueprint(runtime.ArchitectureFamily, rows, warpsPerBlock);
+        Ptx = EmitPtx(runtime.ComputeCapabilityMajor, runtime.ComputeCapabilityMinor, epsilon, rows, warpsPerBlock);
+        _module = runtime.LoadModule(Ptx);
+        _function = _module.GetFunction(EntryPoint, out DirectPtxFunctionInfo functionInfo);
+        FunctionInfo = functionInfo;
+        int blockThreads = warpsPerBlock * 32;
+        int activeBlocks = _module.GetActiveBlocksPerMultiprocessor(_function, blockThreads);
+        Blueprint.ResourceBudget.Validate(EntryPoint, functionInfo, blockThreads, activeBlocks);
+        Audit = DirectPtxKernelAudit.Create(
+            Blueprint, runtime.DeviceFingerprint, Ptx, functionInfo,
+            blockThreads, activeBlocks, _module.JitInfoLog);
+    }
+
+    private static DirectPtxKernelBlueprint CreateBlueprint(
+        DirectPtxArchitectureFamily architecture,
+        int rows,
+        int warpsPerBlock)
+    {
+        var matrix = new DirectPtxExtent(rows, Dimension);
+        var vector = new DirectPtxExtent(Dimension);
+        var rms = new DirectPtxExtent(rows);
+        return new DirectPtxKernelBlueprint(
+            Operation: "residual-rmsnorm-d64",
+            Version: 1,
+            Architecture: architecture,
+            Variant: $"warp-row-w{warpsPerBlock}",
+            Tensors:
+            [
+                new("input", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.RowMajor2D,
+                    matrix, matrix, 16, DirectPtxTensorAccess.Read),
+                new("residual", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.RowMajor2D,
+                    matrix, matrix, 16, DirectPtxTensorAccess.Read),
+                new("gamma", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.Vector,
+                    vector, vector, 16, DirectPtxTensorAccess.Read),
+                new("output", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.RowMajor2D,
+                    matrix, matrix, 16, DirectPtxTensorAccess.Write),
+                new("rms", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.Vector,
+                    rms, rms, 16, DirectPtxTensorAccess.Write)
+            ],
+            ResourceBudget: new DirectPtxResourceBudget(
+                MaxRegistersPerThread: 32,
+                MaxStaticSharedBytes: 0,
+                MaxLocalBytesPerThread: 0,
+                MinBlocksPerMultiprocessor: 4),
+            Semantics: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["equation"] = "rmsnorm(input+residual,gamma)",
+                ["input"] = "fp32",
+                ["accumulator"] = "fp32",
+                ["output"] = "fp32",
+                ["layout"] = "row-major-2d",
+                ["intermediate-global-bytes"] = "0"
+            });
+    }
+
+    internal unsafe void Launch(
+        DirectPtxTensorView input,
+        DirectPtxTensorView residual,
+        DirectPtxTensorView gamma,
+        DirectPtxTensorView output,
+        DirectPtxTensorView rms)
+    {
+        Require(input, Blueprint.Tensors[0], nameof(input));
+        Require(residual, Blueprint.Tensors[1], nameof(residual));
+        Require(gamma, Blueprint.Tensors[2], nameof(gamma));
+        Require(output, Blueprint.Tensors[3], nameof(output));
+        Require(rms, Blueprint.Tensors[4], nameof(rms));
+        if (output.Pointer == input.Pointer || output.Pointer == residual.Pointer)
+            throw new ArgumentException("The fused output must not alias either input.", nameof(output));
+
+        IntPtr inputPointer = input.Pointer;
+        IntPtr residualPointer = residual.Pointer;
+        IntPtr gammaPointer = gamma.Pointer;
+        IntPtr outputPointer = output.Pointer;
+        IntPtr rmsPointer = rms.Pointer;
+        void** arguments = stackalloc void*[5];
+        arguments[0] = &inputPointer;
+        arguments[1] = &residualPointer;
+        arguments[2] = &gammaPointer;
+        arguments[3] = &outputPointer;
+        arguments[4] = &rmsPointer;
+        _module.Launch(
+            _function, (uint)((Rows + WarpsPerBlock - 1) / WarpsPerBlock), 1, 1,
+            (uint)(WarpsPerBlock * 32), 1, 1, 0, arguments);
+    }
+
+    private static void Require(
+        DirectPtxTensorView view,
+        DirectPtxTensorContract contract,
+        string parameter)
+    {
+        if (view.Pointer == IntPtr.Zero || view.PhysicalType != contract.PhysicalType ||
+            view.Layout != contract.Layout || view.LogicalExtent != contract.LogicalExtent ||
+            view.PhysicalExtent != contract.PhysicalExtent || view.ByteLength < contract.RequiredBytes)
+            throw new ArgumentException(
+                $"{parameter} does not satisfy physical ABI '{contract.Name}'.", parameter);
+    }
+
+    public void Dispose() => _module.Dispose();
+
+    internal static string EmitPtx(
+        int ccMajor,
+        int ccMinor,
+        float epsilon,
+        int rows = 1,
+        int warpsPerBlock = 1)
+    {
+        if (!float.IsFinite(epsilon) || epsilon <= 0) throw new ArgumentOutOfRangeException(nameof(epsilon));
+        if (rows <= 0) throw new ArgumentOutOfRangeException(nameof(rows));
+        if (warpsPerBlock is not (1 or 2 or 4 or 8))
+            throw new ArgumentOutOfRangeException(nameof(warpsPerBlock));
+        string epsilonHex = FloatLiteral(epsilon);
+        var ptx = new StringBuilder(8192);
+        ptx.AppendLine(".version 7.1");
+        ptx.AppendLine($".target sm_{ccMajor}{ccMinor}");
+        ptx.AppendLine(".address_size 64");
+        ptx.AppendLine();
+        ptx.AppendLine($".visible .entry {EntryPoint}(");
+        ptx.AppendLine("    .param .u64 input_ptr,");
+        ptx.AppendLine("    .param .u64 residual_ptr,");
+        ptx.AppendLine("    .param .u64 gamma_ptr,");
+        ptx.AppendLine("    .param .u64 output_ptr,");
+        ptx.AppendLine("    .param .u64 rms_ptr");
+        ptx.AppendLine(")");
+        ptx.AppendLine("{");
+        ptx.AppendLine("    .reg .pred %p<2>;");
+        ptx.AppendLine("    .reg .b32 %r<16>;");
+        ptx.AppendLine("    .reg .b64 %rd<20>;");
+        ptx.AppendLine("    .reg .f32 %f<20>;");
+        ptx.AppendLine("    ld.param.u64 %rd0, [input_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd1, [residual_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd2, [gamma_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd3, [output_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd4, [rms_ptr];");
+        ptx.AppendLine("    mov.u32 %r0, %tid.x;");
+        ptx.AppendLine("    shr.u32 %r4, %r0, 5;");
+        ptx.AppendLine("    and.b32 %r0, %r0, 31;");
+        ptx.AppendLine("    mov.u32 %r1, %ctaid.x;");
+        ptx.AppendLine($"    mad.lo.u32 %r1, %r1, {warpsPerBlock}, %r4;");
+        ptx.AppendLine($"    setp.ge.u32 %p1, %r1, {rows};");
+        ptx.AppendLine("    @%p1 bra DONE;");
+        ptx.AppendLine("    mul.wide.u32 %rd5, %r1, 256;");
+        ptx.AppendLine("    mul.wide.u32 %rd6, %r0, 4;");
+        ptx.AppendLine("    add.u64 %rd7, %rd0, %rd5;");
+        ptx.AppendLine("    add.u64 %rd7, %rd7, %rd6;");
+        ptx.AppendLine("    add.u64 %rd8, %rd1, %rd5;");
+        ptx.AppendLine("    add.u64 %rd8, %rd8, %rd6;");
+        ptx.AppendLine("    ld.global.f32 %f0, [%rd7];");
+        ptx.AppendLine("    ld.global.f32 %f1, [%rd7+128];");
+        ptx.AppendLine("    ld.global.f32 %f2, [%rd8];");
+        ptx.AppendLine("    ld.global.f32 %f3, [%rd8+128];");
+        ptx.AppendLine("    add.rn.f32 %f4, %f0, %f2;");
+        ptx.AppendLine("    add.rn.f32 %f5, %f1, %f3;");
+        ptx.AppendLine("    mul.rn.f32 %f6, %f4, %f4;");
+        ptx.AppendLine("    fma.rn.f32 %f6, %f5, %f5, %f6;");
+        foreach (int delta in new[] { 16, 8, 4, 2, 1 })
+        {
+            ptx.AppendLine("    mov.b32 %r2, %f6;");
+            ptx.AppendLine($"    shfl.sync.bfly.b32 %r3, %r2, {delta}, 31, 0xffffffff;");
+            ptx.AppendLine("    mov.b32 %f7, %r3;");
+            ptx.AppendLine("    add.rn.f32 %f6, %f6, %f7;");
+        }
+        ptx.AppendLine("    mul.rn.f32 %f8, %f6, 0f3C800000;"); // 1/64
+        ptx.AppendLine($"    add.rn.f32 %f8, %f8, {epsilonHex};");
+        ptx.AppendLine("    sqrt.rn.f32 %f9, %f8;");
+        ptx.AppendLine("    rcp.approx.f32 %f10, %f9;");
+        ptx.AppendLine("    add.u64 %rd9, %rd2, %rd6;");
+        ptx.AppendLine("    ld.global.f32 %f11, [%rd9];");
+        ptx.AppendLine("    ld.global.f32 %f12, [%rd9+128];");
+        ptx.AppendLine("    mul.rn.f32 %f13, %f4, %f10;");
+        ptx.AppendLine("    mul.rn.f32 %f13, %f13, %f11;");
+        ptx.AppendLine("    mul.rn.f32 %f14, %f5, %f10;");
+        ptx.AppendLine("    mul.rn.f32 %f14, %f14, %f12;");
+        ptx.AppendLine("    add.u64 %rd10, %rd3, %rd5;");
+        ptx.AppendLine("    add.u64 %rd10, %rd10, %rd6;");
+        ptx.AppendLine("    st.global.f32 [%rd10], %f13;");
+        ptx.AppendLine("    st.global.f32 [%rd10+128], %f14;");
+        ptx.AppendLine("    setp.eq.u32 %p0, %r0, 0;");
+        ptx.AppendLine("    mul.wide.u32 %rd11, %r1, 4;");
+        ptx.AppendLine("    add.u64 %rd11, %rd4, %rd11;");
+        ptx.AppendLine("    @%p0 st.global.f32 [%rd11], %f9;");
+        ptx.AppendLine("DONE:");
+        ptx.AppendLine("    ret;");
+        ptx.AppendLine("}");
+        return ptx.ToString();
+    }
+
+    private static string FloatLiteral(float value) =>
+        "0f" + BitConverter.SingleToInt32Bits(value).ToString("X8", CultureInfo.InvariantCulture);
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxOnlineFusedAttention128x64Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxOnlineFusedAttention128x64Kernel.cs
@@ -1,0 +1,793 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// SM80+ online FlashAttention proof for S in {16,32,64,128}, D=64. Each warp owns a 16-row
+/// query tile, keeps the FP32 online max/sum and 16x64 output fragment in registers, and the
+/// warps in a block share double-buffered 16-row K/V tiles staged with cp.async. No score or
+/// probability matrix is materialized in global or shared memory.
+/// </summary>
+internal sealed class PtxOnlineFusedAttention128x64Kernel : IDisposable
+{
+    internal const string EntryPoint = "aidotnet_online_attention_128x64";
+    internal const int DefaultSequenceLength = 128;
+    internal const int HeadDimension = 64;
+    internal const int QueryTileRows = 16;
+    internal const int KeyTileRows = 16;
+
+    private readonly DirectPtxModule _module;
+    private readonly IntPtr _function;
+
+    internal int BatchHeads { get; }
+    internal int SequenceLength { get; }
+    internal bool IsCausal { get; }
+    internal bool FuseLayerNormGelu { get; }
+    internal bool EmitSoftmaxStats { get; }
+    internal float Scale { get; }
+    internal float Epsilon { get; }
+    internal string Ptx { get; }
+    internal DirectPtxFunctionInfo FunctionInfo { get; }
+    internal DirectPtxKernelBlueprint Blueprint { get; }
+    internal DirectPtxKernelAudit Audit { get; }
+    internal string JitInfoLog => _module.JitInfoLog;
+
+    private int InputElementsPerHead => SequenceLength * HeadDimension;
+    private int InputBytesPerHead => InputElementsPerHead * sizeof(ushort);
+    private int OutputBytesPerHead => InputElementsPerHead * sizeof(float);
+    private int StatsBytesPerHead => SequenceLength * sizeof(float);
+    internal int WarpsPerBlock { get; }
+
+    internal nuint QBytes => checked((nuint)BatchHeads * (nuint)InputBytesPerHead);
+    internal nuint KBytes => QBytes;
+    internal nuint VBytes => QBytes;
+    internal nuint OutputBytes => checked((nuint)BatchHeads * (nuint)OutputBytesPerHead);
+    internal nuint StatsBytes => checked((nuint)BatchHeads * (nuint)StatsBytesPerHead);
+    internal const nuint GammaBytes = HeadDimension * sizeof(float);
+    internal const nuint BetaBytes = HeadDimension * sizeof(float);
+
+    internal PtxOnlineFusedAttention128x64Kernel(
+        DirectPtxRuntime runtime,
+        int batchHeads,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float scale = 0.125f,
+        float epsilon = 1e-5f,
+        int sequenceLength = DefaultSequenceLength,
+        bool emitSoftmaxStats = true,
+        int? warpsPerBlock = null)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        if (batchHeads <= 0 || batchHeads > 65535) throw new ArgumentOutOfRangeException(nameof(batchHeads));
+        if (!float.IsFinite(scale)) throw new ArgumentOutOfRangeException(nameof(scale));
+        if (!float.IsFinite(epsilon) || epsilon <= 0) throw new ArgumentOutOfRangeException(nameof(epsilon));
+        if (sequenceLength is not (16 or 32 or 64 or 128))
+            throw new ArgumentOutOfRangeException(
+                nameof(sequenceLength), "Online PTX sequence length must be one of 16, 32, 64, or 128.");
+        if (!DirectPtxArchitecture.HasValidatedOnlineAttention(runtime.ArchitectureFamily))
+            throw new NotSupportedException(
+                $"Online attention has no validated {runtime.ArchitectureFamily} specialization. " +
+                "Architecture families fail closed until separately tuned and benchmarked.");
+
+        int queryTiles = sequenceLength / QueryTileRows;
+        int selectedWarps = warpsPerBlock ?? Math.Min(8, queryTiles);
+        if (selectedWarps is not (1 or 2 or 4 or 8) || selectedWarps > queryTiles || queryTiles % selectedWarps != 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(warpsPerBlock), "Warp count must be 1/2/4/8 and evenly divide the query-tile count.");
+
+        BatchHeads = batchHeads;
+        SequenceLength = sequenceLength;
+        IsCausal = isCausal;
+        FuseLayerNormGelu = fuseLayerNormGelu;
+        EmitSoftmaxStats = emitSoftmaxStats;
+        Scale = scale;
+        Epsilon = epsilon;
+        WarpsPerBlock = selectedWarps;
+        Blueprint = CreateBlueprint(
+            runtime.ArchitectureFamily, batchHeads, sequenceLength,
+            isCausal, fuseLayerNormGelu, emitSoftmaxStats, selectedWarps);
+        Ptx = EmitPtx(
+            runtime.ComputeCapabilityMajor,
+            runtime.ComputeCapabilityMinor,
+            isCausal,
+            fuseLayerNormGelu,
+            scale,
+            epsilon,
+            sequenceLength,
+            emitSoftmaxStats,
+            selectedWarps);
+        _module = runtime.LoadModule(Ptx);
+        _function = _module.GetFunction(EntryPoint, out DirectPtxFunctionInfo functionInfo);
+        FunctionInfo = functionInfo;
+        int blockThreads = selectedWarps * 32;
+        int activeBlocks = _module.GetActiveBlocksPerMultiprocessor(_function, blockThreads);
+        Blueprint.ResourceBudget.Validate(EntryPoint, functionInfo, blockThreads, activeBlocks);
+        Audit = DirectPtxKernelAudit.Create(
+            Blueprint, runtime.DeviceFingerprint, Ptx, functionInfo,
+            blockThreads, activeBlocks, _module.JitInfoLog);
+    }
+
+    private static DirectPtxKernelBlueprint CreateBlueprint(
+        DirectPtxArchitectureFamily architecture,
+        int batchHeads,
+        int sequenceLength,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        bool emitSoftmaxStats,
+        int warpsPerBlock)
+    {
+        var bhsdHalf = new DirectPtxExtent(1, batchHeads, sequenceLength, HeadDimension);
+        var bhsdFloat = new DirectPtxExtent(1, batchHeads, sequenceLength, HeadDimension);
+        var stats = new DirectPtxExtent(batchHeads, sequenceLength);
+        var vector = new DirectPtxExtent(HeadDimension);
+        return new DirectPtxKernelBlueprint(
+            Operation: "online-attention-d64",
+            Version: 2,
+            Architecture: architecture,
+            Variant: $"q16-k16-w{warpsPerBlock}",
+            Tensors:
+            [
+                new("query", DirectPtxPhysicalType.Float16, DirectPtxPhysicalLayout.Bhsd,
+                    bhsdHalf, bhsdHalf, 16, DirectPtxTensorAccess.Read),
+                new("key", DirectPtxPhysicalType.Float16, DirectPtxPhysicalLayout.Bhsd,
+                    bhsdHalf, bhsdHalf, 16, DirectPtxTensorAccess.Read),
+                new("value", DirectPtxPhysicalType.Float16, DirectPtxPhysicalLayout.Bhsd,
+                    bhsdHalf, bhsdHalf, 16, DirectPtxTensorAccess.Read),
+                new("gamma", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.Vector,
+                    vector, vector, 16, DirectPtxTensorAccess.Read),
+                new("beta", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.Vector,
+                    vector, vector, 16, DirectPtxTensorAccess.Read),
+                new("output", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.Bhsd,
+                    bhsdFloat, bhsdFloat, 16, DirectPtxTensorAccess.Write),
+                new("softmax-stats", DirectPtxPhysicalType.Float32, DirectPtxPhysicalLayout.RowMajor2D,
+                    stats, stats, 16, DirectPtxTensorAccess.Write)
+            ],
+            ResourceBudget: new DirectPtxResourceBudget(
+                MaxRegistersPerThread: 96,
+                MaxStaticSharedBytes: 32 * 1024,
+                MaxLocalBytesPerThread: 0,
+                MinBlocksPerMultiprocessor: 1),
+            Semantics: new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["input"] = "fp16",
+                ["accumulator"] = "fp32",
+                ["output"] = "fp32",
+                ["mask"] = isCausal ? "causal-top-left" : "none",
+                ["epilogue"] = fuseLayerNormGelu ? "layernorm-affine-tanh-gelu" : "none",
+                ["stats"] = emitSoftmaxStats ? "lse" : "none",
+                ["layout"] = "dense-bhsd"
+            });
+    }
+
+    internal unsafe void Launch(
+        DirectPtxTensorView query,
+        DirectPtxTensorView key,
+        DirectPtxTensorView value,
+        DirectPtxTensorView gamma,
+        DirectPtxTensorView beta,
+        DirectPtxTensorView output,
+        DirectPtxTensorView softmaxStats)
+    {
+        Require(query, Blueprint.Tensors[0], nameof(query));
+        Require(key, Blueprint.Tensors[1], nameof(key));
+        Require(value, Blueprint.Tensors[2], nameof(value));
+        Require(output, Blueprint.Tensors[5], nameof(output));
+        Require(softmaxStats, Blueprint.Tensors[6], nameof(softmaxStats));
+        if (FuseLayerNormGelu)
+        {
+            Require(gamma, Blueprint.Tensors[3], nameof(gamma));
+            Require(beta, Blueprint.Tensors[4], nameof(beta));
+        }
+        if (output.Pointer == query.Pointer || output.Pointer == key.Pointer || output.Pointer == value.Pointer)
+            throw new ArgumentException("The FP32 output may not alias an FP16 attention input.", nameof(output));
+
+        IntPtr q = query.Pointer;
+        IntPtr k = key.Pointer;
+        IntPtr v = value.Pointer;
+        IntPtr g = gamma.Pointer;
+        IntPtr b = beta.Pointer;
+        IntPtr o = output.Pointer;
+        IntPtr s = softmaxStats.Pointer;
+        void** args = stackalloc void*[7];
+        args[0] = &q;
+        args[1] = &k;
+        args[2] = &v;
+        args[3] = &g;
+        args[4] = &b;
+        args[5] = &o;
+        args[6] = &s;
+
+        _module.Launch(
+            _function,
+            (uint)((SequenceLength / QueryTileRows) / WarpsPerBlock), (uint)BatchHeads, 1,
+            (uint)(WarpsPerBlock * 32), 1, 1,
+            0,
+            args);
+    }
+
+    private static void Require(DirectPtxTensorView view, DirectPtxTensorContract contract, string name)
+    {
+        if (view.Pointer == IntPtr.Zero || view.Layout != contract.Layout ||
+            view.PhysicalType != contract.PhysicalType || view.ByteLength < contract.RequiredBytes ||
+            view.LogicalExtent != contract.LogicalExtent || view.PhysicalExtent != contract.PhysicalExtent)
+            throw new ArgumentException(
+                $"{name} does not satisfy physical ABI '{contract.Name}' " +
+                $"({contract.Layout}/{contract.PhysicalType}/{contract.PhysicalExtent}).", name);
+    }
+
+    internal double AttentionTflops(float milliseconds)
+    {
+        double flops = 4.0 * BatchHeads * SequenceLength * SequenceLength * HeadDimension;
+        return flops / (milliseconds * 1e-3) / 1e12;
+    }
+
+    public void Dispose() => _module.Dispose();
+
+    internal static string EmitPtx(
+        int ccMajor,
+        int ccMinor,
+        bool isCausal,
+        bool fuseLayerNormGelu,
+        float scale,
+        float epsilon,
+        int sequenceLength = DefaultSequenceLength,
+        bool emitSoftmaxStats = true,
+        int? warpsPerBlock = null)
+    {
+        if (sequenceLength is not (16 or 32 or 64 or 128))
+            throw new ArgumentOutOfRangeException(nameof(sequenceLength));
+        int inputBytesPerHead = sequenceLength * HeadDimension * sizeof(ushort);
+        int outputBytesPerHead = sequenceLength * HeadDimension * sizeof(float);
+        int statsBytesPerHead = sequenceLength * sizeof(float);
+        int queryTiles = sequenceLength / QueryTileRows;
+        int selectedWarpsPerBlock = warpsPerBlock ?? Math.Min(8, queryTiles);
+        if (selectedWarpsPerBlock is not (1 or 2 or 4 or 8) ||
+            selectedWarpsPerBlock > queryTiles || queryTiles % selectedWarpsPerBlock != 0)
+            throw new ArgumentOutOfRangeException(nameof(warpsPerBlock));
+        int warps = selectedWarpsPerBlock;
+        string target = $"sm_{ccMajor}{ccMinor}";
+        string scaleHex = FloatLiteral(scale);
+        string epsilonHex = FloatLiteral(epsilon);
+        const string log2E = "0f3FB8AA3B";
+        const string ln2 = "0f3F317218";
+        const string inv64 = "0f3C800000";
+        const string geluA = "0f3F4C422A"; // sqrt(2/pi)
+        const string geluB = "0f3D372713"; // 0.044715
+
+        int kShared0 = 2048 * warps;
+        int vShared0 = kShared0 + 2048;
+        int kShared1 = vShared0 + 2048;
+        int vShared1 = kShared1 + 2048;
+        int gammaShared = vShared1 + 2048;
+        int betaShared = gammaShared + 256;
+        int sharedBytes = betaShared + 256;
+
+        var ptx = new StringBuilder(96 * 1024);
+        ptx.AppendLine(".version 7.1");
+        ptx.AppendLine($".target {target}");
+        ptx.AppendLine(".address_size 64");
+        ptx.AppendLine();
+        ptx.AppendLine($".visible .entry {EntryPoint}(");
+        ptx.AppendLine("    .param .u64 q_ptr,");
+        ptx.AppendLine("    .param .u64 k_ptr,");
+        ptx.AppendLine("    .param .u64 v_ptr,");
+        ptx.AppendLine("    .param .u64 gamma_ptr,");
+        ptx.AppendLine("    .param .u64 beta_ptr,");
+        ptx.AppendLine("    .param .u64 o_ptr,");
+        ptx.AppendLine("    .param .u64 stats_ptr");
+        ptx.AppendLine(")");
+        ptx.AppendLine("{");
+        ptx.AppendLine("    .reg .pred %p<8>;");
+        ptx.AppendLine("    .reg .b16 %h<8>;");
+        ptx.AppendLine("    .reg .b32 %a<4>;");
+        ptx.AppendLine("    .reg .b32 %b<4>;");
+        ptx.AppendLine("    .reg .b32 %r<32>;");
+        ptx.AppendLine("    .reg .b64 %rd<32>;");
+        ptx.AppendLine("    .reg .f32 %s<8>;");
+        ptx.AppendLine("    .reg .f32 %o<32>;");
+        ptx.AppendLine("    .reg .f32 %f<40>;");
+        ptx.AppendLine($"    .shared .align 16 .b8 smem[{sharedBytes}];");
+        ptx.AppendLine();
+        ptx.AppendLine("    ld.param.u64 %rd0, [q_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd1, [k_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd2, [v_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd3, [gamma_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd4, [beta_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd5, [o_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd6, [stats_ptr];");
+        ptx.AppendLine("    mov.u32 %r21, %tid.x;"); // whole cooperative block
+        ptx.AppendLine("    shr.u32 %r22, %r21, 5;"); // warp owning this query tile
+        ptx.AppendLine("    and.b32 %r0, %r21, 31;"); // lane within the owning warp
+        ptx.AppendLine("    mov.u32 %r23, %ctaid.x;");
+        ptx.AppendLine($"    mad.lo.u32 %r1, %r23, {warps}, %r22;");
+        ptx.AppendLine("    mov.u32 %r2, %ctaid.y;");
+        ptx.AppendLine("    shr.u32 %r3, %r0, 2;"); // row group 0..7
+        ptx.AppendLine("    and.b32 %r4, %r0, 3;"); // lane within row group
+        ptx.AppendLine("    add.u32 %r5, %r3, 8;");
+        ptx.AppendLine("    shl.b32 %r6, %r4, 1;");
+        ptx.AppendLine("    shl.b32 %r7, %r1, 4;");
+        ptx.AppendLine("    add.u32 %r8, %r7, %r3;"); // global query row 0
+        ptx.AppendLine("    add.u32 %r9, %r8, 8;"); // global query row 1
+        // Shared symbols are already addresses in the shared state space. PTX
+        // cvta.to requires a generic-address register source, so use mov for
+        // the statically allocated symbol and keep all following arithmetic u64.
+        ptx.AppendLine("    mov.u64 %rd7, smem;");
+        ptx.AppendLine("    mul.wide.u32 %rd29, %r22, 2048;");
+        ptx.AppendLine("    add.u64 %rd28, %rd7, %rd29;"); // warp-private Q tile
+        ptx.AppendLine($"    mul.wide.u32 %rd8, %r2, {inputBytesPerHead};");
+        ptx.AppendLine("    add.u64 %rd0, %rd0, %rd8;");
+        ptx.AppendLine("    add.u64 %rd1, %rd1, %rd8;");
+        ptx.AppendLine("    add.u64 %rd2, %rd2, %rd8;");
+        ptx.AppendLine($"    mul.wide.u32 %rd9, %r2, {outputBytesPerHead};");
+        ptx.AppendLine("    add.u64 %rd5, %rd5, %rd9;");
+        ptx.AppendLine($"    mul.wide.u32 %rd10, %r2, {statsBytesPerHead};");
+        ptx.AppendLine("    add.u64 %rd6, %rd6, %rd10;");
+        ptx.AppendLine("    mul.wide.u32 %rd11, %r1, 2048;");
+        ptx.AppendLine("    add.u64 %rd12, %rd0, %rd11;"); // q tile global
+        ptx.AppendLine("    mul.wide.u32 %rd13, %r1, 4096;");
+        ptx.AppendLine("    add.u64 %rd5, %rd5, %rd13;"); // output tile global
+        ptx.AppendLine("    mul.wide.u32 %rd14, %r1, 64;");
+        ptx.AppendLine("    add.u64 %rd6, %rd6, %rd14;"); // stats tile global
+        ptx.AppendLine();
+
+        // Per-lane fragment address components reused for every tile.
+        ptx.AppendLine("    mul.lo.u32 %r10, %r3, 128;");
+        ptx.AppendLine("    shl.b32 %r11, %r4, 2;");
+        ptx.AppendLine("    add.u32 %r10, %r10, %r11;"); // row0 Q pair / key-row pair
+        ptx.AppendLine("    add.u32 %r11, %r10, 1024;"); // row1 Q / key+8
+        ptx.AppendLine("    cvt.u64.u32 %rd25, %r10;");
+        ptx.AppendLine("    cvt.u64.u32 %rd26, %r11;");
+
+        // Initial Q and K/V tile 0 are one asynchronous group.
+        EmitAsyncTileCopyFromAddress(ptx, "%rd12", "%rd28", 2048, "%r0", 32);
+        EmitAsyncTileCopy(ptx, "%rd1", kShared0, 2048, "%r21", warps * 32);
+        EmitAsyncTileCopy(ptx, "%rd2", vShared0, 2048, "%r21", warps * 32);
+        if (fuseLayerNormGelu)
+        {
+            ptx.AppendLine("    setp.lt.u32 %p0, %r21, 16;");
+            ptx.AppendLine("    mul.wide.u32 %rd15, %r21, 16;");
+            ptx.AppendLine($"    add.u64 %rd16, %rd7, {gammaShared};");
+            ptx.AppendLine("    add.u64 %rd16, %rd16, %rd15;");
+            ptx.AppendLine("    add.u64 %rd17, %rd3, %rd15;");
+            ptx.AppendLine("    @%p0 cp.async.ca.shared.global [%rd16], [%rd17], 16;");
+            ptx.AppendLine($"    add.u64 %rd16, %rd7, {betaShared};");
+            ptx.AppendLine("    add.u64 %rd16, %rd16, %rd15;");
+            ptx.AppendLine("    add.u64 %rd17, %rd4, %rd15;");
+            ptx.AppendLine("    @%p0 cp.async.ca.shared.global [%rd16], [%rd17], 16;");
+        }
+        ptx.AppendLine("    cp.async.commit_group;");
+        ptx.AppendLine("    cp.async.wait_group 0;");
+        ptx.AppendLine("    bar.sync 0;");
+        ptx.AppendLine();
+
+        ptx.AppendLine("    mov.f32 %f3, 0fFF800000;"); // running max row0
+        ptx.AppendLine("    mov.f32 %f4, 0fFF800000;"); // running max row1
+        ptx.AppendLine("    mov.f32 %f5, 0f00000000;"); // running sum row0
+        ptx.AppendLine("    mov.f32 %f6, 0f00000000;"); // running sum row1
+        for (int i = 0; i < 32; i++) ptx.AppendLine($"    mov.f32 %o{i}, 0f00000000;");
+        ptx.AppendLine();
+
+        for (int tile = 0; tile < sequenceLength / KeyTileRows; tile++)
+        {
+            int currentK = (tile & 1) == 0 ? kShared0 : kShared1;
+            int currentV = (tile & 1) == 0 ? vShared0 : vShared1;
+            int nextK = (tile & 1) == 0 ? kShared1 : kShared0;
+            int nextV = (tile & 1) == 0 ? vShared1 : vShared0;
+
+            ptx.AppendLine($"    // ---- online K/V tile {tile} ----");
+            if (tile + 1 < sequenceLength / KeyTileRows)
+            {
+                int nextByteOffset = (tile + 1) * 2048;
+                ptx.AppendLine($"    add.u64 %rd18, %rd1, {nextByteOffset};");
+                ptx.AppendLine($"    add.u64 %rd19, %rd2, {nextByteOffset};");
+                EmitAsyncTileCopy(ptx, "%rd18", nextK, 2048, "%r21", warps * 32);
+                EmitAsyncTileCopy(ptx, "%rd19", nextV, 2048, "%r21", warps * 32);
+                ptx.AppendLine("    cp.async.commit_group;");
+            }
+
+            if (isCausal)
+            {
+                ptx.AppendLine($"    setp.gt.u32 %p6, {tile}, %r1;");
+                ptx.AppendLine($"    @%p6 bra SKIP_CAUSAL_TILE_{tile};");
+            }
+            EmitScoreTile(ptx, currentK, tile, isCausal, scaleHex);
+            EmitOnlineSoftmaxAndPv(ptx, currentV, log2E, firstTile: tile == 0);
+            if (isCausal)
+                ptx.AppendLine($"SKIP_CAUSAL_TILE_{tile}:");
+
+            if (tile + 1 < sequenceLength / KeyTileRows)
+            {
+                ptx.AppendLine("    cp.async.wait_group 0;");
+                ptx.AppendLine("    bar.sync 0;");
+            }
+            ptx.AppendLine();
+        }
+
+        // Normalize online accumulators and emit log-sum-exp statistics.
+        ptx.AppendLine("    rcp.approx.f32 %f14, %f5;");
+        ptx.AppendLine("    rcp.approx.f32 %f15, %f6;");
+        for (int n = 0; n < 8; n++)
+        {
+            int o = n * 4;
+            ptx.AppendLine($"    mul.rn.f32 %o{o}, %o{o}, %f14;");
+            ptx.AppendLine($"    mul.rn.f32 %o{o + 1}, %o{o + 1}, %f14;");
+            ptx.AppendLine($"    mul.rn.f32 %o{o + 2}, %o{o + 2}, %f15;");
+            ptx.AppendLine($"    mul.rn.f32 %o{o + 3}, %o{o + 3}, %f15;");
+        }
+        if (emitSoftmaxStats)
+        {
+            ptx.AppendLine("    setp.eq.u32 %p0, %r4, 0;");
+            ptx.AppendLine("    lg2.approx.f32 %f16, %f5;");
+            ptx.AppendLine($"    fma.rn.f32 %f16, %f16, {ln2}, %f3;");
+            ptx.AppendLine("    lg2.approx.f32 %f17, %f6;");
+            ptx.AppendLine($"    fma.rn.f32 %f17, %f17, {ln2}, %f4;");
+            ptx.AppendLine("    mul.wide.u32 %rd18, %r3, 4;");
+            ptx.AppendLine("    add.u64 %rd18, %rd6, %rd18;");
+            ptx.AppendLine("    @%p0 st.global.f32 [%rd18], %f16;");
+            ptx.AppendLine("    @%p0 st.global.f32 [%rd18+32], %f17;");
+        }
+
+        if (fuseLayerNormGelu)
+            EmitLayerNormGelu(ptx, gammaShared, betaShared, inv64, epsilonHex, geluA, geluB);
+
+        EmitOutputStores(ptx);
+        ptx.AppendLine("    ret;");
+        ptx.AppendLine("}");
+        return ptx.ToString();
+    }
+
+    private static void EmitAsyncTileCopy(
+        StringBuilder ptx,
+        string globalBase,
+        int sharedBase,
+        int bytes,
+        string threadRegister,
+        int copyThreads)
+    {
+        int vectors = bytes / 16;
+        int participatingThreads = Math.Min(copyThreads, vectors);
+        int passes = vectors / participatingThreads;
+        bool predicateCopy = copyThreads > participatingThreads;
+        if (predicateCopy)
+            ptx.AppendLine($"    setp.lt.u32 %p7, {threadRegister}, {participatingThreads};");
+        ptx.AppendLine($"    mul.wide.u32 %rd20, {threadRegister}, 16;");
+        for (int pass = 0; pass < passes; pass++)
+        {
+            int offset = pass * participatingThreads * 16;
+            ptx.AppendLine($"    add.u64 %rd21, %rd7, {sharedBase + offset};");
+            ptx.AppendLine("    add.u64 %rd21, %rd21, %rd20;");
+            if (offset == 0)
+                ptx.AppendLine($"    add.u64 %rd22, {globalBase}, %rd20;");
+            else
+            {
+                ptx.AppendLine($"    add.u64 %rd22, {globalBase}, {offset};");
+                ptx.AppendLine("    add.u64 %rd22, %rd22, %rd20;");
+            }
+            ptx.AppendLine(predicateCopy
+                ? "    @%p7 cp.async.ca.shared.global [%rd21], [%rd22], 16;"
+                : "    cp.async.ca.shared.global [%rd21], [%rd22], 16;");
+        }
+    }
+
+    private static void EmitAsyncTileCopyFromAddress(
+        StringBuilder ptx,
+        string globalBase,
+        string sharedBase,
+        int bytes,
+        string threadRegister,
+        int copyThreads)
+    {
+        int passes = bytes / (copyThreads * 16);
+        ptx.AppendLine($"    mul.wide.u32 %rd20, {threadRegister}, 16;");
+        for (int pass = 0; pass < passes; pass++)
+        {
+            int offset = pass * copyThreads * 16;
+            if (offset == 0)
+                ptx.AppendLine($"    add.u64 %rd21, {sharedBase}, %rd20;");
+            else
+            {
+                ptx.AppendLine($"    add.u64 %rd21, {sharedBase}, {offset};");
+                ptx.AppendLine("    add.u64 %rd21, %rd21, %rd20;");
+            }
+            if (offset == 0)
+                ptx.AppendLine($"    add.u64 %rd22, {globalBase}, %rd20;");
+            else
+            {
+                ptx.AppendLine($"    add.u64 %rd22, {globalBase}, {offset};");
+                ptx.AppendLine("    add.u64 %rd22, %rd22, %rd20;");
+            }
+            ptx.AppendLine("    cp.async.ca.shared.global [%rd21], [%rd22], 16;");
+        }
+    }
+
+    private static void EmitScoreTile(
+        StringBuilder ptx,
+        int kShared,
+        int tile,
+        bool isCausal,
+        string scaleHex)
+    {
+        for (int i = 0; i < 8; i++) ptx.AppendLine($"    mov.f32 %s{i}, 0f00000000;");
+
+        for (int chunk = 0; chunk < HeadDimension; chunk += 16)
+        {
+            int chunkBytes = chunk * sizeof(ushort);
+            ptx.AppendLine($"    add.u64 %rd23, %rd28, {chunkBytes};");
+            ptx.AppendLine("    add.u64 %rd23, %rd23, %rd25;");
+            ptx.AppendLine("    ld.shared.b32 %a0, [%rd23];");
+            ptx.AppendLine("    ld.shared.b32 %a2, [%rd23+16];");
+            ptx.AppendLine($"    add.u64 %rd24, %rd28, {chunkBytes};");
+            ptx.AppendLine("    add.u64 %rd24, %rd24, %rd26;");
+            ptx.AppendLine("    ld.shared.b32 %a1, [%rd24];");
+            ptx.AppendLine("    ld.shared.b32 %a3, [%rd24+16];");
+
+            ptx.AppendLine($"    add.u64 %rd23, %rd7, {kShared + chunkBytes};");
+            ptx.AppendLine("    add.u64 %rd23, %rd23, %rd25;");
+            ptx.AppendLine("    ld.shared.b32 %b0, [%rd23];");
+            ptx.AppendLine("    ld.shared.b32 %b1, [%rd23+16];");
+            ptx.AppendLine("    mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 " +
+                "{%s0,%s1,%s2,%s3}, {%a0,%a1,%a2,%a3}, {%b0,%b1}, {%s0,%s1,%s2,%s3};");
+
+            ptx.AppendLine($"    add.u64 %rd24, %rd7, {kShared + chunkBytes};");
+            ptx.AppendLine("    add.u64 %rd24, %rd24, %rd26;");
+            ptx.AppendLine("    ld.shared.b32 %b2, [%rd24];");
+            ptx.AppendLine("    ld.shared.b32 %b3, [%rd24+16];");
+            ptx.AppendLine("    mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 " +
+                "{%s4,%s5,%s6,%s7}, {%a0,%a1,%a2,%a3}, {%b2,%b3}, {%s4,%s5,%s6,%s7};");
+        }
+
+        for (int i = 0; i < 8; i++)
+            ptx.AppendLine($"    mul.rn.f32 %s{i}, %s{i}, {scaleHex};");
+
+        if (isCausal)
+        {
+            int tileBase = tile * KeyTileRows;
+            ptx.AppendLine("    shl.b32 %r12, %r4, 1;");
+            if (tileBase != 0) ptx.AppendLine($"    add.u32 %r12, %r12, {tileBase};");
+            ptx.AppendLine("    add.u32 %r13, %r12, 1;");
+            ptx.AppendLine("    add.u32 %r14, %r12, 8;");
+            ptx.AppendLine("    add.u32 %r15, %r12, 9;");
+            EmitCausalMask(ptx, "%s0", "%r12", "%r8", "%p0");
+            EmitCausalMask(ptx, "%s1", "%r13", "%r8", "%p0");
+            EmitCausalMask(ptx, "%s4", "%r14", "%r8", "%p0");
+            EmitCausalMask(ptx, "%s5", "%r15", "%r8", "%p0");
+            EmitCausalMask(ptx, "%s2", "%r12", "%r9", "%p0");
+            EmitCausalMask(ptx, "%s3", "%r13", "%r9", "%p0");
+            EmitCausalMask(ptx, "%s6", "%r14", "%r9", "%p0");
+            EmitCausalMask(ptx, "%s7", "%r15", "%r9", "%p0");
+        }
+    }
+
+    private static void EmitCausalMask(
+        StringBuilder ptx, string score, string key, string query, string predicate)
+    {
+        ptx.AppendLine($"    setp.gt.u32 {predicate}, {key}, {query};");
+        ptx.AppendLine($"    @{predicate} mov.f32 {score}, 0fFF800000;");
+    }
+
+    private static void EmitOnlineSoftmaxAndPv(
+        StringBuilder ptx, int vShared, string log2E, bool firstTile)
+    {
+        // Each four-lane group owns two rows. It collectively holds 16 scores
+        // per row across the two m16n8 score fragments.
+        ptx.AppendLine("    max.f32 %f0, %s0, %s1;");
+        ptx.AppendLine("    max.f32 %f0, %f0, %s4;");
+        ptx.AppendLine("    max.f32 %f0, %f0, %s5;");
+        ptx.AppendLine("    max.f32 %f1, %s2, %s3;");
+        ptx.AppendLine("    max.f32 %f1, %f1, %s6;");
+        ptx.AppendLine("    max.f32 %f1, %f1, %s7;");
+        EmitGroup4Reduction(ptx, "max.f32", "%f0");
+        EmitGroup4Reduction(ptx, "max.f32", "%f1");
+        ptx.AppendLine("    max.f32 %f7, %f3, %f0;");
+        ptx.AppendLine("    max.f32 %f8, %f4, %f1;");
+        ptx.AppendLine("    sub.rn.f32 %f9, %f3, %f7;");
+        ptx.AppendLine($"    mul.rn.f32 %f9, %f9, {log2E};");
+        ptx.AppendLine("    ex2.approx.f32 %f9, %f9;");
+        ptx.AppendLine("    sub.rn.f32 %f10, %f4, %f8;");
+        ptx.AppendLine($"    mul.rn.f32 %f10, %f10, {log2E};");
+        ptx.AppendLine("    ex2.approx.f32 %f10, %f10;");
+
+        foreach (int index in new[] { 0, 1, 4, 5 })
+            EmitExponent(ptx, index, "%f7", log2E);
+        foreach (int index in new[] { 2, 3, 6, 7 })
+            EmitExponent(ptx, index, "%f8", log2E);
+
+        ptx.AppendLine("    add.rn.f32 %f11, %s0, %s1;");
+        ptx.AppendLine("    add.rn.f32 %f11, %f11, %s4;");
+        ptx.AppendLine("    add.rn.f32 %f11, %f11, %s5;");
+        ptx.AppendLine("    add.rn.f32 %f12, %s2, %s3;");
+        ptx.AppendLine("    add.rn.f32 %f12, %f12, %s6;");
+        ptx.AppendLine("    add.rn.f32 %f12, %f12, %s7;");
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f11");
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f12");
+        ptx.AppendLine("    fma.rn.f32 %f5, %f5, %f9, %f11;");
+        ptx.AppendLine("    fma.rn.f32 %f6, %f6, %f10, %f12;");
+        ptx.AppendLine("    mov.f32 %f3, %f7;");
+        ptx.AppendLine("    mov.f32 %f4, %f8;");
+
+        // The first tile has a zero prior accumulator. On later tiles a row's
+        // maximum usually does not change, so predicate away its 16 register
+        // rescale operations when exp(oldMax-newMax) is exactly one.
+        if (!firstTile)
+        {
+            ptx.AppendLine("    setp.neu.f32 %p2, %f9, 0f3F800000;");
+            ptx.AppendLine("    setp.neu.f32 %p3, %f10, 0f3F800000;");
+            for (int n = 0; n < 8; n++)
+            {
+                int o = n * 4;
+                ptx.AppendLine($"    @%p2 mul.rn.f32 %o{o}, %o{o}, %f9;");
+                ptx.AppendLine($"    @%p2 mul.rn.f32 %o{o + 1}, %o{o + 1}, %f9;");
+                ptx.AppendLine($"    @%p3 mul.rn.f32 %o{o + 2}, %o{o + 2}, %f10;");
+                ptx.AppendLine($"    @%p3 mul.rn.f32 %o{o + 3}, %o{o + 3}, %f10;");
+            }
+        }
+
+        // The score-fragment lane layout is exactly the row-major A operand
+        // layout for the P*V MMA, so conversion requires no shared scratch.
+        EmitPackHalf2(ptx, "%a0", "%s0", "%s1");
+        EmitPackHalf2(ptx, "%a1", "%s2", "%s3");
+        EmitPackHalf2(ptx, "%a2", "%s4", "%s5");
+        EmitPackHalf2(ptx, "%a3", "%s6", "%s7");
+
+        // B is V[16,64] interpreted as a column-major [K,N] operand. Load
+        // the four lane-owned values and pack them into the two f16x2 regs.
+        ptx.AppendLine("    shl.b32 %r16, %r4, 1;");
+        ptx.AppendLine("    mul.lo.u32 %r16, %r16, 128;");
+        ptx.AppendLine("    shl.b32 %r17, %r3, 1;");
+        ptx.AppendLine("    add.u32 %r16, %r16, %r17;");
+        ptx.AppendLine("    cvt.u64.u32 %rd27, %r16;");
+        for (int n = 0; n < 8; n++)
+        {
+            int colBytes = n * 16;
+            int o = n * 4;
+            ptx.AppendLine($"    add.u64 %rd23, %rd7, {vShared + colBytes};");
+            ptx.AppendLine("    add.u64 %rd23, %rd23, %rd27;");
+            ptx.AppendLine("    ld.shared.u16 %h0, [%rd23];");
+            ptx.AppendLine("    ld.shared.u16 %h1, [%rd23+128];");
+            ptx.AppendLine("    mov.b32 %b0, {%h0,%h1};");
+            ptx.AppendLine("    ld.shared.u16 %h2, [%rd23+1024];");
+            ptx.AppendLine("    ld.shared.u16 %h3, [%rd23+1152];");
+            ptx.AppendLine("    mov.b32 %b1, {%h2,%h3};");
+            ptx.AppendLine("    mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 " +
+                $"{{%o{o},%o{o + 1},%o{o + 2},%o{o + 3}}}, " +
+                "{%a0,%a1,%a2,%a3}, {%b0,%b1}, " +
+                $"{{%o{o},%o{o + 1},%o{o + 2},%o{o + 3}}};");
+        }
+    }
+
+    private static void EmitExponent(StringBuilder ptx, int score, string maximum, string log2E)
+    {
+        ptx.AppendLine($"    sub.rn.f32 %s{score}, %s{score}, {maximum};");
+        ptx.AppendLine($"    mul.rn.f32 %s{score}, %s{score}, {log2E};");
+        ptx.AppendLine($"    ex2.approx.f32 %s{score}, %s{score};");
+    }
+
+    private static void EmitGroup4Reduction(StringBuilder ptx, string operation, string accumulator)
+    {
+        foreach (int delta in new[] { 1, 2 })
+        {
+            ptx.AppendLine($"    mov.b32 %r30, {accumulator};");
+            ptx.AppendLine($"    shfl.sync.bfly.b32 %r31, %r30, {delta}, 31, 0xffffffff;");
+            ptx.AppendLine("    mov.b32 %f2, %r31;");
+            ptx.AppendLine($"    {operation} {accumulator}, {accumulator}, %f2;");
+        }
+    }
+
+    private static void EmitPackHalf2(StringBuilder ptx, string packed, string low, string high)
+    {
+        ptx.AppendLine($"    cvt.rn.f16.f32 %h0, {low};");
+        ptx.AppendLine($"    cvt.rn.f16.f32 %h1, {high};");
+        ptx.AppendLine($"    mov.b32 {packed}, {{%h0,%h1}};");
+    }
+
+    private static void EmitLayerNormGelu(
+        StringBuilder ptx,
+        int gammaShared,
+        int betaShared,
+        string inv64,
+        string epsilon,
+        string geluA,
+        string geluB)
+    {
+        ptx.AppendLine("    // Head-local LayerNorm(D=64) + tanh-GELU epilogue.");
+        ptx.AppendLine("    mov.f32 %f16, 0f00000000;");
+        ptx.AppendLine("    mov.f32 %f17, 0f00000000;");
+        ptx.AppendLine("    mov.f32 %f18, 0f00000000;");
+        ptx.AppendLine("    mov.f32 %f19, 0f00000000;");
+        for (int n = 0; n < 8; n++)
+        {
+            int o = n * 4;
+            ptx.AppendLine($"    add.rn.f32 %f16, %f16, %o{o};");
+            ptx.AppendLine($"    add.rn.f32 %f16, %f16, %o{o + 1};");
+            ptx.AppendLine($"    add.rn.f32 %f17, %f17, %o{o + 2};");
+            ptx.AppendLine($"    add.rn.f32 %f17, %f17, %o{o + 3};");
+            ptx.AppendLine($"    fma.rn.f32 %f18, %o{o}, %o{o}, %f18;");
+            ptx.AppendLine($"    fma.rn.f32 %f18, %o{o + 1}, %o{o + 1}, %f18;");
+            ptx.AppendLine($"    fma.rn.f32 %f19, %o{o + 2}, %o{o + 2}, %f19;");
+            ptx.AppendLine($"    fma.rn.f32 %f19, %o{o + 3}, %o{o + 3}, %f19;");
+        }
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f16");
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f17");
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f18");
+        EmitGroup4Reduction(ptx, "add.rn.f32", "%f19");
+        ptx.AppendLine($"    mul.rn.f32 %f20, %f16, {inv64};");
+        ptx.AppendLine($"    mul.rn.f32 %f21, %f17, {inv64};");
+        ptx.AppendLine($"    mul.rn.f32 %f22, %f18, {inv64};");
+        ptx.AppendLine($"    mul.rn.f32 %f23, %f19, {inv64};");
+        ptx.AppendLine("    mul.rn.f32 %f28, %f20, %f20;");
+        ptx.AppendLine("    sub.rn.f32 %f22, %f22, %f28;");
+        ptx.AppendLine("    mul.rn.f32 %f28, %f21, %f21;");
+        ptx.AppendLine("    sub.rn.f32 %f23, %f23, %f28;");
+        ptx.AppendLine($"    add.rn.f32 %f22, %f22, {epsilon};");
+        ptx.AppendLine($"    add.rn.f32 %f23, %f23, {epsilon};");
+        ptx.AppendLine("    rsqrt.approx.f32 %f22, %f22;");
+        ptx.AppendLine("    rsqrt.approx.f32 %f23, %f23;");
+
+        ptx.AppendLine("    shl.b32 %r18, %r4, 3;");
+        ptx.AppendLine("    cvt.u64.u32 %rd27, %r18;");
+        for (int n = 0; n < 8; n++)
+        {
+            int parameterBytes = n * 32;
+            int o = n * 4;
+            ptx.AppendLine($"    add.u64 %rd23, %rd7, {gammaShared + parameterBytes};");
+            ptx.AppendLine("    add.u64 %rd23, %rd23, %rd27;");
+            ptx.AppendLine("    ld.shared.f32 %f24, [%rd23];");
+            ptx.AppendLine("    ld.shared.f32 %f25, [%rd23+4];");
+            ptx.AppendLine($"    add.u64 %rd24, %rd7, {betaShared + parameterBytes};");
+            ptx.AppendLine("    add.u64 %rd24, %rd24, %rd27;");
+            ptx.AppendLine("    ld.shared.f32 %f26, [%rd24];");
+            ptx.AppendLine("    ld.shared.f32 %f27, [%rd24+4];");
+            EmitNormalizeAffineGelu(ptx, $"%o{o}", "%f20", "%f22", "%f24", "%f26", geluA, geluB);
+            EmitNormalizeAffineGelu(ptx, $"%o{o + 1}", "%f20", "%f22", "%f25", "%f27", geluA, geluB);
+            EmitNormalizeAffineGelu(ptx, $"%o{o + 2}", "%f21", "%f23", "%f24", "%f26", geluA, geluB);
+            EmitNormalizeAffineGelu(ptx, $"%o{o + 3}", "%f21", "%f23", "%f25", "%f27", geluA, geluB);
+        }
+    }
+
+    private static void EmitNormalizeAffineGelu(
+        StringBuilder ptx,
+        string value,
+        string mean,
+        string inverseStd,
+        string gamma,
+        string beta,
+        string geluA,
+        string geluB)
+    {
+        ptx.AppendLine($"    sub.rn.f32 {value}, {value}, {mean};");
+        ptx.AppendLine($"    mul.rn.f32 {value}, {value}, {inverseStd};");
+        ptx.AppendLine($"    fma.rn.f32 {value}, {value}, {gamma}, {beta};");
+        ptx.AppendLine($"    mul.rn.f32 %f28, {value}, {value};");
+        ptx.AppendLine($"    mul.rn.f32 %f28, %f28, {value};");
+        ptx.AppendLine($"    fma.rn.f32 %f28, %f28, {geluB}, {value};");
+        ptx.AppendLine($"    mul.rn.f32 %f28, %f28, {geluA};");
+        ptx.AppendLine("    tanh.approx.f32 %f28, %f28;");
+        ptx.AppendLine("    add.rn.f32 %f28, %f28, 0f3F800000;");
+        ptx.AppendLine($"    mul.rn.f32 %f28, %f28, {value};");
+        ptx.AppendLine($"    mul.rn.f32 {value}, %f28, 0f3F000000;");
+    }
+
+    private static void EmitOutputStores(StringBuilder ptx)
+    {
+        ptx.AppendLine("    mul.lo.u32 %r19, %r3, 256;");
+        ptx.AppendLine("    shl.b32 %r20, %r4, 3;");
+        ptx.AppendLine("    add.u32 %r19, %r19, %r20;");
+        ptx.AppendLine("    cvt.u64.u32 %rd27, %r19;");
+        for (int n = 0; n < 8; n++)
+        {
+            int colBytes = n * 32;
+            int o = n * 4;
+            ptx.AppendLine($"    add.u64 %rd23, %rd5, {colBytes};");
+            ptx.AppendLine("    add.u64 %rd23, %rd23, %rd27;");
+            ptx.AppendLine($"    st.global.v2.f32 [%rd23], {{%o{o},%o{o + 1}}};");
+            ptx.AppendLine($"    st.global.v2.f32 [%rd23+2048], {{%o{o + 2},%o{o + 3}}};");
+        }
+    }
+
+    private static string FloatLiteral(float value) =>
+        "0f" + BitConverter.SingleToInt32Bits(value).ToString("X8", CultureInfo.InvariantCulture);
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxOnlineFusedAttention128x64Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxOnlineFusedAttention128x64Kernel.cs
@@ -19,6 +19,9 @@ internal sealed class PtxOnlineFusedAttention128x64Kernel : IDisposable
     internal const int QueryTileRows = 16;
     internal const int KeyTileRows = 16;
 
+    internal static bool IsSupportedSequenceLength(int sequenceLength)
+        => sequenceLength is 16 or 32 or 64 or 128;
+
     private readonly DirectPtxModule _module;
     private readonly IntPtr _function;
 
@@ -64,7 +67,7 @@ internal sealed class PtxOnlineFusedAttention128x64Kernel : IDisposable
         if (batchHeads <= 0 || batchHeads > 65535) throw new ArgumentOutOfRangeException(nameof(batchHeads));
         if (!float.IsFinite(scale)) throw new ArgumentOutOfRangeException(nameof(scale));
         if (!float.IsFinite(epsilon) || epsilon <= 0) throw new ArgumentOutOfRangeException(nameof(epsilon));
-        if (sequenceLength is not (16 or 32 or 64 or 128))
+        if (!IsSupportedSequenceLength(sequenceLength))
             throw new ArgumentOutOfRangeException(
                 nameof(sequenceLength), "Online PTX sequence length must be one of 16, 32, 64, or 128.");
         if (!DirectPtxArchitecture.HasValidatedOnlineAttention(runtime.ArchitectureFamily))
@@ -237,7 +240,7 @@ internal sealed class PtxOnlineFusedAttention128x64Kernel : IDisposable
         bool emitSoftmaxStats = true,
         int? warpsPerBlock = null)
     {
-        if (sequenceLength is not (16 or 32 or 64 or 128))
+        if (!IsSupportedSequenceLength(sequenceLength))
             throw new ArgumentOutOfRangeException(nameof(sequenceLength));
         int inputBytesPerHead = sequenceLength * HeadDimension * sizeof(ushort);
         int outputBytesPerHead = sequenceLength * HeadDimension * sizeof(float);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxWmmaBatchedQkKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxWmmaBatchedQkKernel.cs
@@ -1,0 +1,239 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Hand-emitted PTX Tensor-Core kernel for the Q*K^T stage of multi-head
+/// attention. A and K are row-major FP16; output is row-major FP32.
+/// </summary>
+/// <remarks>
+/// M, N, K, batch count, scale, strides, and loop trip counts are specialized
+/// into the PTX. The execution path is Driver API only: PTX text -&gt;
+/// cuModuleLoadData -&gt; cuLaunchKernel. No NVRTC or vendor math library is used.
+/// </remarks>
+internal sealed class PtxWmmaBatchedQkKernel : IDisposable
+{
+    internal const string EntryPoint = "aidotnet_wmma_batched_qk";
+
+    private readonly DirectPtxRuntime _runtime;
+    private readonly DirectPtxModule _module;
+    private readonly IntPtr _function;
+    private readonly int _blockTile;
+
+    internal int M { get; }
+    internal int N { get; }
+    internal int K { get; }
+    internal int BatchCount { get; }
+    internal float Scale { get; }
+    internal string Ptx { get; }
+
+    internal PtxWmmaBatchedQkKernel(
+        DirectPtxRuntime runtime, int m, int n, int k, int batchCount, float scale)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        if (m <= 0 || (m & 31) != 0) throw new ArgumentOutOfRangeException(nameof(m), "M must be a positive multiple of 32.");
+        if (n <= 0 || (n & 31) != 0) throw new ArgumentOutOfRangeException(nameof(n), "N must be a positive multiple of 32.");
+        if (k <= 0 || (k & 15) != 0) throw new ArgumentOutOfRangeException(nameof(k), "K must be a positive multiple of 16.");
+        if (batchCount <= 0 || batchCount > 65535) throw new ArgumentOutOfRangeException(nameof(batchCount));
+        if (!float.IsFinite(scale)) throw new ArgumentOutOfRangeException(nameof(scale));
+        if (runtime.ComputeCapabilityMajor < 7)
+            throw new NotSupportedException("WMMA Tensor Core PTX requires compute capability 7.0 or newer.");
+
+        M = m;
+        N = n;
+        K = k;
+        BatchCount = batchCount;
+        Scale = scale;
+        _blockTile = m % 64 == 0 && n % 64 == 0 ? 64 : 32;
+        Ptx = EmitPtx(runtime.ComputeCapabilityMajor, runtime.ComputeCapabilityMinor, m, n, k, scale);
+        _module = runtime.LoadModule(Ptx);
+        _function = _module.GetFunction(EntryPoint);
+    }
+
+    internal nuint ABytes => checked((nuint)BatchCount * (nuint)M * (nuint)K * sizeof(ushort));
+    internal nuint BBytes => checked((nuint)BatchCount * (nuint)N * (nuint)K * sizeof(ushort));
+    internal nuint CBytes => checked((nuint)BatchCount * (nuint)M * (nuint)N * sizeof(float));
+
+    internal unsafe void Launch(DirectPtxBuffer a, DirectPtxBuffer b, DirectPtxBuffer c)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+        ArgumentNullException.ThrowIfNull(c);
+        if (a.ByteLength < ABytes || b.ByteLength < BBytes || c.ByteLength < CBytes)
+            throw new ArgumentException("A PTX kernel buffer is smaller than its specialized tensor shape.");
+
+        IntPtr aPointer = a.Pointer;
+        IntPtr bPointer = b.Pointer;
+        IntPtr cPointer = c.Pointer;
+        void** args = stackalloc void*[3];
+        args[0] = &aPointer;
+        args[1] = &bPointer;
+        args[2] = &cPointer;
+
+        _module.Launch(
+            _function,
+            (uint)(N / _blockTile), (uint)(M / _blockTile), (uint)BatchCount,
+            (uint)(_blockTile == 64 ? 512 : 128), 1, 1,
+            0,
+            args);
+    }
+
+    internal double EffectiveTflops(float milliseconds)
+    {
+        double flops = 2.0 * BatchCount * M * N * K;
+        return flops / (milliseconds * 1e-3) / 1e12;
+    }
+
+    public void Dispose() => _module.Dispose();
+
+    internal static string EmitPtx(int ccMajor, int ccMinor, int m, int n, int k, float scale)
+    {
+        if ((m & 31) != 0 || (n & 31) != 0 || (k & 15) != 0)
+            throw new ArgumentException("M and N must be multiples of 32; K must be a multiple of 16.");
+
+        // PTX 7.1 includes the sm_86 target used by Ampere consumer GPUs.
+        // Target the actual device family so the Driver
+        // JIT produces architecture-specific SASS for this context.
+        string target = $"sm_{ccMajor}{ccMinor}";
+        string scaleHex = "0f" + BitConverter.SingleToInt32Bits(scale).ToString("X8", CultureInfo.InvariantCulture);
+        int aBatchBytes = checked(m * k * sizeof(ushort));
+        int bBatchBytes = checked(n * k * sizeof(ushort));
+        int cBatchBytes = checked(m * n * sizeof(float));
+        int blockTile = m % 64 == 0 && n % 64 == 0 ? 64 : 32;
+        int warpsPerAxis = blockTile / 16;
+        int warpAxisShift = warpsPerAxis == 4 ? 2 : 1;
+        int aBlockRowBytes = checked(blockTile * k * sizeof(ushort));
+        int bBlockRowBytes = checked(blockTile * k * sizeof(ushort));
+        int cBlockRowBytes = checked(blockTile * n * sizeof(float));
+        int sharedOperandBytes = blockTile * 16 * sizeof(ushort);
+        int chunksPerOperand = blockTile * 2;
+
+        var ptx = new StringBuilder(8192);
+        ptx.AppendLine(".version 7.1");
+        ptx.AppendLine($".target {target}");
+        ptx.AppendLine(".address_size 64");
+        ptx.AppendLine();
+        ptx.AppendLine($".visible .entry {EntryPoint}(");
+        ptx.AppendLine("    .param .u64 q_ptr,");
+        ptx.AppendLine("    .param .u64 k_ptr,");
+        ptx.AppendLine("    .param .u64 scores_ptr");
+        ptx.AppendLine(")");
+        ptx.AppendLine("{");
+        ptx.AppendLine("    .reg .b32 %a<8>;");
+        ptx.AppendLine("    .reg .b32 %b<8>;");
+        ptx.AppendLine("    .reg .f32 %d<8>;");
+        ptx.AppendLine("    .reg .pred %p<2>;");
+        ptx.AppendLine("    .reg .b32 %r<16>;");
+        ptx.AppendLine("    .reg .b64 %rd<24>;");
+        ptx.AppendLine($"    .shared .align 16 .b8 smem[{sharedOperandBytes * 2}];");
+        ptx.AppendLine();
+        ptx.AppendLine("    ld.param.u64 %rd0, [q_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd1, [k_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd2, [scores_ptr];");
+        ptx.AppendLine("    mov.u32 %r0, %tid.x;");
+        ptx.AppendLine("    mov.u32 %r1, %ctaid.x;");
+        ptx.AppendLine("    mov.u32 %r2, %ctaid.y;");
+        ptx.AppendLine("    mov.u32 %r3, %ctaid.z;");
+        ptx.AppendLine("    shr.u32 %r4, %r0, 5;");
+        ptx.AppendLine($"    shr.u32 %r5, %r4, {warpAxisShift};");
+        ptx.AppendLine($"    and.b32 %r6, %r4, {warpsPerAxis - 1};");
+        ptx.AppendLine();
+        ptx.AppendLine($"    mul.wide.u32 %rd3, %r3, {aBatchBytes};");
+        ptx.AppendLine($"    mul.wide.u32 %rd4, %r2, {aBlockRowBytes};");
+        ptx.AppendLine("    add.u64 %rd5, %rd0, %rd3;");
+        ptx.AppendLine("    add.u64 %rd5, %rd5, %rd4;");
+        ptx.AppendLine($"    mul.wide.u32 %rd3, %r3, {bBatchBytes};");
+        ptx.AppendLine($"    mul.wide.u32 %rd4, %r1, {bBlockRowBytes};");
+        ptx.AppendLine("    add.u64 %rd6, %rd1, %rd3;");
+        ptx.AppendLine("    add.u64 %rd6, %rd6, %rd4;");
+        ptx.AppendLine($"    mul.wide.u32 %rd3, %r3, {cBatchBytes};");
+        ptx.AppendLine($"    mul.wide.u32 %rd4, %r2, {cBlockRowBytes};");
+        ptx.AppendLine($"    mul.wide.u32 %rd7, %r1, {blockTile * sizeof(float)};");
+        ptx.AppendLine("    add.u64 %rd8, %rd2, %rd3;");
+        ptx.AppendLine("    add.u64 %rd8, %rd8, %rd4;");
+        ptx.AppendLine("    add.u64 %rd8, %rd8, %rd7;");
+        ptx.AppendLine($"    mul.wide.u32 %rd9, %r5, {16 * n * sizeof(float)};");
+        ptx.AppendLine($"    mul.wide.u32 %rd10, %r6, {16 * sizeof(float)};");
+        ptx.AppendLine("    add.u64 %rd8, %rd8, %rd9;");
+        ptx.AppendLine("    add.u64 %rd8, %rd8, %rd10;");
+        ptx.AppendLine("    mov.u64 %rd11, smem;");
+        ptx.AppendLine();
+        for (int i = 0; i < 8; i++)
+            ptx.AppendLine($"    mov.f32 %d{i}, 0f00000000;");
+
+        for (int tileK = 0; tileK < k; tileK += 16)
+        {
+            int kByteOffset = tileK * sizeof(ushort);
+            string copyK = $"COPY_K_{tileK}";
+            string copyDone = $"COPY_DONE_{tileK}";
+            ptx.AppendLine();
+            // Aligned 16-byte copies stage one blockTile x 16 tile from
+            // each operand. The 64x64 variant uses 16 warps and reuses
+            // every Q/K tile four times; its remaining threads skip copy.
+            ptx.AppendLine($"    setp.ge.u32 %p1, %r0, {chunksPerOperand * 2};");
+            ptx.AppendLine($"    @%p1 bra {copyDone};");
+            ptx.AppendLine($"    setp.ge.u32 %p0, %r0, {chunksPerOperand};");
+            ptx.AppendLine($"    @%p0 bra {copyK};");
+            ptx.AppendLine("    shr.u32 %r7, %r0, 1;");
+            ptx.AppendLine("    and.b32 %r8, %r0, 1;");
+            ptx.AppendLine($"    mul.wide.u32 %rd12, %r7, {k * sizeof(ushort)};");
+            ptx.AppendLine("    add.u64 %rd12, %rd5, %rd12;");
+            ptx.AppendLine($"    add.u64 %rd12, %rd12, {kByteOffset};");
+            ptx.AppendLine("    mul.wide.u32 %rd13, %r8, 16;");
+            ptx.AppendLine("    add.u64 %rd12, %rd12, %rd13;");
+            ptx.AppendLine("    mul.wide.u32 %rd13, %r7, 32;");
+            ptx.AppendLine("    add.u64 %rd13, %rd11, %rd13;");
+            ptx.AppendLine("    mul.wide.u32 %rd14, %r8, 16;");
+            ptx.AppendLine("    add.u64 %rd13, %rd13, %rd14;");
+            ptx.AppendLine("    ld.global.v4.u32 {%r9,%r10,%r11,%r12}, [%rd12];");
+            ptx.AppendLine("    st.shared.v4.u32 [%rd13], {%r9,%r10,%r11,%r12};");
+            ptx.AppendLine($"    bra {copyDone};");
+            ptx.AppendLine($"{copyK}:");
+            ptx.AppendLine($"    sub.u32 %r7, %r0, {chunksPerOperand};");
+            ptx.AppendLine("    shr.u32 %r8, %r7, 1;");
+            ptx.AppendLine("    and.b32 %r7, %r7, 1;");
+            ptx.AppendLine($"    mul.wide.u32 %rd12, %r8, {k * sizeof(ushort)};");
+            ptx.AppendLine("    add.u64 %rd12, %rd6, %rd12;");
+            ptx.AppendLine($"    add.u64 %rd12, %rd12, {kByteOffset};");
+            ptx.AppendLine("    mul.wide.u32 %rd13, %r7, 16;");
+            ptx.AppendLine("    add.u64 %rd12, %rd12, %rd13;");
+            ptx.AppendLine("    mul.wide.u32 %rd13, %r8, 32;");
+            ptx.AppendLine($"    add.u64 %rd13, %rd13, {sharedOperandBytes};");
+            ptx.AppendLine("    add.u64 %rd13, %rd11, %rd13;");
+            ptx.AppendLine("    mul.wide.u32 %rd14, %r7, 16;");
+            ptx.AppendLine("    add.u64 %rd13, %rd13, %rd14;");
+            ptx.AppendLine("    ld.global.v4.u32 {%r9,%r10,%r11,%r12}, [%rd12];");
+            ptx.AppendLine("    st.shared.v4.u32 [%rd13], {%r9,%r10,%r11,%r12};");
+            ptx.AppendLine($"{copyDone}:");
+            ptx.AppendLine("    bar.sync 0;");
+            ptx.AppendLine("    mul.wide.u32 %rd15, %r5, 512;");
+            ptx.AppendLine("    add.u64 %rd15, %rd11, %rd15;");
+            ptx.AppendLine("    mul.wide.u32 %rd16, %r6, 512;");
+            ptx.AppendLine($"    add.u64 %rd16, %rd16, {sharedOperandBytes};");
+            ptx.AppendLine("    add.u64 %rd16, %rd11, %rd16;");
+            ptx.AppendLine("    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " +
+                "{%a0,%a1,%a2,%a3,%a4,%a5,%a6,%a7}, [%rd15], 16;");
+            ptx.AppendLine("    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 " +
+                "{%b0,%b1,%b2,%b3,%b4,%b5,%b6,%b7}, [%rd16], 16;");
+            ptx.AppendLine("    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 " +
+                "{%d0,%d1,%d2,%d3,%d4,%d5,%d6,%d7}, " +
+                "{%a0,%a1,%a2,%a3,%a4,%a5,%a6,%a7}, " +
+                "{%b0,%b1,%b2,%b3,%b4,%b5,%b6,%b7}, " +
+                "{%d0,%d1,%d2,%d3,%d4,%d5,%d6,%d7};");
+            ptx.AppendLine("    bar.sync 0;");
+        }
+
+        ptx.AppendLine();
+        for (int i = 0; i < 8; i++)
+            ptx.AppendLine($"    mul.rn.f32 %d{i}, %d{i}, {scaleHex};");
+        ptx.AppendLine("    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 " +
+            "[%rd8], {%d0,%d1,%d2,%d3,%d4,%d5,%d6,%d7}, " + n + ";");
+        ptx.AppendLine("    ret;");
+        ptx.AppendLine("}");
+        return ptx.ToString();
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxWmmaFusedAttention32x16Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxWmmaFusedAttention32x16Kernel.cs
@@ -1,0 +1,319 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+/// <summary>
+/// Shape-specialized fused attention-forward proof for S=32, D=16.
+/// Q/K/V are row-major FP16, output is row-major FP32. Scores and
+/// probabilities exist only in shared memory; both Q*K^T and P*V use WMMA.
+/// </summary>
+internal sealed class PtxWmmaFusedAttention32x16Kernel : IDisposable
+{
+    internal const string EntryPoint = "aidotnet_wmma_fused_attention_32x16";
+    internal const int SequenceLength = 32;
+    internal const int HeadDimension = 16;
+
+    private const int InputBytesPerHead = SequenceLength * HeadDimension * sizeof(ushort);
+    private const int OutputBytesPerHead = SequenceLength * HeadDimension * sizeof(float);
+
+    private readonly DirectPtxRuntime _runtime;
+    private readonly DirectPtxModule _module;
+    private readonly IntPtr _function;
+
+    internal int BatchHeads { get; }
+    internal bool IsCausal { get; }
+    internal float Scale { get; }
+    internal string Ptx { get; }
+
+    internal nuint QBytes => checked((nuint)BatchHeads * InputBytesPerHead);
+    internal nuint KBytes => QBytes;
+    internal nuint VBytes => QBytes;
+    internal nuint OutputBytes => checked((nuint)BatchHeads * OutputBytesPerHead);
+
+    internal PtxWmmaFusedAttention32x16Kernel(
+        DirectPtxRuntime runtime, int batchHeads, bool isCausal, float scale = 0.25f)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        if (batchHeads <= 0 || batchHeads > 65535) throw new ArgumentOutOfRangeException(nameof(batchHeads));
+        if (!float.IsFinite(scale)) throw new ArgumentOutOfRangeException(nameof(scale));
+        if (runtime.ComputeCapabilityMajor < 7)
+            throw new NotSupportedException("WMMA Tensor Core PTX requires compute capability 7.0 or newer.");
+
+        BatchHeads = batchHeads;
+        IsCausal = isCausal;
+        Scale = scale;
+        Ptx = EmitPtx(runtime.ComputeCapabilityMajor, runtime.ComputeCapabilityMinor, isCausal, scale);
+        _module = runtime.LoadModule(Ptx);
+        _function = _module.GetFunction(EntryPoint);
+    }
+
+    internal unsafe void Launch(
+        DirectPtxBuffer query, DirectPtxBuffer key, DirectPtxBuffer value, DirectPtxBuffer output)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(output);
+        if (query.ByteLength < QBytes || key.ByteLength < KBytes ||
+            value.ByteLength < VBytes || output.ByteLength < OutputBytes)
+            throw new ArgumentException("A fused-attention buffer is smaller than the specialized shape.");
+
+        IntPtr qPointer = query.Pointer;
+        IntPtr kPointer = key.Pointer;
+        IntPtr vPointer = value.Pointer;
+        IntPtr oPointer = output.Pointer;
+        void** args = stackalloc void*[4];
+        args[0] = &qPointer;
+        args[1] = &kPointer;
+        args[2] = &vPointer;
+        args[3] = &oPointer;
+
+        _module.Launch(
+            _function,
+            (uint)BatchHeads, 1, 1,
+            128, 1, 1,
+            0,
+            args);
+    }
+
+    internal double EffectiveTflops(float milliseconds)
+    {
+        double flops = 4.0 * BatchHeads * SequenceLength * SequenceLength * HeadDimension;
+        return flops / (milliseconds * 1e-3) / 1e12;
+    }
+
+    public void Dispose() => _module.Dispose();
+
+    internal static string EmitPtx(int ccMajor, int ccMinor, bool isCausal, float scale)
+    {
+        string target = $"sm_{ccMajor}{ccMinor}";
+        string scaleHex = FloatLiteral(scale);
+        const string log2E = "0f3FB8AA3B";
+        const int qShared = 0;
+        const int kShared = 1024;
+        const int vShared = 2048;
+        const int scoreShared = 3072;
+        const int invSumShared = scoreShared + 2048;
+        const int probabilityShared = 7168;
+        const int sharedBytes = 9216;
+
+        var ptx = new StringBuilder(24 * 1024);
+        ptx.AppendLine(".version 7.1");
+        ptx.AppendLine($".target {target}");
+        ptx.AppendLine(".address_size 64");
+        ptx.AppendLine();
+        ptx.AppendLine($".visible .entry {EntryPoint}(");
+        ptx.AppendLine("    .param .u64 q_ptr,");
+        ptx.AppendLine("    .param .u64 k_ptr,");
+        ptx.AppendLine("    .param .u64 v_ptr,");
+        ptx.AppendLine("    .param .u64 o_ptr");
+        ptx.AppendLine(")");
+        ptx.AppendLine("{");
+        ptx.AppendLine("    .reg .b16 %h<2>;");
+        ptx.AppendLine("    .reg .b32 %a<8>;");
+        ptx.AppendLine("    .reg .b32 %b<8>;");
+        ptx.AppendLine("    .reg .f32 %d<8>;");
+        ptx.AppendLine("    .reg .f32 %f<8>;");
+        ptx.AppendLine("    .reg .pred %p<4>;");
+        ptx.AppendLine("    .reg .b32 %r<20>;");
+        ptx.AppendLine("    .reg .b64 %rd<24>;");
+        ptx.AppendLine($"    .shared .align 16 .b8 smem[{sharedBytes}];");
+        ptx.AppendLine();
+        ptx.AppendLine("    ld.param.u64 %rd0, [q_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd1, [k_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd2, [v_ptr];");
+        ptx.AppendLine("    ld.param.u64 %rd3, [o_ptr];");
+        ptx.AppendLine("    mov.u32 %r0, %tid.x;");
+        ptx.AppendLine("    mov.u32 %r1, %ctaid.x;");
+        ptx.AppendLine("    mov.u64 %rd4, smem;");
+        ptx.AppendLine($"    mul.wide.u32 %rd5, %r1, {InputBytesPerHead};");
+        ptx.AppendLine("    add.u64 %rd0, %rd0, %rd5;");
+        ptx.AppendLine("    add.u64 %rd1, %rd1, %rd5;");
+        ptx.AppendLine("    add.u64 %rd2, %rd2, %rd5;");
+        ptx.AppendLine($"    mul.wide.u32 %rd6, %r1, {OutputBytesPerHead};");
+        ptx.AppendLine("    add.u64 %rd3, %rd3, %rd6;");
+        ptx.AppendLine();
+
+        // Sixty-four aligned 16-byte chunks cover each 32x16 FP16 operand.
+        ptx.AppendLine("    setp.ge.u32 %p0, %r0, 64;");
+        ptx.AppendLine("    @%p0 bra LOAD_DONE;");
+        ptx.AppendLine("    mul.wide.u32 %rd7, %r0, 16;");
+        EmitVectorCopy(ptx, "%rd0", qShared);
+        EmitVectorCopy(ptx, "%rd1", kShared);
+        EmitVectorCopy(ptx, "%rd2", vShared);
+        ptx.AppendLine("LOAD_DONE:");
+        ptx.AppendLine("    bar.sync 0;");
+        ptx.AppendLine();
+
+        // Warps 0 and 1 compute the two 16-row score tiles. Each warp emits
+        // two 16x16 fragments, covering all 32 keys.
+        ptx.AppendLine("    shr.u32 %r2, %r0, 5;");
+        ptx.AppendLine("    setp.ge.u32 %p0, %r2, 2;");
+        ptx.AppendLine("    @%p0 bra SCORE_DONE;");
+        ptx.AppendLine("    mul.wide.u32 %rd8, %r2, 512;");
+        ptx.AppendLine($"    add.u64 %rd9, %rd4, {qShared};");
+        ptx.AppendLine("    add.u64 %rd9, %rd9, %rd8;");
+        ptx.AppendLine($"    add.u64 %rd10, %rd4, {kShared};");
+        ptx.AppendLine($"    add.u64 %rd11, %rd4, {scoreShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd12, %r2, 2048;");
+        ptx.AppendLine("    add.u64 %rd11, %rd11, %rd12;");
+        ptx.AppendLine("    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " + Fragment("a") + ", [%rd9], 16;");
+        EmitZeroAccumulator(ptx);
+        ptx.AppendLine("    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 " + Fragment("b") + ", [%rd10], 16;");
+        EmitMma(ptx, "row", "col");
+        ptx.AppendLine("    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%rd11], " + Fragment("d") + ", 32;");
+        EmitZeroAccumulator(ptx);
+        ptx.AppendLine("    add.u64 %rd10, %rd10, 512;");
+        ptx.AppendLine("    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 " + Fragment("b") + ", [%rd10], 16;");
+        EmitMma(ptx, "row", "col");
+        ptx.AppendLine("    add.u64 %rd11, %rd11, 64;");
+        ptx.AppendLine("    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%rd11], " + Fragment("d") + ", 32;");
+        ptx.AppendLine("SCORE_DONE:");
+        ptx.AppendLine("    bar.sync 0;");
+        ptx.AppendLine();
+
+        // One thread owns each complete score row. Scores are scaled and
+        // normalized in shared memory; the FP16 probability tile feeds the
+        // second Tensor Core operation without a global-memory round trip.
+        ptx.AppendLine("    setp.ge.u32 %p0, %r0, 32;");
+        ptx.AppendLine("    @%p0 bra SOFTMAX_DONE;");
+        ptx.AppendLine($"    add.u64 %rd10, %rd4, {scoreShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd11, %r0, 128;");
+        ptx.AppendLine("    add.u64 %rd10, %rd10, %rd11;");
+        ptx.AppendLine($"    add.u64 %rd12, %rd4, {probabilityShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd13, %r0, 64;");
+        ptx.AppendLine("    add.u64 %rd12, %rd12, %rd13;");
+        ptx.AppendLine("    mov.f32 %f0, 0fFF800000;");
+        for (int column = 0; column < SequenceLength; column++)
+        {
+            if (isCausal)
+                ptx.AppendLine($"    setp.gt.u32 %p1, {column}, %r0;");
+            ptx.AppendLine($"    ld.shared.f32 %f1, [%rd10+{column * sizeof(float)}];");
+            ptx.AppendLine($"    mul.rn.f32 %f1, %f1, {scaleHex};");
+            if (isCausal)
+                ptx.AppendLine("    @!%p1 max.f32 %f0, %f0, %f1;");
+            else
+                ptx.AppendLine("    max.f32 %f0, %f0, %f1;");
+        }
+        ptx.AppendLine("    mov.f32 %f3, 0f00000000;");
+        for (int column = 0; column < SequenceLength; column++)
+        {
+            if (isCausal)
+            {
+                ptx.AppendLine($"    setp.gt.u32 %p1, {column}, %r0;");
+                ptx.AppendLine("    @%p1 mov.f32 %f2, 0f00000000;");
+                ptx.AppendLine($"    @!%p1 ld.shared.f32 %f1, [%rd10+{column * sizeof(float)}];");
+                ptx.AppendLine($"    @!%p1 mul.rn.f32 %f1, %f1, {scaleHex};");
+                ptx.AppendLine("    @!%p1 sub.rn.f32 %f2, %f1, %f0;");
+                ptx.AppendLine($"    @!%p1 mul.rn.f32 %f2, %f2, {log2E};");
+                ptx.AppendLine("    @!%p1 ex2.approx.f32 %f2, %f2;");
+            }
+            else
+            {
+                ptx.AppendLine($"    ld.shared.f32 %f1, [%rd10+{column * sizeof(float)}];");
+                ptx.AppendLine($"    mul.rn.f32 %f1, %f1, {scaleHex};");
+                ptx.AppendLine("    sub.rn.f32 %f2, %f1, %f0;");
+                ptx.AppendLine($"    mul.rn.f32 %f2, %f2, {log2E};");
+                ptx.AppendLine("    ex2.approx.f32 %f2, %f2;");
+            }
+            ptx.AppendLine("    add.rn.f32 %f3, %f3, %f2;");
+            ptx.AppendLine("    cvt.rn.f16.f32 %h0, %f2;");
+            ptx.AppendLine($"    st.shared.u16 [%rd12+{column * sizeof(ushort)}], %h0;");
+        }
+        ptx.AppendLine("    rcp.approx.f32 %f4, %f3;");
+        ptx.AppendLine($"    add.u64 %rd14, %rd4, {invSumShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd15, %r0, 4;");
+        ptx.AppendLine("    add.u64 %rd14, %rd14, %rd15;");
+        ptx.AppendLine("    st.shared.f32 [%rd14], %f4;");
+        ptx.AppendLine("SOFTMAX_DONE:");
+        ptx.AppendLine("    bar.sync 0;");
+        ptx.AppendLine();
+
+        // Warps 0 and 1 compute unnormalized P*V for 16 query rows each.
+        // The normalization factor is applied during the final coalesced copy.
+        ptx.AppendLine("    setp.ge.u32 %p0, %r2, 2;");
+        ptx.AppendLine("    @%p0 bra PV_DONE;");
+        ptx.AppendLine($"    add.u64 %rd9, %rd4, {probabilityShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd8, %r2, 1024;");
+        ptx.AppendLine("    add.u64 %rd9, %rd9, %rd8;");
+        ptx.AppendLine($"    add.u64 %rd10, %rd4, {vShared};");
+        EmitZeroAccumulator(ptx);
+        ptx.AppendLine("    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " + Fragment("a") + ", [%rd9], 32;");
+        ptx.AppendLine("    wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 " + Fragment("b") + ", [%rd10], 16;");
+        EmitMma(ptx, "row", "row");
+        ptx.AppendLine("    add.u64 %rd9, %rd9, 32;");
+        ptx.AppendLine("    add.u64 %rd10, %rd10, 512;");
+        ptx.AppendLine("    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " + Fragment("a") + ", [%rd9], 32;");
+        ptx.AppendLine("    wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 " + Fragment("b") + ", [%rd10], 16;");
+        EmitMma(ptx, "row", "row");
+        ptx.AppendLine($"    add.u64 %rd11, %rd4, {scoreShared};");
+        ptx.AppendLine("    mul.wide.u32 %rd12, %r2, 1024;");
+        ptx.AppendLine("    add.u64 %rd11, %rd11, %rd12;");
+        ptx.AppendLine("    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%rd11], " + Fragment("d") + ", 16;");
+        ptx.AppendLine("PV_DONE:");
+        ptx.AppendLine("    bar.sync 0;");
+        ptx.AppendLine();
+
+        // Four coalesced passes write the 32x16 result. scoreShared is reused
+        // as the P*V output scratch after all score consumers have finished.
+        for (int pass = 0; pass < 4; pass++)
+        {
+            int add = pass * 128;
+            if (add == 0) ptx.AppendLine("    mov.u32 %r3, %r0;");
+            else ptx.AppendLine($"    add.u32 %r3, %r0, {add};");
+            ptx.AppendLine("    shr.u32 %r4, %r3, 4;");
+            ptx.AppendLine($"    add.u64 %rd9, %rd4, {scoreShared};");
+            ptx.AppendLine("    mul.wide.u32 %rd10, %r3, 4;");
+            ptx.AppendLine("    add.u64 %rd9, %rd9, %rd10;");
+            ptx.AppendLine("    ld.shared.f32 %f1, [%rd9];");
+            ptx.AppendLine($"    add.u64 %rd11, %rd4, {invSumShared};");
+            ptx.AppendLine("    mul.wide.u32 %rd12, %r4, 4;");
+            ptx.AppendLine("    add.u64 %rd11, %rd11, %rd12;");
+            ptx.AppendLine("    ld.shared.f32 %f2, [%rd11];");
+            ptx.AppendLine("    mul.rn.f32 %f1, %f1, %f2;");
+            ptx.AppendLine("    add.u64 %rd13, %rd3, %rd10;");
+            ptx.AppendLine("    st.global.f32 [%rd13], %f1;");
+        }
+        ptx.AppendLine("    ret;");
+        ptx.AppendLine("}");
+        return ptx.ToString();
+    }
+
+    private static void EmitVectorCopy(StringBuilder ptx, string globalBase, int sharedOffset)
+    {
+        ptx.AppendLine($"    add.u64 %rd8, {globalBase}, %rd7;");
+        ptx.AppendLine($"    add.u64 %rd9, %rd4, {sharedOffset};");
+        ptx.AppendLine("    add.u64 %rd9, %rd9, %rd7;");
+        ptx.AppendLine("    ld.global.v4.u32 {%r8,%r9,%r10,%r11}, [%rd8];");
+        ptx.AppendLine("    st.shared.v4.u32 [%rd9], {%r8,%r9,%r10,%r11};");
+    }
+
+    private static void EmitZeroAccumulator(StringBuilder ptx)
+    {
+        for (int i = 0; i < 8; i++) ptx.AppendLine($"    mov.f32 %d{i}, 0f00000000;");
+    }
+
+    private static void EmitMma(StringBuilder ptx, string aLayout, string bLayout)
+    {
+        ptx.AppendLine($"    wmma.mma.sync.aligned.{aLayout}.{bLayout}.m16n16k16.f32.f32 " +
+            Fragment("d") + ", " + Fragment("a") + ", " + Fragment("b") + ", " + Fragment("d") + ";");
+    }
+
+    private static string Fragment(string prefix)
+    {
+        var result = new StringBuilder("{");
+        for (int i = 0; i < 8; i++)
+        {
+            if (i != 0) result.Append(',');
+            result.Append('%').Append(prefix).Append(i);
+        }
+        return result.Append('}').ToString();
+    }
+
+    private static string FloatLiteral(float value) =>
+        "0f" + BitConverter.SingleToInt32Bits(value).ToString("X8", CultureInfo.InvariantCulture);
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4003,6 +4003,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     private OwnedBuffer GetOrAllocateContiguousInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> tensor)
     {
+        // Validate the logical-to-physical contract before accepting ANY
+        // resident/cached fast path. A contiguous view with a storage offset,
+        // or a view into a larger backing allocation, is not a canonical base
+        // pointer and cannot be passed to a stride-free device kernel.
+        if (!tensor.IsContiguous || tensor.IsSparse)
+            throw new InvalidOperationException("GPU destination-aware tensor ops require contiguous dense inputs.");
+        if (tensor._storageOffset != 0 || tensor._storage.Length != tensor.Length)
+            throw new InvalidOperationException(
+                "GPU destination-aware tensor ops require a zero-offset canonical allocation.");
+
         // #3 FP16-act CONVERT-AT-GAP: an FP16-tagged input → stable up-converted FP32 (see GetResidentOrPersistentInputBuffer).
         var tHalfC = TryFp16ResidentInput(tensor, out var tCountC);
         if (tHalfC is not null)
@@ -4012,11 +4022,6 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
             return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
-
-        if (!tensor.IsContiguous || tensor.IsSparse)
-            throw new InvalidOperationException("GPU destination-aware tensor ops require contiguous dense inputs.");
-        if (tensor._storageOffset != 0 || tensor._storage.Length != tensor.Length)
-            throw new InvalidOperationException("GPU destination-aware tensor ops require simple CPU-backed inputs.");
 
         return GetOrAllocateBuffer(backend, tensor);
     }
@@ -10047,6 +10052,82 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // Compute scale if not provided
         float scaleFloat = (float)(scale ?? (1.0 / Math.Sqrt(headDim)));
+
+#if NET5_0_OR_GREATER
+        // Opt-in direct-PTX specialization. This is the only dynamic boundary:
+        // prove a zero-offset dense [B,H,S,D] allocation here, resolve it once
+        // to the kernel's physical FP16 dtype, then launch PTX containing no
+        // shape/stride/layout checks. Unsupported shapes or any JIT failure
+        // fall through to the existing NVRTC FlashAttention implementation.
+        if (typeof(T) == typeof(float) && attentionBias is null
+            && backend is Engines.DirectGpu.CUDA.CudaBackend directCuda
+            && directCuda.IsDirectPtxAttentionEnabled
+            // Module JIT and the eager scratch allocations below are not
+            // stream-capture safe. Captured graphs keep the established
+            // resident NVRTC path until a PTX prewarm/capture API is added.
+            && !directCuda.IsStreamCapturing()
+            && seqQ == seqK && seqQ is 16 or 32 or 64 or 128 && headDim == 64
+            && key.Shape._dims[0] == batch && value.Shape._dims[0] == batch
+            && key.Shape._dims[1] == heads && value.Shape._dims[1] == heads
+            && key.Shape._dims[3] == headDim && value.Shape._dims[2] == seqK
+            && value.Shape._dims[3] == headDim
+            && query.IsContiguous && key.IsContiguous && value.IsContiguous
+            && !query.IsSparse && !key.IsSparse && !value.IsSparse
+            && query._storageOffset == 0 && key._storageOffset == 0 && value._storageOffset == 0
+            && query._storage.Length == query.Length
+            && key._storage.Length == key.Length
+            && value._storage.Length == value.Length)
+        {
+            IGpuBuffer? queryHalfOwned = null;
+            IGpuBuffer? keyHalfOwned = null;
+            IGpuBuffer? valueHalfOwned = null;
+            var directOutput = AllocateOutputBuffer(backend, batch * heads * seqQ * headDim);
+            var directStats = AllocateOutputBuffer(backend, batch * heads * seqQ);
+            bool directHanded = false;
+            try
+            {
+                int inputElements = batch * heads * seqQ * headDim;
+                IGpuBuffer queryHalf = ResolveToFp16(
+                    query, inputElements, directCuda, backend, out queryHalfOwned);
+                IGpuBuffer keyHalf = ResolveToFp16(
+                    key, inputElements, directCuda, backend, out keyHalfOwned);
+                IGpuBuffer valueHalf = ResolveToFp16(
+                    value, inputElements, directCuda, backend, out valueHalfOwned);
+                if (directCuda.TryDirectPtxOnlineAttention(
+                    queryHalf, keyHalf, valueHalf,
+                    directOutput.Buffer, directStats.Buffer,
+                    batch * heads, scaleFloat, isCausal, seqQ))
+                {
+                    var directResult = DeferTensorResult<T>(
+                        backend, directOutput.Buffer,
+                        batch * heads * seqQ * headDim,
+                        new[] { batch, heads, seqQ, headDim });
+                    softmaxStats = DeferTensorResult<T>(
+                        backend, directStats.Buffer,
+                        batch * heads * seqQ,
+                        new[] { batch, heads, seqQ });
+                    directHanded = true;
+                    return directResult;
+                }
+                AliasDiag($"FlashAttention direct-PTX FELLBACK: {directCuda.DirectPtxLastError ?? "specialization unavailable"}");
+            }
+            catch (Exception ptxEx)
+            {
+                AliasDiag($"FlashAttention direct-PTX FELLBACK: {ptxEx.GetType().Name}: {ptxEx.Message}");
+            }
+            finally
+            {
+                queryHalfOwned?.Dispose();
+                keyHalfOwned?.Dispose();
+                valueHalfOwned?.Dispose();
+                if (!directHanded)
+                {
+                    directOutput.Dispose();
+                    directStats.Dispose();
+                }
+            }
+        }
+#endif
 
         // #638/#1650 GPU-RESIDENT capture path: run FlashAttentionV2 into resident output + softmax-stats
         // buffers and BIND them (no DownloadBuffer), so the diffusion attention block stays fully on-device

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -7,6 +7,9 @@ using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
+#if NET5_0_OR_GREATER
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+#endif
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -4001,17 +4004,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return destinationArray is not null;
     }
 
+    private static bool IsCanonicalDenseAllocation<T>(Tensor<T> tensor)
+        => tensor.IsContiguous && !tensor.IsSparse
+            && tensor._storageOffset == 0 && tensor._storage.Length == tensor.Length;
+
     private OwnedBuffer GetOrAllocateContiguousInputBuffer<T>(IDirectGpuBackend backend, Tensor<T> tensor)
     {
         // Validate the logical-to-physical contract before accepting ANY
         // resident/cached fast path. A contiguous view with a storage offset,
         // or a view into a larger backing allocation, is not a canonical base
         // pointer and cannot be passed to a stride-free device kernel.
-        if (!tensor.IsContiguous || tensor.IsSparse)
-            throw new InvalidOperationException("GPU destination-aware tensor ops require contiguous dense inputs.");
-        if (tensor._storageOffset != 0 || tensor._storage.Length != tensor.Length)
+        if (!IsCanonicalDenseAllocation(tensor))
             throw new InvalidOperationException(
-                "GPU destination-aware tensor ops require a zero-offset canonical allocation.");
+                "GPU destination-aware tensor ops require a contiguous, dense, zero-offset canonical allocation.");
 
         // #3 FP16-act CONVERT-AT-GAP: an FP16-tagged input → stable up-converted FP32 (see GetResidentOrPersistentInputBuffer).
         var tHalfC = TryFp16ResidentInput(tensor, out var tCountC);
@@ -10066,17 +10071,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // stream-capture safe. Captured graphs keep the established
             // resident NVRTC path until a PTX prewarm/capture API is added.
             && !directCuda.IsStreamCapturing()
-            && seqQ == seqK && seqQ is 16 or 32 or 64 or 128 && headDim == 64
+            && seqQ == seqK
+            && PtxOnlineFusedAttention128x64Kernel.IsSupportedSequenceLength(seqQ)
+            && headDim == PtxOnlineFusedAttention128x64Kernel.HeadDimension
             && key.Shape._dims[0] == batch && value.Shape._dims[0] == batch
             && key.Shape._dims[1] == heads && value.Shape._dims[1] == heads
             && key.Shape._dims[3] == headDim && value.Shape._dims[2] == seqK
             && value.Shape._dims[3] == headDim
-            && query.IsContiguous && key.IsContiguous && value.IsContiguous
-            && !query.IsSparse && !key.IsSparse && !value.IsSparse
-            && query._storageOffset == 0 && key._storageOffset == 0 && value._storageOffset == 0
-            && query._storage.Length == query.Length
-            && key._storage.Length == key.Length
-            && value._storage.Length == value.Length)
+            && IsCanonicalDenseAllocation(query)
+            && IsCanonicalDenseAllocation(key)
+            && IsCanonicalDenseAllocation(value))
         {
             IGpuBuffer? queryHalfOwned = null;
             IGpuBuffer? keyHalfOwned = null;

--- a/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/run_direct_ptx_gpu_competitors.py
+++ b/tests/AiDotNet.Tensors.Benchmarks/BaselineRunners/py/run_direct_ptx_gpu_competitors.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Hard NVIDIA SDPA baselines for the direct-PTX release gate.
+
+Uses CUDA events and resident tensors. Every backend is forced explicitly;
+unsupported combinations are reported rather than silently falling back.
+"""
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+
+import torch
+import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+
+SHAPES = ((12, 16), (12, 32), (12, 64), (12, 128), (128, 128), (512, 128))
+D = 64
+
+
+def percentile(values, q):
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * q
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def tanh_gelu(x):
+    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x * x * x)))
+
+
+def measure(fn, samples=101, warmups=30):
+    for _ in range(warmups):
+        fn()
+    torch.cuda.synchronize()
+    timings = []
+    torch.cuda.reset_peak_memory_stats()
+    baseline_memory = torch.cuda.memory_allocated()
+    for _ in range(samples):
+        start = torch.cuda.Event(enable_timing=True)
+        stop = torch.cuda.Event(enable_timing=True)
+        start.record()
+        result = fn()
+        stop.record()
+        stop.synchronize()
+        timings.append(start.elapsed_time(stop))
+        del result
+    peak_memory = max(0, torch.cuda.max_memory_allocated() - baseline_memory)
+    return {
+        "median_us": percentile(timings, 0.50) * 1000.0,
+        "p95_us": percentile(timings, 0.95) * 1000.0,
+        "p99_us": percentile(timings, 0.99) * 1000.0,
+        "mean_us": statistics.fmean(timings) * 1000.0,
+        "peak_device_bytes": peak_memory,
+    }
+
+
+def emit(record, json_lines):
+    if json_lines:
+        print(json.dumps(record, separators=(",", ":")))
+    else:
+        print(
+            f"{record['shape']:<12} {record['mode']:<7} {record['lane']:<10} "
+            f"{record['method']:<31} {record['median_us']:10.2f} {record['p95_us']:10.2f} "
+            f"{record['p99_us']:10.2f} {record['mean_us']:10.2f} {record['tflops']:9.3f} "
+            f"{record['peak_device_bytes']:12d} {record['max_error']:10.4g}"
+        )
+
+
+def run_sdpa_backend(name, backend, q, k, v, gamma, beta, causal, fused, compile_graph):
+    def core():
+        output = F.scaled_dot_product_attention(q, k, v, is_causal=causal).float()
+        if fused:
+            output = tanh_gelu(F.layer_norm(output, (D,), gamma, beta, 1e-5))
+        return output
+
+    method = name + ("+LN+GELU" if fused else "")
+    if compile_graph:
+        core = torch.compile(core, fullgraph=True, mode="max-autotune")
+        method += " [compile]"
+
+    def operation():
+        with sdpa_kernel(backends=[backend]):
+            return core()
+
+    # Force compilation/backend eligibility outside the measured distribution.
+    probe = operation()
+    probe.sum().item()
+    del probe
+    return method, operation
+
+
+def run_flash_attention_package(q, k, v, gamma, beta, causal, fused):
+    from flash_attn import flash_attn_func
+
+    q_bshd = q.transpose(1, 2).contiguous()
+    k_bshd = k.transpose(1, 2).contiguous()
+    v_bshd = v.transpose(1, 2).contiguous()
+
+    def operation():
+        output = flash_attn_func(q_bshd, k_bshd, v_bshd, causal=causal).transpose(1, 2).float()
+        if fused:
+            output = tanh_gelu(F.layer_norm(output, (D,), gamma, beta, 1e-5))
+        return output
+
+    return "FlashAttention package" + ("+LN+GELU" if fused else ""), operation
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json-lines", action="store_true")
+    parser.add_argument("--no-compile", action="store_true")
+    args = parser.parse_args()
+    if not torch.cuda.is_available():
+        print("CUDA-enabled Python PyTorch is required.", file=sys.stderr)
+        return 2
+
+    torch.manual_seed(20260720)
+    device = torch.device("cuda")
+    if not args.json_lines:
+        print(f"GPU: {torch.cuda.get_device_name(device)}; torch={torch.__version__}; CUDA={torch.version.cuda}")
+        print(f"{'Shape':<12} {'Mode':<7} {'Lane':<10} {'Method':<31} {'median us':>10} {'p95 us':>10} {'p99 us':>10} {'mean us':>10} {'TFLOPS':>9} {'peak B':>12} {'max err':>10}")
+        print("-" * 152)
+
+    backends = (
+        ("PyTorch Flash-SDPA", SDPBackend.FLASH_ATTENTION),
+        ("PyTorch cuDNN-SDPA", SDPBackend.CUDNN_ATTENTION),
+        ("PyTorch Efficient-SDPA", SDPBackend.EFFICIENT_ATTENTION),
+        ("PyTorch Math-SDPA", SDPBackend.MATH),
+    )
+    for batch_heads, sequence in SHAPES:
+        q = (torch.rand((1, batch_heads, sequence, D), device=device, dtype=torch.float16) - 0.5) * 0.5
+        k = (torch.rand_like(q) - 0.5) * 0.5
+        v = (torch.rand_like(q) - 0.5) * 0.5
+        gamma = torch.linspace(0.75, 0.99609375, D, device=device)
+        beta = torch.linspace(-0.0625, 0.060546875, D, device=device)
+        for causal in (False, True):
+            for fused in (False, True):
+                with sdpa_kernel(backends=[SDPBackend.MATH]):
+                    reference = F.scaled_dot_product_attention(q, k, v, is_causal=causal).float()
+                if fused:
+                    reference = tanh_gelu(F.layer_norm(reference, (D,), gamma, beta, 1e-5))
+                candidates = []
+                for name, backend in backends:
+                    candidates.append((name, backend, False))
+                    if not args.no_compile:
+                        candidates.append((name, backend, True))
+                for name, backend, compiled in candidates:
+                    try:
+                        method, operation = run_sdpa_backend(
+                            name, backend, q, k, v, gamma, beta, causal, fused, compiled)
+                        candidate_output = operation()
+                        max_error = (candidate_output - reference).abs().max().item()
+                        del candidate_output
+                        timing = measure(operation)
+                    except Exception as exc:
+                        if not args.json_lines:
+                            print(f"SKIP BH{batch_heads}S{sequence} {name} compiled={compiled}: {type(exc).__name__}: {exc}")
+                        continue
+                    flops = 4.0 * batch_heads * sequence * sequence * D
+                    timing.update({
+                        "shape": f"BH{batch_heads}S{sequence}",
+                        "mode": "causal" if causal else "plain",
+                        "lane": "attn+epi" if fused else "attention",
+                        "method": method,
+                        "tflops": flops / (timing["median_us"] * 1e-6) / 1e12,
+                        "max_error": max_error,
+                    })
+                    emit(timing, args.json_lines)
+                try:
+                    method, operation = run_flash_attention_package(q, k, v, gamma, beta, causal, fused)
+                    candidate_output = operation()
+                    max_error = (candidate_output - reference).abs().max().item()
+                    del candidate_output
+                    timing = measure(operation)
+                    flops = 4.0 * batch_heads * sequence * sequence * D
+                    timing.update({
+                        "shape": f"BH{batch_heads}S{sequence}",
+                        "mode": "causal" if causal else "plain",
+                        "lane": "attn+epi" if fused else "attention",
+                        "method": method,
+                        "tflops": flops / (timing["median_us"] * 1e-6) / 1e12,
+                        "max_error": max_error,
+                    })
+                    emit(timing, args.json_lines)
+                except (ImportError, RuntimeError) as exc:
+                    if not args.json_lines:
+                        print(f"SKIP FlashAttention package: {type(exc).__name__}: {exc}")
+                del reference
+        del q, k, v, gamma, beta
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxAttentionExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxAttentionExperiment.cs
@@ -1,0 +1,351 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Phase-1 experiment for a driver-only, hand-emitted PTX attention kernel.
+/// The timed region contains device work only; allocation, upload, PTX JIT,
+/// and cuBLAS handle creation are deliberately outside it.
+/// </summary>
+internal static class DirectPtxAttentionExperiment
+{
+    private readonly record struct Shape(string Name, int BatchHeads, int M, int N, int K, int Seed);
+    private readonly record struct Distribution(double Min, double Mean, double Median, double P95, double P99, double Max);
+
+    private static readonly Shape[] Shapes =
+    [
+        new("AIsEval MHA",       512,  32,  32, 16, 20260721),
+        new("BERT-base MHA",      96, 128, 128, 64, 20260722),
+        new("Long-context MHA",   16, 256, 256, 64, 20260723),
+        new("Decoder MHA",        12, 512, 512, 64, 20260724),
+    ];
+
+    internal static void Run()
+    {
+        if (!DirectPtxRuntime.IsAvailable)
+        {
+            Console.WriteLine("NVIDIA CUDA Driver API is unavailable.");
+            return;
+        }
+
+        using var runtime = new DirectPtxRuntime();
+        Console.WriteLine("AiDotNet direct-PTX attention Q*K^T experiment");
+        Console.WriteLine($"GPU: {runtime.DeviceName} (SM {runtime.ComputeCapabilityMajor}.{runtime.ComputeCapabilityMinor})");
+        Console.WriteLine("Custom path: emitted PTX -> CUDA Driver JIT -> SASS -> cuLaunchKernel");
+        Console.WriteLine("Excluded from custom path: CUDA Runtime, NVRTC, cuBLAS, cuDNN");
+        Console.WriteLine("Math: FP16 inputs, FP32 accumulation/output, fused 1/sqrt(K) scale");
+        Console.WriteLine();
+        Console.WriteLine($"{"Shape",-21} {"Method",-21} {"med us",9} {"p95 us",9} {"p99 us",9} {"mean us",9} {"TF/s",8} {"E2E med",9} {"E2E p95",9} {"E2E p99",9} {"B/call",9}");
+        Console.WriteLine(new string('-', 131));
+
+        foreach (Shape shape in Shapes)
+            RunShape(runtime, shape);
+
+        Console.WriteLine();
+        Console.WriteLine("med/p95/p99/mean are CUDA-event device times; E2E is host launch + synchronize time (microseconds).");
+        Console.WriteLine("B/call is managed allocation on the calling thread. Device allocation and input/output buffers are setup-only.");
+        Console.WriteLine("AiDotNet per-head floor is the current cublasGemmEx launch granularity without scheduler/list overhead.");
+        Console.WriteLine();
+        RunCurrentProductionApi();
+    }
+
+    private static void RunShape(DirectPtxRuntime runtime, Shape shape)
+    {
+        float scale = 1.0f / MathF.Sqrt(shape.K);
+        var setupTimer = Stopwatch.StartNew();
+        using var kernel = new PtxWmmaBatchedQkKernel(
+            runtime, shape.M, shape.N, shape.K, shape.BatchHeads, scale);
+        setupTimer.Stop();
+        using var q = runtime.AllocateBytes(kernel.ABytes);
+        using var keys = runtime.AllocateBytes(kernel.BBytes);
+        using var ptxScores = runtime.AllocateBytes(kernel.CBytes);
+        using var blasScores = runtime.AllocateBytes(kernel.CBytes);
+
+        var random = new Random(shape.Seed);
+        ushort[] qHost = RandomHalf(random, checked(shape.BatchHeads * shape.M * shape.K));
+        ushort[] kHost = RandomHalf(random, checked(shape.BatchHeads * shape.N * shape.K));
+        q.Upload<ushort>(qHost);
+        keys.Upload<ushort>(kHost);
+
+        var blasSetupTimer = Stopwatch.StartNew();
+        using var blas = new CuBlasQkComparator(runtime, shape, scale);
+        blasSetupTimer.Stop();
+        kernel.Launch(q, keys, ptxScores);
+        blas.LaunchStrided(q, keys, blasScores);
+        runtime.Synchronize();
+        var error = Validate(ptxScores, blasScores, checked(shape.BatchHeads * shape.M * shape.N), shape.Name);
+
+        Action ptxAction = () => kernel.Launch(q, keys, ptxScores);
+        Action blasAction = () => blas.LaunchStrided(q, keys, blasScores);
+        Action legacyAction = () => blas.LaunchPerHead(q, keys, blasScores);
+
+        Distribution ptxDevice = Summarize(runtime.MeasureKernelSamples(
+            ptxAction, warmup: 30, samples: 101, launchesPerSample: 10));
+        Distribution blasDevice = Summarize(runtime.MeasureKernelSamples(
+            blasAction, warmup: 30, samples: 101, launchesPerSample: 10));
+
+        // The legacy path can contain hundreds of library launches per sample;
+        // use one launch group and 51 samples while retaining p99 visibility.
+        Distribution legacyDevice = Summarize(runtime.MeasureKernelSamples(
+            legacyAction, warmup: 2, samples: 51, launchesPerSample: 1));
+
+        Distribution ptxE2e = MeasureEndToEnd(runtime, ptxAction, 101);
+        Distribution blasE2e = MeasureEndToEnd(runtime, blasAction, 101);
+        Distribution legacyE2e = MeasureEndToEnd(runtime, legacyAction, 51);
+        long ptxAllocation = MeasureAllocation(runtime, ptxAction, 200);
+        long blasAllocation = MeasureAllocation(runtime, blasAction, 200);
+        long legacyAllocation = MeasureAllocation(runtime, legacyAction, 20);
+
+        Print(shape.Name, "Direct PTX (new)", ptxDevice, ptxE2e,
+            kernel.EffectiveTflops((float)ptxDevice.Median), ptxAllocation);
+        Print(shape.Name, "cuBLAS best", blasDevice, blasE2e,
+            kernel.EffectiveTflops((float)blasDevice.Median), blasAllocation);
+        Print(shape.Name, "AiDotNet per-head floor", legacyDevice, legacyE2e,
+            kernel.EffectiveTflops((float)legacyDevice.Median), legacyAllocation);
+        Console.WriteLine($"  setup: PTX emit+driver JIT={setupTimer.Elapsed.TotalMilliseconds:F3} ms, " +
+            $"cuBLAS handle={blasSetupTimer.Elapsed.TotalMilliseconds:F3} ms, " +
+            $"max |PTX-cuBLAS|={error.maxAbsolute:G4}, max relative={error.maxRelative:G4}");
+    }
+
+    private static ushort[] RandomHalf(Random random, int length)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < length; i++)
+            result[i] = BitConverter.HalfToUInt16Bits((Half)(random.NextDouble() * 0.5 - 0.25));
+        return result;
+    }
+
+    private static (float maxAbsolute, float maxRelative) Validate(
+        DirectPtxBuffer ptx, DirectPtxBuffer blas, int length, string name)
+    {
+        var actual = new float[length];
+        var expected = new float[length];
+        ptx.Download<float>(actual);
+        blas.Download<float>(expected);
+
+        float maxAbsolute = 0;
+        float maxRelative = 0;
+        for (int i = 0; i < length; i++)
+        {
+            float absolute = MathF.Abs(actual[i] - expected[i]);
+            float relative = absolute / MathF.Max(MathF.Abs(expected[i]), 1e-5f);
+            maxAbsolute = MathF.Max(maxAbsolute, absolute);
+            maxRelative = MathF.Max(maxRelative, relative);
+        }
+
+        if (maxAbsolute > 0.003f)
+            throw new InvalidOperationException(
+                $"{name}: PTX/cuBLAS mismatch; max abs={maxAbsolute:G9}, max rel={maxRelative:G9}.");
+        return (maxAbsolute, maxRelative);
+    }
+
+    private static Distribution MeasureEndToEnd(
+        DirectPtxRuntime runtime, Action action, int sampleCount)
+    {
+        for (int i = 0; i < 10; i++) action();
+        runtime.Synchronize();
+        var samples = new double[sampleCount];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            action();
+            runtime.Synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        return Summarize(samples);
+    }
+
+    private static long MeasureAllocation(DirectPtxRuntime runtime, Action action, int calls)
+    {
+        action();
+        runtime.Synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < calls; i++) action();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+        runtime.Synchronize();
+        return (after - before) / calls;
+    }
+
+    private static Distribution Summarize(float[] samples)
+    {
+        var converted = new double[samples.Length];
+        for (int i = 0; i < samples.Length; i++) converted[i] = samples[i];
+        return Summarize(converted);
+    }
+
+    private static Distribution Summarize(double[] samples)
+    {
+        var sorted = (double[])samples.Clone();
+        Array.Sort(sorted);
+        return new Distribution(
+            sorted[0],
+            samples.Average(),
+            Percentile(sorted, 0.50),
+            Percentile(sorted, 0.95),
+            Percentile(sorted, 0.99),
+            sorted[^1]);
+    }
+
+    private static double Percentile(double[] sorted, double percentile)
+    {
+        double position = (sorted.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, sorted.Length - 1);
+        double fraction = position - lower;
+        return sorted[lower] + (sorted[upper] - sorted[lower]) * fraction;
+    }
+
+    private static void Print(
+        string shape, string method, Distribution device, Distribution e2e,
+        double tflops, long allocatedBytes)
+    {
+        Console.WriteLine(
+            $"{shape,-21} {method,-21} {device.Median * 1000,9:F2} {device.P95 * 1000,9:F2} " +
+            $"{device.P99 * 1000,9:F2} {device.Mean * 1000,9:F2} {tflops,8:F3} " +
+            $"{e2e.Median * 1000,9:F2} {e2e.P95 * 1000,9:F2} {e2e.P99 * 1000,9:F2} {allocatedBytes,9}");
+    }
+
+    private static void RunCurrentProductionApi()
+    {
+        Console.WriteLine("Current AiDotNet production API (CUDA C/NVRTC backend + per-head cuBLAS scheduler)");
+        Console.WriteLine($"{"Shape",-21} {"median us",11} {"p95 us",11} {"p99 us",11} {"mean us",11} {"TF/s",9} {"B/call",12}");
+        Console.WriteLine(new string('-', 94));
+
+        using var backend = new CudaBackend();
+        if (!backend.IsAvailable)
+        {
+            Console.WriteLine("Current CUDA backend unavailable (it requires both CUDA Driver and NVRTC).");
+            return;
+        }
+        using var pool = new GpuStreamPool(backend);
+        using var scheduler = new GpuStreamScheduler(pool);
+
+        foreach (Shape shape in Shapes)
+        {
+            int qElements = checked(shape.BatchHeads * shape.M * shape.K);
+            int kElements = checked(shape.BatchHeads * shape.N * shape.K);
+            int scoreElements = checked(shape.BatchHeads * shape.M * shape.N);
+            using var q = backend.AllocateByteBuffer(checked(qElements * sizeof(ushort)));
+            using var keys = backend.AllocateByteBuffer(checked(kElements * sizeof(ushort)));
+            using var scores = backend.AllocateBuffer(scoreElements);
+
+            var random = new Random(shape.Seed);
+            backend.UploadByteBuffer(q, ToBytes(RandomHalf(random, qElements)));
+            backend.UploadByteBuffer(keys, ToBytes(RandomHalf(random, kElements)));
+            float scale = 1.0f / MathF.Sqrt(shape.K);
+            Action action = () => backend.MultiHeadAttentionScoresFanoutMixed(
+                q, keys, scores,
+                batch: 1, numHeads: shape.BatchHeads,
+                seqLen: shape.M, headDim: shape.K,
+                scheduler,
+                useBFloat16: false,
+                alpha: scale, beta: 0);
+
+            for (int i = 0; i < 3; i++) action();
+            var samples = new double[101];
+            for (int i = 0; i < samples.Length; i++)
+            {
+                long start = Stopwatch.GetTimestamp();
+                action();
+                samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            }
+            Distribution stats = Summarize(samples);
+
+            action();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            const int allocationCalls = 10;
+            for (int i = 0; i < allocationCalls; i++) action();
+            long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / allocationCalls;
+            double flops = 2.0 * shape.BatchHeads * shape.M * shape.N * shape.K;
+            double tflops = flops / (stats.Median * 1e-3) / 1e12;
+            Console.WriteLine(
+                $"{shape.Name,-21} {stats.Median * 1000,11:F2} {stats.P95 * 1000,11:F2} " +
+                $"{stats.P99 * 1000,11:F2} {stats.Mean * 1000,11:F2} {tflops,9:F3} {allocation,12}");
+        }
+    }
+
+    private static byte[] ToBytes(ushort[] values)
+    {
+        var bytes = new byte[checked(values.Length * sizeof(ushort))];
+        Buffer.BlockCopy(values, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    private sealed class CuBlasQkComparator : IDisposable
+    {
+        private readonly DirectPtxRuntime _runtime;
+        private readonly Shape _shape;
+        private readonly float _scale;
+        private IntPtr _handle;
+
+        internal CuBlasQkComparator(DirectPtxRuntime runtime, Shape shape, float scale)
+        {
+            _runtime = runtime;
+            _shape = shape;
+            _scale = scale;
+            using var _ = runtime.Enter();
+            CuBlasNative.CheckCublasStatus(CuBlasNative.cublasCreate(out _handle), "cublasCreate(PTX comparator)");
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasSetMathMode(_handle, CuBlasNative.CUBLAS_TENSOR_OP_MATH),
+                "cublasSetMathMode(PTX comparator)");
+        }
+
+        internal unsafe void LaunchStrided(DirectPtxBuffer q, DirectPtxBuffer keys, DirectPtxBuffer scores)
+        {
+            using var _ = _runtime.Enter();
+            float alpha = _scale, beta = 0;
+            AiDotNet.Tensors.Engines.CublasStatus status = CuBlasNative.cublasGemmStridedBatchedEx(
+                _handle,
+                CublasOperation.Transpose, CublasOperation.None,
+                _shape.N, _shape.M, _shape.K,
+                (IntPtr)(&alpha),
+                keys.Pointer, CuBlasNative.CUDA_R_16F, _shape.K, (long)_shape.N * _shape.K,
+                q.Pointer, CuBlasNative.CUDA_R_16F, _shape.K, (long)_shape.M * _shape.K,
+                (IntPtr)(&beta),
+                scores.Pointer, CuBlasNative.CUDA_R_32F, _shape.N, (long)_shape.M * _shape.N,
+                _shape.BatchHeads,
+                CuBlasNative.CUBLAS_COMPUTE_32F,
+                0);
+            CuBlasNative.CheckCublasStatus(status, "cublasGemmStridedBatchedEx(QK^T)");
+        }
+
+        internal unsafe void LaunchPerHead(DirectPtxBuffer q, DirectPtxBuffer keys, DirectPtxBuffer scores)
+        {
+            using var _ = _runtime.Enter();
+            float alpha = _scale, beta = 0;
+            long qStrideBytes = (long)_shape.M * _shape.K * sizeof(ushort);
+            long kStrideBytes = (long)_shape.N * _shape.K * sizeof(ushort);
+            long cStrideBytes = (long)_shape.M * _shape.N * sizeof(float);
+            for (int batch = 0; batch < _shape.BatchHeads; batch++)
+            {
+                AiDotNet.Tensors.Engines.CublasStatus status = CuBlasNative.cublasGemmEx(
+                    _handle,
+                    CublasOperation.Transpose, CublasOperation.None,
+                    _shape.N, _shape.M, _shape.K,
+                    (IntPtr)(&alpha),
+                    Add(keys.Pointer, batch * kStrideBytes), CuBlasNative.CUDA_R_16F, _shape.K,
+                    Add(q.Pointer, batch * qStrideBytes), CuBlasNative.CUDA_R_16F, _shape.K,
+                    (IntPtr)(&beta),
+                    Add(scores.Pointer, batch * cStrideBytes), CuBlasNative.CUDA_R_32F, _shape.N,
+                    CuBlasNative.CUBLAS_COMPUTE_32F,
+                    0);
+                CuBlasNative.CheckCublasStatus(status, "cublasGemmEx(per-head QK^T)");
+            }
+        }
+
+        private static IntPtr Add(IntPtr pointer, long byteOffset) =>
+            new(checked(pointer.ToInt64() + byteOffset));
+
+        public void Dispose()
+        {
+            if (_handle == IntPtr.Zero) return;
+            using var _ = _runtime.Enter();
+            CuBlasNative.CheckCublasStatus(CuBlasNative.cublasDestroy(_handle), "cublasDestroy(PTX comparator)");
+            _handle = IntPtr.Zero;
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxExternalBaselines.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxExternalBaselines.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+internal static class DirectPtxExternalBaselines
+{
+    internal static void Run()
+    {
+        string script = Path.Combine(
+            AppContext.BaseDirectory, "BaselineRunners", "py", "run_direct_ptx_gpu_competitors.py");
+        if (!File.Exists(script))
+            script = Path.Combine(AppContext.BaseDirectory, "run_direct_ptx_gpu_competitors.py");
+        if (!File.Exists(script))
+            throw new FileNotFoundException("The direct-PTX Python competitor harness was not copied to output.", script);
+
+        var start = new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("PYTHON") ?? "python",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false
+        };
+        start.ArgumentList.Add(script);
+        using Process process = Process.Start(start) ??
+            throw new InvalidOperationException("Could not start the Python GPU baseline process.");
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            Console.WriteLine($"Python GPU baselines unavailable or failed (exit {process.ExitCode}).");
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxFusedAttentionExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxFusedAttentionExperiment.cs
@@ -1,0 +1,550 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using TorchSharp;
+using TorchTensor = TorchSharp.torch.Tensor;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Championship-cell experiment for a complete resident attention forward:
+/// [BH=512,S=32,D=16], FP16 Q/K/V, FP32 output. The custom kernel never
+/// materializes scores or probabilities in global memory.
+/// </summary>
+internal static class DirectPtxFusedAttentionExperiment
+{
+    private const int BatchHeads = 512;
+    private const int Sequence = 32;
+    private const int Dimension = 16;
+    private const float Scale = 0.25f;
+
+    private readonly record struct Distribution(double Mean, double Median, double P95, double P99);
+
+    internal static void Run()
+    {
+        if (!DirectPtxRuntime.IsAvailable)
+        {
+            Console.WriteLine("NVIDIA CUDA Driver API is unavailable.");
+            return;
+        }
+
+        using var runtime = new DirectPtxRuntime();
+        Console.WriteLine("Direct-PTX fused-attention championship cell");
+        Console.WriteLine($"GPU: {runtime.DeviceName} (SM {runtime.ComputeCapabilityMajor}.{runtime.ComputeCapabilityMinor})");
+        Console.WriteLine("Shape: batch-heads=512, sequence=32, head-dim=16");
+        Console.WriteLine("Math: FP16 Q/K/V, FP32 accumulation/output; scores and probabilities are shared-memory-only");
+        Console.WriteLine();
+        Console.WriteLine($"{"Mode",-12} {"Method",-34} {"med us",10} {"p95 us",10} {"p99 us",10} {"mean us",10} {"GF/s",9} {"B/call",11} {"tmp MiB",9} {"max err",11}");
+        Console.WriteLine(new string('-', 133));
+
+        RunMode(runtime, isCausal: false);
+        RunMode(runtime, isCausal: true);
+        RunCurrentAiDotNet();
+        RunTorchSharp();
+    }
+
+    private static void RunMode(DirectPtxRuntime runtime, bool isCausal)
+    {
+        using var kernel = new PtxWmmaFusedAttention32x16Kernel(runtime, BatchHeads, isCausal, Scale);
+        using var q = runtime.AllocateBytes(kernel.QBytes);
+        using var k = runtime.AllocateBytes(kernel.KBytes);
+        using var v = runtime.AllocateBytes(kernel.VBytes);
+        using var output = runtime.AllocateBytes(kernel.OutputBytes);
+        using var cuBlasOutput = runtime.AllocateBytes(kernel.OutputBytes);
+        using var cuBlas = new CuBlasAttentionComparator(runtime, BatchHeads, isCausal, Scale);
+
+        var random = new Random(isCausal ? 20260728 : 20260727);
+        ushort[] qHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+        ushort[] kHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+        ushort[] vHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+        q.Upload<ushort>(qHost);
+        k.Upload<ushort>(kHost);
+        v.Upload<ushort>(vHost);
+
+        Action action = () => kernel.Launch(q, k, v, output);
+        action();
+        runtime.Synchronize();
+        float maxError = ValidateFirstHeads(output, qHost, kHost, vHost, isCausal, headsToCheck: 4);
+
+        Distribution device = Summarize(runtime.MeasureKernelSamples(
+            action, warmup: 100, samples: 101, launchesPerSample: 10));
+        Distribution e2e = MeasureEndToEnd(runtime, action);
+        long allocation = MeasureAllocation(runtime, action);
+        Print(isCausal ? "causal" : "unmasked", "Direct PTX fused (new)", device,
+            kernel.EffectiveTflops((float)device.Median), allocation, temporaryBytes: 0, maxError);
+        Print(isCausal ? "causal" : "unmasked", "Direct PTX fused E2E", e2e,
+            kernel.EffectiveTflops((float)e2e.Median), allocation, temporaryBytes: 0, maxError);
+
+        Action cuBlasAction = () => cuBlas.Launch(q, k, v, cuBlasOutput);
+        cuBlasAction();
+        runtime.Synchronize();
+        float cuBlasError = ValidateFirstHeads(
+            cuBlasOutput, qHost, kHost, vHost, isCausal, headsToCheck: 4);
+        Distribution cuBlasDevice = Summarize(runtime.MeasureKernelSamples(
+            cuBlasAction, warmup: 100, samples: 101, launchesPerSample: 10));
+        Distribution cuBlasE2e = MeasureEndToEnd(runtime, cuBlasAction);
+        long cuBlasAllocation = MeasureAllocation(runtime, cuBlasAction);
+        long temporaryBytes = checked((long)cuBlas.ScoreBytes + (long)cuBlas.ProbabilityBytes);
+        Print(isCausal ? "causal" : "unmasked", "cuBLAS GEMMs + PTX softmax", cuBlasDevice,
+            EffectiveTflops(cuBlasDevice.Median), cuBlasAllocation, temporaryBytes, cuBlasError);
+        Print(isCausal ? "causal" : "unmasked", "cuBLAS composition E2E", cuBlasE2e,
+            EffectiveTflops(cuBlasE2e.Median), cuBlasAllocation, temporaryBytes, cuBlasError);
+    }
+
+    private static void RunCurrentAiDotNet()
+    {
+        using var backend = new CudaBackend();
+        if (!backend.IsAvailable)
+        {
+            Console.WriteLine("Current AiDotNet CUDA backend unavailable.");
+            return;
+        }
+
+        int elements = BatchHeads * Sequence * Dimension;
+        var random = new Random(20260727);
+        ushort[] qHalf = RandomHalf(random, elements);
+        ushort[] kHalf = RandomHalf(random, elements);
+        ushort[] vHalf = RandomHalf(random, elements);
+        float[] qHost = ToFloat(qHalf);
+        float[] kHost = ToFloat(kHalf);
+        float[] vHost = ToFloat(vHalf);
+
+        using var q = backend.AllocateBuffer(qHost);
+        using var k = backend.AllocateBuffer(kHost);
+        using var v = backend.AllocateBuffer(vHost);
+        using var output = backend.AllocateBuffer(elements);
+        using var stats = backend.AllocateBuffer(BatchHeads * Sequence);
+
+        foreach (bool isCausal in new[] { false, true })
+        {
+            Action action = () => backend.FlashAttentionV2(
+                q, k, v, output, stats,
+                batch: 1, numHeads: BatchHeads,
+                seqQ: Sequence, seqK: Sequence, headDim: Dimension,
+                scale: Scale, isCausal: isCausal);
+
+            for (int i = 0; i < 20; i++) action();
+            backend.Synchronize();
+            float maxError = ValidateFirstHeads(
+                backend.DownloadBuffer(output), qHalf, kHalf, vHalf, isCausal, headsToCheck: 4);
+            var samples = new double[101];
+            for (int i = 0; i < samples.Length; i++)
+            {
+                long start = Stopwatch.GetTimestamp();
+                action();
+                backend.Synchronize();
+                samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            }
+            Distribution e2e = Summarize(samples);
+
+            action();
+            backend.Synchronize();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            const int calls = 50;
+            for (int i = 0; i < calls; i++) action();
+            long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+            backend.Synchronize();
+
+            double tflops = EffectiveTflops(e2e.Median);
+            Print(isCausal ? "causal" : "unmasked", "AiDotNet NVRTC FlashAttn E2E", e2e,
+                tflops, allocation, BatchHeads * Sequence * sizeof(float), maxError);
+        }
+    }
+
+    private static float ValidateFirstHeads(
+        DirectPtxBuffer output, ushort[] q, ushort[] k, ushort[] v, bool isCausal, int headsToCheck)
+    {
+        var actual = new float[BatchHeads * Sequence * Dimension];
+        output.Download<float>(actual);
+        return ValidateFirstHeads(actual, q, k, v, isCausal, headsToCheck);
+    }
+
+    private static float ValidateFirstHeads(
+        float[] actual, ushort[] q, ushort[] k, ushort[] v, bool isCausal, int headsToCheck)
+    {
+        float maxError = 0;
+        Span<float> scores = stackalloc float[Sequence];
+        for (int bh = 0; bh < headsToCheck; bh++)
+        for (int row = 0; row < Sequence; row++)
+        {
+            int lastKey = isCausal ? row : Sequence - 1;
+            float rowMax = float.NegativeInfinity;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                float score = 0;
+                for (int inner = 0; inner < Dimension; inner++)
+                {
+                    score += HalfAt(q, (bh * Sequence + row) * Dimension + inner) *
+                        HalfAt(k, (bh * Sequence + column) * Dimension + inner);
+                }
+                scores[column] = score * Scale;
+                rowMax = MathF.Max(rowMax, scores[column]);
+            }
+
+            float sum = 0;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                scores[column] = MathF.Exp(scores[column] - rowMax);
+                sum += scores[column];
+            }
+            for (int outputColumn = 0; outputColumn < Dimension; outputColumn++)
+            {
+                float expected = 0;
+                for (int column = 0; column <= lastKey; column++)
+                    expected += scores[column] / sum *
+                        HalfAt(v, (bh * Sequence + column) * Dimension + outputColumn);
+                float got = actual[(bh * Sequence + row) * Dimension + outputColumn];
+                maxError = MathF.Max(maxError, MathF.Abs(got - expected));
+            }
+        }
+
+        if (maxError > 0.003f)
+            throw new InvalidOperationException($"Fused attention validation failed: max abs error {maxError:G9}.");
+        return maxError;
+    }
+
+    private static void RunTorchSharp()
+    {
+        try
+        {
+            if (!torch.cuda.is_available())
+            {
+                Console.WriteLine("TorchSharp/libtorch CUDA is unavailable; PyTorch eager baseline skipped.");
+                return;
+            }
+
+            int elements = BatchHeads * Sequence * Dimension;
+            var random = new Random(20260727);
+            ushort[] qHalf = RandomHalf(random, elements);
+            ushort[] kHalf = RandomHalf(random, elements);
+            ushort[] vHalf = RandomHalf(random, elements);
+            using TorchTensor qFloat = torch.tensor(
+                ToFloat(qHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor kFloat = torch.tensor(
+                ToFloat(kHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor vFloat = torch.tensor(
+                ToFloat(vHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor q = qFloat.half();
+            using TorchTensor k = kFloat.half();
+            using TorchTensor v = vFloat.half();
+
+            foreach (bool isCausal in new[] { false, true })
+            {
+                TorchTensor? mask = null;
+                if (isCausal)
+                {
+                    var maskHost = new float[Sequence * Sequence];
+                    for (int row = 0; row < Sequence; row++)
+                    for (int column = row + 1; column < Sequence; column++)
+                        maskHost[row * Sequence + column] = float.NegativeInfinity;
+                    using TorchTensor maskFloat = torch.tensor(
+                        maskHost, [Sequence, Sequence], device: torch.CUDA);
+                    mask = maskFloat.half();
+                }
+
+                try
+                {
+                    using (TorchTensor validation = TorchAttention(q, k, v, mask))
+                    using (TorchTensor validationCpu = validation.cpu())
+                    {
+                        float[] actual = validationCpu.data<float>().ToArray();
+                        float error = ValidateFirstHeads(
+                            actual, qHalf, kHalf, vHalf, isCausal, headsToCheck: 4);
+
+                        for (int i = 0; i < 20; i++)
+                        {
+                            using TorchTensor warmup = TorchAttention(q, k, v, mask);
+                        }
+                        torch.cuda.synchronize();
+
+                        var samples = new double[101];
+                        for (int i = 0; i < samples.Length; i++)
+                        {
+                            long start = Stopwatch.GetTimestamp();
+                            using TorchTensor result = TorchAttention(q, k, v, mask);
+                            torch.cuda.synchronize();
+                            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+                        }
+                        Distribution e2e = Summarize(samples);
+
+                        using (TorchTensor allocationWarmup = TorchAttention(q, k, v, mask))
+                            torch.cuda.synchronize();
+                        long before = GC.GetAllocatedBytesForCurrentThread();
+                        const int calls = 50;
+                        for (int i = 0; i < calls; i++)
+                        {
+                            using TorchTensor result = TorchAttention(q, k, v, mask);
+                        }
+                        long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+                        torch.cuda.synchronize();
+
+                        long minimumTemporaries =
+                            2L * BatchHeads * Sequence * Sequence * sizeof(ushort) +
+                            (long)BatchHeads * Sequence * Dimension * sizeof(ushort);
+                        Print(isCausal ? "causal" : "unmasked", "PyTorch eager composition E2E", e2e,
+                            EffectiveTflops(e2e.Median), allocation, minimumTemporaries, error);
+                    }
+                }
+                finally
+                {
+                    mask?.Dispose();
+                }
+            }
+
+            bool previousFlash = torch.backends.cuda.flash_sdp_enabled();
+            bool previousMath = torch.backends.cuda.math_sdp_enabled();
+            try
+            {
+                torch.backends.cuda.enable_flash_sdp(true);
+                torch.backends.cuda.enable_math_sdp(false);
+                foreach (bool isCausal in new[] { false, true })
+                    RunTorchSharpFused(q, k, v, qHalf, kHalf, vHalf, isCausal);
+            }
+            finally
+            {
+                torch.backends.cuda.enable_flash_sdp(previousFlash);
+                torch.backends.cuda.enable_math_sdp(previousMath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"TorchSharp/libtorch baseline unavailable: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static TorchTensor TorchAttention(
+        TorchTensor q, TorchTensor k, TorchTensor v, TorchTensor? mask)
+    {
+        using TorchTensor kt = k.transpose(2, 3);
+        using TorchTensor scores = torch.matmul(q, kt);
+        scores.mul_(Scale);
+        if (mask is not null) scores.add_(mask);
+        using TorchTensor probabilities = torch.nn.functional.softmax(scores, -1);
+        using TorchTensor halfOutput = torch.matmul(probabilities, v);
+        return halfOutput.to_type(torch.ScalarType.Float32);
+    }
+
+    private static void RunTorchSharpFused(
+        TorchTensor q, TorchTensor k, TorchTensor v,
+        ushort[] qHost, ushort[] kHost, ushort[] vHost, bool isCausal)
+    {
+        using (TorchTensor validation = TorchFusedAttention(q, k, v, isCausal))
+        using (TorchTensor validationFloat = validation.to_type(torch.ScalarType.Float32))
+        using (TorchTensor validationCpu = validationFloat.cpu())
+        {
+            float error = ValidateFirstHeads(
+                validationCpu.data<float>().ToArray(), qHost, kHost, vHost, isCausal, headsToCheck: 4);
+            for (int i = 0; i < 20; i++)
+            {
+                using TorchTensor warmup = TorchFusedAttention(q, k, v, isCausal);
+            }
+            torch.cuda.synchronize();
+
+            var samples = new double[101];
+            for (int i = 0; i < samples.Length; i++)
+            {
+                long start = Stopwatch.GetTimestamp();
+                using TorchTensor result = TorchFusedAttention(q, k, v, isCausal);
+                torch.cuda.synchronize();
+                samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            }
+            Distribution e2e = Summarize(samples);
+
+            using (TorchTensor allocationWarmup = TorchFusedAttention(q, k, v, isCausal))
+                torch.cuda.synchronize();
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            const int calls = 50;
+            for (int i = 0; i < calls; i++)
+            {
+                using TorchTensor result = TorchFusedAttention(q, k, v, isCausal);
+            }
+            long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+            torch.cuda.synchronize();
+            Print(isCausal ? "causal" : "unmasked", "PyTorch Flash-SDPA E2E", e2e,
+                EffectiveTflops(e2e.Median), allocation, temporaryBytes: -1, error);
+        }
+    }
+
+    private static TorchTensor TorchFusedAttention(
+        TorchTensor q, TorchTensor k, TorchTensor v, bool isCausal) =>
+        torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, null, 0.0, isCausal);
+
+    private static Distribution MeasureEndToEnd(DirectPtxRuntime runtime, Action action)
+    {
+        for (int i = 0; i < 20; i++) action();
+        runtime.Synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            action();
+            runtime.Synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        return Summarize(samples);
+    }
+
+    private static long MeasureAllocation(DirectPtxRuntime runtime, Action action)
+    {
+        action();
+        runtime.Synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        const int calls = 200;
+        for (int i = 0; i < calls; i++) action();
+        long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+        runtime.Synchronize();
+        return allocation;
+    }
+
+    private static void Print(
+        string mode, string method, Distribution distribution,
+        double tflops, long allocation, long temporaryBytes, double maxError)
+    {
+        string error = double.IsNaN(maxError) ? "n/a" : maxError.ToString("G4");
+        string temporary = temporaryBytes < 0
+            ? "n/a"
+            : (temporaryBytes / 1048576.0).ToString("F3");
+        Console.WriteLine(
+            $"{mode,-12} {method,-34} {distribution.Median * 1000,10:F2} " +
+            $"{distribution.P95 * 1000,10:F2} {distribution.P99 * 1000,10:F2} " +
+            $"{distribution.Mean * 1000,10:F2} {tflops * 1000,9:F2} {allocation,11} " +
+            $"{temporary,9} {error,11}");
+    }
+
+    private static Distribution Summarize(float[] samples)
+    {
+        var converted = new double[samples.Length];
+        for (int i = 0; i < samples.Length; i++) converted[i] = samples[i];
+        return Summarize(converted);
+    }
+
+    private static Distribution Summarize(double[] samples)
+    {
+        var sorted = (double[])samples.Clone();
+        Array.Sort(sorted);
+        return new Distribution(samples.Average(), Percentile(sorted, 0.50),
+            Percentile(sorted, 0.95), Percentile(sorted, 0.99));
+    }
+
+    private static double Percentile(double[] sorted, double percentile)
+    {
+        double position = (sorted.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, sorted.Length - 1);
+        return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+    }
+
+    private static double EffectiveTflops(double milliseconds)
+    {
+        double flops = 4.0 * BatchHeads * Sequence * Sequence * Dimension;
+        return flops / (milliseconds * 1e-3) / 1e12;
+    }
+
+    private static ushort[] RandomHalf(Random random, int length)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < length; i++)
+            result[i] = BitConverter.HalfToUInt16Bits((Half)(random.NextDouble() * 0.5 - 0.25));
+        return result;
+    }
+
+    private static float[] ToFloat(ushort[] source)
+    {
+        var result = new float[source.Length];
+        for (int i = 0; i < source.Length; i++) result[i] = HalfAt(source, i);
+        return result;
+    }
+
+    private static float HalfAt(ushort[] source, int index) =>
+        (float)BitConverter.UInt16BitsToHalf(source[index]);
+
+    /// <summary>
+    /// Best-case decomposed vendor-library boundary: one strided batched
+    /// cuBLAS Tensor Core GEMM for Q*K^T, a shape-specialized warp softmax,
+    /// then one strided batched cuBLAS Tensor Core GEMM for P*V.
+    /// </summary>
+    private sealed class CuBlasAttentionComparator : IDisposable
+    {
+        private readonly DirectPtxRuntime _runtime;
+        private readonly PtxAttentionSoftmax32Kernel _softmax;
+        private readonly DirectPtxBuffer _scores;
+        private readonly DirectPtxBuffer _probabilities;
+        private readonly float _scale;
+        private IntPtr _handle;
+
+        internal nuint ScoreBytes => _softmax.ScoreBytes;
+        internal nuint ProbabilityBytes => _softmax.ProbabilityBytes;
+
+        internal CuBlasAttentionComparator(
+            DirectPtxRuntime runtime, int batchHeads, bool isCausal, float scale)
+        {
+            _runtime = runtime;
+            _scale = scale;
+            _softmax = new PtxAttentionSoftmax32Kernel(runtime, batchHeads, isCausal);
+            _scores = runtime.AllocateBytes(_softmax.ScoreBytes);
+            _probabilities = runtime.AllocateBytes(_softmax.ProbabilityBytes);
+            using var _ = runtime.Enter();
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasCreate(out _handle), "cublasCreate(fused-attention comparator)");
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasSetMathMode(_handle, CuBlasNative.CUBLAS_TENSOR_OP_MATH),
+                "cublasSetMathMode(fused-attention comparator)");
+        }
+
+        internal unsafe void Launch(
+            DirectPtxBuffer q, DirectPtxBuffer k, DirectPtxBuffer v, DirectPtxBuffer output)
+        {
+            using var _ = _runtime.Enter();
+            float alphaQk = _scale;
+            float alphaPv = 1f;
+            float beta = 0f;
+
+            AiDotNet.Tensors.Engines.CublasStatus qkStatus = CuBlasNative.cublasGemmStridedBatchedEx(
+                _handle,
+                CublasOperation.Transpose, CublasOperation.None,
+                Sequence, Sequence, Dimension,
+                (IntPtr)(&alphaQk),
+                k.Pointer, CuBlasNative.CUDA_R_16F, Dimension, Sequence * Dimension,
+                q.Pointer, CuBlasNative.CUDA_R_16F, Dimension, Sequence * Dimension,
+                (IntPtr)(&beta),
+                _scores.Pointer, CuBlasNative.CUDA_R_32F, Sequence, Sequence * Sequence,
+                BatchHeads,
+                CuBlasNative.CUBLAS_COMPUTE_32F,
+                0);
+            CuBlasNative.CheckCublasStatus(qkStatus, "cublasGemmStridedBatchedEx(QK^T)");
+
+            _softmax.Launch(_scores, _probabilities);
+
+            // Row-major P*V is column-major V^T*P^T to cuBLAS.
+            AiDotNet.Tensors.Engines.CublasStatus pvStatus = CuBlasNative.cublasGemmStridedBatchedEx(
+                _handle,
+                CublasOperation.None, CublasOperation.None,
+                Dimension, Sequence, Sequence,
+                (IntPtr)(&alphaPv),
+                v.Pointer, CuBlasNative.CUDA_R_16F, Dimension, Sequence * Dimension,
+                _probabilities.Pointer, CuBlasNative.CUDA_R_16F, Sequence, Sequence * Sequence,
+                (IntPtr)(&beta),
+                output.Pointer, CuBlasNative.CUDA_R_32F, Dimension, Sequence * Dimension,
+                BatchHeads,
+                CuBlasNative.CUBLAS_COMPUTE_32F,
+                0);
+            CuBlasNative.CheckCublasStatus(pvStatus, "cublasGemmStridedBatchedEx(PV)");
+        }
+
+        public void Dispose()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                using var _ = _runtime.Enter();
+                CuBlasNative.CheckCublasStatus(
+                    CuBlasNative.cublasDestroy(_handle), "cublasDestroy(fused-attention comparator)");
+                _handle = IntPtr.Zero;
+            }
+            _probabilities.Dispose();
+            _scores.Dispose();
+            _softmax.Dispose();
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxGpuMatrixExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxGpuMatrixExperiment.cs
@@ -1,0 +1,316 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using TorchSharp;
+using TorchTensor = TorchSharp.torch.Tensor;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// NVIDIA-only, apples-to-apples matrix for the online attention family.
+/// Every row executes resident GPU buffers and the same mathematical lane.
+/// </summary>
+internal static class DirectPtxGpuMatrixExperiment
+{
+    private const int Dimension = 64;
+    private const float Scale = 0.125f;
+    private const int LaunchesPerSample = 1;
+    private readonly record struct Shape(string Name, int BatchHeads, int Sequence);
+    private readonly record struct Distribution(double Mean, double Median, double P95, double P99);
+
+    private static readonly Shape[] Shapes =
+    [
+        new("decode", 12, 16),
+        new("short", 12, 32),
+        new("medium", 12, 64),
+        new("bert", 12, 128),
+        new("throughput", 128, 128),
+        new("saturation", 512, 128),
+    ];
+
+    internal static void Run()
+    {
+        GpuBenchmarkEnvironment.PrintSnapshot("start");
+        Console.WriteLine(
+            $"NVIDIA GPU-only steady-state matrix ({LaunchesPerSample} launches/sample, FP16 Q/K/V, FP32 output, D=64)");
+        Console.WriteLine($"{"Shape",-11} {"Mode",-8} {"Lane",-10} {"Method",-27} {"median us",10} {"p95 us",10} {"p99 us",10} {"mean us",10} {"TFLOPS",9} {"B/call",9} {"tmp MiB",9}");
+        Console.WriteLine(new string('-', 139));
+        RunDirectAndCuBlas();
+        RunAiDotNet();
+        RunPyTorch();
+        GpuBenchmarkEnvironment.PrintSnapshot("end");
+    }
+
+    private static void RunDirectAndCuBlas()
+    {
+        using var runtime = new DirectPtxRuntime();
+        using (runtime.Enter())
+        {
+            foreach (Shape shape in Shapes)
+            foreach (bool causal in new[] { false, true })
+            {
+                int elements = shape.BatchHeads * shape.Sequence * Dimension;
+                ushort[] qHost = RandomHalf(new Random(1000 + elements), elements);
+                ushort[] kHost = RandomHalf(new Random(2000 + elements), elements);
+                ushort[] vHost = RandomHalf(new Random(3000 + elements), elements);
+                foreach (bool fused in new[] { false, true })
+                {
+                    using var kernel = new PtxOnlineFusedAttention128x64Kernel(
+                        runtime, shape.BatchHeads, causal, fused,
+                        Scale, 1e-5f, shape.Sequence, emitSoftmaxStats: false);
+                    using var q = runtime.AllocateBytes(kernel.QBytes);
+                    using var k = runtime.AllocateBytes(kernel.KBytes);
+                    using var v = runtime.AllocateBytes(kernel.VBytes);
+                    using var gamma = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.GammaBytes);
+                    using var beta = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.BetaBytes);
+                    using var output = runtime.AllocateBytes(kernel.OutputBytes);
+                    using var stats = runtime.AllocateBytes(kernel.StatsBytes);
+                    q.Upload<ushort>(qHost);
+                    k.Upload<ushort>(kHost);
+                    v.Upload<ushort>(vHost);
+                    gamma.Upload<float>(Enumerable.Repeat(1f, Dimension).ToArray());
+                    beta.Upload<float>(new float[Dimension]);
+                    Action launch = () => kernel.Launch(
+                        DirectPtxTensorView.CreateOwned(q, kernel.Blueprint.Tensors[0]),
+                        DirectPtxTensorView.CreateOwned(k, kernel.Blueprint.Tensors[1]),
+                        DirectPtxTensorView.CreateOwned(v, kernel.Blueprint.Tensors[2]),
+                        DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[3]),
+                        DirectPtxTensorView.CreateOwned(beta, kernel.Blueprint.Tensors[4]),
+                        DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[5]),
+                        DirectPtxTensorView.CreateOwned(stats, kernel.Blueprint.Tensors[6]));
+                    Distribution time = Measure(runtime.Synchronize, launch);
+                    long allocation = Allocation(runtime.Synchronize, launch);
+                    Print(shape, causal, fused, "Direct PTX online", time,
+                        Tflops(shape, time.Median), allocation, 0);
+
+                    if (!fused)
+                    {
+                        using var cuBlas = new DirectPtxOnlineAttentionExperiment.CuBlasAttentionComparator(
+                            runtime, shape.BatchHeads, shape.Sequence, Dimension, causal, Scale);
+                        Action vendor = () => cuBlas.Launch(q, k, v, output);
+                        Distribution vendorTime = Measure(runtime.Synchronize, vendor);
+                        long vendorAllocation = Allocation(runtime.Synchronize, vendor);
+                        long temporary = checked((long)cuBlas.ScoreBytes + (long)cuBlas.ProbabilityBytes);
+                        Print(shape, causal, false, "cuBLAS+PTX softmax", vendorTime,
+                            Tflops(shape, vendorTime.Median), vendorAllocation, temporary);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void RunAiDotNet()
+    {
+        using var backend = new CudaBackend();
+        foreach (Shape shape in Shapes)
+        foreach (bool causal in new[] { false, true })
+        {
+            int elements = shape.BatchHeads * shape.Sequence * Dimension;
+            int rows = shape.BatchHeads * shape.Sequence;
+            using var q = backend.AllocateBuffer(ToFloat(RandomHalf(new Random(1000 + elements), elements)));
+            using var k = backend.AllocateBuffer(ToFloat(RandomHalf(new Random(2000 + elements), elements)));
+            using var v = backend.AllocateBuffer(ToFloat(RandomHalf(new Random(3000 + elements), elements)));
+            using var gamma = backend.AllocateBuffer(Enumerable.Repeat(1f, Dimension).ToArray());
+            using var beta = backend.AllocateBuffer(new float[Dimension]);
+            using var attention = backend.AllocateBuffer(elements);
+            using var normalized = backend.AllocateBuffer(elements);
+            using var final = backend.AllocateBuffer(elements);
+            using var stats = backend.AllocateBuffer(rows);
+            using var means = backend.AllocateBuffer(rows);
+            using var inverse = backend.AllocateBuffer(rows);
+            Action attentionAction = () => backend.FlashAttentionV2(
+                q, k, v, attention, stats, 1, shape.BatchHeads,
+                shape.Sequence, shape.Sequence, Dimension, Scale, causal);
+            Distribution attentionTime = Measure(backend.Synchronize, attentionAction);
+            Print(shape, causal, false, "AiDotNet NVRTC Flash", attentionTime,
+                Tflops(shape, attentionTime.Median), Allocation(backend.Synchronize, attentionAction),
+                rows * sizeof(float));
+
+            Action fusedAction = () =>
+            {
+                attentionAction();
+                backend.LayerNorm(attention, normalized, gamma, beta, means, inverse, rows, Dimension, 1e-5f);
+                backend.Gelu(normalized, final, elements);
+            };
+            Distribution fusedTime = Measure(backend.Synchronize, fusedAction);
+            long temporary = (long)rows * sizeof(float) * 3 + (long)elements * sizeof(float) * 2;
+            Print(shape, causal, true, "AiDotNet Flash+LN+GELU", fusedTime,
+                Tflops(shape, fusedTime.Median), Allocation(backend.Synchronize, fusedAction), temporary);
+        }
+    }
+
+    private static void RunPyTorch()
+    {
+        if (!torch.cuda.is_available()) return;
+        bool oldFlash = torch.backends.cuda.flash_sdp_enabled();
+        bool oldMath = torch.backends.cuda.math_sdp_enabled();
+        try
+        {
+            foreach ((string backendName, bool flash, bool math) in new[]
+            {
+                ("PyTorch Flash-SDPA", true, false),
+                ("PyTorch Math-SDPA", false, true),
+            })
+            {
+                torch.backends.cuda.enable_flash_sdp(flash);
+                torch.backends.cuda.enable_math_sdp(math);
+                foreach (Shape shape in Shapes)
+                foreach (bool causal in new[] { false, true })
+                {
+                    int elements = shape.BatchHeads * shape.Sequence * Dimension;
+                    using TorchTensor qFloat = torch.tensor(
+                        ToFloat(RandomHalf(new Random(1000 + elements), elements)),
+                        [1, shape.BatchHeads, shape.Sequence, Dimension], device: torch.CUDA);
+                    using TorchTensor kFloat = torch.tensor(
+                        ToFloat(RandomHalf(new Random(2000 + elements), elements)),
+                        [1, shape.BatchHeads, shape.Sequence, Dimension], device: torch.CUDA);
+                    using TorchTensor vFloat = torch.tensor(
+                        ToFloat(RandomHalf(new Random(3000 + elements), elements)),
+                        [1, shape.BatchHeads, shape.Sequence, Dimension], device: torch.CUDA);
+                    using TorchTensor q = qFloat.half();
+                    using TorchTensor k = kFloat.half();
+                    using TorchTensor v = vFloat.half();
+                    using TorchTensor gamma = torch.ones([Dimension], device: torch.CUDA);
+                    using TorchTensor beta = torch.zeros([Dimension], device: torch.CUDA);
+                    TorchTensor Attention()
+                    {
+                        using TorchTensor half = torch.nn.functional.scaled_dot_product_attention(
+                            q, k, v, null, 0.0, causal);
+                        return half.to_type(torch.ScalarType.Float32);
+                    }
+                    TorchTensor Fused()
+                    {
+                        using TorchTensor a = Attention();
+                        using TorchTensor n = torch.nn.functional.layer_norm(
+                            a, [Dimension], gamma, beta, 1e-5);
+                        return TanhGelu(n);
+                    }
+                    Distribution attentionTime = MeasureTorch(Attention);
+                    Print(shape, causal, false, backendName, attentionTime,
+                        Tflops(shape, attentionTime.Median), AllocationTorch(Attention), -1);
+                    Distribution fusedTime = MeasureTorch(Fused);
+                    Print(shape, causal, true, backendName + "+LN+GELU", fusedTime,
+                        Tflops(shape, fusedTime.Median), AllocationTorch(Fused), -1);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"PyTorch matrix stopped: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            torch.backends.cuda.enable_flash_sdp(oldFlash);
+            torch.backends.cuda.enable_math_sdp(oldMath);
+        }
+    }
+
+    // TorchSharp 0.106 exposes only exact GELU. Spell out PyTorch's
+    // approximate="tanh" equation so this lane matches AiDotNet and PTX.
+    private static TorchTensor TanhGelu(TorchTensor x)
+    {
+        using TorchTensor square = x.mul(x);
+        using TorchTensor cube = square.mul(x);
+        using TorchTensor corrected = cube.mul(0.044715).add(x);
+        using TorchTensor scaled = corrected.mul(0.7978845608028654);
+        using TorchTensor activated = scaled.tanh().add(1.0);
+        return activated.mul(x).mul_(0.5);
+    }
+
+    private static Distribution Measure(Action synchronize, Action action)
+    {
+        for (int i = 0; i < 30; i++) action();
+        synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            for (int launch = 0; launch < LaunchesPerSample; launch++) action();
+            synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds / LaunchesPerSample;
+        }
+        return Summarize(samples);
+    }
+
+    private static Distribution MeasureTorch(Func<TorchTensor> action)
+    {
+        for (int i = 0; i < 30; i++) using (TorchTensor t = action()) { }
+        torch.cuda.synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            for (int launch = 0; launch < LaunchesPerSample; launch++)
+                using (TorchTensor t = action()) { }
+            torch.cuda.synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds / LaunchesPerSample;
+        }
+        return Summarize(samples);
+    }
+
+    private static long Allocation(Action synchronize, Action action)
+    {
+        action(); synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 50; i++) action();
+        long value = (GC.GetAllocatedBytesForCurrentThread() - before) / 50;
+        synchronize();
+        return value;
+    }
+
+    private static long AllocationTorch(Func<TorchTensor> action)
+    {
+        using (TorchTensor t = action()) torch.cuda.synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 50; i++) using (TorchTensor t = action()) { }
+        long value = (GC.GetAllocatedBytesForCurrentThread() - before) / 50;
+        torch.cuda.synchronize();
+        return value;
+    }
+
+    private static Distribution Summarize(double[] values)
+    {
+        double[] sorted = (double[])values.Clone();
+        Array.Sort(sorted);
+        return new Distribution(values.Average(), P(sorted, .5), P(sorted, .95), P(sorted, .99));
+    }
+
+    private static double P(double[] sorted, double percentile)
+    {
+        double position = (sorted.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, sorted.Length - 1);
+        return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+    }
+
+    private static double Tflops(Shape shape, double milliseconds) =>
+        4.0 * shape.BatchHeads * shape.Sequence * shape.Sequence * Dimension /
+        (milliseconds * 1e-3) / 1e12;
+
+    private static void Print(
+        Shape shape, bool causal, bool fused, string method,
+        Distribution d, double tflops, long allocation, long temporaryBytes)
+    {
+        string temporary = temporaryBytes < 0 ? "n/a" : (temporaryBytes / 1048576.0).ToString("F3");
+        Console.WriteLine(
+            $"{shape.Name,-11} {(causal ? "causal" : "plain"),-8} {(fused ? "attn+epi" : "attention"),-10} " +
+            $"{method,-27} {d.Median * 1000,10:F2} {d.P95 * 1000,10:F2} {d.P99 * 1000,10:F2} " +
+            $"{d.Mean * 1000,10:F2} {tflops,9:F3} {allocation,9} {temporary,9}");
+    }
+
+    private static ushort[] RandomHalf(Random random, int length)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = BitConverter.HalfToUInt16Bits((Half)((random.NextSingle() - 0.5f) * 0.5f));
+        return result;
+    }
+
+    private static float[] ToFloat(ushort[] values)
+    {
+        var result = new float[values.Length];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = (float)BitConverter.UInt16BitsToHalf(values[i]);
+        return result;
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxGpuMatrixExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxGpuMatrixExperiment.cs
@@ -30,6 +30,21 @@ internal static class DirectPtxGpuMatrixExperiment
 
     internal static void Run()
     {
+        if (!DirectPtxRuntime.IsAvailable)
+        {
+            Console.WriteLine("NVIDIA CUDA Driver API is unavailable.");
+            return;
+        }
+        using (var probe = new DirectPtxRuntime())
+        {
+            if (!DirectPtxArchitecture.HasValidatedOnlineAttention(probe.ArchitectureFamily))
+            {
+                Console.WriteLine(
+                    $"Direct PTX online attention has no validated {probe.ArchitectureFamily} specialization.");
+                return;
+            }
+        }
+
         GpuBenchmarkEnvironment.PrintSnapshot("start");
         Console.WriteLine(
             $"NVIDIA GPU-only steady-state matrix ({LaunchesPerSample} launches/sample, FP16 Q/K/V, FP32 output, D=64)");

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxOnlineAttentionExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxOnlineAttentionExperiment.cs
@@ -1,0 +1,575 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using TorchSharp;
+using TorchTensor = TorchSharp.torch.Tensor;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>Hardware smoke test for the async online S=128,D=64 specialization.</summary>
+internal static class DirectPtxOnlineAttentionExperiment
+{
+    private const int BatchHeads = 128;
+    private const int Sequence = 128;
+    private const int Dimension = 64;
+    private const float Scale = 0.125f;
+    private readonly record struct Distribution(double Mean, double Median, double P95, double P99);
+
+    internal static void Run()
+    {
+        GpuBenchmarkEnvironment.PrintSnapshot("start");
+        using var runtime = new DirectPtxRuntime();
+        // Model a resident execution thread: establish the context once so
+        // host timing measures launch/sync, not repeated context switching.
+        Console.WriteLine("Async online FlashAttention championship: [BH=128,S=128,D=64]");
+        Console.WriteLine($"GPU: {runtime.DeviceName} (SM {runtime.ComputeCapabilityMajor}.{runtime.ComputeCapabilityMinor})");
+        Console.WriteLine($"{"Mode",-9} {"Method",-34} {"median us",10} {"p95 us",10} {"p99 us",10} {"mean us",10} {"TFLOPS",9} {"B/call",10} {"tmp MiB",9} {"max err",10} {"regs",6} {"local B",8}");
+        Console.WriteLine(new string('-', 145));
+
+        using (runtime.Enter())
+        {
+        foreach (bool causal in new[] { false, true })
+        foreach (bool epilogue in new[] { false, true })
+        {
+            using var kernel = new PtxOnlineFusedAttention128x64Kernel(
+                runtime, BatchHeads, causal, epilogue, Scale,
+                emitSoftmaxStats: false);
+            using var q = runtime.AllocateBytes(kernel.QBytes);
+            using var k = runtime.AllocateBytes(kernel.KBytes);
+            using var v = runtime.AllocateBytes(kernel.VBytes);
+            using var gamma = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.GammaBytes);
+            using var beta = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.BetaBytes);
+            using var output = runtime.AllocateBytes(kernel.OutputBytes);
+            using var stats = runtime.AllocateBytes(kernel.StatsBytes);
+
+            var random = new Random(1771);
+            ushort[] qHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+            ushort[] kHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+            ushort[] vHost = RandomHalf(random, BatchHeads * Sequence * Dimension);
+            float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+            float[] betaHost = Enumerable.Range(0, Dimension).Select(i => (i - 32) / 512f).ToArray();
+            q.Upload<ushort>(qHost);
+            k.Upload<ushort>(kHost);
+            v.Upload<ushort>(vHost);
+            gamma.Upload<float>(gammaHost);
+            beta.Upload<float>(betaHost);
+
+            Action launch = () => kernel.Launch(
+                DirectPtxTensorView.CreateOwned(q, kernel.Blueprint.Tensors[0]),
+                DirectPtxTensorView.CreateOwned(k, kernel.Blueprint.Tensors[1]),
+                DirectPtxTensorView.CreateOwned(v, kernel.Blueprint.Tensors[2]),
+                DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[3]),
+                DirectPtxTensorView.CreateOwned(beta, kernel.Blueprint.Tensors[4]),
+                DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[5]),
+                DirectPtxTensorView.CreateOwned(stats, kernel.Blueprint.Tensors[6]));
+
+            launch();
+            runtime.Synchronize();
+            var actual = new float[BatchHeads * Sequence * Dimension];
+            output.Download<float>(actual);
+            float maxError = Validate(actual, qHost, kHost, vHost, gammaHost, betaHost, causal, epilogue);
+            Distribution device = Summarize(runtime.MeasureKernelSamples(
+                launch, warmup: 100, samples: 101, launchesPerSample: 10));
+            Distribution e2e = MeasureEndToEnd(runtime, launch);
+            long allocation = MeasureAllocation(runtime, launch);
+            string mode = causal ? "causal" : "unmasked";
+            string suffix = epilogue ? "+LN+GELU" : string.Empty;
+            Print(mode, $"Direct PTX online{suffix} [device]", device,
+                kernel.AttentionTflops((float)device.Median), allocation, 0, maxError,
+                kernel.FunctionInfo.RegistersPerThread, kernel.FunctionInfo.LocalBytesPerThread);
+            Print(mode, $"Direct PTX online{suffix} [E2E]", e2e,
+                kernel.AttentionTflops((float)e2e.Median), allocation, 0, maxError,
+                kernel.FunctionInfo.RegistersPerThread, kernel.FunctionInfo.LocalBytesPerThread);
+
+            if (!epilogue)
+            {
+                using var cuBlas = new CuBlasAttentionComparator(
+                    runtime, BatchHeads, Sequence, Dimension, causal, Scale);
+                Action cuBlasLaunch = () => cuBlas.Launch(q, k, v, output);
+                cuBlasLaunch();
+                runtime.Synchronize();
+                output.Download<float>(actual);
+                float cuBlasError = Validate(
+                    actual, qHost, kHost, vHost, gammaHost, betaHost,
+                    causal, epilogue: false);
+                Distribution cuBlasDevice = Summarize(runtime.MeasureKernelSamples(
+                    cuBlasLaunch, warmup: 100, samples: 101, launchesPerSample: 10));
+                Distribution cuBlasE2e = MeasureEndToEnd(runtime, cuBlasLaunch);
+                long cuBlasAllocation = MeasureAllocation(runtime, cuBlasLaunch);
+                long temporaries = checked((long)cuBlas.ScoreBytes + (long)cuBlas.ProbabilityBytes);
+                Print(mode, "cuBLAS GEMMs + PTX softmax [device]", cuBlasDevice,
+                    EffectiveTflops(cuBlasDevice.Median), cuBlasAllocation,
+                    temporaries, cuBlasError);
+                Print(mode, "cuBLAS GEMMs + PTX softmax [E2E]", cuBlasE2e,
+                    EffectiveTflops(cuBlasE2e.Median), cuBlasAllocation,
+                    temporaries, cuBlasError);
+            }
+        }
+        }
+
+        RunAiDotNetNvrtc();
+        RunTorchSharp();
+        GpuBenchmarkEnvironment.PrintSnapshot("end");
+    }
+
+    private static void RunAiDotNetNvrtc()
+    {
+        using var backend = new CudaBackend();
+        if (!backend.IsAvailable) return;
+        int elements = BatchHeads * Sequence * Dimension;
+        int rows = BatchHeads * Sequence;
+        var random = new Random(1771);
+        ushort[] qHalf = RandomHalf(random, elements);
+        ushort[] kHalf = RandomHalf(random, elements);
+        ushort[] vHalf = RandomHalf(random, elements);
+        float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+        float[] betaHost = Enumerable.Range(0, Dimension).Select(i => (i - 32) / 512f).ToArray();
+        using var q = backend.AllocateBuffer(ToFloat(qHalf));
+        using var k = backend.AllocateBuffer(ToFloat(kHalf));
+        using var v = backend.AllocateBuffer(ToFloat(vHalf));
+        using var gamma = backend.AllocateBuffer(gammaHost);
+        using var beta = backend.AllocateBuffer(betaHost);
+        using var attention = backend.AllocateBuffer(elements);
+        using var normalized = backend.AllocateBuffer(elements);
+        using var final = backend.AllocateBuffer(elements);
+        using var stats = backend.AllocateBuffer(rows);
+        using var means = backend.AllocateBuffer(rows);
+        using var inverseVariances = backend.AllocateBuffer(rows);
+
+        foreach (bool causal in new[] { false, true })
+        {
+            Action attentionAction = () => backend.FlashAttentionV2(
+                q, k, v, attention, stats,
+                1, BatchHeads, Sequence, Sequence, Dimension, Scale, causal);
+            attentionAction();
+            backend.Synchronize();
+            float attentionError = Validate(
+                backend.DownloadBuffer(attention), qHalf, kHalf, vHalf,
+                gammaHost, betaHost, causal, epilogue: false);
+            Distribution attentionTime = MeasureEndToEnd(backend, attentionAction);
+            long attentionAllocation = MeasureAllocation(backend, attentionAction);
+            Print(causal ? "causal" : "unmasked", "AiDotNet NVRTC FlashAttn [E2E]", attentionTime,
+                EffectiveTflops(attentionTime.Median), attentionAllocation,
+                rows * sizeof(float), attentionError);
+
+            Action composition = () =>
+            {
+                backend.FlashAttentionV2(
+                    q, k, v, attention, stats,
+                    1, BatchHeads, Sequence, Sequence, Dimension, Scale, causal);
+                backend.LayerNorm(
+                    attention, normalized, gamma, beta, means, inverseVariances,
+                    rows, Dimension, 1e-5f);
+                backend.Gelu(normalized, final, elements);
+            };
+            composition();
+            backend.Synchronize();
+            float fusedError = Validate(
+                backend.DownloadBuffer(final), qHalf, kHalf, vHalf,
+                gammaHost, betaHost, causal, epilogue: true);
+            Distribution compositionTime = MeasureEndToEnd(backend, composition);
+            long compositionAllocation = MeasureAllocation(backend, composition);
+            long temporaryBytes =
+                (long)rows * sizeof(float) * 3 + (long)elements * sizeof(float) * 2;
+            Print(causal ? "causal" : "unmasked", "AiDotNet NVRTC+LN+GELU [E2E]", compositionTime,
+                EffectiveTflops(compositionTime.Median), compositionAllocation,
+                temporaryBytes, fusedError);
+        }
+    }
+
+    private static void RunTorchSharp()
+    {
+        try
+        {
+            if (!torch.cuda.is_available()) return;
+            int elements = BatchHeads * Sequence * Dimension;
+            var random = new Random(1771);
+            ushort[] qHalf = RandomHalf(random, elements);
+            ushort[] kHalf = RandomHalf(random, elements);
+            ushort[] vHalf = RandomHalf(random, elements);
+            float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+            float[] betaHost = Enumerable.Range(0, Dimension).Select(i => (i - 32) / 512f).ToArray();
+            using TorchTensor qFloat = torch.tensor(ToFloat(qHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor kFloat = torch.tensor(ToFloat(kHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor vFloat = torch.tensor(ToFloat(vHalf), [1, BatchHeads, Sequence, Dimension], device: torch.CUDA);
+            using TorchTensor q = qFloat.half();
+            using TorchTensor k = kFloat.half();
+            using TorchTensor v = vFloat.half();
+            using TorchTensor gamma = torch.tensor(gammaHost, device: torch.CUDA);
+            using TorchTensor beta = torch.tensor(betaHost, device: torch.CUDA);
+            bool oldFlash = torch.backends.cuda.flash_sdp_enabled();
+            bool oldMath = torch.backends.cuda.math_sdp_enabled();
+            try
+            {
+                torch.backends.cuda.enable_flash_sdp(true);
+                torch.backends.cuda.enable_math_sdp(false);
+                foreach (bool causal in new[] { false, true })
+                {
+                    TorchTensor Attention()
+                    {
+                        using TorchTensor half = torch.nn.functional.scaled_dot_product_attention(
+                            q, k, v, null, 0.0, causal);
+                        return half.to_type(torch.ScalarType.Float32);
+                    }
+                    TorchTensor Composition()
+                    {
+                        using TorchTensor attention = Attention();
+                        using TorchTensor normalized = torch.nn.functional.layer_norm(
+                            attention, [Dimension], gamma, beta, 1e-5);
+                        return TanhGelu(normalized);
+                    }
+
+                    using (TorchTensor check = Attention())
+                    using (TorchTensor checkCpu = check.cpu())
+                    {
+                        float error = Validate(checkCpu.data<float>().ToArray(), qHalf, kHalf, vHalf,
+                            gammaHost, betaHost, causal, epilogue: false);
+                        Distribution time = MeasureTorch(Attention);
+                        long allocation = MeasureTorchAllocation(Attention);
+                        Print(causal ? "causal" : "unmasked", "PyTorch Flash-SDPA [E2E]", time,
+                            EffectiveTflops(time.Median), allocation, -1, error);
+                    }
+
+                    using (TorchTensor check = Composition())
+                    using (TorchTensor checkCpu = check.cpu())
+                    {
+                        float error = Validate(checkCpu.data<float>().ToArray(), qHalf, kHalf, vHalf,
+                            gammaHost, betaHost, causal, epilogue: true);
+                        Distribution time = MeasureTorch(Composition);
+                        long allocation = MeasureTorchAllocation(Composition);
+                        Print(causal ? "causal" : "unmasked", "PyTorch Flash+LN+GELU [E2E]", time,
+                            EffectiveTflops(time.Median), allocation, -1, error);
+                    }
+                }
+            }
+            finally
+            {
+                torch.backends.cuda.enable_flash_sdp(oldFlash);
+                torch.backends.cuda.enable_math_sdp(oldMath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"PyTorch Flash baseline unavailable: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static TorchTensor TanhGelu(TorchTensor x)
+    {
+        using TorchTensor square = x.mul(x);
+        using TorchTensor cube = square.mul(x);
+        using TorchTensor corrected = cube.mul(0.044715).add(x);
+        using TorchTensor scaled = corrected.mul(0.7978845608028654);
+        using TorchTensor activated = scaled.tanh().add(1.0);
+        return activated.mul(x).mul_(0.5);
+    }
+
+    private static float Validate(
+        float[] actual,
+        ushort[] q,
+        ushort[] k,
+        ushort[] v,
+        float[] gamma,
+        float[] beta,
+        bool causal,
+        bool epilogue)
+    {
+        var scores = new float[Sequence];
+        var expectedRow = new float[Dimension];
+        float maxError = 0;
+        for (int row = 0; row < Sequence; row++)
+        {
+            int lastKey = causal ? row : Sequence - 1;
+            float maximum = float.NegativeInfinity;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                float score = 0;
+                for (int d = 0; d < Dimension; d++)
+                    score += HalfAt(q, row * Dimension + d) * HalfAt(k, column * Dimension + d);
+                scores[column] = score * Scale;
+                maximum = MathF.Max(maximum, scores[column]);
+            }
+
+            float sum = 0;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                scores[column] = MathF.Exp(scores[column] - maximum);
+                sum += scores[column];
+            }
+            for (int d = 0; d < Dimension; d++)
+            {
+                float value = 0;
+                for (int column = 0; column <= lastKey; column++)
+                    value += scores[column] / sum * HalfAt(v, column * Dimension + d);
+                expectedRow[d] = value;
+            }
+
+            if (epilogue)
+            {
+                float mean = expectedRow.Average();
+                float variance = 0;
+                for (int d = 0; d < Dimension; d++)
+                    variance += (expectedRow[d] - mean) * (expectedRow[d] - mean);
+                float inverseStd = 1f / MathF.Sqrt(variance / Dimension + 1e-5f);
+                for (int d = 0; d < Dimension; d++)
+                {
+                    float x = (expectedRow[d] - mean) * inverseStd * gamma[d] + beta[d];
+                    expectedRow[d] = 0.5f * x *
+                        (1f + MathF.Tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+                }
+            }
+
+            for (int d = 0; d < Dimension; d++)
+                maxError = MathF.Max(maxError, MathF.Abs(actual[row * Dimension + d] - expectedRow[d]));
+        }
+
+        if (!float.IsFinite(maxError) || maxError > (epilogue ? 0.025f : 0.012f))
+            throw new InvalidOperationException($"Online attention validation failed: max abs error {maxError:G9}.");
+        return maxError;
+    }
+
+    private static Distribution MeasureEndToEnd(DirectPtxRuntime runtime, Action action)
+    {
+        for (int i = 0; i < 30; i++) action();
+        runtime.Synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            action();
+            runtime.Synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        return Summarize(samples);
+    }
+
+    private static Distribution MeasureEndToEnd(CudaBackend backend, Action action)
+    {
+        for (int i = 0; i < 30; i++) action();
+        backend.Synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            action();
+            backend.Synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        return Summarize(samples);
+    }
+
+    private static Distribution MeasureTorch(Func<TorchTensor> action)
+    {
+        for (int i = 0; i < 30; i++) using (TorchTensor warmup = action()) { }
+        torch.cuda.synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            using TorchTensor result = action();
+            torch.cuda.synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        return Summarize(samples);
+    }
+
+    private static long MeasureAllocation(DirectPtxRuntime runtime, Action action)
+    {
+        action();
+        runtime.Synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        const int calls = 100;
+        for (int i = 0; i < calls; i++) action();
+        long result = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+        runtime.Synchronize();
+        return result;
+    }
+
+    private static long MeasureAllocation(CudaBackend backend, Action action)
+    {
+        action();
+        backend.Synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        const int calls = 100;
+        for (int i = 0; i < calls; i++) action();
+        long result = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+        backend.Synchronize();
+        return result;
+    }
+
+    private static long MeasureTorchAllocation(Func<TorchTensor> action)
+    {
+        using (TorchTensor warmup = action()) torch.cuda.synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        const int calls = 100;
+        for (int i = 0; i < calls; i++) using (TorchTensor result = action()) { }
+        long allocated = (GC.GetAllocatedBytesForCurrentThread() - before) / calls;
+        torch.cuda.synchronize();
+        return allocated;
+    }
+
+    private static Distribution Summarize(float[] samples) =>
+        Summarize(samples.Select(static value => (double)value).ToArray());
+
+    private static Distribution Summarize(double[] samples)
+    {
+        var sorted = (double[])samples.Clone();
+        Array.Sort(sorted);
+        return new Distribution(samples.Average(), Percentile(sorted, 0.50),
+            Percentile(sorted, 0.95), Percentile(sorted, 0.99));
+    }
+
+    private static double Percentile(double[] sorted, double percentile)
+    {
+        double position = (sorted.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, sorted.Length - 1);
+        return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+    }
+
+    private static double EffectiveTflops(double milliseconds)
+    {
+        double flops = 4.0 * BatchHeads * Sequence * Sequence * Dimension;
+        return flops / (milliseconds * 1e-3) / 1e12;
+    }
+
+    private static void Print(
+        string mode,
+        string method,
+        Distribution distribution,
+        double tflops,
+        long allocation,
+        long temporaryBytes,
+        double maxError,
+        int registers = 0,
+        int localBytes = 0)
+    {
+        string temporary = temporaryBytes < 0 ? "n/a" : (temporaryBytes / 1048576.0).ToString("F3");
+        string error = double.IsNaN(maxError) ? "n/a" : maxError.ToString("G4");
+        string registerText = registers == 0 ? "n/a" : registers.ToString();
+        string localText = registers == 0 ? "n/a" : localBytes.ToString();
+        Console.WriteLine(
+            $"{mode,-9} {method,-34} {distribution.Median * 1000,10:F2} " +
+            $"{distribution.P95 * 1000,10:F2} {distribution.P99 * 1000,10:F2} " +
+            $"{distribution.Mean * 1000,10:F2} {tflops,9:F3} {allocation,10} " +
+            $"{temporary,9} {error,10} {registerText,6} {localText,8}");
+    }
+
+    private static ushort[] RandomHalf(Random random, int length)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = BitConverter.HalfToUInt16Bits((Half)((random.NextSingle() - 0.5f) * 0.5f));
+        return result;
+    }
+
+    private static float HalfAt(ushort[] source, int index) =>
+        (float)BitConverter.UInt16BitsToHalf(source[index]);
+
+    private static float[] ToFloat(ushort[] source)
+    {
+        var result = new float[source.Length];
+        for (int i = 0; i < result.Length; i++) result[i] = HalfAt(source, i);
+        return result;
+    }
+
+    /// <summary>
+    /// Vendor-library attention boundary: Tensor-Core strided-batched cuBLAS
+    /// Q*K^T, shape-baked PTX softmax, Tensor-Core cuBLAS P*V.
+    /// </summary>
+    internal sealed class CuBlasAttentionComparator : IDisposable
+    {
+        private readonly DirectPtxRuntime _runtime;
+        private readonly PtxAttentionSoftmax32Kernel _softmax;
+        private readonly DirectPtxBuffer _scores;
+        private readonly DirectPtxBuffer _probabilities;
+        private readonly int _batchHeads;
+        private readonly int _sequence;
+        private readonly int _dimension;
+        private readonly float _scale;
+        private IntPtr _handle;
+
+        internal nuint ScoreBytes => _softmax.ScoreBytes;
+        internal nuint ProbabilityBytes => _softmax.ProbabilityBytes;
+
+        internal CuBlasAttentionComparator(
+            DirectPtxRuntime runtime,
+            int batchHeads,
+            int sequence,
+            int dimension,
+            bool isCausal,
+            float scale)
+        {
+            _runtime = runtime;
+            _batchHeads = batchHeads;
+            _sequence = sequence;
+            _dimension = dimension;
+            _scale = scale;
+            _softmax = new PtxAttentionSoftmax32Kernel(
+                runtime, batchHeads, isCausal, sequence);
+            _scores = runtime.AllocateBytes(_softmax.ScoreBytes);
+            _probabilities = runtime.AllocateBytes(_softmax.ProbabilityBytes);
+            using var _ = runtime.Enter();
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasCreate(out _handle), "cublasCreate(online-attention comparator)");
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasSetMathMode(_handle, CuBlasNative.CUBLAS_TENSOR_OP_MATH),
+                "cublasSetMathMode(online-attention comparator)");
+        }
+
+        internal unsafe void Launch(
+            DirectPtxBuffer q,
+            DirectPtxBuffer k,
+            DirectPtxBuffer v,
+            DirectPtxBuffer output)
+        {
+            using var _ = _runtime.Enter();
+            float alphaQk = _scale;
+            float alphaPv = 1f;
+            float beta = 0f;
+            int inputStride = _sequence * _dimension;
+            int scoreStride = _sequence * _sequence;
+
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasGemmStridedBatchedEx(
+                    _handle,
+                    CublasOperation.Transpose, CublasOperation.None,
+                    _sequence, _sequence, _dimension,
+                    (IntPtr)(&alphaQk),
+                    k.Pointer, CuBlasNative.CUDA_R_16F, _dimension, inputStride,
+                    q.Pointer, CuBlasNative.CUDA_R_16F, _dimension, inputStride,
+                    (IntPtr)(&beta),
+                    _scores.Pointer, CuBlasNative.CUDA_R_32F, _sequence, scoreStride,
+                    _batchHeads, CuBlasNative.CUBLAS_COMPUTE_32F, 0),
+                "cublasGemmStridedBatchedEx(QK^T)");
+            _softmax.Launch(_scores, _probabilities);
+            CuBlasNative.CheckCublasStatus(
+                CuBlasNative.cublasGemmStridedBatchedEx(
+                    _handle,
+                    CublasOperation.None, CublasOperation.None,
+                    _dimension, _sequence, _sequence,
+                    (IntPtr)(&alphaPv),
+                    v.Pointer, CuBlasNative.CUDA_R_16F, _dimension, inputStride,
+                    _probabilities.Pointer, CuBlasNative.CUDA_R_16F, _sequence, scoreStride,
+                    (IntPtr)(&beta),
+                    output.Pointer, CuBlasNative.CUDA_R_32F, _dimension, inputStride,
+                    _batchHeads, CuBlasNative.CUBLAS_COMPUTE_32F, 0),
+                "cublasGemmStridedBatchedEx(PV)");
+        }
+
+        public void Dispose()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                using var _ = _runtime.Enter();
+                CuBlasNative.CheckCublasStatus(
+                    CuBlasNative.cublasDestroy(_handle), "cublasDestroy(online-attention comparator)");
+                _handle = IntPtr.Zero;
+            }
+            _probabilities.Dispose();
+            _scores.Dispose();
+            _softmax.Dispose();
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxProfileTarget.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxProfileTarget.cs
@@ -1,0 +1,72 @@
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>Small deterministic targets for Nsight Compute release evidence.</summary>
+internal static class DirectPtxProfileTarget
+{
+    internal static void RunAttention()
+    {
+        using var runtime = new DirectPtxRuntime();
+        using var kernel = new PtxOnlineFusedAttention128x64Kernel(
+            runtime, 128, isCausal: false, fuseLayerNormGelu: false,
+            sequenceLength: 128, emitSoftmaxStats: false);
+        using var q = runtime.AllocateBytes(kernel.QBytes);
+        using var k = runtime.AllocateBytes(kernel.KBytes);
+        using var v = runtime.AllocateBytes(kernel.VBytes);
+        using var gamma = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.GammaBytes);
+        using var beta = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.BetaBytes);
+        using var output = runtime.AllocateBytes(kernel.OutputBytes);
+        using var stats = runtime.AllocateBytes(kernel.StatsBytes);
+        q.Upload<ushort>(new ushort[128 * 128 * 64]);
+        k.Upload<ushort>(new ushort[128 * 128 * 64]);
+        v.Upload<ushort>(new ushort[128 * 128 * 64]);
+        Action launch = () => kernel.Launch(
+            DirectPtxTensorView.CreateOwned(q, kernel.Blueprint.Tensors[0]),
+            DirectPtxTensorView.CreateOwned(k, kernel.Blueprint.Tensors[1]),
+            DirectPtxTensorView.CreateOwned(v, kernel.Blueprint.Tensors[2]),
+            DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[3]),
+            DirectPtxTensorView.CreateOwned(beta, kernel.Blueprint.Tensors[4]),
+            DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[5]),
+            DirectPtxTensorView.CreateOwned(stats, kernel.Blueprint.Tensors[6]));
+        for (int i = 0; i < 10; i++) launch();
+        runtime.Synchronize();
+        Console.WriteLine(kernel.Audit.ToJson());
+    }
+
+    internal static void RunResidualRmsNorm()
+    {
+        using var runtime = new DirectPtxRuntime();
+        using var kernel = new PtxFusedResidualRmsNormD64Kernel(runtime, 8192);
+        using var input = runtime.AllocateBytes(kernel.InputBytes);
+        using var residual = runtime.AllocateBytes(kernel.InputBytes);
+        using var gamma = runtime.AllocateBytes(PtxFusedResidualRmsNormD64Kernel.GammaBytes);
+        using var output = runtime.AllocateBytes(kernel.OutputBytes);
+        using var rms = runtime.AllocateBytes(kernel.RmsBytes);
+        input.Upload<float>(new float[8192 * 64]);
+        residual.Upload<float>(new float[8192 * 64]);
+        gamma.Upload<float>(Enumerable.Repeat(1f, 64).ToArray());
+        Action launch = () => kernel.Launch(
+            DirectPtxTensorView.CreateOwned(input, kernel.Blueprint.Tensors[0]),
+            DirectPtxTensorView.CreateOwned(residual, kernel.Blueprint.Tensors[1]),
+            DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[2]),
+            DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[3]),
+            DirectPtxTensorView.CreateOwned(rms, kernel.Blueprint.Tensors[4]));
+        for (int i = 0; i < 10; i++) launch();
+        runtime.Synchronize();
+        Console.WriteLine(kernel.Audit.ToJson());
+    }
+
+    internal static void VerifyNcuCsv(string path)
+    {
+        DirectPtxProfilerEvidence evidence = DirectPtxProfilerEvidence.FromNcuCsv(path);
+        Console.WriteLine($"source: {evidence.Source}");
+        Console.WriteLine($"register-spill instructions: {evidence.RegisterSpillInstructions}");
+        Console.WriteLine($"local-load instructions: {evidence.LocalLoadInstructions}");
+        Console.WriteLine($"local-store instructions: {evidence.LocalStoreInstructions}");
+        Console.WriteLine($"local-spill requests: {evidence.LocalSpillRequests}");
+        Console.WriteLine($"required metric groups observed: {evidence.ObservedMetricGroups}/4");
+        Console.WriteLine(evidence.ProvesZeroExecutedSpills ? "PASS: zero executed spills" : "FAIL: spill/local traffic detected");
+        if (!evidence.ProvesZeroExecutedSpills) Environment.ExitCode = 2;
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxProfileTarget.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxProfileTarget.cs
@@ -64,8 +64,7 @@ internal static class DirectPtxProfileTarget
         Console.WriteLine($"register-spill instructions: {evidence.RegisterSpillInstructions}");
         Console.WriteLine($"local-load instructions: {evidence.LocalLoadInstructions}");
         Console.WriteLine($"local-store instructions: {evidence.LocalStoreInstructions}");
-        Console.WriteLine($"local-spill requests: {evidence.LocalSpillRequests}");
-        Console.WriteLine($"required metric groups observed: {evidence.ObservedMetricGroups}/4");
+        Console.WriteLine($"required metric groups observed: {evidence.ObservedMetricGroups}/3");
         Console.WriteLine(evidence.ProvesZeroExecutedSpills ? "PASS: zero executed spills" : "FAIL: spill/local traffic detected");
         if (!evidence.ProvesZeroExecutedSpills) Environment.ExitCode = 2;
     }

--- a/tests/AiDotNet.Tensors.Benchmarks/DirectPtxResidualRmsNormExperiment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/DirectPtxResidualRmsNormExperiment.cs
@@ -1,0 +1,236 @@
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using TorchSharp;
+using TorchTensor = TorchSharp.torch.Tensor;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>Second-blueprint NVIDIA-only fused residual + RMSNorm benchmark.</summary>
+internal static class DirectPtxResidualRmsNormExperiment
+{
+    private const int Dimension = 64;
+    private const float Epsilon = 1e-5f;
+    private readonly record struct Distribution(double Mean, double Median, double P95, double P99);
+    private readonly record struct Result(
+        int Rows, string Method, Distribution Time, double GigabytesPerSecond,
+        long Allocation, long TemporaryBytes, float MaxError, int Registers, int LocalBytes);
+
+    internal static void Run()
+    {
+        GpuBenchmarkEnvironment.PrintSnapshot("start");
+        int[] rowCounts = [32, 256, 2048, 8192];
+        var results = new List<Result>();
+        RunDirect(rowCounts, results);
+        RunAiDotNet(rowCounts, results);
+        RunPyTorch(rowCounts, results);
+
+        Console.WriteLine("NVIDIA GPU-only fused residual + RMSNorm D=64 (resident FP32 tensors)");
+        Console.WriteLine($"{"Rows",7} {"Method",-29} {"median us",10} {"p95 us",10} {"p99 us",10} {"mean us",10} {"GB/s",9} {"B/call",9} {"tmp MiB",9} {"max err",10} {"regs",6} {"local B",8}");
+        Console.WriteLine(new string('-', 135));
+        foreach (Result result in results.OrderBy(r => r.Rows).ThenBy(r => r.Time.Median))
+        {
+            string temporary = result.TemporaryBytes < 0
+                ? "n/a"
+                : (result.TemporaryBytes / 1048576.0).ToString("F3");
+            string registers = result.Registers < 0 ? "n/a" : result.Registers.ToString();
+            string local = result.LocalBytes < 0 ? "n/a" : result.LocalBytes.ToString();
+            Console.WriteLine(
+                $"{result.Rows,7} {result.Method,-29} {result.Time.Median * 1000,10:F2} " +
+                $"{result.Time.P95 * 1000,10:F2} {result.Time.P99 * 1000,10:F2} " +
+                $"{result.Time.Mean * 1000,10:F2} {result.GigabytesPerSecond,9:F2} " +
+                $"{result.Allocation,9} {temporary,9} {result.MaxError,10:G4} {registers,6} {local,8}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Diagnostic gate: production policy except this single capture counts as one independent run (production requires three).");
+        DirectPtxReleaseGatePolicy policy = DirectPtxReleaseGatePolicy.ProductionDefault with
+        {
+            RequiredIndependentRuns = 1
+        };
+        foreach (int rows in rowCounts)
+        {
+            Result direct = results.Single(r => r.Rows == rows && r.Method == "Direct PTX fused");
+            Result best = results.Where(r => r.Rows == rows && r.Method != "Direct PTX fused")
+                .OrderBy(r => r.Time.Median).First();
+            var directEvidence = new DirectPtxPerformanceEvidence(
+                direct.Time.Median * 1000, direct.Time.P95 * 1000,
+                direct.Allocation, direct.TemporaryBytes, direct.MaxError,
+                direct.LocalBytes, IndependentRuns: 1);
+            var competitorEvidence = new DirectPtxPerformanceEvidence(
+                best.Time.Median * 1000, best.Time.P95 * 1000,
+                best.Allocation, best.TemporaryBytes, best.MaxError,
+                best.LocalBytes, IndependentRuns: 1);
+            DirectPtxReleaseDecision decision = policy.Evaluate(directEvidence, competitorEvidence);
+            Console.WriteLine(
+                $"rows={rows,-5}: {(decision.Passed ? "PASS" : "HOLD"),-4} {decision.MedianSpeedup:F2}x vs {best.Method}; " +
+                (decision.Passed ? "all gates passed" : string.Join("; ", decision.Failures)));
+        }
+        GpuBenchmarkEnvironment.PrintSnapshot("end");
+    }
+
+    private static void RunDirect(int[] rowCounts, List<Result> results)
+    {
+        using var runtime = new DirectPtxRuntime();
+        if (runtime.ArchitectureFamily != DirectPtxArchitectureFamily.Ampere) return;
+        using (runtime.Enter())
+        foreach (int rows in rowCounts)
+        {
+            using var kernel = new PtxFusedResidualRmsNormD64Kernel(runtime, rows, Epsilon);
+            float[] x = Values(rows * Dimension, 100 + rows, 1f);
+            float[] residualHost = Values(rows * Dimension, 200 + rows, 0.25f);
+            float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+            using var input = runtime.AllocateBytes(kernel.InputBytes);
+            using var residual = runtime.AllocateBytes(kernel.InputBytes);
+            using var gamma = runtime.AllocateBytes(PtxFusedResidualRmsNormD64Kernel.GammaBytes);
+            using var output = runtime.AllocateBytes(kernel.OutputBytes);
+            using var rms = runtime.AllocateBytes(kernel.RmsBytes);
+            input.Upload<float>(x);
+            residual.Upload<float>(residualHost);
+            gamma.Upload<float>(gammaHost);
+            Action launch = () => kernel.Launch(
+                DirectPtxTensorView.CreateOwned(input, kernel.Blueprint.Tensors[0]),
+                DirectPtxTensorView.CreateOwned(residual, kernel.Blueprint.Tensors[1]),
+                DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[2]),
+                DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[3]),
+                DirectPtxTensorView.CreateOwned(rms, kernel.Blueprint.Tensors[4]));
+            Distribution distribution = Measure(runtime.Synchronize, launch);
+            long allocation = Allocation(runtime.Synchronize, launch);
+            launch(); runtime.Synchronize();
+            var actual = new float[x.Length];
+            output.Download<float>(actual);
+            float error = Validate(actual, x, residualHost, gammaHost, rows);
+            results.Add(new Result(rows, "Direct PTX fused", distribution,
+                Bandwidth(rows, distribution.Median), allocation, 0, error,
+                kernel.FunctionInfo.RegistersPerThread, kernel.FunctionInfo.LocalBytesPerThread));
+        }
+    }
+
+    private static void RunAiDotNet(int[] rowCounts, List<Result> results)
+    {
+        using var backend = new CudaBackend();
+        foreach (int rows in rowCounts)
+        {
+            float[] x = Values(rows * Dimension, 100 + rows, 1f);
+            float[] residualHost = Values(rows * Dimension, 200 + rows, 0.25f);
+            float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+            using var input = backend.AllocateBuffer(x);
+            using var residual = backend.AllocateBuffer(residualHost);
+            using var gamma = backend.AllocateBuffer(gammaHost);
+            using var sum = backend.AllocateBuffer(x.Length);
+            using var output = backend.AllocateBuffer(x.Length);
+            using var rms = backend.AllocateBuffer(rows);
+            Action launch = () =>
+            {
+                backend.Add(input, residual, sum, x.Length);
+                backend.RmsNorm(sum, output, gamma, rms, rows, Dimension, Epsilon);
+            };
+            Distribution distribution = Measure(backend.Synchronize, launch);
+            long allocation = Allocation(backend.Synchronize, launch);
+            launch(); backend.Synchronize();
+            float error = Validate(backend.DownloadBuffer(output), x, residualHost, gammaHost, rows);
+            results.Add(new Result(rows, "AiDotNet add + RMSNorm", distribution,
+                Bandwidth(rows, distribution.Median), allocation, (long)x.Length * sizeof(float),
+                error, -1, -1));
+        }
+    }
+
+    private static void RunPyTorch(int[] rowCounts, List<Result> results)
+    {
+        if (!torch.cuda.is_available()) return;
+        foreach (int rows in rowCounts)
+        {
+            float[] xHost = Values(rows * Dimension, 100 + rows, 1f);
+            float[] residualHost = Values(rows * Dimension, 200 + rows, 0.25f);
+            float[] gammaHost = Enumerable.Range(0, Dimension).Select(i => 0.75f + i / 256f).ToArray();
+            using TorchTensor input = torch.tensor(xHost, [rows, Dimension], device: torch.CUDA);
+            using TorchTensor residual = torch.tensor(residualHost, [rows, Dimension], device: torch.CUDA);
+            using TorchTensor gamma = torch.tensor(gammaHost, [Dimension], device: torch.CUDA);
+            void Launch()
+            {
+                using TorchTensor sum = input.add(residual);
+                using TorchTensor square = sum.mul(sum);
+                using TorchTensor mean = square.mean([1L], keepdim: true);
+                using TorchTensor rms = mean.add(Epsilon).sqrt();
+                using TorchTensor output = sum.div(rms).mul_(gamma);
+            }
+            Distribution distribution = Measure(() => torch.cuda.synchronize(), Launch);
+            long allocation = Allocation(() => torch.cuda.synchronize(), Launch);
+            results.Add(new Result(rows, "PyTorch eager composition", distribution,
+                Bandwidth(rows, distribution.Median), allocation, -1, 0, -1, -1));
+        }
+    }
+
+    private static Distribution Measure(Action synchronize, Action launch)
+    {
+        for (int i = 0; i < 30; i++) launch();
+        synchronize();
+        var samples = new double[101];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            launch();
+            synchronize();
+            samples[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+        Array.Sort(samples);
+        return new Distribution(samples.Average(), Percentile(samples, .5),
+            Percentile(samples, .95), Percentile(samples, .99));
+    }
+
+    private static long Allocation(Action synchronize, Action launch)
+    {
+        launch(); synchronize();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 50; i++) launch();
+        long allocation = (GC.GetAllocatedBytesForCurrentThread() - before) / 50;
+        synchronize();
+        return allocation;
+    }
+
+    private static double Percentile(double[] sorted, double percentile)
+    {
+        double position = (sorted.Length - 1) * percentile;
+        int lower = (int)position;
+        int upper = Math.Min(lower + 1, sorted.Length - 1);
+        return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+    }
+
+    private static double Bandwidth(int rows, double milliseconds)
+    {
+        long bytes = checked((long)rows * Dimension * sizeof(float) * 3L +
+            Dimension * sizeof(float) + rows * sizeof(float));
+        return bytes / (milliseconds * 1e-3) / 1e9;
+    }
+
+    private static float[] Values(int length, int seed, float magnitude)
+    {
+        var random = new Random(seed);
+        return Enumerable.Range(0, length)
+            .Select(_ => (random.NextSingle() - 0.5f) * 2f * magnitude).ToArray();
+    }
+
+    private static float Validate(
+        float[] actual, float[] input, float[] residual, float[] gamma, int rows)
+    {
+        float maximum = 0;
+        for (int row = 0; row < rows; row++)
+        {
+            float sumSquares = 0;
+            for (int d = 0; d < Dimension; d++)
+            {
+                float value = input[row * Dimension + d] + residual[row * Dimension + d];
+                sumSquares += value * value;
+            }
+            float rms = MathF.Sqrt(sumSquares / Dimension + Epsilon);
+            for (int d = 0; d < Dimension; d++)
+            {
+                float expected = (input[row * Dimension + d] + residual[row * Dimension + d]) /
+                    rms * gamma[d];
+                maximum = MathF.Max(maximum,
+                    MathF.Abs(actual[row * Dimension + d] - expected));
+            }
+        }
+        return maximum;
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/GpuBenchmarkEnvironment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/GpuBenchmarkEnvironment.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+internal static class GpuBenchmarkEnvironment
+{
+    internal static void PrintSnapshot(string label)
+    {
+        Console.WriteLine($"[{label}] OS={RuntimeInformation.OSDescription}; .NET={Environment.Version}; " +
+            $"process={Environment.ProcessId}; UTC={DateTime.UtcNow:O}");
+        try
+        {
+            var start = new ProcessStartInfo
+            {
+                FileName = "nvidia-smi",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            start.ArgumentList.Add("--query-gpu=name,uuid,driver_version,pstate,clocks.sm,clocks.mem,temperature.gpu,power.draw,power.limit");
+            start.ArgumentList.Add("--format=csv,noheader,nounits");
+            using Process process = Process.Start(start)!;
+            string output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit(5000);
+            if (process.ExitCode == 0 && output.Length != 0)
+                Console.WriteLine($"[{label}] GPU name, uuid, driver, pstate, SM MHz, memory MHz, C, W, limit W: {output}");
+        }
+        catch
+        {
+            Console.WriteLine($"[{label}] nvidia-smi metadata unavailable");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/GpuBenchmarkEnvironment.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/GpuBenchmarkEnvironment.cs
@@ -16,7 +16,7 @@ internal static class GpuBenchmarkEnvironment
                 FileName = "nvidia-smi",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                RedirectStandardError = false,
                 CreateNoWindow = true
             };
             start.ArgumentList.Add("--query-gpu=name,uuid,driver_version,pstate,clocks.sm,clocks.mem,temperature.gpu,power.draw,power.limit");

--- a/tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1
+++ b/tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1
@@ -33,8 +33,7 @@ $metrics = @(
     'sass__inst_executed_register_spilling',
     'sass__inst_executed_register_spilling_mem_local',
     'sass__inst_executed_local_loads',
-    'sass__inst_executed_local_stores',
-    'derived__local_spilling_requests'
+    'sass__inst_executed_local_stores'
 ) -join ','
 
 & $ncuSource `

--- a/tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1
+++ b/tests/AiDotNet.Tensors.Benchmarks/Profiling/run-direct-ptx-ncu.ps1
@@ -1,0 +1,50 @@
+param(
+    [ValidateSet('attention', 'residual-rmsnorm')]
+    [string]$Target = 'attention',
+    [string]$OutputCsv = 'direct-ptx-ncu.csv',
+    [string]$NcuPath = $env:NSIGHT_COMPUTE_CLI
+)
+
+$ErrorActionPreference = 'Stop'
+$ncuSource = if ($NcuPath) {
+    if (-not (Test-Path -LiteralPath $NcuPath -PathType Leaf)) {
+        throw "Nsight Compute CLI was not found at '$NcuPath'."
+    }
+    (Resolve-Path -LiteralPath $NcuPath).Path
+} else {
+    (Get-Command ncu -ErrorAction Stop).Source
+}
+$targetDll = Join-Path $PSScriptRoot '..\bin\Release\net10.0\AiDotNet.Tensors.Benchmarks.dll'
+if (-not (Test-Path -LiteralPath $targetDll -PathType Leaf)) {
+    throw "Benchmark target is missing. Build AiDotNet.Tensors.Benchmarks in Release/net10.0 first."
+}
+$targetDll = (Resolve-Path -LiteralPath $targetDll).Path
+$switch = if ($Target -eq 'attention') {
+    '--direct-ptx-profile-attention'
+} else {
+    '--direct-ptx-profile-residual-rmsnorm'
+}
+$kernel = if ($Target -eq 'attention') {
+    'regex:aidotnet_online_attention_128x64'
+} else {
+    'regex:aidotnet_fused_residual_rmsnorm_d64'
+}
+$metrics = @(
+    'sass__inst_executed_register_spilling',
+    'sass__inst_executed_register_spilling_mem_local',
+    'sass__inst_executed_local_loads',
+    'sass__inst_executed_local_stores',
+    'derived__local_spilling_requests'
+) -join ','
+
+& $ncuSource `
+    --target-processes all `
+    --kernel-name $kernel `
+    --metrics $metrics `
+    --csv `
+    --log-file $OutputCsv `
+    dotnet $targetDll $switch
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet $targetDll --direct-ptx-verify-ncu $OutputCsv
+exit $LASTEXITCODE

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -13,6 +13,55 @@ class Program
 
     static void Main(string[] args)
     {
+        if (args.Length > 0 && args[0] == "--direct-ptx-attention")
+        {
+            DirectPtxAttentionExperiment.Run();
+            return;
+        }
+
+        if (args.Length > 0 && args[0] == "--direct-ptx-fused-attention")
+        {
+            DirectPtxFusedAttentionExperiment.Run();
+            return;
+        }
+
+        if (args.Length > 0 && args[0] == "--direct-ptx-online-attention")
+        {
+            DirectPtxOnlineAttentionExperiment.Run();
+            return;
+        }
+
+        if (args.Length > 0 && args[0] == "--direct-ptx-gpu-matrix")
+        {
+            DirectPtxGpuMatrixExperiment.Run();
+            return;
+        }
+        if (args.Length > 0 && args[0] == "--direct-ptx-residual-rmsnorm")
+        {
+            DirectPtxResidualRmsNormExperiment.Run();
+            return;
+        }
+        if (args.Length > 0 && args[0] == "--direct-ptx-external-gpu-baselines")
+        {
+            DirectPtxExternalBaselines.Run();
+            return;
+        }
+        if (args.Length > 0 && args[0] == "--direct-ptx-profile-attention")
+        {
+            DirectPtxProfileTarget.RunAttention();
+            return;
+        }
+        if (args.Length > 0 && args[0] == "--direct-ptx-profile-residual-rmsnorm")
+        {
+            DirectPtxProfileTarget.RunResidualRmsNorm();
+            return;
+        }
+        if (args.Length > 1 && args[0] == "--direct-ptx-verify-ncu")
+        {
+            DirectPtxProfileTarget.VerifyNcuCsv(args[1]);
+            return;
+        }
+
         // Run quick performance test first for immediate feedback
         if (args.Length == 0 || args[0] == "--quick")
         {
@@ -944,6 +993,15 @@ class Program
         Console.WriteLine("  --verify-vdpbf16: Verify emitted VDPBF16PS (run under Intel SDE); exits non-zero on mismatch (#378)");
         Console.WriteLine("  --verify-bf16gemm: Verify the BF16 GEMM microkernel end to end (run under Intel SDE); exits non-zero on mismatch (#378)");
 #if !NET462
+        Console.WriteLine("  --direct-ptx-attention: Driver-only emitted-PTX Q*K^T vs cuBLAS/current CUDA path");
+        Console.WriteLine("  --direct-ptx-fused-attention: Fused PTX QK+softmax+PV championship cell");
+        Console.WriteLine("  --direct-ptx-online-attention: Async online S128/D64 GPU championship table");
+        Console.WriteLine("  --direct-ptx-gpu-matrix: NVIDIA-only S16/S32/S64/S128 attention matrix");
+        Console.WriteLine("  --direct-ptx-residual-rmsnorm: second-blueprint fused residual + RMSNorm D64");
+        Console.WriteLine("  --direct-ptx-external-gpu-baselines: forced cuDNN/Flash/Math/compiled Python GPU matrix");
+        Console.WriteLine("  --direct-ptx-profile-attention: deterministic Nsight Compute attention target");
+        Console.WriteLine("  --direct-ptx-profile-residual-rmsnorm: deterministic Nsight Compute fusion target");
+        Console.WriteLine("  --direct-ptx-verify-ncu <csv>: enforce zero executed spill/local-memory counters");
         Console.WriteLine("  --cublas   : Run cuBLAS vs DirectGpu GEMM benchmark");
         Console.WriteLine("  --opencl   : Run OpenCL GEMM benchmark (AMD/Intel GPUs)");
         Console.WriteLine("  --clblast  : Run CLBlast vs AiDotNet OpenCL comparison (AMD/Intel)");

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
@@ -559,8 +559,7 @@ public class DirectPtxWmmaTests
             System.IO.File.WriteAllText(path,
                 "\"sass__inst_executed_register_spilling\",\"0\"\n" +
                 "\"sass__inst_executed_local_loads\",\"0\"\n" +
-                "\"sass__inst_executed_local_stores\",\"0\"\n" +
-                "\"derived__local_spilling_requests\",\"0\"\n");
+                "\"sass__inst_executed_local_stores\",\"0\"\n");
             DirectPtxProfilerEvidence zero = DirectPtxProfilerEvidence.FromNcuCsv(path);
             Assert.True(zero.ProvesZeroExecutedSpills);
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
@@ -1,0 +1,866 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public class DirectPtxWmmaTests
+{
+    [SkippableTheory]
+    [InlineData(16, false)]
+    [InlineData(16, true)]
+    [InlineData(32, false)]
+    [InlineData(32, true)]
+    [InlineData(64, false)]
+    [InlineData(64, true)]
+    [InlineData(128, false)]
+    [InlineData(128, true)]
+    public void DriverOnlyWarpSoftmax_MatchesCpuReference(int sequence, bool isCausal)
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+
+        const int batchHeads = 3;
+        using var runtime = new DirectPtxRuntime();
+        using var kernel = new PtxAttentionSoftmax32Kernel(runtime, batchHeads, isCausal, sequence);
+        using var scoresDevice = runtime.AllocateBytes(kernel.ScoreBytes);
+        using var probabilitiesDevice = runtime.AllocateBytes(kernel.ProbabilityBytes);
+        var random = new Random(isCausal ? 20260730 : 20260729);
+        var scores = new float[batchHeads * sequence * sequence];
+        for (int i = 0; i < scores.Length; i++) scores[i] = (float)(random.NextDouble() * 4 - 2);
+        scoresDevice.Upload<float>(scores);
+
+        kernel.Launch(scoresDevice, probabilitiesDevice);
+        runtime.Synchronize();
+        var actualBits = new ushort[scores.Length];
+        probabilitiesDevice.Download<ushort>(actualBits);
+
+        float maxAbsoluteError = 0;
+        for (int row = 0; row < batchHeads * sequence; row++)
+        {
+            int queryRow = row % sequence;
+            int lastColumn = isCausal ? queryRow : sequence - 1;
+            int offset = row * sequence;
+            float maximum = float.NegativeInfinity;
+            for (int column = 0; column <= lastColumn; column++)
+                maximum = MathF.Max(maximum, scores[offset + column]);
+            float sum = 0;
+            for (int column = 0; column <= lastColumn; column++)
+                sum += MathF.Exp(scores[offset + column] - maximum);
+            for (int column = 0; column < sequence; column++)
+            {
+                float expected = column <= lastColumn
+                    ? MathF.Exp(scores[offset + column] - maximum) / sum
+                    : 0f;
+                float actual = (float)BitConverter.UInt16BitsToHalf(actualBits[offset + column]);
+                maxAbsoluteError = MathF.Max(maxAbsoluteError, MathF.Abs(expected - actual));
+            }
+        }
+
+        Assert.True(maxAbsoluteError <= 0.001f,
+            $"Warp softmax max absolute error {maxAbsoluteError:G9} (causal={isCausal}).");
+    }
+
+    [SkippableTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DriverOnlyFusedAttention32x16_MatchesCpuReference(bool isCausal)
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+
+        const int batchHeads = 3, sequence = 32, dimension = 16;
+        const float scale = 0.25f;
+        using var runtime = new DirectPtxRuntime();
+        Skip.IfNot(runtime.ComputeCapabilityMajor >= 7, "Requires Tensor Core compute capability 7.0+.");
+        using var kernel = new PtxWmmaFusedAttention32x16Kernel(runtime, batchHeads, isCausal, scale);
+        using var qDevice = runtime.AllocateBytes(kernel.QBytes);
+        using var kDevice = runtime.AllocateBytes(kernel.KBytes);
+        using var vDevice = runtime.AllocateBytes(kernel.VBytes);
+        using var outputDevice = runtime.AllocateBytes(kernel.OutputBytes);
+
+        var random = new Random(isCausal ? 20260726 : 20260725);
+        ushort[] q = RandomHalf(random, batchHeads * sequence * dimension);
+        ushort[] k = RandomHalf(random, batchHeads * sequence * dimension);
+        ushort[] v = RandomHalf(random, batchHeads * sequence * dimension);
+        var actual = new float[batchHeads * sequence * dimension];
+        qDevice.Upload<ushort>(q);
+        kDevice.Upload<ushort>(k);
+        vDevice.Upload<ushort>(v);
+        kernel.Launch(qDevice, kDevice, vDevice, outputDevice);
+        runtime.Synchronize();
+        outputDevice.Download<float>(actual);
+
+        float maxAbsoluteError = 0;
+        for (int bh = 0; bh < batchHeads; bh++)
+        for (int row = 0; row < sequence; row++)
+        {
+            var scores = new float[sequence];
+            float rowMax = float.NegativeInfinity;
+            int lastKey = isCausal ? row : sequence - 1;
+            for (int col = 0; col <= lastKey; col++)
+            {
+                float score = 0;
+                for (int inner = 0; inner < dimension; inner++)
+                {
+                    float qValue = (float)BitConverter.UInt16BitsToHalf(
+                        q[(bh * sequence + row) * dimension + inner]);
+                    float kValue = (float)BitConverter.UInt16BitsToHalf(
+                        k[(bh * sequence + col) * dimension + inner]);
+                    score += qValue * kValue;
+                }
+                scores[col] = score * scale;
+                rowMax = MathF.Max(rowMax, scores[col]);
+            }
+
+            float sum = 0;
+            for (int col = 0; col <= lastKey; col++)
+            {
+                scores[col] = MathF.Exp(scores[col] - rowMax);
+                sum += scores[col];
+            }
+            for (int outputColumn = 0; outputColumn < dimension; outputColumn++)
+            {
+                float expected = 0;
+                for (int col = 0; col <= lastKey; col++)
+                {
+                    float vValue = (float)BitConverter.UInt16BitsToHalf(
+                        v[(bh * sequence + col) * dimension + outputColumn]);
+                    expected += (scores[col] / sum) * vValue;
+                }
+                float got = actual[(bh * sequence + row) * dimension + outputColumn];
+                maxAbsoluteError = MathF.Max(maxAbsoluteError, MathF.Abs(got - expected));
+            }
+        }
+
+        Assert.True(maxAbsoluteError <= 0.003f,
+            $"Fused PTX attention max absolute error {maxAbsoluteError:G9} (causal={isCausal}).");
+    }
+
+    [SkippableFact]
+    public void DriverOnlyWmmaBatchedQk_MatchesCpuReference()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+
+        const int batch = 2, m = 32, n = 32, k = 64;
+        float scale = 1.0f / MathF.Sqrt(k);
+        using var runtime = new DirectPtxRuntime();
+        Skip.IfNot(runtime.ComputeCapabilityMajor >= 7, "Requires Tensor Core compute capability 7.0+.");
+
+        using var kernel = new PtxWmmaBatchedQkKernel(runtime, m, n, k, batch, scale);
+        using var qDevice = runtime.AllocateBytes(kernel.ABytes);
+        using var kDevice = runtime.AllocateBytes(kernel.BBytes);
+        using var scoresDevice = runtime.AllocateBytes(kernel.CBytes);
+
+        var random = new Random(20260720);
+        var q = RandomHalf(random, batch * m * k);
+        var keys = RandomHalf(random, batch * n * k);
+        var actual = new float[batch * m * n];
+        qDevice.Upload<ushort>(q);
+        kDevice.Upload<ushort>(keys);
+
+        kernel.Launch(qDevice, kDevice, scoresDevice);
+        runtime.Synchronize();
+        scoresDevice.Download<float>(actual);
+
+        float maxAbsoluteError = 0;
+        float maxRelativeError = 0;
+        for (int b = 0; b < batch; b++)
+        for (int row = 0; row < m; row++)
+        for (int col = 0; col < n; col++)
+        {
+            float expected = 0;
+            for (int inner = 0; inner < k; inner++)
+            {
+                float qValue = (float)BitConverter.UInt16BitsToHalf(q[(b * m + row) * k + inner]);
+                float kValue = (float)BitConverter.UInt16BitsToHalf(keys[(b * n + col) * k + inner]);
+                expected += qValue * kValue;
+            }
+            expected *= scale;
+
+            float got = actual[(b * m + row) * n + col];
+            float absolute = MathF.Abs(got - expected);
+            float relative = absolute / MathF.Max(1e-5f, MathF.Abs(expected));
+            maxAbsoluteError = MathF.Max(maxAbsoluteError, absolute);
+            maxRelativeError = MathF.Max(maxRelativeError, relative);
+        }
+
+        Assert.True(maxAbsoluteError <= 0.003f,
+            $"PTX WMMA max absolute error {maxAbsoluteError:G9}, max relative {maxRelativeError:G9}");
+    }
+
+    [Fact]
+    public void PtxEmitter_BakesShapeScaleAndTensorCoreInstructions()
+    {
+        string ptx = PtxWmmaBatchedQkKernel.EmitPtx(8, 6, 32, 32, 64, 0.125f);
+        Assert.Contains(".target sm_86", ptx);
+        Assert.Equal(4, Count(ptx, "wmma.mma.sync"));
+        Assert.Contains("0f3E000000", ptx);
+        Assert.Contains(".shared .align 16", ptx);
+        Assert.Contains("ld.global.v4.u32", ptx);
+        Assert.DoesNotContain(".param .u32 m", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("nvrtc", ptx, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FusedAttentionEmitter_UsesTwoTensorCoreStagesAndNoScoreOutput()
+    {
+        string ptx = PtxWmmaFusedAttention32x16Kernel.EmitPtx(8, 6, isCausal: true, scale: 0.25f);
+        Assert.Contains(".target sm_86", ptx);
+        Assert.Equal(4, Count(ptx, "wmma.mma.sync"));
+        Assert.Contains("ex2.approx.f32", ptx);
+        Assert.Contains("wmma.mma.sync.aligned.row.col", ptx);
+        Assert.Contains("wmma.mma.sync.aligned.row.row", ptx);
+        Assert.DoesNotContain("scores_ptr", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("probabilities_ptr", ptx, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SoftmaxEmitter_UsesWarpReductionAndCompileTimeCausalMask()
+    {
+        string ptx = PtxAttentionSoftmax32Kernel.EmitPtx(8, 6, isCausal: true);
+        Assert.Contains(".target sm_86", ptx);
+        Assert.Equal(10, Count(ptx, "shfl.sync.bfly.b32"));
+        Assert.Contains("ex2.approx.f32", ptx);
+        Assert.Contains("setp.gt.u32", ptx);
+        Assert.DoesNotContain(".param .u32 rows", ptx, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void OnlineEmitter_UsesAsyncDoubleBufferingOnlineStateAndFusedEpilogue(
+        bool isCausal, bool fuseLayerNormGelu)
+    {
+        string ptx = PtxOnlineFusedAttention128x64Kernel.EmitPtx(
+            8, 6, isCausal, fuseLayerNormGelu, 0.125f, 1e-5f);
+
+        Assert.Contains(".target sm_86", ptx);
+        Assert.Contains("cp.async.ca.shared.global", ptx);
+        Assert.Contains("cp.async.commit_group", ptx);
+        Assert.Contains("cp.async.wait_group", ptx);
+        Assert.Contains("mma.sync.aligned.m16n8k16", ptx);
+        Assert.Contains("// ---- online K/V tile 7 ----", ptx);
+        Assert.DoesNotContain("scores_ptr", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("probabilities_ptr", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("stride", ptx, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(".param .u32", ptx, StringComparison.Ordinal);
+        if (fuseLayerNormGelu)
+        {
+            Assert.Contains("Head-local LayerNorm(D=64) + tanh-GELU epilogue", ptx);
+            Assert.Contains("tanh.approx.f32", ptx);
+        }
+        else
+        {
+            Assert.DoesNotContain("tanh.approx.f32", ptx);
+        }
+    }
+
+    [Fact]
+    public void OnlineInferenceEmitter_OmitsStatsAndSkipsFutureCausalTiles()
+    {
+        string ptx = PtxOnlineFusedAttention128x64Kernel.EmitPtx(
+            8, 6, isCausal: true, fuseLayerNormGelu: false,
+            0.125f, 1e-5f, 128, emitSoftmaxStats: false);
+
+        Assert.Contains("SKIP_CAUSAL_TILE_7", ptx);
+        Assert.Contains("@%p6 bra SKIP_CAUSAL_TILE_7", ptx);
+        Assert.DoesNotContain("lg2.approx.f32", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("st.global.f32 [%rd18]", ptx, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CanonicalPhysicalView_RejectsBadExtentAlignmentAndDtypeExtent()
+    {
+        using var aligned = new SyntheticGpuBuffer((IntPtr)0x1000, 1024);
+        DirectPtxTensorView view = DirectPtxTensorView.CreateBhsd(
+            aligned, DirectPtxPhysicalType.Float16, 1024);
+        Assert.Equal((IntPtr)0x1000, view.Pointer);
+
+        Assert.Throws<ArgumentException>(() => DirectPtxTensorView.CreateBhsd(
+            aligned, DirectPtxPhysicalType.Float16, 2048));
+        using var unaligned = new SyntheticGpuBuffer((IntPtr)0x1004, 1024);
+        Assert.Throws<ArgumentException>(() => DirectPtxTensorView.CreateBhsd(
+            unaligned, DirectPtxPhysicalType.Float16, 1024));
+        using var oddExtent = new SyntheticGpuBuffer((IntPtr)0x1000, 1023);
+        Assert.Throws<ArgumentException>(() => DirectPtxTensorView.CreateBhsd(
+            oddExtent, DirectPtxPhysicalType.Float32, 1020));
+    }
+
+    [Fact]
+    public void DirectPtxFeatureGate_TestOverrideIsFailClosed()
+    {
+        bool? previous = DirectPtxFeatureGate.TestOverride;
+        try
+        {
+            DirectPtxFeatureGate.TestOverride = false;
+            Assert.False(DirectPtxFeatureGate.IsEnabled);
+            DirectPtxFeatureGate.TestOverride = true;
+            Assert.True(DirectPtxFeatureGate.IsEnabled);
+        }
+        finally
+        {
+            DirectPtxFeatureGate.TestOverride = previous;
+        }
+    }
+
+    [SkippableTheory]
+    [InlineData(16, false, false, 1)]
+    [InlineData(16, true, true, 1)]
+    [InlineData(32, false, false, 1)]
+    [InlineData(32, true, true, 2)]
+    [InlineData(64, false, false, 2)]
+    [InlineData(64, true, true, 4)]
+    [InlineData(128, false, false, 4)]
+    [InlineData(128, false, true, 8)]
+    [InlineData(128, true, false, 4)]
+    [InlineData(128, true, true, 8)]
+    public void DriverOnlyOnlineAttention_MatchesOracleAndHasZeroLocalBytes(
+        int sequence, bool isCausal, bool fuseLayerNormGelu, int warpsPerBlock)
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        const int dimension = 64;
+        using var runtime = new DirectPtxRuntime();
+        Skip.IfNot(runtime.ComputeCapabilityMajor >= 8, "Requires SM80+ cp.async and mma.m16n8k16.");
+        using var current = runtime.Enter();
+        using var kernel = new PtxOnlineFusedAttention128x64Kernel(
+            runtime, 1, isCausal, fuseLayerNormGelu, 0.125f, 1e-5f, sequence,
+            emitSoftmaxStats: true, warpsPerBlock);
+        Assert.Equal(0, kernel.FunctionInfo.LocalBytesPerThread);
+        Assert.InRange(kernel.FunctionInfo.RegistersPerThread, 1, 255);
+
+        using var qDevice = runtime.AllocateBytes(kernel.QBytes);
+        using var kDevice = runtime.AllocateBytes(kernel.KBytes);
+        using var vDevice = runtime.AllocateBytes(kernel.VBytes);
+        using var gammaDevice = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.GammaBytes);
+        using var betaDevice = runtime.AllocateBytes(PtxOnlineFusedAttention128x64Kernel.BetaBytes);
+        using var outputDevice = runtime.AllocateBytes(kernel.OutputBytes);
+        using var statsDevice = runtime.AllocateBytes(kernel.StatsBytes);
+        var random = new Random(20260720);
+        ushort[] q = RandomHalfRange(random, sequence * dimension, 0.25f);
+        ushort[] k = RandomHalfRange(random, sequence * dimension, 0.25f);
+        ushort[] v = RandomHalfRange(random, sequence * dimension, 0.25f);
+        float[] gamma = Enumerable.Range(0, dimension).Select(i => 0.75f + i / 256f).ToArray();
+        float[] beta = Enumerable.Range(0, dimension).Select(i => (i - 32) / 512f).ToArray();
+        qDevice.Upload<ushort>(q);
+        kDevice.Upload<ushort>(k);
+        vDevice.Upload<ushort>(v);
+        gammaDevice.Upload<float>(gamma);
+        betaDevice.Upload<float>(beta);
+
+        kernel.Launch(
+            DirectPtxTensorView.CreateOwned(qDevice, kernel.Blueprint.Tensors[0]),
+            DirectPtxTensorView.CreateOwned(kDevice, kernel.Blueprint.Tensors[1]),
+            DirectPtxTensorView.CreateOwned(vDevice, kernel.Blueprint.Tensors[2]),
+            DirectPtxTensorView.CreateOwned(gammaDevice, kernel.Blueprint.Tensors[3]),
+            DirectPtxTensorView.CreateOwned(betaDevice, kernel.Blueprint.Tensors[4]),
+            DirectPtxTensorView.CreateOwned(outputDevice, kernel.Blueprint.Tensors[5]),
+            DirectPtxTensorView.CreateOwned(statsDevice, kernel.Blueprint.Tensors[6]));
+        runtime.Synchronize();
+        var actual = new float[sequence * dimension];
+        outputDevice.Download<float>(actual);
+
+        float maxError = ValidateOnlineFirstHead(
+            actual, q, k, v, gamma, beta, sequence, isCausal, fuseLayerNormGelu);
+        Assert.True(maxError <= (fuseLayerNormGelu ? 0.025f : 0.012f),
+            $"Online PTX max abs error {maxError:G9}.");
+    }
+
+    [SkippableFact]
+    public void CudaBackend_OptInUsesBorrowedContextAndCarriesZeroSpillAudit()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        bool? previous = DirectPtxFeatureGate.TestOverride;
+        DirectPtxFeatureGate.TestOverride = true;
+        try
+        {
+            using var backend = new CudaBackend();
+            Skip.IfNot(backend.IsDirectPtxAttentionEnabled, "Requires an SM80+ CUDA backend.");
+            const int elements = 128 * 64;
+            float[] host = Enumerable.Range(0, elements).Select(i => (i % 29 - 14) / 128f).ToArray();
+            using var qFloat = backend.AllocateBuffer(host);
+            using var kFloat = backend.AllocateBuffer(host);
+            using var vFloat = backend.AllocateBuffer(host);
+            using var qHalf = backend.AllocateByteBuffer(elements * 2);
+            using var kHalf = backend.AllocateByteBuffer(elements * 2);
+            using var vHalf = backend.AllocateByteBuffer(elements * 2);
+            using var output = backend.AllocateBuffer(elements);
+            using var stats = backend.AllocateBuffer(128);
+            backend.ConvertToFp16Native(qFloat, qHalf, elements);
+            backend.ConvertToFp16Native(kFloat, kHalf, elements);
+            backend.ConvertToFp16Native(vFloat, vHalf, elements);
+
+            Assert.True(backend.TryDirectPtxOnlineAttention(
+                qHalf, kHalf, vHalf, output, stats, 1, 0.125f, isCausal: false),
+                backend.DirectPtxLastError);
+            backend.Synchronize();
+            Assert.All(backend.DownloadBuffer(output), value => Assert.True(float.IsFinite(value)));
+            Assert.True(backend.TryGetDirectPtxAttentionAudit(
+                1, 0.125f, false, false, 1e-5f, 128,
+                out DirectPtxFunctionInfo info, out _));
+            Assert.Equal(0, info.LocalBytesPerThread);
+            Assert.True(backend.TryGetDirectPtxAttentionKernelAudit(
+                1, 0.125f, false, false, 1e-5f, 128,
+                out DirectPtxKernelAudit audit));
+            Assert.Contains("online-attention-d64-v2-Ampere-q16-k16-w", audit.BlueprintId);
+            Assert.Equal(64, audit.PtxSha256.Length);
+        }
+        finally
+        {
+            DirectPtxFeatureGate.TestOverride = previous;
+        }
+    }
+
+    [SkippableFact]
+    public void TensorEngine_FlashAttentionRoutesCanonicalShapeThroughFeatureGate()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        bool? previous = DirectPtxFeatureGate.TestOverride;
+        DirectPtxFeatureGate.TestOverride = true;
+        try
+        {
+            using var engine = new DirectGpuTensorEngine();
+            Skip.IfNot(engine.IsGpuAvailable, "CUDA tensor engine is unavailable.");
+            var backend = Assert.IsType<CudaBackend>(engine.GetBackend());
+            Skip.IfNot(backend.IsDirectPtxAttentionEnabled, "Requires SM80+.");
+            const int elements = 128 * 64;
+            var q = new Tensor<float>(
+                Enumerable.Range(0, elements).Select(i => (i % 17 - 8) / 128f).ToArray(),
+                [1, 1, 128, 64]);
+            var k = new Tensor<float>(
+                Enumerable.Range(0, elements).Select(i => (i % 19 - 9) / 128f).ToArray(),
+                [1, 1, 128, 64]);
+            var v = new Tensor<float>(
+                Enumerable.Range(0, elements).Select(i => (i % 23 - 11) / 128f).ToArray(),
+                [1, 1, 128, 64]);
+            long before = backend.DirectPtxAttentionDispatchCount;
+
+            Tensor<float> result = engine.FlashAttention(
+                q, k, v, 0.125, false, out Tensor<float> stats);
+
+            Assert.True(float.IsFinite(result.GetFlat(0)));
+            Assert.True(float.IsFinite(stats.GetFlat(0)));
+            Assert.Equal(before + 1, backend.DirectPtxAttentionDispatchCount);
+        }
+        finally
+        {
+            DirectPtxFeatureGate.TestOverride = previous;
+        }
+    }
+
+    [Fact]
+    public void PhysicalAbi_SeparatesLogicalPhysicalLayoutAndAlignment()
+    {
+        var logical = new DirectPtxExtent(2, 3);
+        var physical = new DirectPtxExtent(2, 8);
+        var contract = new DirectPtxTensorContract(
+            "padded", DirectPtxPhysicalType.Float16, DirectPtxPhysicalLayout.RowMajor2D,
+            logical, physical, 16, DirectPtxTensorAccess.Read, DirectPtxExtentMode.Exact);
+        using var exact = new SyntheticGpuBuffer((IntPtr)0x2000, 32);
+        DirectPtxTensorView view = DirectPtxTensorView.Create(exact, contract);
+        Assert.Equal(logical, view.LogicalExtent);
+        Assert.Equal(physical, view.PhysicalExtent);
+        Assert.Equal(DirectPtxPhysicalLayout.RowMajor2D, view.Layout);
+        Assert.Equal((nuint)32, view.ByteLength);
+
+        using var oversized = new SyntheticGpuBuffer((IntPtr)0x2000, 48);
+        Assert.Throws<ArgumentException>(() => DirectPtxTensorView.Create(oversized, contract));
+        using var misaligned = new SyntheticGpuBuffer((IntPtr)0x2008, 32);
+        Assert.Throws<ArgumentException>(() => DirectPtxTensorView.Create(misaligned, contract));
+    }
+
+    [Theory]
+    [InlineData(8, 0, (int)DirectPtxArchitectureFamily.Ampere)]
+    [InlineData(8, 6, (int)DirectPtxArchitectureFamily.Ampere)]
+    [InlineData(8, 9, (int)DirectPtxArchitectureFamily.Ada)]
+    [InlineData(9, 0, (int)DirectPtxArchitectureFamily.Hopper)]
+    [InlineData(10, 0, (int)DirectPtxArchitectureFamily.Blackwell)]
+    [InlineData(7, 5, (int)DirectPtxArchitectureFamily.Unsupported)]
+    public void ArchitectureFamilies_AreSeparateDispatchDomains(
+        int major, int minor, int expectedValue)
+    {
+        var expected = (DirectPtxArchitectureFamily)expectedValue;
+        Assert.Equal(expected, DirectPtxArchitecture.Classify(major, minor));
+        Assert.Equal(expected == DirectPtxArchitectureFamily.Ampere,
+            DirectPtxArchitecture.HasValidatedOnlineAttention(expected));
+    }
+
+    [Fact]
+    public void KernelCache_IsBoundedLruAndDisposesEvictions()
+    {
+        using var cache = new DirectPtxKernelCache<int, TrackingDisposable>(2);
+        TrackingDisposable one = cache.GetOrAdd(1, () => new TrackingDisposable());
+        TrackingDisposable two = cache.GetOrAdd(2, () => new TrackingDisposable());
+        Assert.True(cache.TryGetValue(1, out _)); // 2 becomes least-recently used
+        TrackingDisposable three = cache.GetOrAdd(3, () => new TrackingDisposable());
+        Assert.True(two.IsDisposed);
+        Assert.False(one.IsDisposed);
+        Assert.False(three.IsDisposed);
+        Assert.Equal(2, cache.Count);
+
+        var plans = new DirectPtxPlanCache<int, string>(2);
+        plans.Set(1, "one");
+        plans.Set(2, "two");
+        Assert.True(plans.TryGetValue(1, out _));
+        plans.Set(3, "three");
+        Assert.False(plans.TryGetValue(2, out _));
+        Assert.True(plans.TryGetValue(3, out string value));
+        Assert.Equal("three", value);
+    }
+
+    [Fact]
+    public void AttentionAutotuner_ExposesArchitectureIndependentShapeCandidates()
+    {
+        Assert.Equal(new[] { 1 }, DirectPtxAttentionAutotuner.Candidates(16));
+        Assert.Equal(new[] { 2, 1 }, DirectPtxAttentionAutotuner.Candidates(32));
+        Assert.Equal(new[] { 4, 2 }, DirectPtxAttentionAutotuner.Candidates(64));
+        Assert.Equal(new[] { 8, 4 }, DirectPtxAttentionAutotuner.Candidates(128));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DirectPtxAttentionAutotuner.Candidates(96));
+    }
+
+    [Fact]
+    public void AttentionEligibility_AdmitsOnlyTheProvenSemanticDomain()
+    {
+        var supported = new DirectPtxAttentionRequest(
+            DirectPtxArchitectureFamily.Ampere, DirectPtxPhysicalType.Float16,
+            DirectPtxPhysicalLayout.Bhsd, 2, 8, 8, 128, 128, 64,
+            DirectPtxAttentionMaskKind.CausalTopLeft, DirectPtxAttentionPhase.Inference,
+            0, false, false);
+        Assert.True(DirectPtxAttentionEligibility.Evaluate(supported).IsEligible);
+
+        Assert.Equal("dtype-not-fp16", DirectPtxAttentionEligibility.Evaluate(
+            supported with { InputType = DirectPtxPhysicalType.BFloat16 }).Reason);
+        Assert.Equal("non-square-attention-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { KeyValueSequence = 64 }).Reason);
+        Assert.Equal("gqa-mqa-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { KeyValueHeads = 2 }).Reason);
+        Assert.Equal("mask-kind-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { Mask = DirectPtxAttentionMaskKind.AdditiveBias }).Reason);
+        Assert.Equal("dropout-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { DropoutProbability = 0.1f }).Reason);
+        Assert.Equal("training-or-backward-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { Phase = DirectPtxAttentionPhase.Backward }).Reason);
+        Assert.Equal("ragged-layout-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { IsRagged = true }).Reason);
+        Assert.Equal("paged-kv-not-implemented", DirectPtxAttentionEligibility.Evaluate(
+            supported with { UsesPagedKv = true }).Reason);
+    }
+
+    [Fact]
+    public void NsightEvidence_RequiresEveryExecutedSpillCounterToBeZero()
+    {
+        string path = System.IO.Path.GetTempFileName();
+        try
+        {
+            System.IO.File.WriteAllText(path,
+                "\"sass__inst_executed_register_spilling\",\"0\"\n" +
+                "\"sass__inst_executed_local_loads\",\"0\"\n" +
+                "\"sass__inst_executed_local_stores\",\"0\"\n" +
+                "\"derived__local_spilling_requests\",\"0\"\n");
+            DirectPtxProfilerEvidence zero = DirectPtxProfilerEvidence.FromNcuCsv(path);
+            Assert.True(zero.ProvesZeroExecutedSpills);
+
+            System.IO.File.WriteAllText(path,
+                "\"sass__inst_executed_register_spilling\",\"4\"\n");
+            DirectPtxProfilerEvidence spilling = DirectPtxProfilerEvidence.FromNcuCsv(path);
+            Assert.False(spilling.ProvesZeroExecutedSpills);
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReleaseGate_RequiresSpeedTailAllocationAccuracySpillsAndRepetition()
+    {
+        DirectPtxReleaseGatePolicy policy = DirectPtxReleaseGatePolicy.ProductionDefault;
+        var competitor = new DirectPtxPerformanceEvidence(
+            100, 120, 64, 4096, 0, -1, 3);
+        var passing = new DirectPtxPerformanceEvidence(
+            80, 110, 0, 0, 1e-6, 0, 3);
+        Assert.True(policy.Evaluate(passing, competitor).Passed);
+
+        DirectPtxReleaseDecision failing = policy.Evaluate(
+            passing with
+            {
+                MedianMicroseconds = 95,
+                P95Microseconds = 140,
+                ManagedBytesPerCall = 8,
+                TemporaryDeviceBytes = 4,
+                MaxAbsoluteError = 1e-3,
+                LocalBytesPerThread = 16,
+                IndependentRuns = 1
+            }, competitor);
+        Assert.False(failing.Passed);
+        Assert.Equal(7, failing.Failures.Count);
+    }
+
+    [Fact]
+    public void ResidualRmsNormEmitter_IsRegisterReducedAndStrideFree()
+    {
+        string ptx = PtxFusedResidualRmsNormD64Kernel.EmitPtx(8, 6, 1e-5f);
+        Assert.Equal(5, Count(ptx, "shfl.sync.bfly.b32"));
+        Assert.Contains("sqrt.rn.f32", ptx);
+        Assert.Contains("rmsnorm", ptx, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(".shared", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("stride", ptx, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(".param .u32", ptx, StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public void DriverOnlyResidualRmsNorm_MatchesReferenceAndHasZeroLocalBytes()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        using var runtime = new DirectPtxRuntime();
+        Skip.IfNot(runtime.ArchitectureFamily == DirectPtxArchitectureFamily.Ampere,
+            "The checked-in residual RMSNorm specialization is validated on Ampere.");
+        const int rows = 37, dimension = 64;
+        using var kernel = new PtxFusedResidualRmsNormD64Kernel(runtime, rows);
+        Assert.Equal(0, kernel.FunctionInfo.LocalBytesPerThread);
+        Assert.Equal(0, kernel.FunctionInfo.StaticSharedBytes);
+        Assert.Equal(64, kernel.Blueprint.Tensors[0].LogicalExtent.D1);
+        Assert.Equal(64, kernel.Audit.PtxSha256.Length);
+
+        using var input = runtime.AllocateBytes(kernel.InputBytes);
+        using var residual = runtime.AllocateBytes(kernel.InputBytes);
+        using var gamma = runtime.AllocateBytes(PtxFusedResidualRmsNormD64Kernel.GammaBytes);
+        using var output = runtime.AllocateBytes(kernel.OutputBytes);
+        using var rms = runtime.AllocateBytes(kernel.RmsBytes);
+        var random = new Random(20260721);
+        float[] x = Enumerable.Range(0, rows * dimension)
+            .Select(_ => (random.NextSingle() - 0.5f) * 2f).ToArray();
+        float[] r = Enumerable.Range(0, rows * dimension)
+            .Select(_ => (random.NextSingle() - 0.5f) * 0.5f).ToArray();
+        float[] g = Enumerable.Range(0, dimension).Select(i => 0.75f + i / 256f).ToArray();
+        input.Upload<float>(x);
+        residual.Upload<float>(r);
+        gamma.Upload<float>(g);
+        kernel.Launch(
+            DirectPtxTensorView.CreateOwned(input, kernel.Blueprint.Tensors[0]),
+            DirectPtxTensorView.CreateOwned(residual, kernel.Blueprint.Tensors[1]),
+            DirectPtxTensorView.CreateOwned(gamma, kernel.Blueprint.Tensors[2]),
+            DirectPtxTensorView.CreateOwned(output, kernel.Blueprint.Tensors[3]),
+            DirectPtxTensorView.CreateOwned(rms, kernel.Blueprint.Tensors[4]));
+        runtime.Synchronize();
+        var actual = new float[x.Length];
+        var actualRms = new float[rows];
+        output.Download<float>(actual);
+        rms.Download<float>(actualRms);
+
+        float maxError = 0;
+        for (int row = 0; row < rows; row++)
+        {
+            float sumSquares = 0;
+            for (int d = 0; d < dimension; d++)
+            {
+                float value = x[row * dimension + d] + r[row * dimension + d];
+                sumSquares += value * value;
+            }
+            float expectedRms = MathF.Sqrt(sumSquares / dimension + 1e-5f);
+            maxError = MathF.Max(maxError, MathF.Abs(actualRms[row] - expectedRms));
+            for (int d = 0; d < dimension; d++)
+            {
+                float expected = (x[row * dimension + d] + r[row * dimension + d]) /
+                    expectedRms * g[d];
+                maxError = MathF.Max(maxError,
+                    MathF.Abs(actual[row * dimension + d] - expected));
+            }
+        }
+        Assert.True(maxError < 5e-5f, $"Residual RMSNorm max error {maxError:G9}.");
+    }
+
+    [SkippableFact]
+    public void BackendResidualRmsNorm_PrewarmedKernelIsCudaGraphCapturable()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        bool? previous = DirectPtxFeatureGate.TestOverride;
+        DirectPtxFeatureGate.TestOverride = true;
+        try
+        {
+            using var backend = new CudaBackend();
+            Skip.IfNot(backend.IsDirectPtxResidualRmsNormEnabled, "Requires an Ampere CUDA backend.");
+            const int rows = 32, elements = rows * 64;
+            using var input = backend.AllocateBuffer(Enumerable.Repeat(0.25f, elements).ToArray());
+            using var residual = backend.AllocateBuffer(Enumerable.Repeat(0.5f, elements).ToArray());
+            using var gamma = backend.AllocateBuffer(Enumerable.Repeat(1f, 64).ToArray());
+            using var output = backend.AllocateBuffer(elements);
+            using var rms = backend.AllocateBuffer(rows);
+            Assert.True(backend.PrewarmDirectPtxFusedResidualRmsNorm(rows), backend.DirectPtxLastError);
+
+            IntPtr graph = backend.CaptureGraph(() =>
+                Assert.True(backend.TryDirectPtxFusedResidualRmsNorm(
+                    input, residual, gamma, output, rms, rows), backend.DirectPtxLastError));
+            Assert.NotEqual(IntPtr.Zero, graph);
+            try
+            {
+                backend.LaunchCapturedGraph(graph);
+                Assert.All(backend.DownloadBuffer(output), value => Assert.True(float.IsFinite(value)));
+            }
+            finally
+            {
+                backend.DestroyCapturedGraph(graph);
+            }
+        }
+        finally
+        {
+            DirectPtxFeatureGate.TestOverride = previous;
+        }
+    }
+
+    [SkippableFact]
+    public void BackendAttention_PrewarmedKernelIsCudaGraphCapturable()
+    {
+        Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
+        bool? previous = DirectPtxFeatureGate.TestOverride;
+        DirectPtxFeatureGate.TestOverride = true;
+        try
+        {
+            using var backend = new CudaBackend();
+            Skip.IfNot(backend.IsDirectPtxAttentionEnabled, "Requires an Ampere CUDA backend.");
+            const int sequence = 16, elements = sequence * 64;
+            float[] host = Enumerable.Range(0, elements).Select(i => (i % 13 - 6) / 128f).ToArray();
+            using var qFloat = backend.AllocateBuffer(host);
+            using var kFloat = backend.AllocateBuffer(host);
+            using var vFloat = backend.AllocateBuffer(host);
+            using var q = backend.AllocateByteBuffer(elements * 2);
+            using var k = backend.AllocateByteBuffer(elements * 2);
+            using var v = backend.AllocateByteBuffer(elements * 2);
+            using var output = backend.AllocateBuffer(elements);
+            using var stats = backend.AllocateBuffer(sequence);
+            backend.ConvertToFp16Native(qFloat, q, elements);
+            backend.ConvertToFp16Native(kFloat, k, elements);
+            backend.ConvertToFp16Native(vFloat, v, elements);
+            Assert.True(backend.PrewarmDirectPtxAttention(
+                1, sequence, false, false, 0.125f), backend.DirectPtxLastError);
+
+            IntPtr graph = backend.CaptureGraph(() =>
+                Assert.True(backend.TryDirectPtxOnlineAttention(
+                    q, k, v, output, stats, 1, 0.125f, false, sequence),
+                    backend.DirectPtxLastError));
+            Assert.NotEqual(IntPtr.Zero, graph);
+            try
+            {
+                backend.LaunchCapturedGraph(graph);
+                Assert.All(backend.DownloadBuffer(output), value => Assert.True(float.IsFinite(value)));
+            }
+            finally
+            {
+                backend.DestroyCapturedGraph(graph);
+            }
+        }
+        finally
+        {
+            DirectPtxFeatureGate.TestOverride = previous;
+        }
+    }
+
+    private static ushort[] RandomHalfRange(Random random, int length, float magnitude)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = BitConverter.HalfToUInt16Bits(
+                (Half)((random.NextSingle() - 0.5f) * 2f * magnitude));
+        return result;
+    }
+
+    private static float ValidateOnlineFirstHead(
+        float[] actual, ushort[] q, ushort[] k, ushort[] v,
+        float[] gamma, float[] beta, int sequence, bool causal, bool epilogue)
+    {
+        const int dimension = 64;
+        var scores = new float[sequence];
+        var rowOutput = new float[dimension];
+        float maxError = 0;
+        for (int row = 0; row < sequence; row++)
+        {
+            int lastKey = causal ? row : sequence - 1;
+            float maximum = float.NegativeInfinity;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                float score = 0;
+                for (int d = 0; d < dimension; d++)
+                    score += Half(q[row * dimension + d]) * Half(k[column * dimension + d]);
+                scores[column] = score * 0.125f;
+                maximum = MathF.Max(maximum, scores[column]);
+            }
+            float sum = 0;
+            for (int column = 0; column <= lastKey; column++)
+            {
+                scores[column] = MathF.Exp(scores[column] - maximum);
+                sum += scores[column];
+            }
+            for (int d = 0; d < dimension; d++)
+            {
+                float value = 0;
+                for (int column = 0; column <= lastKey; column++)
+                    value += scores[column] / sum * Half(v[column * dimension + d]);
+                rowOutput[d] = value;
+            }
+            if (epilogue)
+            {
+                float mean = rowOutput.Average();
+                float variance = rowOutput.Select(x => (x - mean) * (x - mean)).Average();
+                float inverseStd = 1f / MathF.Sqrt(variance + 1e-5f);
+                for (int d = 0; d < dimension; d++)
+                {
+                    float x = (rowOutput[d] - mean) * inverseStd * gamma[d] + beta[d];
+                    rowOutput[d] = 0.5f * x *
+                        (1f + MathF.Tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+                }
+            }
+            for (int d = 0; d < dimension; d++)
+                maxError = MathF.Max(maxError, MathF.Abs(actual[row * dimension + d] - rowOutput[d]));
+        }
+        return maxError;
+    }
+
+    private static float Half(ushort bits) => (float)BitConverter.UInt16BitsToHalf(bits);
+
+    private static ushort[] RandomHalf(Random random, int length)
+    {
+        var result = new ushort[length];
+        for (int i = 0; i < length; i++)
+        {
+            var value = (Half)(random.NextDouble() * 2.0 - 1.0);
+            result[i] = BitConverter.HalfToUInt16Bits(value);
+        }
+        return result;
+    }
+
+    private static int Count(string text, string value)
+    {
+        int count = 0, offset = 0;
+        while ((offset = text.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += value.Length;
+        }
+        return count;
+    }
+
+    private sealed class SyntheticGpuBuffer : IGpuBuffer
+    {
+        internal SyntheticGpuBuffer(IntPtr handle, long bytes)
+        {
+            Handle = handle;
+            SizeInBytes = bytes;
+        }
+
+        public int Size => checked((int)(SizeInBytes / sizeof(float)));
+        public long SizeInBytes { get; }
+        public IntPtr Handle { get; }
+        public void Dispose() { }
+    }
+
+    private sealed class TrackingDisposable : IDisposable
+    {
+        internal bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaErrorStringTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/CudaErrorStringTests.cs
@@ -1,0 +1,18 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+public sealed class CudaErrorStringTests
+{
+    [Fact]
+    public void InvalidPtx_ReportsJitCompilationFailure()
+    {
+        string message = CuBlasNative.GetCudaErrorString(CudaResult.InvalidPtx);
+
+        Assert.Contains("Invalid PTX", message, StringComparison.Ordinal);
+        Assert.Contains("JIT compilation failed", message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #865

## Summary  Introduces an opt-in, CUDA Driver API + runtime-emitted PTX blueprint for shape-specialized fused NVIDIA kernels without CUDA Runtime or NVRTC in the custom path.  The PR proves the process with:  - async tiled online attention for FP16 BHSD, D=64, S in {16,32,64,128} - unmasked and causal variants - optional fused FP32 LayerNorm + tanh-GELU epilogue - a second independent fusion: FP32 `RMSNorm(input + residual)`, D=64 - formal layout/extent/alignment/access ABI validation at the dispatch boundary - per-GPU/driver architecture identity, resource manifests, bounded module caches, autotuning, prewarm, and graph-capture-safe dispatch - explicit eligibility/fallback reasons for unsupported semantics - correctness, benchmark, release-gate, CUDA-event, external PyTorch, and Nsight Compute profiler harnesses  ## Why  The existing CUDA/NVRTC and library-composition paths materialize intermediates and repeat generic dispatch work. The new blueprint validates tensor layout once, emits stride-free PTX for a proven specialization, pipelines global memory through shared memory/registers, uses Tensor Core `mma.sync`, and fuses epilogues before the single final global write.  This PR is the foundation for a repository-wide PTX fused-kernel migration. It does not advertise unsupported shapes or architectures: unproven cells fail closed to the existing backend.  ## Measured evidence  RTX 3080 / SM86:  - unmasked direct attention: 33.69 us device median, 15.936 effective TFLOPS, 0 B managed allocation, 0 temporary VRAM - causal direct attention: 25.60 us device median, 20.972 effective TFLOPS, 0 B managed allocation, 0 temporary VRAM - cuBLAS composition: 51.30/51.51 us median and 12 MiB temporary VRAM - residual + RMSNorm median speedup over current AiDotNet: 1.15x to 2.04x across tested row counts - Driver JIT audit: attention 66-80 registers/thread, 25,088 B shared, 0 local B/thread; residual RMSNorm 18 registers/thread, 0 shared, 0 local B/thread  CUDA PyTorch 2.12.1+cu130 was installed and the forced cuDNN/Efficient/Math external matrix was executed. PyTorch Flash-SDPA and the third-party `flash-attn` package are unavailable in this Windows environment and are reported as explicit skips.  Nsight Compute 2025.4.1 attaches to the deterministic target, but the driver returns `ERR_NVGPUCTRPERM`. Executed hardware-counter proof therefore remains intentionally unclaimed until an administrator enables counter access.  ## Validation  - `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release --no-restore -p:UseSharedCompilation=false`   - net471, net8.0, net10.0: 0 warnings, 0 errors - `dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f net10.0 --filter DirectPtxWmmaTests --no-restore -p:UseSharedCompilation=false`   - 47 passed, 0 failed, 0 skipped - benchmark project Release/net10.0 build: succeeded; existing unrelated warnings remain - external forced CUDA PyTorch benchmark: succeeded for cuDNN/Efficient/Math - Nsight deterministic target: attached; counter collection blocked by host permission as described above  ## Safety and rollout  - disabled by default - opt-in with `AIDOTNET_DIRECT_PTX=1` or per-kernel feature gates - unsupported dtype/layout/shape/mask/training/architecture combinations fall back - architecture families are separate dispatch domains; this PR admits only the measured Ampere implementation - production release policy requires >=1.10x median, bounded P95, zero hot allocations/temporary VRAM, numerical tolerance, zero local bytes, and three clean independent runs  The complete benchmark matrix, ABI, dataflow, acceptance policy, commands, and remaining evidence boundaries are in `docs/research/2026-07-20-fused-attention-championship-blueprint.md`. ## Tracking  - PTX migration epic: #833 - Full attention-family follow-up: #834 - Normalization/residual-family follow-up: #838  This foundation PR proves representative attention and residual+RMSNorm specializations; it does not close the broader operation-family children.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  - **New Features**   - Added an opt-in Direct PTX CUDA acceleration path for supported FP16 attention workloads on compatible NVIDIA GPUs.   - Added fused residual addition and RMSNorm acceleration for 64-wide vectors.   - Added optional fused LayerNorm and GELU processing for eligible attention operations.   - Added automatic kernel selection, caching, prewarming, and safe fallback to existing GPU implementations.  - **Documentation**   - Added research, benchmarking, profiling, eligibility, and reproduction guidance for the new GPU paths.  - **Tests**   - Added extensive correctness, compatibility, CUDA graph, and performance validation coverage.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->