### PR TITLE
perf(fft): blittable buffer-reusing NativeComplexFFT — kill per-call Complex<T> allocation

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -45317,8 +45317,48 @@ public partial class CpuEngine : ITensorLevelEngine
         if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<T, Complex<T>>(LazyNodeType.Custom, "NativeComplexFFT", input, input._shape, (eng, output) => { var r = eng.NativeComplexFFT(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<Complex<T>>("NativeComplexFFT", input._shape); if (ac is not null) return ac.Execute(); }
 
-        var ops = MathHelper.GetNumericOperations<T>();
         var result = new Tensor<Complex<T>>(input._shape);
+
+        // Blittable fast path: float/double + contiguous input. See the
+        // "Blittable FFT fast path" comment near NativeFFTInPlace for rationale.
+        if ((typeof(T) == typeof(double) || typeof(T) == typeof(float)) && input.IsContiguous)
+        {
+            var inSpan = input.AsSpan();
+            var outSpan = result.AsWritableSpan();
+            var scratch = RentFftBlittableScratch(2 * fftSize);
+            bool isDouble = typeof(T) == typeof(double);
+            for (int b = 0; b < batchCount; b++)
+            {
+                int offset = b * fftSize;
+                for (int i = 0; i < fftSize; i++)
+                {
+                    T v = inSpan[offset + i];
+                    scratch[2 * i] = isDouble
+                        ? System.Runtime.CompilerServices.Unsafe.As<T, double>(ref v)
+                        : (double)System.Runtime.CompilerServices.Unsafe.As<T, float>(ref v);
+                    scratch[2 * i + 1] = 0.0;
+                }
+                AiDotNet.Tensors.LinearAlgebra.Fft.FftKernels.IterativeRadix2NoCache(
+                    scratch.AsSpan(0, 2 * fftSize), fftSize, inverse: false);
+                for (int i = 0; i < fftSize; i++)
+                {
+                    if (isDouble)
+                    {
+                        var c = new Complex<double>(scratch[2 * i], scratch[2 * i + 1]);
+                        outSpan[offset + i] = System.Runtime.CompilerServices.Unsafe.As<Complex<double>, Complex<T>>(ref c);
+                    }
+                    else
+                    {
+                        var c = new Complex<float>((float)scratch[2 * i], (float)scratch[2 * i + 1]);
+                        outSpan[offset + i] = System.Runtime.CompilerServices.Unsafe.As<Complex<float>, Complex<T>>(ref c);
+                    }
+                }
+            }
+            { var ci = input; AutoTracer.RecordOp("NativeComplexFFT", result, eng => eng.NativeComplexFFT(ci)); }
+            return result;
+        }
+
+        var ops = MathHelper.GetNumericOperations<T>();
 
         // Transform along last axis, batch over leading dimensions
         var slice = new Complex<T>[fftSize];
@@ -46587,9 +46627,57 @@ public partial class CpuEngine : ITensorLevelEngine
         if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; return scope.RecordCrossType<Complex<T>, T>(LazyNodeType.Custom, "NativeComplexIFFTReal", input, input._shape, (eng, output) => { var r = eng.NativeComplexIFFTReal(ci); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }); } }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("NativeComplexIFFTReal", input._shape); if (ac is not null) return ac.Execute(); }
 
