### PR TITLE
fix(gpu): gate Sparsemax on CUDA where-select availability

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -69,6 +69,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     // FP16 (Half) element width in bytes — used to validate half-buffer sizes before launching FP16-native kernels.
     private const int Fp16ByteWidth = 2;
     private readonly ConcurrentDictionary<string, IntPtr> _kernelCache;
+    internal bool HasWhereSelectKernel => _kernelCache.ContainsKey("where_select");
     private IntPtr _cudaContext;
     private IntPtr _stream;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -2774,7 +2774,8 @@ public partial class DirectGpuTensorEngine
         // would silently drop the input gradient.
         if (typeof(T) != typeof(float) || normalizedAxis != input.Rank - 1
             || input.Length == 0 || !input.IsContiguous || IsTapeActive<T>()
-            || Compilation.GraphMode.IsActive || !TryGetBackend(out var backend))
+            || Compilation.GraphMode.IsActive || !TryGetBackend(out var backend)
+            || (backend is DirectGpu.CUDA.CudaBackend cudaBackend && !cudaBackend.HasWhereSelectKernel))
             return base.Sparsemax(input, axis);
 
         int columns = input._shape[normalizedAxis];

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/SparsemaxCudaFallbackTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/SparsemaxCudaFallbackTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Serialization;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("EngineCurrentGlobalState")]
+public class SparsemaxCudaFallbackTests
+{
+    [Fact]
+    public void Sparsemax_FallsBackToCpu_WhenCudaWhereSelectKernelIsUnavailable()
+    {
+        string? priorBackends = Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS");
+        DirectGpuEngine directGpu;
+        try
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", "none");
+            directGpu = new DirectGpuEngine();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", priorBackends);
+        }
+
+#pragma warning disable SYSLIB0050 // Exercise capability fallback without constructing CUDA hardware state.
+        var cuda = (CudaBackend)FormatterServices.GetUninitializedObject(typeof(CudaBackend));
+#pragma warning restore SYSLIB0050
+        GC.SuppressFinalize(cuda);
+        SetField(cuda, "_kernelCache", new ConcurrentDictionary<string, IntPtr>(StringComparer.Ordinal));
+        SetField(directGpu, "_backend", cuda);
+        SetField(directGpu, "_isAvailable", true);
+
+        var engine = new DirectGpuTensorEngine(directGpu);
+        try
+        {
+            using var input = new Tensor<float>(new[] { 1f, 2f, -1f, 0.5f }, new[] { 1, 4 });
+            using var expected = new CpuEngine().Sparsemax(input, -1);
+            using var actual = ((IEngine)engine).Sparsemax(input, -1);
+
+            Assert.Equal(expected.Shape.ToArray(), actual.Shape.ToArray());
+            for (int i = 0; i < expected.Length; i++)
+                Assert.True(Math.Abs(expected[i] - actual[i]) <= 1e-6f,
+                    $"Sparsemax mismatch at {i}: expected {expected[i]}, actual {actual[i]}.");
+        }
+        finally
+        {
+            engine.Dispose();
+            SetField(directGpu, "_backend", null);
+            directGpu.Dispose();
+        }
+    }
+
+    private static void SetField(object target, string name, object? value)
+    {
+        FieldInfo field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field not found: {name}");
+        field.SetValue(target, value);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #829 after it was merged. Current `main` already contains all six requested inline fixes, so this PR changes only the remaining valid outside-diff finding:

- expose whether the CUDA backend actually registered `where_select`
- return through `CpuEngine.Sparsemax` when a CUDA backend lacks that dependency
- preserve the GPU-resident Sparsemax path when `where_select` is available
- add a hardware-independent regression test for the missing-kernel fallback

## Root cause and impact

Sparsemax's eligibility gate checked tensor shape, dtype, tape state, and backend availability, but assumed that every CUDA backend could execute `backend.Where`. That operation resolves to `where_select`; if the kernel was absent, dispatch threw instead of taking the supported CPU fallback.

The new capability check runs before any GPU allocation or dispatch. Normal CUDA execution is unchanged when `where_select` is registered.

## Verification of requested findings

| Finding | Result against current `main` |
|---|---|
| `CpuEngine` FFT docs and concurrent benchmark switch | Skipped: documentation is already split between `UseLegacyFftCore` and `FftScratch<T>`, and `UseLegacyFftCore` is already `[ThreadStatic]`. |
| CUDA/HIP packed-complex validation | Skipped: both backends already validate split buffers and require the packed buffer to contain `checked((long)n * 2)` elements. |
| Vulkan/WebGPU packed-complex validation | Skipped: both call `ValidateComplexLayoutBuffers` before dispatch, including null, split-size, and checked packed-size validation. |
| `MathHelper.OperationsCache<T>` exception scope | Skipped: the cache already catches only `NotSupportedException`; other initialization failures propagate. |
| Tape leaf reference comparers | Skipped: both `HashSet<Tensor<float>>` instances already use the repository-local `ReferenceEqualityComparer<Tensor<float>>.Instance`. |
| net471 FFT benchmark compatibility | Skipped: both benchmarks already use a `NET6_0_OR_GREATER` allocation helper with `GC.GetTotalMemory` fallback, and the trig estimate uses integer shifts rather than `Math.Log2`. |
| Sparsemax `where_select` dependency | Fixed: CUDA capability is checked before entering the resident path, with CPU fallback when unavailable. |

## Validation

- `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj --configuration Release --no-restore` — succeeded, 0 warnings / 0 errors
- net10 focused fallback and complex-layout tests — 8 passed
- net471 focused fallback and complex-layout tests — 7 passed
- CUDA lookup, tape-bail, and Sparsemax invariant audits — 6 passed
- net10 test-project build — succeeded
- net471 test-project build — succeeded
- `git diff --check` — clean

Follow-up to #829.