+        var result = new Tensor<T>(input._shape);
+
+        // Blittable fast path: float/double + contiguous input. Mirrors the
+        // NativeComplexFFT fast path (unnormalized inverse kernel, then /fftSize).
+        if ((typeof(T) == typeof(double) || typeof(T) == typeof(float)) && input.IsContiguous)
+        {
+            var inSpan = input.AsSpan();
+            var outSpan = result.AsWritableSpan();
+            var scratch = RentFftBlittableScratch(2 * fftSize);
+            bool isDouble = typeof(T) == typeof(double);
+            for (int b = 0; b < batchCount; b++)
+            {
+                int offset = b * fftSize;
+                for (int i = 0; i < fftSize; i++)
+                {
+                    Complex<T> cv = inSpan[offset + i];
+                    if (isDouble)
+                    {
+                        var cd = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<double>>(ref cv);
+                        scratch[2 * i] = cd.Real;
+                        scratch[2 * i + 1] = cd.Imaginary;
+                    }
+                    else
+                    {
+                        var cf = System.Runtime.CompilerServices.Unsafe.As<Complex<T>, Complex<float>>(ref cv);
+                        scratch[2 * i] = cf.Real;
+                        scratch[2 * i + 1] = cf.Imaginary;
+                    }
+                }
+                AiDotNet.Tensors.LinearAlgebra.Fft.FftKernels.IterativeRadix2NoCache(
+                    scratch.AsSpan(0, 2 * fftSize), fftSize, inverse: true);
+                for (int i = 0; i < fftSize; i++)
+                {
+                    double re = scratch[2 * i] / fftSize;
+                    if (isDouble)
+                    {
+                        outSpan[offset + i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref re);
+                    }
+                    else
+                    {
+                        float rf = (float)re;
+                        outSpan[offset + i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref rf);
+                    }
+                }
+            }
+            { var ci = input; AutoTracer.RecordOp("NativeComplexIFFTReal", result, eng => eng.NativeComplexIFFTReal(ci)); }
+            return result;
+        }
+
         var ops = MathHelper.GetNumericOperations<T>();
         var scale = ops.FromDouble(fftSize);
-        var result = new Tensor<T>(input._shape);
 
         var slice = new Complex<T>[fftSize];
         for (int b = 0; b < batchCount; b++)
@@ -47957,6 +48045,82 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </summary>
     // Cache twiddle factors across FFT calls — key is (n, inverse)
     [ThreadStatic] private static Dictionary<(int n, bool inverse), Complex<double>[]>? _twiddleCache;
+
+    // ── Blittable FFT fast path (float/double) ──────────────────────────────
+    // NativeComplexFFT / NativeComplexIFFTReal historically allocated a per-call
+    // Complex<T>[] working buffer and ran the radix-2 butterfly over Complex<T>
+    // structs. Complex<T> carries a redundant INumericOperations<T> reference
+    // field (24 bytes/element for double, 16 for float), so every butterfly
+    // wrote that ref on top of the arithmetic and the hot loop touched
+    // cache-sparse memory through property accessors. Profiling the HRE spectral
+    // FFN path (SpectralHebbianLayer.ForwardBatch) showed this Complex<T>
+    // overhead — not the O(n log n) arithmetic — dominated wall time (~10x vs
+    // the blittable Fft.RFft kernel on identical shapes). For the common
+    // float/double element types we instead run the SAME tested SIMD radix-2
+    // kernel (FftKernels.IterativeRadix2NoCache — raw/unnormalized, the exact
+    // contract of the old scalar butterfly: callers still apply any 1/n scaling)
+    // over a [ThreadStatic] interleaved double[] scratch ([re,im,re,im,...]).
+    // Result: no per-call FFT working allocation, native double arithmetic over
+    // tight 16-byte-per-complex memory, and the ONLY remaining allocation is the
+    // returned tensor (the theoretical floor). Non-float/double element types and
+    // non-contiguous inputs keep the exact generic Complex<T> path below.
+    [ThreadStatic] private static double[]? _fftBlittableScratch;
+
+    private static double[] RentFftBlittableScratch(int minLen)
+    {
+        var buf = _fftBlittableScratch;
+        if (buf is null || buf.Length < minLen)
+        {
+            buf = new double[minLen];
+            _fftBlittableScratch = buf;
+        }
+        return buf;
+    }
+
+    // Test-only reference: the pre-blittable generic Complex<T>[] path, retained
+    // so bit-exactness and allocation-regression tests can A/B the fast path
+    // against the exact prior implementation in the same process (immune to
+    // cross-build / machine-load noise). NOT called by production code.
+    internal Tensor<Complex<T>> NativeComplexFFTLegacyGeneric<T>(Tensor<T> input)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
+        ValidatePowerOfTwo(fftSize, nameof(input));
+        var ops = MathHelper.GetNumericOperations<T>();
+        var result = new Tensor<Complex<T>>(input._shape);
+        var slice = new Complex<T>[fftSize];
+        for (int b = 0; b < batchCount; b++)
+        {
+            int offset = b * fftSize;
+            for (int i = 0; i < fftSize; i++)
+                slice[i] = new Complex<T>(input[offset + i], ops.Zero);
+            NativeFFTInPlace(slice, false, ops);
+            for (int i = 0; i < fftSize; i++)
+                result[offset + i] = slice[i];
+        }
+        return result;
+    }
+
+    // Test-only reference for the inverse-real path (see NativeComplexFFTLegacyGeneric).
+    internal Tensor<T> NativeComplexIFFTRealLegacyGeneric<T>(Tensor<Complex<T>> input)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        var (batchCount, fftSize) = GetBatchedFFTDims(input._shape);
+        ValidatePowerOfTwo(fftSize, nameof(input));
+        var ops = MathHelper.GetNumericOperations<T>();
+        var scale = ops.FromDouble(fftSize);
+        var result = new Tensor<T>(input._shape);
+        var slice = new Complex<T>[fftSize];
+        for (int b = 0; b < batchCount; b++)
+        {
+            int offset = b * fftSize;
+            for (int i = 0; i < fftSize; i++) slice[i] = input[offset + i];
+            NativeFFTInPlace(slice, true, ops);
+            for (int i = 0; i < fftSize; i++)
+                result[offset + i] = ops.Divide(slice[i].Real, scale);
+        }
+        return result;
+    }
 
     private static void NativeFFTInPlace<T>(Complex<T>[] data, bool inverse,
         INumericOperations<T> ops)

--- a/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Bit-exactness + allocation/wall-time coverage for the blittable NativeComplexFFT /
+/// NativeComplexIFFTReal fast path (float/double, contiguous). The fast path runs the
+/// tested SIMD radix-2 kernel (FftKernels) over a [ThreadStatic] interleaved double[]
+/// scratch instead of a per-call Complex&lt;T&gt;[] buffer. Each test A/Bs the fast path
+/// against the retained legacy generic Complex&lt;T&gt;[] path IN THE SAME PROCESS
+/// (NativeComplexFFTLegacyGeneric / NativeComplexIFFTRealLegacyGeneric), so results are
+/// immune to cross-build / machine-load noise. Runs on net10.0 + net471.
+/// </summary>
+public class NativeComplexFftBlittableTests
+{
+    private readonly ITestOutputHelper _output;
+    public NativeComplexFftBlittableTests(ITestOutputHelper output) => _output = output;
+
+    private static CpuEngine Cpu() => (AiDotNetEngine.Current as CpuEngine) ?? new CpuEngine();
+
+    private static Tensor<double> RandD(int b, int n, int seed)
+    {
+        var t = new Tensor<double>([b, n]);
+        var sp = t.AsWritableSpan();
+        uint s = (uint)seed | 1u;
+        for (int i = 0; i < sp.Length; i++) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; sp[i] = (s / (double)uint.MaxValue) - 0.5; }
+        return t;
+    }
+
+    private static Tensor<float> RandF(int b, int n, int seed)
+    {
+        var t = new Tensor<float>([b, n]);
+        var sp = t.AsWritableSpan();
+        uint s = (uint)seed | 1u;
+        for (int i = 0; i < sp.Length; i++) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; sp[i] = (float)((s / (double)uint.MaxValue) - 0.5); }
+        return t;
+    }
+
+    // ---- Bit-exactness: fast path vs retained legacy generic path -------------
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(512)]
+    [InlineData(1024)]
+    public void NativeComplexFFT_Double_MatchesLegacyGeneric(int n)
+    {
+        int b = 8;
+        var cpu = Cpu();
+        var x = RandD(b, n, 1234 + n);
+        var fast = cpu.NativeComplexFFT(x);
+        var legacy = cpu.NativeComplexFFTLegacyGeneric(x);
+        double maxDiff = 0;
+        for (int i = 0; i < fast.Length; i++)
+        {
+            maxDiff = Math.Max(maxDiff, Math.Abs(fast[i].Real - legacy[i].Real));
+            maxDiff = Math.Max(maxDiff, Math.Abs(fast[i].Imaginary - legacy[i].Imaginary));
+        }
+        _output.WriteLine($"double FFT n={n} max|fast-legacy|={maxDiff:E3}");
+        Assert.True(maxDiff < 1e-9, $"double FFT fast vs legacy maxDiff {maxDiff:E3} exceeds 1e-9 (n={n})");
+    }
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(512)]
+    [InlineData(1024)]
+    public void NativeComplexIFFTReal_Double_MatchesLegacyGeneric(int n)
+    {
+        int b = 8;
+        var cpu = Cpu();
+        var real = RandD(b, n, 77 + n);
+        var spec = cpu.NativeComplexFFT(real); // shared contiguous spectrum
+        var fast = cpu.NativeComplexIFFTReal(spec);
+        var legacy = cpu.NativeComplexIFFTRealLegacyGeneric(spec);
+        double maxDiff = 0;
+        for (int i = 0; i < fast.Length; i++)
+            maxDiff = Math.Max(maxDiff, Math.Abs(fast[i] - legacy[i]));
+        _output.WriteLine($"double IFFTReal n={n} max|fast-legacy|={maxDiff:E3}");
+        Assert.True(maxDiff < 1e-9, $"double IFFTReal fast vs legacy maxDiff {maxDiff:E3} exceeds 1e-9 (n={n})");
+    }
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(1024)]
+    public void NativeComplexFFT_Float_MatchesLegacyGeneric(int n)
+    {
+        // Float fast path uses a double-precision intermediate (reuses the double
+        // SIMD kernel), so it is MORE accurate than the all-float legacy butterfly;
+        // the two differ only by float rounding of the legacy path, not a bug.
+        int b = 8;
+        var cpu = Cpu();
+        var x = RandF(b, n, 4242 + n);
+        var fast = cpu.NativeComplexFFT(x);
+        var legacy = cpu.NativeComplexFFTLegacyGeneric(x);
+        double maxAbs = 0, maxRel = 0;
+        for (int i = 0; i < fast.Length; i++)
+        {
+            double d = Math.Abs((double)fast[i].Real - legacy[i].Real);
+            double d2 = Math.Abs((double)fast[i].Imaginary - legacy[i].Imaginary);
+            double denom = 1.0 + Math.Abs(legacy[i].Real) + Math.Abs(legacy[i].Imaginary);
+            maxAbs = Math.Max(maxAbs, Math.Max(d, d2));
+            maxRel = Math.Max(maxRel, Math.Max(d, d2) / denom);
+        }
+        _output.WriteLine($"float FFT n={n} max|fast-legacy|={maxAbs:E3} maxRel={maxRel:E3}");
+        Assert.True(maxRel < 1e-3, $"float FFT fast vs legacy maxRel {maxRel:E3} exceeds 1e-3 (n={n})");
+    }
+
+    // ---- Absolute correctness: fast path vs independent O(n^2) DFT ------------
+
+    [Theory]
+    [InlineData(256)]
+    [InlineData(512)]
+    public void NativeComplexFFT_Double_MatchesNaiveDft(int n)
+    {
+        var cpu = Cpu();
+        var x = RandD(1, n, 909 + n);
+        var fast = cpu.NativeComplexFFT(x);
+        double maxDiff = 0;
+        for (int k = 0; k < n; k++)
+        {
+            double re = 0, im = 0;
+            for (int t = 0; t < n; t++)
+            {
+                double ang = -2.0 * Math.PI * k * t / n;
+                re += x[t] * Math.Cos(ang);
+                im += x[t] * Math.Sin(ang);
+            }
+            maxDiff = Math.Max(maxDiff, Math.Abs(fast[k].Real - re));
+            maxDiff = Math.Max(maxDiff, Math.Abs(fast[k].Imaginary - im));
+        }
+        _output.WriteLine($"double FFT n={n} max|fast-naiveDFT|={maxDiff:E3}");
+        Assert.True(maxDiff < 1e-8, $"double FFT vs naive DFT maxDiff {maxDiff:E3} exceeds 1e-8 (n={n})");
+    }
+
+    [Fact]
+    public void FFT_IFFTReal_RoundTrip_Double_Batched()
+    {
+        int b = 16, n = 1024;
+        var cpu = Cpu();
+        var x = RandD(b, n, 5150);
+        var recovered = cpu.NativeComplexIFFTReal(cpu.NativeComplexFFT(x));
+        double maxDiff = 0;
+        for (int i = 0; i < x.Length; i++)
+            maxDiff = Math.Max(maxDiff, Math.Abs(x[i] - recovered[i]));
+        _output.WriteLine($"roundtrip [b={b},n={n}] max|x-IFFT(FFT(x))|={maxDiff:E3}");
+        Assert.True(maxDiff < 1e-9, $"round-trip maxDiff {maxDiff:E3} exceeds 1e-9");
+    }
+
+    // ---- Allocation + wall-time A/B (opt-in) ---------------------------------
+    // HE_FFT_ALLOC_BENCH=1 : prints GC.GetAllocatedBytesForCurrentThread and median
+    // ms/call for the blittable fast path vs the legacy generic path on [128,1024],
+    // same process. This is the trustworthy before/after (no cross-build noise).
+
+    [Fact]
+    public void NativeComplexFFT_AllocAndTime_Bench()
+    {
+        if (Environment.GetEnvironmentVariable("HE_FFT_ALLOC_BENCH") != "1") return;
+        int b = 128, n = 1024, WARM = 5, REP = 50;
+        var cpu = Cpu();
+        var x = RandD(b, n, 20260721);
+        var spec = cpu.NativeComplexFFT(x);
+        var sb = new StringBuilder();
+        sb.AppendLine($"NativeComplexFFT / NativeComplexIFFTReal blittable-vs-legacy on [{b},{n}] (REP={REP}) engine={cpu.GetType().Name}");
+        sb.AppendLine("  op                       path      bytes/call     median_ms");
+
+        void Bench(string op, string path, Func<long> oneCallReturningBytesUnused, Action call)
+        {
+            for (int i = 0; i < WARM; i++) call();
+            // allocation: measure a single call delta after warmup (steady state)
+            long bytes;
+#if NET5_0_OR_GREATER
+            long a0 = GC.GetAllocatedBytesForCurrentThread();
+            call();
+            long a1 = GC.GetAllocatedBytesForCurrentThread();
+            bytes = a1 - a0;
+#else
+            call();
+            bytes = -1; // GC.GetAllocatedBytesForCurrentThread unavailable on net471
+#endif
+            var times = new double[REP];
+            for (int i = 0; i < REP; i++) { var sw = Stopwatch.StartNew(); call(); sw.Stop(); times[i] = sw.Elapsed.TotalMilliseconds; }
+            Array.Sort(times);
+            sb.AppendLine($"  {op,-24} {path,-8} {bytes,12}     {times[REP / 2],9:F3}");
+        }
+
+        Bench("NativeComplexFFT", "legacy", () => 0, () => { _ = cpu.NativeComplexFFTLegacyGeneric(x); });
+        Bench("NativeComplexFFT", "fast", () => 0, () => { _ = cpu.NativeComplexFFT(x); });
+        Bench("NativeComplexIFFTReal", "legacy", () => 0, () => { _ = cpu.NativeComplexIFFTRealLegacyGeneric(spec); });
+        Bench("NativeComplexIFFTReal", "fast", () => 0, () => { _ = cpu.NativeComplexIFFTReal(spec); });
+
+        var outp = sb.ToString();
+        _output.WriteLine(outp);
+        try { System.IO.File.WriteAllText(@"C:\Users\cheat\Temp\he-m2-audit\localpkgs\fft_alloc_bench.txt", outp); } catch { /* print is the record */ }
+    }
+}


### PR DESCRIPTION
## Problem

`NativeComplexFFT` / `NativeComplexIFFTReal` — the ops the HRE spectral-FFN path (`SpectralHebbianLayer.ForwardBatch`) actually calls — allocated a per-call `Complex<T>[]` working buffer and ran the radix-2 butterfly over `Complex<T>` structs. `Complex<T>` carries a redundant `INumericOperations<T>` reference field (24 bytes/element for double, 16 for float), so every butterfly writes that ref on top of the arithmetic and the hot loop walks cache-sparse memory through property accessors.

An op-level audit showed this `Complex<T>` overhead — **not** the O(n log n) arithmetic — dominated wall time: `NativeComplexFFT` ran ~10x slower than the blittable `Fft.RFft` SIMD kernel on identical butterfly counts.

## Change

For the common **float/double** element types with a contiguous input, run the **same tested SIMD radix-2 kernel** (`FftKernels.IterativeRadix2NoCache` — raw/unnormalized, the exact contract of the old scalar butterfly: callers still apply any `1/n` scaling) over a `[ThreadStatic]` interleaved `double[]` scratch (`[re,im,re,im,...]`).

- No per-call FFT working allocation (thread-static scratch, grown on demand).
- Native `double` arithmetic over tight 16-byte-per-complex memory instead of 24-byte `Complex<T>` structs + property accessors + ref-field writes.
- The **only** remaining allocation is the returned tensor (the theoretical floor).
- Non-float/double element types and non-contiguous inputs keep the **exact** generic `Complex<T>` path (unchanged).

## Measurement — same-process A/B on `[128,1024]`

Measured against the retained legacy generic path in the same process (immune to cross-build / machine-load noise), median of 50 calls:

| op | path | ms/call | bytes/call |
|---|---|---|---|
| `NativeComplexFFT` | legacy | 29.681 | 3,170,816 |
| `NativeComplexFFT` | **fast** | **7.710** | **3,146,240** |
| `NativeComplexIFFTReal` | legacy | 10.747 | 1,073,664 |
| `NativeComplexIFFTReal` | **fast** | **5.490** | **1,049,088** |

**Wall-time: FFT 3.85x, IFFTReal 1.96x.** The bytes/call drop (24,576 B) is exactly the eliminated `Complex<T>[fftSize]` working slice; the fast path now allocates only the returned `Tensor<Complex<T>>` (128×1024×24 = 3,145,728 B — the irreducible API-contract floor). The lever is wall-time via the blittable butterfly; the allocation floor is the result tensor and can't shrink without changing the public signature.

## Correctness

New `NativeComplexFftBlittableTests` (net10.0 + net471, 12/12 green):
- fast vs retained legacy generic path — **double `<1e-9`**, **float `<1e-3` relative** (float uses a double-precision intermediate, so it is *more* accurate than the old all-float butterfly, not a regression);
- fast vs independent O(n²) DFT — double `<1e-8`;
- batched `IFFTReal(FFT(x))` round-trip — `<1e-9`.

All 3 TFMs (net10.0 / net8.0 / net471) build 0-warn (Release, TreatWarningsAsErrors). Existing FFT suite green (104 passed / 2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)