### PR TITLE
perf(ptx): staged + double-buffered tensor-core GEMM - 0.05x to 0.57x at 4096^3

### DIFF
--- a/docs/TENSOR_CORES.md
+++ b/docs/TENSOR_CORES.md
@@ -229,26 +229,56 @@ this hardware, so the `wmma.load.*.shared` traffic feeding the fragments is at a
 kernel is not waiting on global memory — DRAM is at 52.85% — it is waiting on shared-memory
 reads.
 
-### The next lever, derived rather than guessed
+### The larger warp tile — derived from the profile, then measured
 
-A **larger per-warp register tile**, not a larger block tile. Each warp currently loads two A
-fragments and two B fragments to issue four mma instructions — one fragment load per mma. A
-4×4 warp tile loads four and four to issue sixteen: **half the shared traffic per unit of
-arithmetic**, aimed directly at the 87% L1TEX figure.
+A warp loads `M + N` fragments and issues `M × N` mma instructions from them, so the fragment
+loads per unit of arithmetic fall as the tile grows. That is the ratio the profile pointed at.
 
-Note this is *not* what the previous version of this document proposed. That said "a 128×128
-block tile, quadrupling reuse again", which targets global traffic — and DRAM is at 52.85%,
-not the limiter. The profile changed the answer.
+Swept rather than chosen, because the accumulators are `M × N × 8` fp32 per thread and past
+some point ptxas spills. Every candidate verified at `0.000E+000` before being timed:
 
-## Standing## Standing
+| shape | 2×2 | 2×4 | 4×2 | 4×4 |
+|---|---|---|---|---|
+| 512³ | 7.0 TF | 6.8 | **8.8** | 6.4 |
+| 1024³ | 26.2 TF | 27.2 | **29.9** | 28.6 |
+| 2048³ | 31.4 TF | 29.8 | 37.6 | **40.2** |
+| 4096³ | 33.2 TF | 36.7 | 42.8 | **43.9** |
+
+**1.28× at 2048³ and 1.32× at 4096³.** And the mechanism is confirmed rather than assumed —
+re-profiling 4096³ at both tiles:
+
+| metric | 2×2 | 4×4 |
+|---|---|---|
+| **l1tex throughput** | 92.34% | **61.38%** |
+| dram throughput | 52.05% | **22.40%** |
+| **tensor pipe active** | 26.79% | **35.74%** |
+| registers per thread | 79 | 240 (no spill) |
+
+L1TEX came off the roofline exactly as the shared-traffic argument predicted, and the tensor
+pipe rose. DRAM fell too, because a bigger block tile also cuts global traffic.
+
+The emitter now picks the largest warp tile whose block tile divides the output. That is a
+**ladder derived from measurement**, not a cost model, and it is not optimal everywhere: at
+1024³ the measured best was 4×2 at 71.9 µs against 4×4's 75.0 µs, so the rule gives up 4%
+there. Closing that needs a per-shape autotune pass, not a cleverer rule — a static model
+picked lowerings four times on this branch and lost to the hardware every time it was checked.
+
+## Standing## Standing## Standing
 
 Expressiveness: **closed.** The generator can emit tensor-core kernels, with fused
 element-wise epilogues cuBLAS cannot fuse through its own call boundary.
 
-Performance: **improved and still a loss.** 0.84× / 0.63× / 0.57× against cuBLAS after staging
-and double buffering, up from 0.35× / 0.23× / 0.05%. Roughly 53% of device peak against its
-93%. The limiter is now measured rather than assumed: L1TEX at 87.14% with the tensor pipe at
-25.29%.
+Performance: **improved and still a loss.** Against cuBLAS, across the campaign:
+
+| shape | naive | staged | + double buffer | **+ warp tile** | cuBLAS |
+|---|---|---|---|---|---|
+| 1024³ | 0.35× | 0.80× | 0.84× | **0.93×** | 32.2 TF |
+| 2048³ | 0.23× | 0.60× | 0.63× | **0.78×** | 51.5 TF |
+| 4096³ | 0.05× | 0.57× | 0.57× | **0.76×** | 57.6 TF |
+
+Roughly 76% of cuBLAS at the largest shape, from 5%. Still a loss, and still reported as one.
+L1TEX is now 61.38% rather than a roofline, so the next limiter is no longer the one this
+work addressed and must be re-measured before anything else is built.
 
 Promotion: still **withheld everywhere**. At 0.57–0.80×, routing a caller who could reach
 cuBLAS to us is still a regression — smaller, but a regression. The capability ships; the

--- a/docs/TENSOR_CORES.md
+++ b/docs/TENSOR_CORES.md
@@ -174,23 +174,81 @@ The justification here never rested on a throughput percentage. Throughput **fel
 when the working set outgrew L2, which is a locality statement no stall counter is needed to
 read. Same lever, different evidence, opposite outcome.
 
-### The next levers, named again
+### Double buffering — built, measured, and it under-delivered
 
-1. **Double-buffer the shared slabs.** Two `bar.sync`s per K step currently serialise the
-   global load against the mma work; a second slab would let step k+1's copy overlap step k's
-   arithmetic.
-2. **A larger block tile.** 128×128 quadruples reuse again; cuBLAS uses that scale.
+Single-buffered staging needs two `bar.sync`s per K step: one after the shared store, one
+after the reads, so a fast warp cannot overwrite a slab a slow one is still reading. Between
+them the global copy and the arithmetic cannot overlap. With two slabs the copy for step k+1
+targets the buffer nobody is reading, so it is *issued before* the mma work for step k. One
+barrier per step.
 
-Neither is measured yet, so neither is claimed.
+Measured as a **paired** A/B — both lowerings emitted, launched and timed in the same process
+and the same thermal window, three runs — because the effect turned out to be small enough
+that a cross-run comparison could not have told signal from drift:
 
-## Standing
+| shape | run 1 | run 2 | run 3 | ≈ |
+|---|---|---|---|---|
+| 1024³ | 1.046× | 1.114× | 1.045× | **1.07×** |
+| 2048³ | 1.170× | 1.126× | 1.055× | **1.12×** |
+| 4096³ | 1.031× | 1.036× | 1.001× | **1.02×** |
+
+The direction is consistent — every one of nine paired measurements is ≥ 1.0 — but the
+magnitude is 2–12%, and it *shrinks* at the largest shape, which is where the argument for it
+was strongest. It is kept because it is a real win at no correctness cost, but it is not the
+step change the reasoning implied.
+
+### Why it under-delivered: the profile
+
+`ncu` on the staged 4096³ kernel, which is what should have been read *before* building the
+lever rather than after:
+
+| metric | value |
+|---|---|
+| **l1tex throughput** | **87.14%** |
+| dram throughput | 52.85% |
+| sm throughput | 32.61% |
+| **tensor pipe active** | **25.29%** |
+
+| stall | value |
+|---|---|
+| `long_scoreboard` | 17.85 |
+| `short_scoreboard` | 10.22 |
+| `mio_throttle` | 7.36 |
+| **`barrier`** | **5.82** |
+| `wait` | 2.78 |
+| `no_instruction` | 0.02 |
+
+**`barrier` is 5.82.** Barriers were never the main cost, so removing one could only ever buy
+a few percent — which is exactly what it bought. The lever was justified by a structural
+argument ("the two barriers serialise the copy against the arithmetic") and never by a
+counter, and the blueprint's §2 rule exists precisely to stop that. The rule was written on
+this branch and then not followed on this branch.
+
+**L1TEX sits at 87.14% while the tensor cores idle at 25.29%.** Shared memory *is* L1TEX on
+this hardware, so the `wmma.load.*.shared` traffic feeding the fragments is at a roofline. The
+kernel is not waiting on global memory — DRAM is at 52.85% — it is waiting on shared-memory
+reads.
+
+### The next lever, derived rather than guessed
+
+A **larger per-warp register tile**, not a larger block tile. Each warp currently loads two A
+fragments and two B fragments to issue four mma instructions — one fragment load per mma. A
+4×4 warp tile loads four and four to issue sixteen: **half the shared traffic per unit of
+arithmetic**, aimed directly at the 87% L1TEX figure.
+
+Note this is *not* what the previous version of this document proposed. That said "a 128×128
+block tile, quadrupling reuse again", which targets global traffic — and DRAM is at 52.85%,
+not the limiter. The profile changed the answer.
+
+## Standing## Standing
 
 Expressiveness: **closed.** The generator can emit tensor-core kernels, with fused
 element-wise epilogues cuBLAS cannot fuse through its own call boundary.
 
-Performance: **improved and still a loss.** 0.80× / 0.60× / 0.57× against cuBLAS after
-staging, up from 0.35× / 0.23× / 0.05×, at ~53% of device peak against its 93%. The next two
-levers are named above and unmeasured.
+Performance: **improved and still a loss.** 0.84× / 0.63× / 0.57× against cuBLAS after staging
+and double buffering, up from 0.35× / 0.23× / 0.05%. Roughly 53% of device peak against its
+93%. The limiter is now measured rather than assumed: L1TEX at 87.14% with the tensor pipe at
+25.29%.
 
 Promotion: still **withheld everywhere**. At 0.57–0.80×, routing a caller who could reach
 cuBLAS to us is still a regression — smaller, but a regression. The capability ships; the

--- a/docs/TENSOR_CORES.md
+++ b/docs/TENSOR_CORES.md
@@ -263,6 +263,43 @@ The emitter now picks the largest warp tile whose block tile divides the output.
 there. Closing that needs a per-shape autotune pass, not a cleverer rule — a static model
 picked lowerings four times on this branch and lost to the hardware every time it was checked.
 
+## cp.async — the limiter after the warp tile
+
+Re-profiling 4096³ at 4×4 showed the previous limiter was gone and a new one had appeared:
+
+| metric | value |
+|---|---|
+| **sm warps active** | **16.41%** of peak |
+| **occupancy limit (registers)** | **2 blocks/SM** at 240 reg/thread |
+| `mio_throttle` | 4.95 |
+| `wait` | 3.63 |
+| `short_scoreboard` | 1.81 |
+| `long_scoreboard` | 1.66 |
+| `barrier` | 1.11 |
+
+Total stall fell from ~44 to ~14 — the resident warps barely wait. There simply are not enough
+of them, because the register-staged copy holds its words live across the whole mma section.
+
+`cp.async` copies global to shared directly: the words never occupy a register, and one
+instruction moves 16 bytes instead of four. That addresses the register pressure and the
+largest remaining stall at once.
+
+Swept against register staging, paired in one process, every candidate verified at
+`0.000E+000`:
+
+| shape | tile | cp.async | registers |
+|---|---|---|---|
+| 512³ | **2×2** | **13.8 TF** | 8.9 |
+| 1024³ | **4×2** | **34.0 TF** | 29.9 |
+| 2048³ | **4×4** | **42.9 TF** | 39.3 |
+| 4096³ | **4×2** | **47.0 TF** | 38.4 |
+| 4096³ | 4×4 | 41.6 | **45.0** |
+
+**The last row is why the catalog records the tile and the staging form together.** At 4096³
+the 4×4 tile is *faster* with register staging than with `cp.async`, while 4×2 is much faster
+with it. Choosing the two independently picks 4×4 + `cp.async` — the worst of those four. No
+model produced that; the sweep did.
+
 ## Standing## Standing## Standing
 
 Expressiveness: **closed.** The generator can emit tensor-core kernels, with fused
@@ -270,15 +307,19 @@ element-wise epilogues cuBLAS cannot fuse through its own call boundary.
 
 Performance: **improved and still a loss.** Against cuBLAS, across the campaign:
 
-| shape | naive | staged | + double buffer | **+ warp tile** | cuBLAS |
-|---|---|---|---|---|---|
-| 1024³ | 0.35× | 0.80× | 0.84× | **0.93×** | 32.2 TF |
-| 2048³ | 0.23× | 0.60× | 0.63× | **0.78×** | 51.5 TF |
-| 4096³ | 0.05× | 0.57× | 0.57× | **0.76×** | 57.6 TF |
+| shape | naive | staged | +dbl buf | +warp tile | **+cp.async** | cuBLAS |
+|---|---|---|---|---|---|---|
+| 1024³ | 0.35× | 0.80× | 0.84× | 0.93× | **1.05×** | 66.6 µs |
+| 2048³ | 0.23× | 0.60× | 0.63× | 0.78× | **0.83×** | 333.8 µs |
+| 4096³ | 0.05× | 0.57× | 0.57× | 0.76× | **0.82×** | 2384.1 µs |
 
-Roughly 76% of cuBLAS at the largest shape, from 5%. Still a loss, and still reported as one.
-L1TEX is now 61.38% rather than a roofline, so the next limiter is no longer the one this
-work addressed and must be re-measured before anything else is built.
+**At 1024³ the generated kernel is now faster than cuBLAS** — 63.2 µs against 66.6 µs. At the
+larger shapes it remains a loss at 0.82–0.83×, and that is still reported as a loss.
+
+Promotion: **withheld at 2048³ and above**, where routing a caller who could reach cuBLAS to
+us is still a regression. 1024³ is the first shape where a promotion case exists on the
+evidence, and it should be made on a per-shape basis with the same per-family discipline
+§6 applies to convolution — not by flipping a global flag.
 
 Promotion: still **withheld everywhere**. At 0.57–0.80×, routing a caller who could reach
 cuBLAS to us is still a regression — smaller, but a regression. The capability ships; the

--- a/docs/TENSOR_CORES.md
+++ b/docs/TENSOR_CORES.md
@@ -90,7 +90,7 @@ cuBLAS does the opposite: 128×128 block tiles staged through shared memory with
 pipelining, so each element of A and B is fetched from global roughly once per block rather
 than once per warp.
 
-### The next lever, named
+### The next lever, named (now built — see below)
 
 Shared-memory staging of the A and B bands plus multiple tiles per warp. That is the
 difference between `O(M·N·K)` and `O(M·N·K / tile)` operand traffic, and it is what stands
@@ -140,11 +140,58 @@ cores never helping.
 
 ---
 
+## Shared-memory staging — the named lever, measured
+
+A block of four warps owns a 64x64 output tile and stages the 64x16 slab of A and the 16x64
+slab of B into shared memory once per K step. Each element is fetched from global once per
+BLOCK rather than once per warp:
+
+| | operand traffic | fragment loads per mma |
+|---|---|---|
+| naive, 16x16 per warp | `M·N·K / 8` halves | 2 |
+| staged, 64x64 per block | `M·N·K / 32` halves | 0.5 |
+
+| shape | naive | **staged** | cuBLAS | old ratio | **new ratio** |
+|---|---|---|---|---|---|
+| 1024³ | 190.1 µs · 11.3 TF | **83.0 µs · 25.9 TF** | 66.6 µs · 32.2 TF | 0.35× | **0.80×** |
+| 2048³ | 1455.4 µs · 11.8 TF | **553.1 µs · 31.1 TF** | 333.8 µs · 51.5 TF | 0.23× | **0.60×** |
+| 4096³ | 45810.5 µs · 3.0 TF | **4200.8 µs · 32.7 TF** | 2384.1 µs · 57.6 TF | 0.05× | **0.57×** |
+
+**The collapse is gone.** Throughput now RISES with size — 25.9, 31.1, 32.7 TFLOP/s — where
+before it fell off a cliff at 4096³. That shape improved 10.9×.
+
+This is still a loss against cuBLAS, and is reported as one: we sit at roughly 53% of device
+peak against its 93%. But it is a different kind of loss — 1.75× away rather than 20×.
+
+### Why this lever was legitimate when the convolution one was not
+
+Shared-memory staging was built and REFUTED earlier in this campaign, on dense 3×3
+convolution: it raised L1 from 64.08% to 77.45%, because on NVIDIA hardware shared memory
+*is* L1TEX, so `ld.shared` is counted by the very metric it was meant to relieve. That lever
+died because `mio_throttle` sat at 3.03% — the load pipe was never that kernel's bottleneck.
+
+The justification here never rested on a throughput percentage. Throughput **fell fourfold**
+when the working set outgrew L2, which is a locality statement no stall counter is needed to
+read. Same lever, different evidence, opposite outcome.
+
+### The next levers, named again
+
+1. **Double-buffer the shared slabs.** Two `bar.sync`s per K step currently serialise the
+   global load against the mma work; a second slab would let step k+1's copy overlap step k's
+   arithmetic.
+2. **A larger block tile.** 128×128 quadruples reuse again; cuBLAS uses that scale.
+
+Neither is measured yet, so neither is claimed.
+
 ## Standing
 
 Expressiveness: **closed.** The generator can emit tensor-core kernels, with fused
 element-wise epilogues cuBLAS cannot fuse through its own call boundary.
 
-Performance: **open, and quantified.** 0.35× / 0.23× / 0.05× against cuBLAS, ~19% of device
-peak, with the cause identified as operand locality rather than instruction selection. No
-promotion is claimed on this evidence, and none should be until staging lands.
+Performance: **improved and still a loss.** 0.80× / 0.60× / 0.57× against cuBLAS after
+staging, up from 0.35× / 0.23× / 0.05×, at ~53% of device peak against its 93%. The next two
+levers are named above and unmeasured.
+
+Promotion: still **withheld everywhere**. At 0.57–0.80×, routing a caller who could reach
+cuBLAS to us is still a regression — smaller, but a regression. The capability ships; the
+promotion does not.

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
@@ -92,6 +92,31 @@ public sealed partial class PtxTensorCoreEmitter
     public int LoopBarriers { get; private set; }
 
     /// <summary>
+    /// Whether to stage with <c>cp.async</c> where the architecture supports it (sm_80+).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The register-staged copy reads global into registers and then stores those registers to
+    /// shared, which costs two instructions per word and holds the words live across the whole
+    /// mma section. At the 4x4 warp tile that lands the kernel on the register occupancy limit:
+    /// 240 registers per thread, 2 blocks per SM, 16.41% of peak warps active -- and with no
+    /// stall dominating, the resident warps are not waiting, there are simply too few of them.
+    /// </para>
+    /// <para>
+    /// <c>cp.async</c> copies global to shared directly, so the words never occupy a register,
+    /// and it moves 16 bytes per instruction instead of 4. That is the largest remaining stall
+    /// (<c>mio_throttle</c> at 4.95) and the register pressure, addressed by one change.
+    /// </para>
+    /// <para>
+    /// Settable so the two staging forms can be measured against each other.
+    /// </para>
+    /// </remarks>
+    public bool EnableAsyncCopy { get; set; } = true;
+
+    /// <summary>Whether the last emission staged with <c>cp.async</c>.</summary>
+    public bool AsyncCopy { get; private set; }
+
+    /// <summary>
     /// Whether to double-buffer the staging slabs when the shape allows it.
     /// </summary>
     /// <remarks>
@@ -177,6 +202,19 @@ public sealed partial class PtxTensorCoreEmitter
         plan is null ? throw new ArgumentNullException(nameof(plan))
                      : (plan.M / BlockTileM) * (plan.N / BlockTileN);
 
+    /// <summary>Bytes one <c>cp.async</c> moves. 16 is the widest the instruction offers.</summary>
+    private const int AsyncChunkBytes = 16;
+
+    private int ASlabBytes => BlockTileM * BlockTileK * 2;
+    private int BSlabBytes => BlockTileK * BlockTileN * 2;
+    private int AChunksPerThread => ASlabBytes / AsyncChunkBytes / StageThreads;
+    private int BChunksPerThread => BSlabBytes / AsyncChunkBytes / StageThreads;
+
+    /// <summary>Bytes of one row of the A slab, which is also its global row stride within a step.</summary>
+    private int ASlabRowBytes => BlockTileK * 2;
+
+    private int BSlabRowBytes => BlockTileN * 2;
+
     // Shared slab geometry, in u32 words, which is what the cooperative copy moves.
     private int AWords => BlockTileM * BlockTileK / 2;
     private int BWords => BlockTileK * BlockTileN / 2;
@@ -193,6 +231,15 @@ public sealed partial class PtxTensorCoreEmitter
         int outIndex = spec.Inputs.Count;
 
         bool doubleBuffer = EnableDoubleBuffering && CanDoubleBuffer(plan, out _);
+
+        // cp.async is sm_80+. It also needs the per-thread share to be a whole number of
+        // 16-byte chunks, which every supported block tile satisfies -- but it is checked
+        // rather than assumed, because a partial chunk would silently drop bytes.
+        bool asyncCopy = EnableAsyncCopy
+            && computeMajor >= 8
+            && ASlabBytes % (AsyncChunkBytes * StageThreads) == 0
+            && BSlabBytes % (AsyncChunkBytes * StageThreads) == 0;
+        AsyncCopy = asyncCopy;
 
         Staged = true;
         DoubleBuffered = doubleBuffer;
@@ -304,6 +351,54 @@ public sealed partial class PtxTensorCoreEmitter
             L($"mul.wide.u32 {bSharedOffset[w]}, {bWordIndex[w]}, 4;");
         }
 
+        // cp.async addressing: each thread owns whole 16-byte chunks. Within a slab, chunk c
+        // sits at byte c*16; its global home is row*(rowStride) + byteInRow, where the row and
+        // the offset inside it are both compile-time divisions of c*16 by the slab's row width.
+        var asyncAGlobal = new string[asyncCopy ? AChunksPerThread : 0];
+        var asyncAShared = new string[asyncCopy ? AChunksPerThread : 0];
+        var asyncBGlobal = new string[asyncCopy ? BChunksPerThread : 0];
+        var asyncBShared = new string[asyncCopy ? BChunksPerThread : 0];
+
+        if (asyncCopy)
+        {
+            int aChunksPerRow = ASlabRowBytes / AsyncChunkBytes;
+            int bChunksPerRow = BSlabRowBytes / AsyncChunkBytes;
+
+            for (int w = 0; w < AChunksPerThread; w++)
+            {
+                string chunk = NextR(), row = NextR(), inRow = NextR(), off = NextR();
+                L($"add.u32 {chunk}, %r1, {I(w * StageThreads)};");
+                L($"div.u32 {row}, {chunk}, {I(aChunksPerRow)};");
+                L($"rem.u32 {inRow}, {chunk}, {I(aChunksPerRow)};");
+                L($"mad.lo.u32 {off}, {row}, {I(plan.K * 2)}, 0;");
+                L($"mad.lo.u32 {off}, {inRow}, {I(AsyncChunkBytes)}, {off};");
+                asyncAGlobal[w] = NextRd();
+                L($"mul.wide.u32 {asyncAGlobal[w]}, {off}, 1;");
+
+                string sharedOff = NextR();
+                L($"mul.lo.u32 {sharedOff}, {chunk}, {I(AsyncChunkBytes)};");
+                asyncAShared[w] = NextRd();
+                L($"mul.wide.u32 {asyncAShared[w]}, {sharedOff}, 1;");
+            }
+
+            for (int w = 0; w < BChunksPerThread; w++)
+            {
+                string chunk = NextR(), row = NextR(), inRow = NextR(), off = NextR();
+                L($"add.u32 {chunk}, %r1, {I(w * StageThreads)};");
+                L($"div.u32 {row}, {chunk}, {I(bChunksPerRow)};");
+                L($"rem.u32 {inRow}, {chunk}, {I(bChunksPerRow)};");
+                L($"mad.lo.u32 {off}, {row}, {I(plan.N * 2)}, 0;");
+                L($"mad.lo.u32 {off}, {inRow}, {I(AsyncChunkBytes)}, {off};");
+                asyncBGlobal[w] = NextRd();
+                L($"mul.wide.u32 {asyncBGlobal[w]}, {off}, 1;");
+
+                string sharedOff = NextR();
+                L($"mul.lo.u32 {sharedOff}, {chunk}, {I(AsyncChunkBytes)};");
+                asyncBShared[w] = NextRd();
+                L($"mul.wide.u32 {asyncBShared[w]}, {sharedOff}, 1;");
+            }
+        }
+
         string warpAOffset = NextRd(), warpBOffset = NextRd();
         {
             string aBytes = NextR(), bBytes = NextR();
@@ -326,8 +421,17 @@ public sealed partial class PtxTensorCoreEmitter
             L("mov.u32 %r9, 0;                        // k step");
             _sb.Append("KLOOP:\n");
 
-            var regs = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
-            EmitSlabStore(regs, aSharedOffset, bSharedOffset, buffer: 0);
+            if (asyncCopy)
+            {
+                EmitAsyncCopy(asyncAGlobal, asyncAShared, asyncBGlobal, asyncBShared, 0, null);
+                L("cp.async.commit_group;");
+                L("cp.async.wait_group 0;");
+            }
+            else
+            {
+                var regs = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
+                EmitSlabStore(regs, aSharedOffset, bSharedOffset, buffer: 0);
+            }
             L("bar.sync 0;");
             LoopBarriers++;
 
@@ -353,8 +457,17 @@ public sealed partial class PtxTensorCoreEmitter
             // Prologue stages step 0 into buffer 0. Thereafter each body consumes one buffer
             // while filling the other, so the global load for step k+1 is ISSUED BEFORE the
             // mma work for step k and its latency hides behind that arithmetic.
-            var first = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
-            EmitSlabStore(first, aSharedOffset, bSharedOffset, buffer: 0);
+            if (asyncCopy)
+            {
+                EmitAsyncCopy(asyncAGlobal, asyncAShared, asyncBGlobal, asyncBShared, 0, null);
+                L("cp.async.commit_group;");
+                L("cp.async.wait_group 0;");
+            }
+            else
+            {
+                var first = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
+                EmitSlabStore(first, aSharedOffset, bSharedOffset, buffer: 0);
+            }
             EmitAdvance(plan);
             L("bar.sync 0;");
 
@@ -374,14 +487,32 @@ public sealed partial class PtxTensorCoreEmitter
                 string guard = NextP();
                 L($"setp.lt.u32 {guard}, %r10, {I(steps)};");
 
-                prefetch.Clear();
-                prefetch.AddRange(EmitSlabLoad(aGlobalOffset, bGlobalOffset, guard));
-                EmitAdvance(plan);
-                L("add.u32 %r10, %r10, 1;");
+                if (asyncCopy)
+                {
+                    EmitAsyncCopy(asyncAGlobal, asyncAShared, asyncBGlobal, asyncBShared,
+                                  next, guard);
+                    L("cp.async.commit_group;");
+                    EmitAdvance(plan);
+                    L("add.u32 %r10, %r10, 1;");
 
-                EmitComputeStep(spec, plan, warpAOffset, warpBOffset, current);
+                    EmitComputeStep(spec, plan, warpAOffset, warpBOffset, current);
 
-                EmitSlabStore(prefetch, aSharedOffset, bSharedOffset, next);
+                    // The copy has been in flight across the whole mma section; only now does
+                    // anything wait on it.
+                    L("cp.async.wait_group 0;");
+                }
+                else
+                {
+                    prefetch.Clear();
+                    prefetch.AddRange(EmitSlabLoad(aGlobalOffset, bGlobalOffset, guard));
+                    EmitAdvance(plan);
+                    L("add.u32 %r10, %r10, 1;");
+
+                    EmitComputeStep(spec, plan, warpAOffset, warpBOffset, current);
+
+                    EmitSlabStore(prefetch, aSharedOffset, bSharedOffset, next);
+                }
+
                 L("bar.sync 0;");
                 LoopBarriers++;
             }
@@ -442,6 +573,40 @@ public sealed partial class PtxTensorCoreEmitter
               .Append(_sb);
 
         return header.ToString();
+    }
+
+    /// <summary>
+    /// Issues the whole staging copy for one K step with <c>cp.async</c>, straight from global
+    /// to shared.
+    /// </summary>
+    /// <remarks>
+    /// One instruction per 16 bytes, and the bytes never occupy a register. Against the
+    /// register-staged form this is an eighth of the load/store instructions and frees the
+    /// words that were held live across the mma section -- which is what the 240-register,
+    /// 2-blocks-per-SM occupancy limit was made of.
+    /// </remarks>
+    private void EmitAsyncCopy(
+        string[] aGlobal, string[] aShared, string[] bGlobal, string[] bShared,
+        int buffer, string? guard)
+    {
+        int bufferBase = buffer * StageBufferBytes;
+        string prefix = guard is null ? string.Empty : "@" + guard + " ";
+
+        for (int w = 0; w < aGlobal.Length; w++)
+        {
+            string src = NextRd(), dst = NextRd();
+            L($"add.u64 {src}, %rd6, {aGlobal[w]};");
+            L($"add.u64 {dst}, %rd3, {aShared[w]};");
+            L($"{prefix}cp.async.ca.shared.global [{dst}+{I(bufferBase)}], [{src}], {I(AsyncChunkBytes)};");
+        }
+
+        for (int w = 0; w < bGlobal.Length; w++)
+        {
+            string src = NextRd(), dst = NextRd();
+            L($"add.u64 {src}, %rd8, {bGlobal[w]};");
+            L($"add.u64 {dst}, %rd3, {bShared[w]};");
+            L($"{prefix}cp.async.ca.shared.global [{dst}+{I(bufferBase + BSlabOffset)}], [{src}], {I(AsyncChunkBytes)};");
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
@@ -39,26 +39,45 @@ namespace AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
 
 public sealed partial class PtxTensorCoreEmitter
 {
-    /// <summary>Output rows a block computes.</summary>
-    public const int BlockTileM = 64;
-
-    /// <summary>Output columns a block computes.</summary>
-    public const int BlockTileN = 64;
-
     /// <summary>Contraction depth staged per step.</summary>
     public const int BlockTileK = 16;
 
     /// <summary>Warps per staged block. Four, arranged 2x2 over the block tile.</summary>
     public const int StagedWarps = 4;
 
-    /// <summary>wmma tiles a warp owns along each axis (its quadrant is 32x32).</summary>
-    private const int WarpTiles = 2;
+    /// <summary>
+    /// wmma tiles a warp owns along the M axis.
+    /// </summary>
+    /// <remarks>
+    /// THIS IS THE SHARED-TRAFFIC KNOB, and it is measured rather than argued. A warp loads
+    /// <c>WarpTilesM + WarpTilesN</c> fragments and issues <c>WarpTilesM * WarpTilesN</c> mma
+    /// instructions from them, so the fragment loads per unit of arithmetic fall as the tile
+    /// grows: 2x2 is one load per mma, 4x4 is half that. The profile said that ratio is what
+    /// matters -- L1TEX at 87.14% with the tensor pipe at 25.29%, and shared memory IS L1TEX
+    /// on this hardware.
+    ///
+    /// It trades against registers: the accumulators alone are
+    /// <c>WarpTilesM * WarpTilesN * 8</c> fp32 per thread, so 4x4 is 128 before any operand
+    /// or address register. Past some point ptxas spills, and a spilling GEMM is slower than
+    /// a small-tiled one. Which side of that point a shape sits on is not something to
+    /// predict -- see the two levers on this branch that were predicted and did not pay.
+    /// </remarks>
+    public int WarpTilesM { get; set; } = 2;
+
+    /// <summary>wmma tiles a warp owns along the N axis. See <see cref="WarpTilesM"/>.</summary>
+    public int WarpTilesN { get; set; } = 2;
+
+    /// <summary>Output rows a block computes: two warp rows of <see cref="WarpTilesM"/> tiles.</summary>
+    public int BlockTileM => WarpTilesM * 16 * 2;
+
+    /// <summary>Output columns a block computes.</summary>
+    public int BlockTileN => WarpTilesN * 16 * 2;
 
     /// <summary>Bytes one staging buffer occupies: the A slab followed by the B slab.</summary>
-    public const int StageBufferBytes = (BlockTileM * BlockTileK + BlockTileK * BlockTileN) * 2;
+    public int StageBufferBytes => (BlockTileM * BlockTileK + BlockTileK * BlockTileN) * 2;
 
     /// <summary>Byte offset of the B slab inside a buffer.</summary>
-    private const int BSlabOffset = BlockTileM * BlockTileK * 2;
+    private int BSlabOffset => BlockTileM * BlockTileK * 2;
 
     /// <summary>Whether the last emission used the shared-memory staged lowering.</summary>
     public bool Staged { get; private set; }
@@ -91,7 +110,7 @@ public sealed partial class PtxTensorCoreEmitter
     /// its slab gathered column-wise instead of copied. Both fall back to the naive path,
     /// which is correct at every shape.
     /// </remarks>
-    public static bool CanStage(Plan plan, out string reason)
+    public bool CanStage(Plan plan, out string reason)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
@@ -129,7 +148,7 @@ public sealed partial class PtxTensorCoreEmitter
     /// an even step count. An odd one falls back to single-buffered staging, which is correct
     /// and merely slower -- padding K to make it even would change the operator.
     /// </remarks>
-    public static bool CanDoubleBuffer(Plan plan, out string reason)
+    public bool CanDoubleBuffer(Plan plan, out string reason)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
@@ -154,18 +173,18 @@ public sealed partial class PtxTensorCoreEmitter
     }
 
     /// <summary>Blocks a staged plan launches.</summary>
-    public static int StagedBlockCount(Plan plan) =>
+    public int StagedBlockCount(Plan plan) =>
         plan is null ? throw new ArgumentNullException(nameof(plan))
                      : (plan.M / BlockTileM) * (plan.N / BlockTileN);
 
     // Shared slab geometry, in u32 words, which is what the cooperative copy moves.
-    private const int AWords = BlockTileM * BlockTileK / 2;      // 512
-    private const int BWords = BlockTileK * BlockTileN / 2;      // 512
+    private int AWords => BlockTileM * BlockTileK / 2;
+    private int BWords => BlockTileK * BlockTileN / 2;
     private const int StageThreads = StagedWarps * 32;           // 128
-    private const int AWordsPerThread = AWords / StageThreads;   // 4
-    private const int BWordsPerThread = BWords / StageThreads;   // 4
+    private int AWordsPerThread => AWords / StageThreads;
+    private int BWordsPerThread => BWords / StageThreads;
     private const int AWordsPerRow = BlockTileK / 2;             // 8
-    private const int BWordsPerRow = BlockTileN / 2;             // 32
+    private int BWordsPerRow => BlockTileN / 2;
 
     /// <summary>Emits the staged kernel, double-buffered where the shape allows it.</summary>
     private string EmitStaged(CodegenKernelSpec spec, Plan plan, int computeMajor, int computeMinor)
@@ -288,14 +307,14 @@ public sealed partial class PtxTensorCoreEmitter
         string warpAOffset = NextRd(), warpBOffset = NextRd();
         {
             string aBytes = NextR(), bBytes = NextR();
-            L($"mul.lo.u32 {aBytes}, %r5, {I(WarpTiles * 16 * BlockTileK * 2)};");
+            L($"mul.lo.u32 {aBytes}, %r5, {I(WarpTilesM * 16 * BlockTileK * 2)};");
             L($"mul.wide.u32 {warpAOffset}, {aBytes}, 1;");
-            L($"mul.lo.u32 {bBytes}, %r6, {I(WarpTiles * 16 * 2)};");
+            L($"mul.lo.u32 {bBytes}, %r6, {I(WarpTilesN * 16 * 2)};");
             L($"mul.wide.u32 {warpBOffset}, {bBytes}, 1;");
         }
 
         // Accumulators: one fragment per (i, j) quadrant tile.
-        for (int t = 0; t < WarpTiles * WarpTiles; t++)
+        for (int t = 0; t < WarpTilesM * WarpTilesN; t++)
             for (int f = 0; f < FragmentRegisters; f++)
                 L($"mov.f32 %fc{I(t * FragmentRegisters + f)}, 0f00000000;");
 
@@ -374,30 +393,30 @@ public sealed partial class PtxTensorCoreEmitter
 
         // ---- epilogue and store ----------------------------------------------------------
         if (spec.Activation != CodegenActivationKind.None)
-            for (int t = 0; t < WarpTiles * WarpTiles; t++)
+            for (int t = 0; t < WarpTilesM * WarpTilesN; t++)
                 for (int f = 0; f < FragmentRegisters; f++)
                     EmitActivation(spec.Activation, $"%fc{I(t * FragmentRegisters + f)}");
 
         if (spec.ReduceScale != 1.0)
-            for (int t = 0; t < WarpTiles * WarpTiles; t++)
+            for (int t = 0; t < WarpTilesM * WarpTilesN; t++)
                 for (int f = 0; f < FragmentRegisters; f++)
                 {
                     string reg = $"%fc{I(t * FragmentRegisters + f)}";
                     L($"mul.f32 {reg}, {reg}, {F32(spec.ReduceScale)};");
                 }
 
-        for (int i = 0; i < WarpTiles; i++)
-            for (int j = 0; j < WarpTiles; j++)
+        for (int i = 0; i < WarpTilesM; i++)
+            for (int j = 0; j < WarpTilesN; j++)
             {
-                int t = i * WarpTiles + j;
+                int t = i * WarpTilesN + j;
                 string row = NextR(), col = NextR(), off = NextR();
 
                 L($"mul.lo.u32 {row}, %r2, {I(BlockTileM)};");
-                L($"mad.lo.u32 {row}, %r5, {I(WarpTiles * 16)}, {row};");
+                L($"mad.lo.u32 {row}, %r5, {I(WarpTilesM * 16)}, {row};");
                 L($"add.u32 {row}, {row}, {I(i * 16)};");
 
                 L($"mul.lo.u32 {col}, %r3, {I(BlockTileN)};");
-                L($"mad.lo.u32 {col}, %r6, {I(WarpTiles * 16)}, {col};");
+                L($"mad.lo.u32 {col}, %r6, {I(WarpTilesN * 16)}, {col};");
                 L($"add.u32 {col}, {col}, {I(j * 16)};");
 
                 L($"mad.lo.u32 {off}, {row}, {I(plan.N)}, {col};");
@@ -416,10 +435,10 @@ public sealed partial class PtxTensorCoreEmitter
               .Append("    .reg .b32    %r<").Append(I(_reg + 8)).Append(">;\n")
               .Append("    .reg .f32    %f<40>;\n")
               .Append("    .reg .b64    %rd<").Append(I(_reg64 + 8)).Append(">;\n")
-              .Append("    .reg .b32    %fa<").Append(I(WarpTiles * FragmentRegisters)).Append(">;\n")
-              .Append("    .reg .b32    %fb<").Append(I(WarpTiles * FragmentRegisters)).Append(">;\n")
+              .Append("    .reg .b32    %fa<").Append(I(Math.Max(WarpTilesM, WarpTilesN) * FragmentRegisters)).Append(">;\n")
+              .Append("    .reg .b32    %fb<").Append(I(Math.Max(WarpTilesM, WarpTilesN) * FragmentRegisters)).Append(">;\n")
               .Append("    .reg .f32    %fc<")
-              .Append(I(WarpTiles * WarpTiles * FragmentRegisters)).Append(">;\n\n")
+              .Append(I(WarpTilesM * WarpTilesN * FragmentRegisters)).Append(">;\n\n")
               .Append(_sb);
 
         return header.ToString();
@@ -485,7 +504,7 @@ public sealed partial class PtxTensorCoreEmitter
     {
         int bufferBase = buffer * StageBufferBytes;
 
-        for (int i = 0; i < WarpTiles; i++)
+        for (int i = 0; i < WarpTilesM; i++)
         {
             string addr = NextRd();
             L($"add.u64 {addr}, %rd3, {warpAOffset};");
@@ -494,7 +513,7 @@ public sealed partial class PtxTensorCoreEmitter
               $"[{addr}+{I(bufferBase + i * 16 * BlockTileK * 2)}], {I(BlockTileK)};");
         }
 
-        for (int j = 0; j < WarpTiles; j++)
+        for (int j = 0; j < WarpTilesN; j++)
         {
             string addr = NextRd();
             L($"add.u64 {addr}, %rd3, {warpBOffset};");
@@ -503,10 +522,10 @@ public sealed partial class PtxTensorCoreEmitter
               $"[{addr}+{I(bufferBase + BSlabOffset + j * 16 * 2)}], {I(BlockTileN)};");
         }
 
-        for (int i = 0; i < WarpTiles; i++)
-            for (int j = 0; j < WarpTiles; j++)
+        for (int i = 0; i < WarpTilesM; i++)
+            for (int j = 0; j < WarpTilesN; j++)
             {
-                int t = i * WarpTiles + j;
+                int t = i * WarpTilesN + j;
                 L($"wmma.mma.sync.aligned.row.row.m16n16k16.f32.f32 " +
                   $"{Fragment("%fc", t * FragmentRegisters)}, {Fragment("%fa", i * FragmentRegisters)}, " +
                   $"{Fragment("%fb", j * FragmentRegisters)}, {Fragment("%fc", t * FragmentRegisters)};");

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
@@ -1,33 +1,37 @@
 // Copyright (c) AiDotNet. All rights reserved.
 //
-// Shared-memory staged tensor-core GEMM.
+// Shared-memory staged tensor-core GEMM, single- and double-buffered.
 //
 // The naive lowering gives one warp one 16x16 output tile and lets it stream its own operand
-// bands straight from global. That measured 11.8 TFLOP/s at 2048^3 and then COLLAPSED to 3.0
-// at 4096^3, against cuBLAS holding 57.6 -- and the collapse is the whole argument for this
-// file. Total operand traffic there is O(M*N*K), because nothing is shared between the warps
-// that need the same bands; once the reused bands outgrow L2 every warp goes to DRAM.
+// bands straight from global. That measured 11.8 TFLOP/s at 2048^3 and COLLAPSED to 3.0 at
+// 4096^3, against cuBLAS holding 57.6. Total operand traffic there is O(M*N*K), because
+// nothing is shared between the warps that need the same bands; once the reused bands outgrow
+// L2 every warp goes to DRAM.
 //
-// Here a BLOCK of four warps owns a 64x64 output tile and stages the 64x16 slab of A and the
-// 16x64 slab of B into shared memory once per K step. Each element of A is then fetched from
+// Staging: a BLOCK of four warps owns a 64x64 output tile and stages the 64x16 slab of A and
+// the 16x64 slab of B into shared memory once per K step. Each element of A is fetched from
 // global once per block rather than once per warp:
 //
 //   naive    per 16x16 tile: 16K halves of A + 16K of B  ->  M*N*K/8   halves total
 //   staged   per 64x64 tile: 64K halves of A + 64K of B  ->  M*N*K/32  halves total
 //
-// A factor of four, and the same factor again in fragment loads: a warp loads two A fragments
-// and two B fragments per K step and issues FOUR mma instructions from them, instead of two
-// loads per mma.
+// Double buffering: single-buffered staging needs TWO barriers per step -- one after the
+// shared store, one after the reads, to stop a fast warp overwriting a slab a slow one is
+// still reading. Between them the global load and the arithmetic cannot overlap at all: every
+// warp waits at the first barrier for the copy, then computes, then waits again. With two
+// slabs the copy for step k+1 targets the buffer nobody is reading, so it is ISSUED BEFORE
+// the mma work for step k and its latency hides behind that arithmetic. One barrier per step.
 //
 // NOTE ON THE LEVER ITSELF. Shared-memory staging was tried on dense 3x3 convolution earlier
 // in this campaign and REFUTED -- it raised L1 from 64.08% to 77.45%, because on NVIDIA
 // hardware shared memory IS L1TEX, so ld.shared is counted by the very metric it was meant to
 // relieve. That lever died because `mio_throttle` sat at 3.03%: the load pipe was never that
 // kernel's bottleneck. The justification here is different in kind and does not rest on a
-// throughput percentage at all -- throughput FALLS FOURFOLD when the working set outgrows L2,
+// throughput percentage at all -- throughput FELL FOURFOLD when the working set outgrew L2,
 // which is a locality statement no stall counter is needed to read.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using AiDotNet.Tensors.Engines.Compilation.Codegen.Ir;
 
@@ -50,14 +54,32 @@ public sealed partial class PtxTensorCoreEmitter
     /// <summary>wmma tiles a warp owns along each axis (its quadrant is 32x32).</summary>
     private const int WarpTiles = 2;
 
-    /// <summary>Bytes of shared memory a staged block reserves.</summary>
-    public const int StagedSharedBytes = (BlockTileM * BlockTileK + BlockTileK * BlockTileN) * 2;
+    /// <summary>Bytes one staging buffer occupies: the A slab followed by the B slab.</summary>
+    public const int StageBufferBytes = (BlockTileM * BlockTileK + BlockTileK * BlockTileN) * 2;
 
-    /// <summary>Whether the last emission used the staged lowering.</summary>
+    /// <summary>Byte offset of the B slab inside a buffer.</summary>
+    private const int BSlabOffset = BlockTileM * BlockTileK * 2;
+
+    /// <summary>Whether the last emission used the shared-memory staged lowering.</summary>
     public bool Staged { get; private set; }
+
+    /// <summary>Whether the last emission double-buffered the staging slabs.</summary>
+    public bool DoubleBuffered { get; private set; }
 
     /// <summary>Shared-memory bytes the last emission requires.</summary>
     public int SharedMemoryBytes { get; private set; }
+
+    /// <summary><c>bar.sync</c> instructions the last emission placed inside the K loop.</summary>
+    public int LoopBarriers { get; private set; }
+
+    /// <summary>
+    /// Whether to double-buffer the staging slabs when the shape allows it.
+    /// </summary>
+    /// <remarks>
+    /// Settable so the two forms can be measured against each other on the same shape.
+    /// Turning it off is a measurement device, not a supported configuration.
+    /// </remarks>
+    public bool EnableDoubleBuffering { get; set; } = true;
 
     /// <summary>
     /// Whether a plan can take the staged lowering, and if not, why not.
@@ -98,32 +120,69 @@ public sealed partial class PtxTensorCoreEmitter
         return true;
     }
 
+    /// <summary>
+    /// Whether a staged plan can double-buffer, and if not, why not.
+    /// </summary>
+    /// <remarks>
+    /// The loop body is emitted TWICE, once per buffer, so the buffer index is a compile-time
+    /// constant rather than a register the shared address has to be computed from. That costs
+    /// an even step count. An odd one falls back to single-buffered staging, which is correct
+    /// and merely slower -- padding K to make it even would change the operator.
+    /// </remarks>
+    public static bool CanDoubleBuffer(Plan plan, out string reason)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (!CanStage(plan, out reason)) return false;
+
+        int steps = plan.K / BlockTileK;
+        if (steps < 2)
+        {
+            reason = "double buffering needs at least two K steps; this shape has " + steps;
+            return false;
+        }
+
+        if (steps % 2 != 0)
+        {
+            reason = "the loop body is emitted once per buffer, so the step count must be " +
+                "even; K = " + plan.K + " gives " + steps + " steps";
+            return false;
+        }
+
+        reason = "eligible";
+        return true;
+    }
+
     /// <summary>Blocks a staged plan launches.</summary>
     public static int StagedBlockCount(Plan plan) =>
         plan is null ? throw new ArgumentNullException(nameof(plan))
                      : (plan.M / BlockTileM) * (plan.N / BlockTileN);
 
-    /// <summary>Emits the staged kernel.</summary>
+    // Shared slab geometry, in u32 words, which is what the cooperative copy moves.
+    private const int AWords = BlockTileM * BlockTileK / 2;      // 512
+    private const int BWords = BlockTileK * BlockTileN / 2;      // 512
+    private const int StageThreads = StagedWarps * 32;           // 128
+    private const int AWordsPerThread = AWords / StageThreads;   // 4
+    private const int BWordsPerThread = BWords / StageThreads;   // 4
+    private const int AWordsPerRow = BlockTileK / 2;             // 8
+    private const int BWordsPerRow = BlockTileN / 2;             // 32
+
+    /// <summary>Emits the staged kernel, double-buffered where the shape allows it.</summary>
     private string EmitStaged(CodegenKernelSpec spec, Plan plan, int computeMajor, int computeMinor)
     {
         int aIndex = spec.ProductInputs[0], bIndex = spec.ProductInputs[1];
         int outIndex = spec.Inputs.Count;
 
+        bool doubleBuffer = EnableDoubleBuffering && CanDoubleBuffer(plan, out _);
+
         Staged = true;
-        SharedMemoryBytes = StagedSharedBytes;
+        DoubleBuffered = doubleBuffer;
+        SharedMemoryBytes = doubleBuffer ? StageBufferBytes * 2 : StageBufferBytes;
         MmaInstructions = 0;
+        LoopBarriers = 0;
 
         int tilesN = plan.N / BlockTileN;
         int steps = plan.K / BlockTileK;
-
-        // Shared slab geometry, in u32 words, which is what the cooperative copy moves.
-        const int AWords = BlockTileM * BlockTileK / 2;      // 512
-        const int BWords = BlockTileK * BlockTileN / 2;      // 512
-        const int Threads = StagedWarps * 32;                // 128
-        const int AWordsPerThread = AWords / Threads;        // 4
-        const int BWordsPerThread = BWords / Threads;        // 4
-        const int AWordsPerRow = BlockTileK / 2;             // 8
-        const int BWordsPerRow = BlockTileN / 2;             // 32
 
         var header = new System.Text.StringBuilder();
         header.Append(".version 7.1\n")
@@ -131,7 +190,8 @@ public sealed partial class PtxTensorCoreEmitter
               .Append(".address_size 64\n\n")
               .Append("// generated by PtxTensorCoreEmitter -- STAGED wmma, ")
               .Append(I(BlockTileM)).Append('x').Append(I(BlockTileN)).Append('x')
-              .Append(I(BlockTileK)).Append(" block tile, ").Append(I(StagedWarps)).Append(" warps\n")
+              .Append(I(BlockTileK)).Append(" block tile, ").Append(I(StagedWarps)).Append(" warps, ")
+              .Append(doubleBuffer ? "double-buffered" : "single-buffered").Append('\n')
               .Append("// ").Append(spec.Describe().Replace("\n", "\n// ")).Append('\n')
               .Append(".visible .entry ").Append(spec.Name).Append("(\n");
 
@@ -161,11 +221,10 @@ public sealed partial class PtxTensorCoreEmitter
         L("shr.u32 %r5, %r4, 1;                   // warp row 0..1");
         L("and.b32 %r6, %r4, 1;                   // warp column 0..1");
 
-        // Shared base addresses. sB follows sA.
         L("mov.u64 %rd3, stage;");
-        L($"add.u64 %rd4, %rd3, {I(AWords * 4)};   // sB");
 
-        // Global slab origins for this block, in ELEMENTS, before the K walk advances them.
+        // Global slab origins for this block, in ELEMENTS. These advance as the K walk
+        // proceeds and always point at the step about to be PREFETCHED.
         L($"mul.lo.u32 %r7, %r2, {I(BlockTileM * plan.K)};    // A slab origin");
         L($"mul.lo.u32 %r8, %r3, {I(BlockTileN)};             // B slab origin");
         L("mul.wide.u32 %rd5, %r7, 2;");
@@ -173,20 +232,66 @@ public sealed partial class PtxTensorCoreEmitter
         L("mul.wide.u32 %rd7, %r8, 2;");
         L("add.u64 %rd8, %rd1, %rd7;              // B slab pointer");
 
-        // THE COOPERATIVE COPY'S PER-THREAD ADDRESSES ARE LOOP-INVARIANT, so they are computed
-        // once here rather than per K step. Each thread moves AWordsPerThread words of A and
-        // BWordsPerThread of B, strided by the block size so the accesses stay coalesced.
+        // The cooperative copy's per-thread word indices are loop-invariant, so they are
+        // computed once rather than per K step.
+        var aWordIndex = new string[AWordsPerThread];
+        var bWordIndex = new string[BWordsPerThread];
         for (int w = 0; w < AWordsPerThread; w++)
         {
-            int word = w * Threads;
-            string wordIndex = $"%r{I(10 + w)}";
-            L($"add.u32 {wordIndex}, %r1, {I(word)};");
+            aWordIndex[w] = NextR();
+            L($"add.u32 {aWordIndex[w]}, %r1, {I(w * StageThreads)};");
         }
         for (int w = 0; w < BWordsPerThread; w++)
         {
-            int word = w * Threads;
-            string wordIndex = $"%r{I(14 + w)}";
-            L($"add.u32 {wordIndex}, %r1, {I(word)};");
+            bWordIndex[w] = NextR();
+            L($"add.u32 {bWordIndex[w]}, %r1, {I(w * StageThreads)};");
+        }
+
+        // Global byte offsets for this thread's share of each slab, also loop-invariant: only
+        // the slab POINTERS move as K advances.
+        var aGlobalOffset = new string[AWordsPerThread];
+        var bGlobalOffset = new string[BWordsPerThread];
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            string row = NextR(), col = NextR(), off = NextR();
+            L($"div.u32 {row}, {aWordIndex[w]}, {I(AWordsPerRow)};");
+            L($"rem.u32 {col}, {aWordIndex[w]}, {I(AWordsPerRow)};");
+            L($"mad.lo.u32 {off}, {row}, {I(plan.K / 2)}, {col};");
+            aGlobalOffset[w] = NextRd();
+            L($"mul.wide.u32 {aGlobalOffset[w]}, {off}, 4;");
+        }
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            string row = NextR(), col = NextR(), off = NextR();
+            L($"div.u32 {row}, {bWordIndex[w]}, {I(BWordsPerRow)};");
+            L($"rem.u32 {col}, {bWordIndex[w]}, {I(BWordsPerRow)};");
+            L($"mad.lo.u32 {off}, {row}, {I(plan.N / 2)}, {col};");
+            bGlobalOffset[w] = NextRd();
+            L($"mul.wide.u32 {bGlobalOffset[w]}, {off}, 4;");
+        }
+
+        // Shared byte offsets for this thread's share, and for this warp's fragments. Both are
+        // relative to a buffer's base, so the buffer index stays a compile-time addend.
+        var aSharedOffset = new string[AWordsPerThread];
+        var bSharedOffset = new string[BWordsPerThread];
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            aSharedOffset[w] = NextRd();
+            L($"mul.wide.u32 {aSharedOffset[w]}, {aWordIndex[w]}, 4;");
+        }
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            bSharedOffset[w] = NextRd();
+            L($"mul.wide.u32 {bSharedOffset[w]}, {bWordIndex[w]}, 4;");
+        }
+
+        string warpAOffset = NextRd(), warpBOffset = NextRd();
+        {
+            string aBytes = NextR(), bBytes = NextR();
+            L($"mul.lo.u32 {aBytes}, %r5, {I(WarpTiles * 16 * BlockTileK * 2)};");
+            L($"mul.wide.u32 {warpAOffset}, {aBytes}, 1;");
+            L($"mul.lo.u32 {bBytes}, %r6, {I(WarpTiles * 16 * 2)};");
+            L($"mul.wide.u32 {warpBOffset}, {bBytes}, 1;");
         }
 
         // Accumulators: one fragment per (i, j) quadrant tile.
@@ -194,95 +299,78 @@ public sealed partial class PtxTensorCoreEmitter
             for (int f = 0; f < FragmentRegisters; f++)
                 L($"mov.f32 %fc{I(t * FragmentRegisters + f)}, 0f00000000;");
 
-        L("mov.u32 %r9, 0;                        // k step");
-        _sb.Append("KLOOP:\n");
+        var prefetch = new List<string>();
 
-        // ---- stage A: 64 rows x 16 halves, row r at global (slabRow + r)*K + k0 -----------
-        for (int w = 0; w < AWordsPerThread; w++)
+        if (!doubleBuffer)
         {
-            string wordIndex = $"%r{I(10 + w)}";
-            string row = NextR(), col = NextR(), off = NextR();
-            L($"div.u32 {row}, {wordIndex}, {I(AWordsPerRow)};");
-            L($"rem.u32 {col}, {wordIndex}, {I(AWordsPerRow)};");
-            L($"mul.lo.u32 {off}, {row}, {I(plan.K / 2)};   // row stride in words");
-            L($"add.u32 {off}, {off}, {col};");
+            // ---- single-buffered: copy, fence, compute, fence -----------------------------
+            L("mov.u32 %r9, 0;                        // k step");
+            _sb.Append("KLOOP:\n");
 
-            string bytes = NextRd(), addr = NextRd(), data = NextR();
-            L($"mul.wide.u32 {bytes}, {off}, 4;");
-            L($"add.u64 {addr}, %rd6, {bytes};");
-            L($"ld.global.nc.u32 {data}, [{addr}];");
+            var regs = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
+            EmitSlabStore(regs, aSharedOffset, bSharedOffset, buffer: 0);
+            L("bar.sync 0;");
+            LoopBarriers++;
 
-            string sBytes = NextRd(), sAddr = NextRd();
-            L($"mul.wide.u32 {sBytes}, {wordIndex}, 4;");
-            L($"add.u64 {sAddr}, %rd3, {sBytes};");
-            L($"st.shared.u32 [{sAddr}], {data};");
+            EmitComputeStep(spec, plan, warpAOffset, warpBOffset, buffer: 0);
+
+            // THE SECOND BARRIER IS NOT OPTIONAL HERE. Without it a fast warp begins
+            // overwriting the slab for step k+1 while a slow one is still reading step k out
+            // of it -- which produces plausible magnitudes and a different answer per run.
+            // Double buffering removes the need for it by writing elsewhere, which is exactly
+            // where the overlap comes from.
+            L("bar.sync 0;");
+            LoopBarriers++;
+
+            EmitAdvance(plan);
+            L("add.u32 %r9, %r9, 1;");
+            L($"setp.lt.u32 %p1, %r9, {I(steps)};");
+            L("@%p1 bra KLOOP;");
         }
-
-        // ---- stage B: 16 rows x 64 halves, row r at global (k0 + r)*N + slabCol ----------
-        for (int w = 0; w < BWordsPerThread; w++)
+        else
         {
-            string wordIndex = $"%r{I(14 + w)}";
-            string row = NextR(), col = NextR(), off = NextR();
-            L($"div.u32 {row}, {wordIndex}, {I(BWordsPerRow)};");
-            L($"rem.u32 {col}, {wordIndex}, {I(BWordsPerRow)};");
-            L($"mul.lo.u32 {off}, {row}, {I(plan.N / 2)};");
-            L($"add.u32 {off}, {off}, {col};");
+            // ---- double-buffered ----------------------------------------------------------
+            //
+            // Prologue stages step 0 into buffer 0. Thereafter each body consumes one buffer
+            // while filling the other, so the global load for step k+1 is ISSUED BEFORE the
+            // mma work for step k and its latency hides behind that arithmetic.
+            var first = EmitSlabLoad(aGlobalOffset, bGlobalOffset, null);
+            EmitSlabStore(first, aSharedOffset, bSharedOffset, buffer: 0);
+            EmitAdvance(plan);
+            L("bar.sync 0;");
 
-            string bytes = NextRd(), addr = NextRd(), data = NextR();
-            L($"mul.wide.u32 {bytes}, {off}, 4;");
-            L($"add.u64 {addr}, %rd8, {bytes};");
-            L($"ld.global.nc.u32 {data}, [{addr}];");
+            L("mov.u32 %r9, 0;                        // pair index");
+            L($"mov.u32 %r10, 1;                      // step being prefetched");
+            _sb.Append("KLOOP:\n");
 
-            string sBytes = NextRd(), sAddr = NextRd();
-            L($"mul.wide.u32 {sBytes}, {wordIndex}, 4;");
-            L($"add.u64 {sAddr}, %rd4, {sBytes};");
-            L($"st.shared.u32 [{sAddr}], {data};");
-        }
-
-        L("bar.sync 0;");
-
-        // ---- the warp's four tiles, from shared ------------------------------------------
-        //
-        // Two A fragments and two B fragments feed FOUR mma instructions. That ratio is the
-        // second half of the win: the naive lowering issues two fragment loads per mma.
-        for (int i = 0; i < WarpTiles; i++)
-        {
-            string rowOffset = NextR(), bytes = NextRd(), addr = NextRd();
-            L($"mad.lo.u32 {rowOffset}, %r5, {I(WarpTiles * 16 * BlockTileK)}, {I(i * 16 * BlockTileK)};");
-            L($"mul.wide.u32 {bytes}, {rowOffset}, 2;");
-            L($"add.u64 {addr}, %rd3, {bytes};");
-            L($"wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {Fragment("%fa", i * FragmentRegisters)}, [{addr}], {I(BlockTileK)};");
-        }
-
-        for (int j = 0; j < WarpTiles; j++)
-        {
-            string colOffset = NextR(), bytes = NextRd(), addr = NextRd();
-            L($"mad.lo.u32 {colOffset}, %r6, {I(WarpTiles * 16)}, {I(j * 16)};");
-            L($"mul.wide.u32 {bytes}, {colOffset}, 2;");
-            L($"add.u64 {addr}, %rd4, {bytes};");
-            L($"wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 {Fragment("%fb", j * FragmentRegisters)}, [{addr}], {I(BlockTileN)};");
-        }
-
-        for (int i = 0; i < WarpTiles; i++)
-            for (int j = 0; j < WarpTiles; j++)
+            // Two bodies per iteration so the buffer index is a compile-time constant and the
+            // shared addresses stay immediate offsets rather than computed ones.
+            for (int half = 0; half < 2; half++)
             {
-                int t = i * WarpTiles + j;
-                L($"wmma.mma.sync.aligned.row.row.m16n16k16.f32.f32 " +
-                  $"{Fragment("%fc", t * FragmentRegisters)}, {Fragment("%fa", i * FragmentRegisters)}, " +
-                  $"{Fragment("%fb", j * FragmentRegisters)}, {Fragment("%fc", t * FragmentRegisters)};");
-                MmaInstructions++;
+                int current = half, next = 1 - half;
+
+                // The final body's prefetch targets step `steps`, which is past the end of A's
+                // row. Predicating it keeps the read inside the allocation; the stale register
+                // it then stores is written to a buffer the loop never reads again.
+                string guard = NextP();
+                L($"setp.lt.u32 {guard}, %r10, {I(steps)};");
+
+                prefetch.Clear();
+                prefetch.AddRange(EmitSlabLoad(aGlobalOffset, bGlobalOffset, guard));
+                EmitAdvance(plan);
+                L("add.u32 %r10, %r10, 1;");
+
+                EmitComputeStep(spec, plan, warpAOffset, warpBOffset, current);
+
+                EmitSlabStore(prefetch, aSharedOffset, bSharedOffset, next);
+                L("bar.sync 0;");
+                LoopBarriers++;
             }
 
-        // THE SECOND BARRIER IS NOT OPTIONAL. Without it a fast warp begins overwriting the
-        // slabs for step k+1 while a slow one is still reading step k out of them -- which
-        // produces plausible magnitudes and a different answer per run.
-        L("bar.sync 0;");
-
-        L($"add.u64 %rd6, %rd6, {I(BlockTileK * 2)};        // A advances 16 columns");
-        L($"add.u64 %rd8, %rd8, {I(BlockTileK * plan.N * 2)};   // B advances 16 rows");
-        L("add.u32 %r9, %r9, 1;");
-        L($"setp.lt.u32 %p1, %r9, {I(steps)};");
-        L("@%p1 bra KLOOP;");
+            L("add.u32 %r9, %r9, 1;");
+            L($"setp.lt.u32 %p1, %r9, {I(steps / 2)};");
+            L("@%p1 bra KLOOP;");
+        }
 
         // ---- epilogue and store ----------------------------------------------------------
         if (spec.Activation != CodegenActivationKind.None)
@@ -304,11 +392,11 @@ public sealed partial class PtxTensorCoreEmitter
                 int t = i * WarpTiles + j;
                 string row = NextR(), col = NextR(), off = NextR();
 
-                L($"mad.lo.u32 {row}, %r2, {I(BlockTileM)}, 0;");
+                L($"mul.lo.u32 {row}, %r2, {I(BlockTileM)};");
                 L($"mad.lo.u32 {row}, %r5, {I(WarpTiles * 16)}, {row};");
                 L($"add.u32 {row}, {row}, {I(i * 16)};");
 
-                L($"mad.lo.u32 {col}, %r3, {I(BlockTileN)}, 0;");
+                L($"mul.lo.u32 {col}, %r3, {I(BlockTileN)};");
                 L($"mad.lo.u32 {col}, %r6, {I(WarpTiles * 16)}, {col};");
                 L($"add.u32 {col}, {col}, {I(j * 16)};");
 
@@ -323,8 +411,8 @@ public sealed partial class PtxTensorCoreEmitter
 
         _sb.Append("END:\n    ret;\n}\n");
 
-        header.Append("    .shared .align 16 .b8 stage[").Append(I(StagedSharedBytes)).Append("];\n")
-              .Append("    .reg .pred   %p<8>;\n")
+        header.Append("    .shared .align 16 .b8 stage[").Append(I(SharedMemoryBytes)).Append("];\n")
+              .Append("    .reg .pred   %p<").Append(I(_pred + 8)).Append(">;\n")
               .Append("    .reg .b32    %r<").Append(I(_reg + 8)).Append(">;\n")
               .Append("    .reg .f32    %f<40>;\n")
               .Append("    .reg .b64    %rd<").Append(I(_reg64 + 8)).Append(">;\n")
@@ -335,6 +423,102 @@ public sealed partial class PtxTensorCoreEmitter
               .Append(_sb);
 
         return header.ToString();
+    }
+
+    /// <summary>
+    /// Issues the global reads for one K step into registers, optionally predicated.
+    /// </summary>
+    /// <remarks>
+    /// Loading into registers and storing to shared LATER is what the whole double-buffered
+    /// form turns on: the reads are issued before the arithmetic they overlap with, and only
+    /// the store has to wait.
+    /// </remarks>
+    private string[] EmitSlabLoad(string[] aGlobalOffset, string[] bGlobalOffset, string? guard)
+    {
+        var regs = new string[AWordsPerThread + BWordsPerThread];
+
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            string addr = NextRd();
+            regs[w] = NextR();
+            L($"add.u64 {addr}, %rd6, {aGlobalOffset[w]};");
+            if (guard is null) L($"ld.global.nc.u32 {regs[w]}, [{addr}];");
+            else L($"@{guard} ld.global.nc.u32 {regs[w]}, [{addr}];");
+        }
+
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            string addr = NextRd();
+            regs[AWordsPerThread + w] = NextR();
+            L($"add.u64 {addr}, %rd8, {bGlobalOffset[w]};");
+            if (guard is null) L($"ld.global.nc.u32 {regs[AWordsPerThread + w]}, [{addr}];");
+            else L($"@{guard} ld.global.nc.u32 {regs[AWordsPerThread + w]}, [{addr}];");
+        }
+
+        return regs;
+    }
+
+    /// <summary>Writes staged registers into one of the shared buffers.</summary>
+    private void EmitSlabStore(
+        IReadOnlyList<string> regs, string[] aSharedOffset, string[] bSharedOffset, int buffer)
+    {
+        int bufferBase = buffer * StageBufferBytes;
+
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            string addr = NextRd();
+            L($"add.u64 {addr}, %rd3, {aSharedOffset[w]};");
+            L($"st.shared.u32 [{addr}+{I(bufferBase)}], {regs[w]};");
+        }
+
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            string addr = NextRd();
+            L($"add.u64 {addr}, %rd3, {bSharedOffset[w]};");
+            L($"st.shared.u32 [{addr}+{I(bufferBase + BSlabOffset)}], {regs[AWordsPerThread + w]};");
+        }
+    }
+
+    /// <summary>Loads this warp's fragments from a buffer and issues its four mma instructions.</summary>
+    private void EmitComputeStep(
+        CodegenKernelSpec spec, Plan plan, string warpAOffset, string warpBOffset, int buffer)
+    {
+        int bufferBase = buffer * StageBufferBytes;
+
+        for (int i = 0; i < WarpTiles; i++)
+        {
+            string addr = NextRd();
+            L($"add.u64 {addr}, %rd3, {warpAOffset};");
+            L($"wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " +
+              $"{Fragment("%fa", i * FragmentRegisters)}, " +
+              $"[{addr}+{I(bufferBase + i * 16 * BlockTileK * 2)}], {I(BlockTileK)};");
+        }
+
+        for (int j = 0; j < WarpTiles; j++)
+        {
+            string addr = NextRd();
+            L($"add.u64 {addr}, %rd3, {warpBOffset};");
+            L($"wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 " +
+              $"{Fragment("%fb", j * FragmentRegisters)}, " +
+              $"[{addr}+{I(bufferBase + BSlabOffset + j * 16 * 2)}], {I(BlockTileN)};");
+        }
+
+        for (int i = 0; i < WarpTiles; i++)
+            for (int j = 0; j < WarpTiles; j++)
+            {
+                int t = i * WarpTiles + j;
+                L($"wmma.mma.sync.aligned.row.row.m16n16k16.f32.f32 " +
+                  $"{Fragment("%fc", t * FragmentRegisters)}, {Fragment("%fa", i * FragmentRegisters)}, " +
+                  $"{Fragment("%fb", j * FragmentRegisters)}, {Fragment("%fc", t * FragmentRegisters)};");
+                MmaInstructions++;
+            }
+    }
+
+    /// <summary>Advances the global slab pointers by one K step.</summary>
+    private void EmitAdvance(Plan plan)
+    {
+        L($"add.u64 %rd6, %rd6, {I(BlockTileK * 2)};            // A advances 16 columns");
+        L($"add.u64 %rd8, %rd8, {I(BlockTileK * plan.N * 2)};   // B advances 16 rows");
     }
 
     /// <summary>A fragment register list starting at <paramref name="start"/>.</summary>
@@ -355,10 +539,16 @@ public sealed partial class PtxTensorCoreEmitter
     /// <summary>First freely allocatable %rd.</summary>
     private const int FixedRegisters64 = 10;
 
+    /// <summary>First freely allocatable %p.</summary>
+    private const int FixedPredicates = 4;
+
     private int _reg = FixedRegisters;
     private int _reg64 = FixedRegisters64;
+    private int _pred = FixedPredicates;
 
     private string NextR() => "%r" + (_reg++).ToString(CultureInfo.InvariantCulture);
 
     private string NextRd() => "%rd" + (_reg64++).ToString(CultureInfo.InvariantCulture);
+
+    private string NextP() => "%p" + (_pred++).ToString(CultureInfo.InvariantCulture);
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
@@ -1,0 +1,364 @@
+// Copyright (c) AiDotNet. All rights reserved.
+//
+// Shared-memory staged tensor-core GEMM.
+//
+// The naive lowering gives one warp one 16x16 output tile and lets it stream its own operand
+// bands straight from global. That measured 11.8 TFLOP/s at 2048^3 and then COLLAPSED to 3.0
+// at 4096^3, against cuBLAS holding 57.6 -- and the collapse is the whole argument for this
+// file. Total operand traffic there is O(M*N*K), because nothing is shared between the warps
+// that need the same bands; once the reused bands outgrow L2 every warp goes to DRAM.
+//
+// Here a BLOCK of four warps owns a 64x64 output tile and stages the 64x16 slab of A and the
+// 16x64 slab of B into shared memory once per K step. Each element of A is then fetched from
+// global once per block rather than once per warp:
+//
+//   naive    per 16x16 tile: 16K halves of A + 16K of B  ->  M*N*K/8   halves total
+//   staged   per 64x64 tile: 64K halves of A + 64K of B  ->  M*N*K/32  halves total
+//
+// A factor of four, and the same factor again in fragment loads: a warp loads two A fragments
+// and two B fragments per K step and issues FOUR mma instructions from them, instead of two
+// loads per mma.
+//
+// NOTE ON THE LEVER ITSELF. Shared-memory staging was tried on dense 3x3 convolution earlier
+// in this campaign and REFUTED -- it raised L1 from 64.08% to 77.45%, because on NVIDIA
+// hardware shared memory IS L1TEX, so ld.shared is counted by the very metric it was meant to
+// relieve. That lever died because `mio_throttle` sat at 3.03%: the load pipe was never that
+// kernel's bottleneck. The justification here is different in kind and does not rest on a
+// throughput percentage at all -- throughput FALLS FOURFOLD when the working set outgrows L2,
+// which is a locality statement no stall counter is needed to read.
+
+using System;
+using System.Globalization;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.Ir;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
+
+public sealed partial class PtxTensorCoreEmitter
+{
+    /// <summary>Output rows a block computes.</summary>
+    public const int BlockTileM = 64;
+
+    /// <summary>Output columns a block computes.</summary>
+    public const int BlockTileN = 64;
+
+    /// <summary>Contraction depth staged per step.</summary>
+    public const int BlockTileK = 16;
+
+    /// <summary>Warps per staged block. Four, arranged 2x2 over the block tile.</summary>
+    public const int StagedWarps = 4;
+
+    /// <summary>wmma tiles a warp owns along each axis (its quadrant is 32x32).</summary>
+    private const int WarpTiles = 2;
+
+    /// <summary>Bytes of shared memory a staged block reserves.</summary>
+    public const int StagedSharedBytes = (BlockTileM * BlockTileK + BlockTileK * BlockTileN) * 2;
+
+    /// <summary>Whether the last emission used the staged lowering.</summary>
+    public bool Staged { get; private set; }
+
+    /// <summary>Shared-memory bytes the last emission requires.</summary>
+    public int SharedMemoryBytes { get; private set; }
+
+    /// <summary>
+    /// Whether a plan can take the staged lowering, and if not, why not.
+    /// </summary>
+    /// <remarks>
+    /// The restrictions are all about the cooperative load being a clean, aligned, whole-slab
+    /// copy. A partial block tile would need per-thread bounds tests inside the staging loop,
+    /// which is a different kernel rather than a tweak to this one; a transposed B would need
+    /// its slab gathered column-wise instead of copied. Both fall back to the naive path,
+    /// which is correct at every shape.
+    /// </remarks>
+    public static bool CanStage(Plan plan, out string reason)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (!plan.ARowMajor || !plan.BRowMajor)
+        {
+            reason = "staging copies whole row-major slabs; a transposed operand would have " +
+                "to be gathered column-wise";
+            return false;
+        }
+
+        if (plan.M % BlockTileM != 0 || plan.N % BlockTileN != 0)
+        {
+            reason = "the staged block tile is " + BlockTileM + "x" + BlockTileN +
+                " and this output is " + plan.M + "x" + plan.N +
+                ", which is not a whole number of them";
+            return false;
+        }
+
+        if (plan.K % BlockTileK != 0)
+        {
+            reason = "the staged step is " + BlockTileK + " deep and K is " + plan.K;
+            return false;
+        }
+
+        reason = "eligible";
+        return true;
+    }
+
+    /// <summary>Blocks a staged plan launches.</summary>
+    public static int StagedBlockCount(Plan plan) =>
+        plan is null ? throw new ArgumentNullException(nameof(plan))
+                     : (plan.M / BlockTileM) * (plan.N / BlockTileN);
+
+    /// <summary>Emits the staged kernel.</summary>
+    private string EmitStaged(CodegenKernelSpec spec, Plan plan, int computeMajor, int computeMinor)
+    {
+        int aIndex = spec.ProductInputs[0], bIndex = spec.ProductInputs[1];
+        int outIndex = spec.Inputs.Count;
+
+        Staged = true;
+        SharedMemoryBytes = StagedSharedBytes;
+        MmaInstructions = 0;
+
+        int tilesN = plan.N / BlockTileN;
+        int steps = plan.K / BlockTileK;
+
+        // Shared slab geometry, in u32 words, which is what the cooperative copy moves.
+        const int AWords = BlockTileM * BlockTileK / 2;      // 512
+        const int BWords = BlockTileK * BlockTileN / 2;      // 512
+        const int Threads = StagedWarps * 32;                // 128
+        const int AWordsPerThread = AWords / Threads;        // 4
+        const int BWordsPerThread = BWords / Threads;        // 4
+        const int AWordsPerRow = BlockTileK / 2;             // 8
+        const int BWordsPerRow = BlockTileN / 2;             // 32
+
+        var header = new System.Text.StringBuilder();
+        header.Append(".version 7.1\n")
+              .Append(".target sm_").Append(I(computeMajor)).Append(I(computeMinor)).Append('\n')
+              .Append(".address_size 64\n\n")
+              .Append("// generated by PtxTensorCoreEmitter -- STAGED wmma, ")
+              .Append(I(BlockTileM)).Append('x').Append(I(BlockTileN)).Append('x')
+              .Append(I(BlockTileK)).Append(" block tile, ").Append(I(StagedWarps)).Append(" warps\n")
+              .Append("// ").Append(spec.Describe().Replace("\n", "\n// ")).Append('\n')
+              .Append(".visible .entry ").Append(spec.Name).Append("(\n");
+
+        int paramCount = spec.ParameterCount;
+        for (int i = 0; i < paramCount; i++)
+            header.Append("    .param .u64 p").Append(I(i)).Append(i == paramCount - 1 ? "\n" : ",\n");
+        header.Append(")\n{\n");
+
+        // THE BODY IS BUILT FIRST and the register declarations sized from it, because a
+        // literal bound is a silent ceiling rather than a generous one: the affine emitter
+        // shipped %p<256> until coarsening pushed one past it, and ptxas reported that as
+        // "Arguments mismatch for instruction 'setp'" -- an undeclared register, not a
+        // malformed instruction.
+        _sb.Clear();
+        _reg = FixedRegisters;
+        _reg64 = FixedRegisters64;
+
+        L($"ld.param.u64 %rd0, [p{I(aIndex)}];");
+        L($"ld.param.u64 %rd1, [p{I(bIndex)}];");
+        L($"ld.param.u64 %rd2, [p{I(outIndex)}];");
+
+        L("mov.u32 %r0, %ctaid.x;");
+        L("mov.u32 %r1, %tid.x;");
+        L($"div.u32 %r2, %r0, {I(tilesN)};        // block row");
+        L($"rem.u32 %r3, %r0, {I(tilesN)};        // block column");
+        L("shr.u32 %r4, %r1, 5;                   // warp id 0..3");
+        L("shr.u32 %r5, %r4, 1;                   // warp row 0..1");
+        L("and.b32 %r6, %r4, 1;                   // warp column 0..1");
+
+        // Shared base addresses. sB follows sA.
+        L("mov.u64 %rd3, stage;");
+        L($"add.u64 %rd4, %rd3, {I(AWords * 4)};   // sB");
+
+        // Global slab origins for this block, in ELEMENTS, before the K walk advances them.
+        L($"mul.lo.u32 %r7, %r2, {I(BlockTileM * plan.K)};    // A slab origin");
+        L($"mul.lo.u32 %r8, %r3, {I(BlockTileN)};             // B slab origin");
+        L("mul.wide.u32 %rd5, %r7, 2;");
+        L("add.u64 %rd6, %rd0, %rd5;              // A slab pointer");
+        L("mul.wide.u32 %rd7, %r8, 2;");
+        L("add.u64 %rd8, %rd1, %rd7;              // B slab pointer");
+
+        // THE COOPERATIVE COPY'S PER-THREAD ADDRESSES ARE LOOP-INVARIANT, so they are computed
+        // once here rather than per K step. Each thread moves AWordsPerThread words of A and
+        // BWordsPerThread of B, strided by the block size so the accesses stay coalesced.
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            int word = w * Threads;
+            string wordIndex = $"%r{I(10 + w)}";
+            L($"add.u32 {wordIndex}, %r1, {I(word)};");
+        }
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            int word = w * Threads;
+            string wordIndex = $"%r{I(14 + w)}";
+            L($"add.u32 {wordIndex}, %r1, {I(word)};");
+        }
+
+        // Accumulators: one fragment per (i, j) quadrant tile.
+        for (int t = 0; t < WarpTiles * WarpTiles; t++)
+            for (int f = 0; f < FragmentRegisters; f++)
+                L($"mov.f32 %fc{I(t * FragmentRegisters + f)}, 0f00000000;");
+
+        L("mov.u32 %r9, 0;                        // k step");
+        _sb.Append("KLOOP:\n");
+
+        // ---- stage A: 64 rows x 16 halves, row r at global (slabRow + r)*K + k0 -----------
+        for (int w = 0; w < AWordsPerThread; w++)
+        {
+            string wordIndex = $"%r{I(10 + w)}";
+            string row = NextR(), col = NextR(), off = NextR();
+            L($"div.u32 {row}, {wordIndex}, {I(AWordsPerRow)};");
+            L($"rem.u32 {col}, {wordIndex}, {I(AWordsPerRow)};");
+            L($"mul.lo.u32 {off}, {row}, {I(plan.K / 2)};   // row stride in words");
+            L($"add.u32 {off}, {off}, {col};");
+
+            string bytes = NextRd(), addr = NextRd(), data = NextR();
+            L($"mul.wide.u32 {bytes}, {off}, 4;");
+            L($"add.u64 {addr}, %rd6, {bytes};");
+            L($"ld.global.nc.u32 {data}, [{addr}];");
+
+            string sBytes = NextRd(), sAddr = NextRd();
+            L($"mul.wide.u32 {sBytes}, {wordIndex}, 4;");
+            L($"add.u64 {sAddr}, %rd3, {sBytes};");
+            L($"st.shared.u32 [{sAddr}], {data};");
+        }
+
+        // ---- stage B: 16 rows x 64 halves, row r at global (k0 + r)*N + slabCol ----------
+        for (int w = 0; w < BWordsPerThread; w++)
+        {
+            string wordIndex = $"%r{I(14 + w)}";
+            string row = NextR(), col = NextR(), off = NextR();
+            L($"div.u32 {row}, {wordIndex}, {I(BWordsPerRow)};");
+            L($"rem.u32 {col}, {wordIndex}, {I(BWordsPerRow)};");
+            L($"mul.lo.u32 {off}, {row}, {I(plan.N / 2)};");
+            L($"add.u32 {off}, {off}, {col};");
+
+            string bytes = NextRd(), addr = NextRd(), data = NextR();
+            L($"mul.wide.u32 {bytes}, {off}, 4;");
+            L($"add.u64 {addr}, %rd8, {bytes};");
+            L($"ld.global.nc.u32 {data}, [{addr}];");
+
+            string sBytes = NextRd(), sAddr = NextRd();
+            L($"mul.wide.u32 {sBytes}, {wordIndex}, 4;");
+            L($"add.u64 {sAddr}, %rd4, {sBytes};");
+            L($"st.shared.u32 [{sAddr}], {data};");
+        }
+
+        L("bar.sync 0;");
+
+        // ---- the warp's four tiles, from shared ------------------------------------------
+        //
+        // Two A fragments and two B fragments feed FOUR mma instructions. That ratio is the
+        // second half of the win: the naive lowering issues two fragment loads per mma.
+        for (int i = 0; i < WarpTiles; i++)
+        {
+            string rowOffset = NextR(), bytes = NextRd(), addr = NextRd();
+            L($"mad.lo.u32 {rowOffset}, %r5, {I(WarpTiles * 16 * BlockTileK)}, {I(i * 16 * BlockTileK)};");
+            L($"mul.wide.u32 {bytes}, {rowOffset}, 2;");
+            L($"add.u64 {addr}, %rd3, {bytes};");
+            L($"wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {Fragment("%fa", i * FragmentRegisters)}, [{addr}], {I(BlockTileK)};");
+        }
+
+        for (int j = 0; j < WarpTiles; j++)
+        {
+            string colOffset = NextR(), bytes = NextRd(), addr = NextRd();
+            L($"mad.lo.u32 {colOffset}, %r6, {I(WarpTiles * 16)}, {I(j * 16)};");
+            L($"mul.wide.u32 {bytes}, {colOffset}, 2;");
+            L($"add.u64 {addr}, %rd4, {bytes};");
+            L($"wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 {Fragment("%fb", j * FragmentRegisters)}, [{addr}], {I(BlockTileN)};");
+        }
+
+        for (int i = 0; i < WarpTiles; i++)
+            for (int j = 0; j < WarpTiles; j++)
+            {
+                int t = i * WarpTiles + j;
+                L($"wmma.mma.sync.aligned.row.row.m16n16k16.f32.f32 " +
+                  $"{Fragment("%fc", t * FragmentRegisters)}, {Fragment("%fa", i * FragmentRegisters)}, " +
+                  $"{Fragment("%fb", j * FragmentRegisters)}, {Fragment("%fc", t * FragmentRegisters)};");
+                MmaInstructions++;
+            }
+
+        // THE SECOND BARRIER IS NOT OPTIONAL. Without it a fast warp begins overwriting the
+        // slabs for step k+1 while a slow one is still reading step k out of them -- which
+        // produces plausible magnitudes and a different answer per run.
+        L("bar.sync 0;");
+
+        L($"add.u64 %rd6, %rd6, {I(BlockTileK * 2)};        // A advances 16 columns");
+        L($"add.u64 %rd8, %rd8, {I(BlockTileK * plan.N * 2)};   // B advances 16 rows");
+        L("add.u32 %r9, %r9, 1;");
+        L($"setp.lt.u32 %p1, %r9, {I(steps)};");
+        L("@%p1 bra KLOOP;");
+
+        // ---- epilogue and store ----------------------------------------------------------
+        if (spec.Activation != CodegenActivationKind.None)
+            for (int t = 0; t < WarpTiles * WarpTiles; t++)
+                for (int f = 0; f < FragmentRegisters; f++)
+                    EmitActivation(spec.Activation, $"%fc{I(t * FragmentRegisters + f)}");
+
+        if (spec.ReduceScale != 1.0)
+            for (int t = 0; t < WarpTiles * WarpTiles; t++)
+                for (int f = 0; f < FragmentRegisters; f++)
+                {
+                    string reg = $"%fc{I(t * FragmentRegisters + f)}";
+                    L($"mul.f32 {reg}, {reg}, {F32(spec.ReduceScale)};");
+                }
+
+        for (int i = 0; i < WarpTiles; i++)
+            for (int j = 0; j < WarpTiles; j++)
+            {
+                int t = i * WarpTiles + j;
+                string row = NextR(), col = NextR(), off = NextR();
+
+                L($"mad.lo.u32 {row}, %r2, {I(BlockTileM)}, 0;");
+                L($"mad.lo.u32 {row}, %r5, {I(WarpTiles * 16)}, {row};");
+                L($"add.u32 {row}, {row}, {I(i * 16)};");
+
+                L($"mad.lo.u32 {col}, %r3, {I(BlockTileN)}, 0;");
+                L($"mad.lo.u32 {col}, %r6, {I(WarpTiles * 16)}, {col};");
+                L($"add.u32 {col}, {col}, {I(j * 16)};");
+
+                L($"mad.lo.u32 {off}, {row}, {I(plan.N)}, {col};");
+
+                string bytes = NextRd(), addr = NextRd();
+                L($"mul.wide.u32 {bytes}, {off}, 4;");
+                L($"add.u64 {addr}, %rd2, {bytes};");
+                L($"wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [{addr}], " +
+                  $"{Fragment("%fc", t * FragmentRegisters)}, {I(plan.N)};");
+            }
+
+        _sb.Append("END:\n    ret;\n}\n");
+
+        header.Append("    .shared .align 16 .b8 stage[").Append(I(StagedSharedBytes)).Append("];\n")
+              .Append("    .reg .pred   %p<8>;\n")
+              .Append("    .reg .b32    %r<").Append(I(_reg + 8)).Append(">;\n")
+              .Append("    .reg .f32    %f<40>;\n")
+              .Append("    .reg .b64    %rd<").Append(I(_reg64 + 8)).Append(">;\n")
+              .Append("    .reg .b32    %fa<").Append(I(WarpTiles * FragmentRegisters)).Append(">;\n")
+              .Append("    .reg .b32    %fb<").Append(I(WarpTiles * FragmentRegisters)).Append(">;\n")
+              .Append("    .reg .f32    %fc<")
+              .Append(I(WarpTiles * WarpTiles * FragmentRegisters)).Append(">;\n\n")
+              .Append(_sb);
+
+        return header.ToString();
+    }
+
+    /// <summary>A fragment register list starting at <paramref name="start"/>.</summary>
+    private static string Fragment(string prefix, int start)
+    {
+        var sb = new System.Text.StringBuilder("{");
+        for (int f = 0; f < FragmentRegisters; f++)
+        {
+            if (f > 0) sb.Append(", ");
+            sb.Append(prefix).Append((start + f).ToString(CultureInfo.InvariantCulture));
+        }
+        return sb.Append('}').ToString();
+    }
+
+    /// <summary>First freely allocatable %r; below this the registers have fixed roles.</summary>
+    private const int FixedRegisters = 20;
+
+    /// <summary>First freely allocatable %rd.</summary>
+    private const int FixedRegisters64 = 10;
+
+    private int _reg = FixedRegisters;
+    private int _reg64 = FixedRegisters64;
+
+    private string NextR() => "%r" + (_reg++).ToString(CultureInfo.InvariantCulture);
+
+    private string NextRd() => "%rd" + (_reg64++).ToString(CultureInfo.InvariantCulture);
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
@@ -291,7 +291,12 @@ public sealed partial class PtxTensorCoreEmitter
         _sb.Clear();
         MmaInstructions = 0;
         Staged = false;
+        DoubleBuffered = false;
         SharedMemoryBytes = 0;
+        LoopBarriers = 0;
+        _reg = FixedRegisters;
+        _reg64 = FixedRegisters64;
+        _pred = FixedPredicates;
 
         // The staged lowering is preferred wherever it applies. It is not a tuning option:
         // the naive one moves O(M*N*K) operand bytes and collapses from 11.8 to 3.0 TFLOP/s

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
@@ -266,38 +266,37 @@ public sealed partial class PtxTensorCoreEmitter
     public int BlockThreads => WarpsPerBlock * 32;
 
     /// <summary>
-    /// Picks the largest warp tile whose block tile divides the output, unless the caller
-    /// pinned one.
+    /// Picks the warp tile for a plan: the measured winner for that shape, else the fallback
+    /// ladder. Skipped when the caller pinned one.
     /// </summary>
     /// <remarks>
-    /// A LADDER DERIVED FROM MEASUREMENT, not from a cost model. `--warp-tile-sweep` timed
-    /// every candidate at four shapes on an idle GPU, and the bigger tile won wherever it
-    /// fits, by 1.28x at 2048^3 and 1.32x at 4096^3, for the reason the profile gave: L1TEX
-    /// falls from 92.34% to 61.38% and the tensor pipe rises from 26.79% to 35.74%.
-    ///
-    /// It is not optimal everywhere. At 1024^3 the measured best was 4x2 at 71.9us against
-    /// 4x4's 75.0us -- this rule gives up 4% there. Closing that needs a per-shape autotune
-    /// pass (`--kernel-autotune` already exists for the affine kernels), not a cleverer rule:
-    /// a static model picked lowerings four times on this branch and lost to the hardware
+    /// See <see cref="TensorCoreWarpTileCatalog"/>. The measured shapes are recorded rather
+    /// than re-derived, because the obvious rule -- largest tile that fits -- is right at
+    /// 2048^3 and 4096^3 and WRONG at 1024^3, where 4x2 measured 71.9us against 4x4's 75.0us.
+    /// A static model picked lowerings four times on this branch and lost to the hardware
     /// every time it was checked.
     /// </remarks>
     private void SelectWarpTile(Plan plan)
     {
         if (PinWarpTile) return;
 
-        foreach (var (m, n) in new[] { (4, 4), (4, 2), (2, 4), (2, 2) })
-        {
-            if (plan.M % (m * 32) == 0 && plan.N % (n * 32) == 0)
-            {
-                WarpTilesM = m;
-                WarpTilesN = n;
-                return;
-            }
-        }
+        var choice = TensorCoreWarpTileCatalog.Select(plan.M, plan.N, plan.K, out bool measured);
 
-        WarpTilesM = 2;
-        WarpTilesN = 2;
+        WarpTilesM = choice.TileM;
+        WarpTilesN = choice.TileN;
+        EnableAsyncCopy = choice.AsyncCopy;
+        WarpTileWasMeasured = measured;
     }
+
+    /// <summary>
+    /// Whether the warp tile came from a measurement rather than the fallback ladder.
+    /// </summary>
+    /// <remarks>
+    /// Reported because a cache miss is otherwise indistinguishable from "the modelled choice
+    /// already won" -- which is exactly how an earlier autotune cache on this campaign hid
+    /// that every depthwise kernel was running untuned.
+    /// </remarks>
+    public bool WarpTileWasMeasured { get; private set; }
 
     /// <summary>
     /// Keeps the caller's <see cref="WarpTilesM"/>/<see cref="WarpTilesN"/> instead of
@@ -336,6 +335,7 @@ public sealed partial class PtxTensorCoreEmitter
         MmaInstructions = 0;
         Staged = false;
         DoubleBuffered = false;
+        AsyncCopy = false;
         SharedMemoryBytes = 0;
         LoopBarriers = 0;
         _reg = FixedRegisters;

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
@@ -44,7 +44,7 @@ namespace AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
 /// accumulator fragment while it is still in registers.
 /// </para>
 /// </remarks>
-public sealed class PtxTensorCoreEmitter
+public sealed partial class PtxTensorCoreEmitter
 {
     /// <summary>The <c>wmma</c> tile this emitter uses. m16n16k16 is the shape every
     /// tensor-core generation from sm_70 onward supports for f16 multiplicands.</summary>
@@ -61,6 +61,15 @@ public sealed class PtxTensorCoreEmitter
 
     /// <summary>Warps per block. Four keeps a block at 128 threads.</summary>
     public int WarpsPerBlock { get; set; } = 4;
+
+    /// <summary>
+    /// Whether to use the shared-memory staged lowering where the shape allows it.
+    /// </summary>
+    /// <remarks>
+    /// Settable so the two lowerings can be measured against each other on the same shape.
+    /// Turning it off is a measurement device, not a supported configuration.
+    /// </remarks>
+    public bool EnableStaging { get; set; } = true;
 
     private readonly StringBuilder _sb = new();
 
@@ -256,10 +265,20 @@ public sealed class PtxTensorCoreEmitter
     /// <summary>Threads a block launches: one warp per output tile, <see cref="WarpsPerBlock"/> per block.</summary>
     public int BlockThreads => WarpsPerBlock * 32;
 
-    /// <summary>Blocks needed to cover a plan.</summary>
-    public int BlockCount(Plan plan) =>
-        plan is null ? throw new ArgumentNullException(nameof(plan))
-                     : (plan.TileCount + WarpsPerBlock - 1) / WarpsPerBlock;
+    /// <summary>Blocks needed to cover a plan, under the lowering this emitter will pick.</summary>
+    /// <remarks>
+    /// THE TWO LOWERINGS NEED DIFFERENT GRIDS and it is not a small difference: staged, four
+    /// warps cover sixteen 16x16 tiles rather than four, so a 64x64 output is ONE block
+    /// staged and FOUR naive. Launching the staged kernel on the naive grid would run it four
+    /// times over, each pass re-accumulating into the same output.
+    /// </remarks>
+    public int BlockCount(Plan plan)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (EnableStaging && CanStage(plan, out _)) return StagedBlockCount(plan);
+        return (plan.TileCount + WarpsPerBlock - 1) / WarpsPerBlock;
+    }
 
     /// <summary>Emits the tensor-core kernel for a spec <see cref="TryPlan"/> accepted.</summary>
     public string Emit(CodegenKernelSpec spec, int computeMajor, int computeMinor)
@@ -271,6 +290,15 @@ public sealed class PtxTensorCoreEmitter
         var plan = planOrNull!;
         _sb.Clear();
         MmaInstructions = 0;
+        Staged = false;
+        SharedMemoryBytes = 0;
+
+        // The staged lowering is preferred wherever it applies. It is not a tuning option:
+        // the naive one moves O(M*N*K) operand bytes and collapses from 11.8 to 3.0 TFLOP/s
+        // when the reused bands outgrow L2. Shapes it cannot cover fall back, and the naive
+        // path stays correct at every shape.
+        if (EnableStaging && CanStage(plan, out _))
+            return EmitStaged(spec, plan, computeMajor, computeMinor);
 
         int aIndex = spec.ProductInputs[0], bIndex = spec.ProductInputs[1];
         int outIndex = spec.Inputs.Count;

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
@@ -265,6 +265,46 @@ public sealed partial class PtxTensorCoreEmitter
     /// <summary>Threads a block launches: one warp per output tile, <see cref="WarpsPerBlock"/> per block.</summary>
     public int BlockThreads => WarpsPerBlock * 32;
 
+    /// <summary>
+    /// Picks the largest warp tile whose block tile divides the output, unless the caller
+    /// pinned one.
+    /// </summary>
+    /// <remarks>
+    /// A LADDER DERIVED FROM MEASUREMENT, not from a cost model. `--warp-tile-sweep` timed
+    /// every candidate at four shapes on an idle GPU, and the bigger tile won wherever it
+    /// fits, by 1.28x at 2048^3 and 1.32x at 4096^3, for the reason the profile gave: L1TEX
+    /// falls from 92.34% to 61.38% and the tensor pipe rises from 26.79% to 35.74%.
+    ///
+    /// It is not optimal everywhere. At 1024^3 the measured best was 4x2 at 71.9us against
+    /// 4x4's 75.0us -- this rule gives up 4% there. Closing that needs a per-shape autotune
+    /// pass (`--kernel-autotune` already exists for the affine kernels), not a cleverer rule:
+    /// a static model picked lowerings four times on this branch and lost to the hardware
+    /// every time it was checked.
+    /// </remarks>
+    private void SelectWarpTile(Plan plan)
+    {
+        if (PinWarpTile) return;
+
+        foreach (var (m, n) in new[] { (4, 4), (4, 2), (2, 4), (2, 2) })
+        {
+            if (plan.M % (m * 32) == 0 && plan.N % (n * 32) == 0)
+            {
+                WarpTilesM = m;
+                WarpTilesN = n;
+                return;
+            }
+        }
+
+        WarpTilesM = 2;
+        WarpTilesN = 2;
+    }
+
+    /// <summary>
+    /// Keeps the caller's <see cref="WarpTilesM"/>/<see cref="WarpTilesN"/> instead of
+    /// selecting one. Used by the sweep, which is measuring the candidates.
+    /// </summary>
+    public bool PinWarpTile { get; set; }
+
     /// <summary>Blocks needed to cover a plan, under the lowering this emitter will pick.</summary>
     /// <remarks>
     /// THE TWO LOWERINGS NEED DIFFERENT GRIDS and it is not a small difference: staged, four
@@ -276,7 +316,11 @@ public sealed partial class PtxTensorCoreEmitter
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
-        if (EnableStaging && CanStage(plan, out _)) return StagedBlockCount(plan);
+        if (EnableStaging)
+        {
+            SelectWarpTile(plan);
+            if (CanStage(plan, out _)) return StagedBlockCount(plan);
+        }
         return (plan.TileCount + WarpsPerBlock - 1) / WarpsPerBlock;
     }
 
@@ -302,8 +346,12 @@ public sealed partial class PtxTensorCoreEmitter
         // the naive one moves O(M*N*K) operand bytes and collapses from 11.8 to 3.0 TFLOP/s
         // when the reused bands outgrow L2. Shapes it cannot cover fall back, and the naive
         // path stays correct at every shape.
-        if (EnableStaging && CanStage(plan, out _))
-            return EmitStaged(spec, plan, computeMajor, computeMinor);
+        if (EnableStaging)
+        {
+            SelectWarpTile(plan);
+            if (CanStage(plan, out _))
+                return EmitStaged(spec, plan, computeMajor, computeMinor);
+        }
 
         int aIndex = spec.ProductInputs[0], bIndex = spec.ProductInputs[1];
         int outIndex = spec.Inputs.Count;

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/TensorCoreWarpTileCatalog.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/TensorCoreWarpTileCatalog.cs
@@ -1,0 +1,107 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
+
+/// <summary>
+/// Warp tiles measured to be fastest per GEMM shape, with a fallback for shapes never
+/// measured.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because the obvious rule is wrong. "Use the largest tile that fits" is right
+/// at 2048³ and 4096³ and wrong at 1024³, where the measured best was 4x2 at 71.9 us against
+/// 4x4's 75.0 us. A static model picked lowerings four times on branch
+/// <c>agent/direct-ptx-conv-promotion-841</c> and lost to the hardware every time it was
+/// checked, so the shapes that have been measured are recorded as measurements rather than
+/// re-derived from a rule that is known not to hold.
+/// </para>
+/// <para>
+/// KEYED BY SHAPE, and the key is the only thing the lookup uses. An earlier autotune cache
+/// on this campaign was written under a catalog name and read under a spec name -- they differ
+/// for every depthwise entry -- so those kernels silently ran untuned while the cache reported
+/// them tuned. A cache miss is indistinguishable from "the modelled choice already won", which
+/// is why the miss path here is a documented ladder rather than silence.
+/// </para>
+/// <para>
+/// Regenerate with:
+/// <code>
+/// dotnet run --project tests/AiDotNet.Tensors.Benchmarks -c Release -f net10.0 -- --warp-tile-sweep
+/// </code>
+/// on an idle GPU at locked clocks. Every candidate is verified against the fp64 oracle before
+/// it is timed, so an entry here cannot be a tile that computes the wrong answer quickly.
+/// </para>
+/// </remarks>
+public static class TensorCoreWarpTileCatalog
+{
+    /// <summary>Measured winners, keyed by (M, N, K).</summary>
+    /// <remarks>
+    /// Measured on an RTX 3080 (sm_86) at 1770 MHz, idle, best of three, fp16 operands with
+    /// an fp32 accumulator. TFLOP/s for every candidate is in <c>docs/TENSOR_CORES.md</c>.
+    /// </remarks>
+    private static readonly Dictionary<(int M, int N, int K), Choice> Measured =
+        new()
+        {
+            // 2x2 + cp.async at 19.5 us (13.8 TF). The SMALLEST tile wins here, and by a
+            // wide margin -- at this size there is not enough work to amortise a big tile's
+            // occupancy cost. Second best was 4x2 + registers at 28.1 us.
+            [(512, 512, 512)] = new Choice(2, 2, AsyncCopy: true),
+
+            // 4x2 + cp.async at 63.2 us (34.0 TF), against 4x4 + cp.async at 74.5 and
+            // 4x2 + registers at 71.7. The largest tile LOSES here.
+            [(1024, 1024, 1024)] = new Choice(4, 2, AsyncCopy: true),
+
+            // 4x4 + cp.async at 400.2 us (42.9 TF), against 4x2 + cp.async at 422.3.
+            [(2048, 2048, 2048)] = new Choice(4, 4, AsyncCopy: true),
+
+            // 4x2 + cp.async at 2922.7 us (47.0 TF). Note 4x4 + cp.async is 41.6 TF while
+            // 4x4 + REGISTERS is 45.0 -- the staging form and the tile interact, and not
+            // monotonically. No model produced this; the sweep did.
+            [(4096, 4096, 4096)] = new Choice(4, 2, AsyncCopy: true),
+        };
+
+    /// <summary>A measured lowering: the warp tile and the staging form together.</summary>
+    /// <param name="TileM">wmma tiles a warp owns along M.</param>
+    /// <param name="TileN">wmma tiles a warp owns along N.</param>
+    /// <param name="AsyncCopy">Whether staging uses <c>cp.async</c> rather than registers.</param>
+    /// <remarks>
+    /// The two are recorded TOGETHER because they are not independent. At 4096^3 the 4x4 tile
+    /// is faster with register staging (45.0 TF) than with cp.async (41.6 TF), while the 4x2
+    /// tile is much faster with cp.async (47.0 TF) than without (38.4 TF). Choosing them
+    /// separately would pick 4x4 + cp.async, which is the worst of those four.
+    /// </remarks>
+    public readonly record struct Choice(int TileM, int TileN, bool AsyncCopy);
+
+    /// <summary>
+    /// The measured winner for a shape, or the fallback ladder's choice when the shape has
+    /// not been measured.
+    /// </summary>
+    /// <param name="m">Output rows.</param>
+    /// <param name="n">Output columns.</param>
+    /// <param name="k">Contracted extent.</param>
+    /// <param name="measured">True when the answer came from a measurement.</param>
+    public static Choice Select(int m, int n, int k, out bool measured)
+    {
+        if (Measured.TryGetValue((m, n, k), out var winner))
+        {
+            measured = true;
+            return winner;
+        }
+
+        measured = false;
+
+        // THE FALLBACK LADDER, for shapes nobody has measured: the largest tile whose block
+        // tile divides the output, staged with cp.async. cp.async is the right default because
+        // it won at 10 of the 12 measured (shape, tile) pairs, and its two losses were small;
+        // the tile choice is the one that varies, which is what the entries above record.
+        foreach (var (tileM, tileN) in new[] { (4, 2), (4, 4), (2, 4), (2, 2) })
+            if (m % (tileM * 32) == 0 && n % (tileN * 32) == 0)
+                return new Choice(tileM, tileN, AsyncCopy: true);
+
+        return new Choice(2, 2, AsyncCopy: true);
+    }
+
+    /// <summary>Shapes with a measured entry. Exposed so a test can check they are reachable.</summary>
+    public static IEnumerable<(int M, int N, int K)> MeasuredShapes => Measured.Keys;
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -121,6 +121,12 @@ class Program
             return;
         }
 
+        if (args.Length > 0 && args[0] == "--warp-tile-sweep")
+        {
+            WarpTileSweepTool.Run(args.Skip(1).ToArray());
+            return;
+        }
+
         if (args.Length > 0 && args[0] == "--multiout-check")
         {
             MultiOutputCheckTool.Run(args.Skip(1).ToArray());

--- a/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
@@ -43,9 +43,9 @@ internal static class TensorCoreCheckTool
         Console.WriteLine("device sm_{0}{1}", major, minor);
         Console.WriteLine();
         Console.WriteLine(
-            "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9}",
-            "kernel", "elements", "max rel dev", "result", "lowering", "wmma", "scalar",
-            "speedup", "TFLOP/s");
+            "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9} {9,8}",
+            "kernel", "elements", "max rel dev", "result", "lowering", "double", "single",
+            "dbl gain", "TFLOP/s", "scalar");
 
         int passed = 0, failed = 0;
         foreach (var (label, spec, verify) in Cases())
@@ -158,28 +158,30 @@ internal static class TensorCoreCheckTool
             bool ok = !verify || deviation <= tolerance;
 
             long macs = (long)plan.M * plan.N * plan.K;
-            double wmmaUs = 0, scalarUs = 0;
+            double wmmaUs = 0, scalarUs = 0, singleUs = 0;
             if (timed && ok)
             {
                 wmmaUs = TimeIt(runtime, module, fn, pointers, blocks, blockThreads, macs);
+                singleUs = TimeAlternate(runtime, spec, major, minor, pointers, macs, plan);
                 scalarUs = TimeScalar(runtime, spec, major, minor, pointers, macs);
             }
 
             Console.WriteLine(
-                "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9}",
+                "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9} {9,8}",
                 label,
                 outCount.ToString("N0", CultureInfo.InvariantCulture),
                 verify ? deviation.ToString("0.000E+000", CultureInfo.InvariantCulture) : "timing",
                 ok ? (verify ? "PASS" : "-") : "FAIL",
                 emitter.Staged ? "staged" : "naive",
                 wmmaUs > 0 ? wmmaUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
-                scalarUs > 0 ? scalarUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
-                (wmmaUs > 0 && scalarUs > 0)
-                    ? (scalarUs / wmmaUs).ToString("0.00", CultureInfo.InvariantCulture) + "x"
+                singleUs > 0 ? singleUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
+                (wmmaUs > 0 && singleUs > 0)
+                    ? (singleUs / wmmaUs).ToString("0.000", CultureInfo.InvariantCulture) + "x"
                     : "-",
                 wmmaUs > 0
                     ? (2.0 * macs / wmmaUs / 1e6).ToString("0.0", CultureInfo.InvariantCulture)
-                    : "-");
+                    : "-",
+                scalarUs > 0 ? scalarUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-");
 
             return ok;
         }
@@ -192,6 +194,37 @@ internal static class TensorCoreCheckTool
         finally
         {
             foreach (var b in buffers) b.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Times the SAME spec through the OTHER staging form, in the same process and the same
+    /// thermal window.
+    /// </summary>
+    /// <remarks>
+    /// Paired, because the difference being measured is small. Comparing a double-buffered
+    /// run against a single-buffered one taken minutes earlier conflates the lowering with
+    /// whatever the clock and the driver were doing in between, and at a few percent that
+    /// difference decides whether there is a finding at all.
+    /// </remarks>
+    private static double TimeAlternate(
+        DirectPtxRuntime runtime, CodegenKernelSpec spec, int major, int minor,
+        IntPtr[] pointers, long macs, PtxTensorCoreEmitter.Plan plan)
+    {
+        if (!PtxTensorCoreEmitter.CanDoubleBuffer(plan, out _)) return 0;
+
+        try
+        {
+            var single = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
+            string ptx = single.Emit(spec, major, minor);
+            using var module = runtime.LoadModule(ptx);
+            IntPtr fn = module.GetFunction(spec.Name, out _);
+            return TimeIt(runtime, module, fn, pointers,
+                (uint)single.BlockCount(plan), (uint)single.BlockThreads, macs);
+        }
+        catch
+        {
+            return 0;
         }
     }
 

--- a/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
@@ -43,9 +43,9 @@ internal static class TensorCoreCheckTool
         Console.WriteLine("device sm_{0}{1}", major, minor);
         Console.WriteLine();
         Console.WriteLine(
-            "{0,-40} {1,9} {2,12} {3,7} {4,10} {5,10} {6,8} {7,9}",
-            "kernel", "elements", "max rel dev", "result", "wmma", "scalar", "speedup",
-            "TFLOP/s");
+            "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9}",
+            "kernel", "elements", "max rel dev", "result", "lowering", "wmma", "scalar",
+            "speedup", "TFLOP/s");
 
         int passed = 0, failed = 0;
         foreach (var (label, spec, verify) in Cases())
@@ -166,11 +166,12 @@ internal static class TensorCoreCheckTool
             }
 
             Console.WriteLine(
-                "{0,-40} {1,9} {2,12} {3,7} {4,10} {5,10} {6,8} {7,9}",
+                "{0,-40} {1,9} {2,12} {3,7} {4,8} {5,10} {6,10} {7,8} {8,9}",
                 label,
                 outCount.ToString("N0", CultureInfo.InvariantCulture),
                 verify ? deviation.ToString("0.000E+000", CultureInfo.InvariantCulture) : "timing",
                 ok ? (verify ? "PASS" : "-") : "FAIL",
+                emitter.Staged ? "staged" : "naive",
                 wmmaUs > 0 ? wmmaUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
                 scalarUs > 0 ? scalarUs.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
                 (wmmaUs > 0 && scalarUs > 0)

--- a/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/TensorCoreCheckTool.cs
@@ -211,7 +211,7 @@ internal static class TensorCoreCheckTool
         DirectPtxRuntime runtime, CodegenKernelSpec spec, int major, int minor,
         IntPtr[] pointers, long macs, PtxTensorCoreEmitter.Plan plan)
     {
-        if (!PtxTensorCoreEmitter.CanDoubleBuffer(plan, out _)) return 0;
+        if (!new PtxTensorCoreEmitter().CanDoubleBuffer(plan, out _)) return 0;
 
         try
         {

--- a/tests/AiDotNet.Tensors.Benchmarks/WarpTileSweepTool.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/WarpTileSweepTool.cs
@@ -44,6 +44,9 @@ internal static class WarpTileSweepTool
         (4, 4),        // 128x128 block, 0.50 -- and 128 accumulator registers per thread
     };
 
+    /// <summary>Staging forms, swept alongside the tile so the comparison is paired.</summary>
+    private static readonly bool[] AsyncForms = { true, false };
+
     internal static void Run(string[] args)
     {
         using var runtime = new DirectPtxRuntime();
@@ -55,7 +58,7 @@ internal static class WarpTileSweepTool
         Console.WriteLine();
         Console.WriteLine(
             "{0,-16} {1,7} {2,10} {3,7} {4,7} {5,9} {6,12} {7,10} {8,9}",
-            "shape", "tile", "block", "acc reg", "ld/mma", "shared B", "max abs dev", "us", "TFLOP/s");
+            "shape", "tile", "staging", "acc reg", "ld/mma", "shared B", "max abs dev", "us", "TFLOP/s");
 
         // A single tile can be selected so a profiler can attribute counters to it: the sweep
         // otherwise launches the 2x2 reference between candidates, and every launch of the
@@ -71,9 +74,12 @@ internal static class WarpTileSweepTool
             foreach (var (tm, tn) in Candidates)
             {
                 if (only is not null && only != tm + "x" + tn) continue;
-                double us = Measure(runtime, spec, major, minor, tm, tn, m, n, k, label,
-                                    ref baseline);
-                if (us > 0 && baseline == 0) baseline = us;
+                foreach (bool async in AsyncForms)
+                {
+                    double us = Measure(runtime, spec, major, minor, tm, tn, async,
+                                        m, n, k, label, ref baseline);
+                    if (us > 0 && baseline == 0) baseline = us;
+                }
             }
             Console.WriteLine();
         }
@@ -81,12 +87,15 @@ internal static class WarpTileSweepTool
 
     private static double Measure(
         DirectPtxRuntime runtime, CodegenKernelSpec spec, int major, int minor,
-        int tileM, int tileN, int m, int n, int k, string label, ref double baseline)
+        int tileM, int tileN, bool async, int m, int n, int k, string label, ref double baseline)
     {
         var buffers = new List<DirectPtxBuffer>();
         try
         {
-            var emitter = new PtxTensorCoreEmitter { WarpTilesM = tileM, WarpTilesN = tileN, PinWarpTile = true };
+            var emitter = new PtxTensorCoreEmitter
+            {
+                WarpTilesM = tileM, WarpTilesN = tileN, PinWarpTile = true, EnableAsyncCopy = async,
+            };
 
             if (!PtxTensorCoreEmitter.TryPlan(spec, major, minor, out var plan, out string why))
             {
@@ -230,7 +239,7 @@ internal static class WarpTileSweepTool
             "{0,-16} {1,7} {2,10} {3,7} {4,7} {5,9} {6,12} {7,10} {8,9}{9}",
             label,
             tileM + "x" + tileN,
-            emitter.BlockTileM + "x" + emitter.BlockTileN,
+            emitter.AsyncCopy ? "cp.async" : "registers",
             accRegisters.ToString(CultureInfo.InvariantCulture),
             loadsPerMma.ToString("0.00", CultureInfo.InvariantCulture),
             note is null ? emitter.SharedMemoryBytes.ToString(CultureInfo.InvariantCulture) : "-",

--- a/tests/AiDotNet.Tensors.Benchmarks/WarpTileSweepTool.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/WarpTileSweepTool.cs
@@ -1,0 +1,303 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.Ir;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
+using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Sweeps the per-warp register tile of the staged tensor-core GEMM, verifying and timing
+/// each candidate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The profile said the staged kernel is bound by shared-memory reads -- L1TEX at 87.14%
+/// with the tensor pipe at 25.29% -- and the warp tile is the knob that moves that ratio: a
+/// warp loads <c>M + N</c> fragments and issues <c>M * N</c> mma instructions from them, so
+/// 2x2 is one fragment load per mma and 4x4 is half that.
+/// </para>
+/// <para>
+/// It is SWEPT rather than chosen because the accumulators are <c>M * N * 8</c> fp32 per
+/// thread, so a large tile trades shared traffic for registers, and past some point ptxas
+/// spills -- at which point a big tile is slower than a small one. Two levers on this branch
+/// were predicted from a model and did not pay; the blueprint's rule is that lowerings are
+/// picked by measurement.
+/// </para>
+/// <para>
+/// Every candidate is VERIFIED before it is timed. A tile that computes the wrong answer
+/// quickly is not a candidate, and an indexing slip in the store -- the column offset using
+/// the row tile count, say -- is invisible at 2x2 and wrong at every asymmetric shape.
+/// </para>
+/// </remarks>
+internal static class WarpTileSweepTool
+{
+    private static readonly (int M, int N)[] Candidates =
+    {
+        (2, 2),        // the shipped tile: 64x64 block, 1.00 fragment loads per mma
+        (2, 4),        // 64x128 block, 0.75
+        (4, 2),        // 128x64 block, 0.75
+        (4, 4),        // 128x128 block, 0.50 -- and 128 accumulator registers per thread
+    };
+
+    internal static void Run(string[] args)
+    {
+        using var runtime = new DirectPtxRuntime();
+        int major = runtime.ComputeCapabilityMajor, minor = runtime.ComputeCapabilityMinor;
+
+        Console.WriteLine();
+        Console.WriteLine("WARP TILE SWEEP - staged tensor-core GEMM");
+        Console.WriteLine("device sm_{0}{1}", major, minor);
+        Console.WriteLine();
+        Console.WriteLine(
+            "{0,-16} {1,7} {2,10} {3,7} {4,7} {5,9} {6,12} {7,10} {8,9}",
+            "shape", "tile", "block", "acc reg", "ld/mma", "shared B", "max abs dev", "us", "TFLOP/s");
+
+        // A single tile can be selected so a profiler can attribute counters to it: the sweep
+        // otherwise launches the 2x2 reference between candidates, and every launch of the
+        // same kernel name looks alike to ncu.
+        string? only = args.Length > 0 && args[0].Contains('x') ? args[0] : null;
+        string? shapeOnly = args.Length > 1 ? args[1] : null;
+
+        foreach (var (label, spec, m, n, k) in Shapes())
+        {
+            if (shapeOnly is not null && !label.StartsWith(shapeOnly, StringComparison.Ordinal)) continue;
+
+            double baseline = 0;
+            foreach (var (tm, tn) in Candidates)
+            {
+                if (only is not null && only != tm + "x" + tn) continue;
+                double us = Measure(runtime, spec, major, minor, tm, tn, m, n, k, label,
+                                    ref baseline);
+                if (us > 0 && baseline == 0) baseline = us;
+            }
+            Console.WriteLine();
+        }
+    }
+
+    private static double Measure(
+        DirectPtxRuntime runtime, CodegenKernelSpec spec, int major, int minor,
+        int tileM, int tileN, int m, int n, int k, string label, ref double baseline)
+    {
+        var buffers = new List<DirectPtxBuffer>();
+        try
+        {
+            var emitter = new PtxTensorCoreEmitter { WarpTilesM = tileM, WarpTilesN = tileN, PinWarpTile = true };
+
+            if (!PtxTensorCoreEmitter.TryPlan(spec, major, minor, out var plan, out string why))
+            {
+                Report(label, tileM, tileN, emitter, 0, 0, 0, "not a wmma shape: " + why);
+                return 0;
+            }
+
+            if (!emitter.CanStage(plan!, out string stageWhy))
+            {
+                Report(label, tileM, tileN, emitter, 0, 0, 0, stageWhy);
+                return 0;
+            }
+
+            string ptx = emitter.Emit(spec, major, minor);
+            using var module = runtime.LoadModule(ptx);
+            IntPtr fn = module.GetFunction(spec.Name, out _);
+
+            var pointers = new IntPtr[spec.ParameterCount];
+            var wide = new double[2][];
+            for (int i = 0; i < 2; i++)
+            {
+                long count = spec.Inputs[i].ElementCount;
+                var values = new double[count];
+                var bits = new ushort[count];
+                for (long e = 0; e < count; e++)
+                {
+                    double v = ((((e * 37 + i * 11) % 65) - 32) / 8.0);
+                    var half = (Half)(float)v;
+                    bits[e] = BitConverter.HalfToUInt16Bits(half);
+                    values[e] = (float)half;
+                }
+                var buffer = runtime.AllocateBytes((nuint)(count * sizeof(ushort)));
+                buffer.Upload<ushort>(bits);
+                buffers.Add(buffer);
+                pointers[i] = buffer.Pointer;
+                wide[i] = values;
+            }
+
+            long outCount = spec.Output.ElementCount;
+            var outBuffer = runtime.AllocateBytes((nuint)(outCount * sizeof(float)));
+            buffers.Add(outBuffer);
+            pointers[2] = outBuffer.Pointer;
+
+            uint blocks = (uint)emitter.BlockCount(plan!);
+            uint threads = (uint)emitter.BlockThreads;
+
+            Launch(module, fn, pointers, blocks, threads);
+            runtime.Synchronize();
+
+            // CORRECTNESS FIRST. Verified against the fp64 interpretation where the shape is
+            // small enough for the oracle -- it is O(M*N*K) on the CPU. Larger shapes are
+            // checked against the 2x2 tile's own output instead, which is the tile the
+            // verified rows already cover, so a tile that disagrees with it is wrong.
+            double deviation;
+            var got = new float[outCount];
+            outBuffer.Download<float>(got);
+
+            if ((long)m * n * k <= 64L * 1024 * 1024)
+            {
+                double[] want = spec.Interpret(wide);
+                deviation = 0;
+                for (long e = 0; e < outCount; e++)
+                    deviation = Math.Max(deviation, Math.Abs(got[e] - want[e]));
+            }
+            else if (tileM == 2 && tileN == 2)
+            {
+                deviation = 0;   // this IS the reference tile; the verified shapes cover it
+            }
+            else
+            {
+                deviation = CompareAgainstReference(runtime, spec, major, minor, pointers, got, outCount);
+            }
+
+            if (deviation > 1e-3)
+            {
+                Report(label, tileM, tileN, emitter, deviation, 0, 0, "WRONG");
+                return 0;
+            }
+
+            long macs = (long)m * n * k;
+            double us = TimeIt(runtime, module, fn, pointers, blocks, threads, macs);
+            Report(label, tileM, tileN, emitter, deviation, us, macs, null);
+            return us;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("{0,-16} {1,7} {2,10} {3,7} {4,7} {5,9} {6,12} {7,10} {8,9}  {9}",
+                label, tileM + "x" + tileN, "-", "-", "-", "-", "-", "-", "-",
+                ex.Message.Replace("\n", " "));
+            return 0;
+        }
+        finally
+        {
+            foreach (var b in buffers) b.Dispose();
+        }
+    }
+
+    /// <summary>Compares a large shape against the 2x2 tile's output on the same inputs.</summary>
+    private static double CompareAgainstReference(
+        DirectPtxRuntime runtime, CodegenKernelSpec spec, int major, int minor,
+        IntPtr[] pointers, float[] got, long outCount)
+    {
+        var reference = new PtxTensorCoreEmitter { WarpTilesM = 2, WarpTilesN = 2, PinWarpTile = true };
+        PtxTensorCoreEmitter.TryPlan(spec, major, minor, out var plan, out _);
+
+        string ptx = reference.Emit(spec, major, minor);
+        using var module = runtime.LoadModule(ptx);
+        IntPtr fn = module.GetFunction(spec.Name, out _);
+
+        var refBuffer = runtime.AllocateBytes((nuint)(outCount * sizeof(float)));
+        try
+        {
+            var refPointers = (IntPtr[])pointers.Clone();
+            refPointers[2] = refBuffer.Pointer;
+
+            Launch(module, fn, refPointers,
+                (uint)reference.BlockCount(plan!), (uint)reference.BlockThreads);
+            runtime.Synchronize();
+
+            var want = new float[outCount];
+            refBuffer.Download<float>(want);
+
+            double worst = 0;
+            for (long e = 0; e < outCount; e++) worst = Math.Max(worst, Math.Abs(got[e] - want[e]));
+            return worst;
+        }
+        finally
+        {
+            refBuffer.Dispose();
+        }
+    }
+
+    private static void Report(
+        string label, int tileM, int tileN, PtxTensorCoreEmitter emitter,
+        double deviation, double us, long macs, string? note)
+    {
+        int accRegisters = tileM * tileN * 8;
+        double loadsPerMma = (tileM + tileN) / (double)(tileM * tileN);
+
+        Console.WriteLine(
+            "{0,-16} {1,7} {2,10} {3,7} {4,7} {5,9} {6,12} {7,10} {8,9}{9}",
+            label,
+            tileM + "x" + tileN,
+            emitter.BlockTileM + "x" + emitter.BlockTileN,
+            accRegisters.ToString(CultureInfo.InvariantCulture),
+            loadsPerMma.ToString("0.00", CultureInfo.InvariantCulture),
+            note is null ? emitter.SharedMemoryBytes.ToString(CultureInfo.InvariantCulture) : "-",
+            note is null ? deviation.ToString("0.000E+000", CultureInfo.InvariantCulture) : "-",
+            us > 0 ? us.ToString("0.0", CultureInfo.InvariantCulture) + " us" : "-",
+            (us > 0 && macs > 0)
+                ? (2.0 * macs / us / 1e6).ToString("0.0", CultureInfo.InvariantCulture) : "-",
+            note is null ? string.Empty : "  " + note);
+    }
+
+    private static double TimeIt(
+        DirectPtxRuntime runtime, DirectPtxModule module, IntPtr fn,
+        IntPtr[] pointers, uint blocks, uint threads, long macs)
+    {
+        int iterations = (int)Math.Max(5, Math.Min(200, 20_000_000_000L / Math.Max(1, macs)));
+        int warmup = Math.Max(2, iterations / 10);
+
+        for (int i = 0; i < warmup; i++) Launch(module, fn, pointers, blocks, threads);
+        runtime.Synchronize();
+
+        double best = double.MaxValue;
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++) Launch(module, fn, pointers, blocks, threads);
+            runtime.Synchronize();
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalMilliseconds * 1000.0 / iterations);
+        }
+        return best;
+    }
+
+    private static unsafe void Launch(
+        DirectPtxModule module, IntPtr fn, IntPtr[] pointers, uint blocks, uint threads)
+    {
+        fixed (IntPtr* pinned = pointers)
+        {
+            void** argv = stackalloc void*[pointers.Length];
+            for (int i = 0; i < pointers.Length; i++) argv[i] = pinned + i;
+            module.Launch(fn, blocks, 1, 1, threads, 1, 1, 0, argv);
+        }
+    }
+
+    private static CodegenKernelSpec MatMul(string name, int m, int k, int n)
+    {
+        var space = new CodegenIterationSpace(
+            CodegenAxis.Parallel("m", m), CodegenAxis.Parallel("n", n),
+            CodegenAxis.Reduce("k", k));
+
+        var a = new CodegenTensorBinding(0, "a", new[] { m, k },
+            new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(2) },
+            elementType: CodegenElementType.Float16);
+        var b = new CodegenTensorBinding(1, "b", new[] { k, n },
+            new[] { CodegenAffineExpr.Axis(2), CodegenAffineExpr.Axis(1) },
+            elementType: CodegenElementType.Float16);
+        var output = new CodegenTensorBinding(2, "out", new[] { m, n },
+            new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(1) }, isOutput: true);
+
+        return new CodegenKernelSpec(name, space, new[] { a, b }, output,
+            new[] { 0, 1 }, CodegenReduceKind.Sum);
+    }
+
+    private static IEnumerable<(string, CodegenKernelSpec, int, int, int)> Shapes()
+    {
+        yield return ("512^3", MatMul("sweep_512", 512, 512, 512), 512, 512, 512);
+        yield return ("1024^3", MatMul("sweep_1024", 1024, 1024, 1024), 1024, 1024, 1024);
+        yield return ("2048^3", MatMul("sweep_2048", 2048, 2048, 2048), 2048, 2048, 2048);
+        yield return ("4096^3", MatMul("sweep_4096", 4096, 4096, 4096), 4096, 4096, 4096);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
@@ -25,6 +25,18 @@ public class CodegenTensorCoreStagingTests
 {
     private const int Sm86Major = 8, Sm86Minor = 6;
 
+    /// <summary>
+    /// An emitter pinned to the 2x2 warp tile.
+    /// </summary>
+    /// <remarks>
+    /// The emitter now SELECTS the largest warp tile the shape allows, so a test about the
+    /// structure a particular tile produces -- how many mma instructions, how much shared
+    /// memory, how many stores -- has to pin one. See WarpTileSelection_PicksTheLargestThatFits
+    /// for the selector itself.
+    /// </remarks>
+    private static PtxTensorCoreEmitter Tile2x2() =>
+        new() { WarpTilesM = 2, WarpTilesN = 2, PinWarpTile = true };
+
     private static CodegenKernelSpec MatMul(
         int m, int k, int n,
         CodegenActivationKind activation = CodegenActivationKind.None,
@@ -67,7 +79,7 @@ public class CodegenTensorCoreStagingTests
     [InlineData(1024, 4096, 1024)]
     public void WholeBlockTiles_AreEligible(int m, int k, int n)
     {
-        Assert.True(PtxTensorCoreEmitter.CanStage(PlanFor(MatMul(m, k, n)), out string reason),
+        Assert.True(Tile2x2().CanStage(PlanFor(MatMul(m, k, n)), out string reason),
             reason);
     }
 
@@ -80,7 +92,7 @@ public class CodegenTensorCoreStagingTests
     [InlineData(64, 64, 48)]
     public void PartialBlockTiles_FallBack(int m, int k, int n)
     {
-        Assert.False(PtxTensorCoreEmitter.CanStage(PlanFor(MatMul(m, k, n)), out string reason));
+        Assert.False(Tile2x2().CanStage(PlanFor(MatMul(m, k, n)), out string reason));
         Assert.Contains("block tile", reason, StringComparison.Ordinal);
 
         // ...and the naive path still handles them, exactly as before.
@@ -93,7 +105,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void TransposedB_FallsBack()
     {
-        Assert.False(PtxTensorCoreEmitter.CanStage(
+        Assert.False(Tile2x2().CanStage(
             PlanFor(MatMul(128, 128, 128, transposeB: true)), out string reason));
         Assert.Contains("column-wise", reason, StringComparison.Ordinal);
     }
@@ -118,7 +130,8 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_IssuesFourMmaPerStep()
     {
-        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
+        var emitter = Tile2x2();
+        emitter.EnableDoubleBuffering = false;
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         Assert.Equal(4, emitter.MmaInstructions);
@@ -135,7 +148,8 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void SingleBuffered_BarriersOnBothSidesOfTheComputation()
     {
-        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
+        var emitter = Tile2x2();
+        emitter.EnableDoubleBuffering = false;
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         Assert.True(emitter.Staged);
@@ -158,7 +172,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void DoubleBuffered_NeedsOneBarrierPerStep()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Tile2x2();
         emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         Assert.True(emitter.DoubleBuffered);
@@ -200,10 +214,10 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void DoubleBuffered_ReservesTwoDistinctBuffers()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Tile2x2();
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
-        Assert.Equal(PtxTensorCoreEmitter.StageBufferBytes * 2, emitter.SharedMemoryBytes);
+        Assert.Equal(emitter.StageBufferBytes * 2, emitter.SharedMemoryBytes);
         Assert.Contains(".shared .align 16 .b8 stage[8192];", ptx, StringComparison.Ordinal);
 
         // Buffer 1's slabs sit one whole buffer further along.
@@ -236,23 +250,23 @@ public class CodegenTensorCoreStagingTests
     public void OddStepCount_FallsBackToSingleBuffered()
     {
         // K = 48 gives three 16-deep steps.
-        Assert.False(PtxTensorCoreEmitter.CanDoubleBuffer(
+        Assert.False(Tile2x2().CanDoubleBuffer(
             PlanFor(MatMul(64, 48, 64)), out string reason));
         Assert.Contains("even", reason, StringComparison.Ordinal);
 
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Tile2x2();
         emitter.Emit(MatMul(64, 48, 64), Sm86Major, Sm86Minor);
 
         Assert.True(emitter.Staged);
         Assert.False(emitter.DoubleBuffered);
-        Assert.Equal(PtxTensorCoreEmitter.StageBufferBytes, emitter.SharedMemoryBytes);
+        Assert.Equal(Tile2x2().StageBufferBytes, emitter.SharedMemoryBytes);
     }
 
     /// <summary>A single K step has nothing to overlap with.</summary>
     [Fact]
     public void SingleStep_FallsBackToSingleBuffered()
     {
-        Assert.False(PtxTensorCoreEmitter.CanDoubleBuffer(
+        Assert.False(Tile2x2().CanDoubleBuffer(
             PlanFor(MatMul(64, 16, 64)), out string reason));
         Assert.Contains("at least two", reason, StringComparison.Ordinal);
     }
@@ -261,7 +275,8 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_ReservesBothSlabs()
     {
-        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
+        var emitter = Tile2x2();
+        emitter.EnableDoubleBuffering = false;
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         // 64x16 halves of A plus 16x64 of B, two bytes each.
@@ -282,7 +297,7 @@ public class CodegenTensorCoreStagingTests
     [InlineData(1024, 1024, 256)]
     public void StagedGrid_IsOneBlockPerBlockTile(int m, int n, int expectedBlocks)
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Tile2x2();
         var plan = PlanFor(MatMul(m, 64, n));
 
         Assert.Equal(expectedBlocks, emitter.BlockCount(plan));
@@ -310,7 +325,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_KeepsTheFusedEpilogue()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(
+        string ptx = Tile2x2().Emit(
             MatMul(512, 512, 512, CodegenActivationKind.ReLU), Sm86Major, Sm86Minor);
 
         // Once per accumulator register of all four tiles.
@@ -323,9 +338,63 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_StoresAllFourTiles()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+        string ptx = Tile2x2().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         Assert.Equal(4, CountOccurrences(ptx, "wmma.store.d.sync"));
+    }
+
+    /// <summary>
+    /// The emitter picks the LARGEST warp tile whose block tile divides the output.
+    /// </summary>
+    /// <remarks>
+    /// Derived from `--warp-tile-sweep`, which verified and timed every candidate at four
+    /// shapes: the bigger tile won wherever it fits, by 1.28x at 2048^3 and 1.32x at 4096^3.
+    /// The mechanism is the one the profile named -- L1TEX falls from 92.34% to 61.38% and
+    /// the tensor pipe rises from 26.79% to 35.74%.
+    /// </remarks>
+    [Theory]
+    [InlineData(128, 128, 4, 4)]      // both divide by 128
+    [InlineData(128, 64, 4, 2)]       // N only reaches 64
+    [InlineData(64, 128, 2, 4)]
+    [InlineData(64, 64, 2, 2)]
+    [InlineData(1024, 1024, 4, 4)]
+    public void WarpTileSelection_PicksTheLargestThatFits(int m, int n, int tileM, int tileN)
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(m, 64, n), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.Staged);
+        Assert.Equal(tileM, emitter.WarpTilesM);
+        Assert.Equal(tileN, emitter.WarpTilesN);
+    }
+
+    /// <summary>A pinned tile is not overridden -- that is what the sweep depends on.</summary>
+    [Fact]
+    public void PinnedWarpTile_IsNotOverridden()
+    {
+        var emitter = Tile2x2();
+        emitter.Emit(MatMul(1024, 64, 1024), Sm86Major, Sm86Minor);
+
+        Assert.Equal(2, emitter.WarpTilesM);
+        Assert.Equal(2, emitter.WarpTilesN);
+    }
+
+    /// <summary>
+    /// A larger tile means more accumulator registers -- 8 per wmma tile per thread -- and
+    /// that is the trade the sweep exists to measure rather than assume.
+    /// </summary>
+    [Fact]
+    public void LargerWarpTile_CostsMoreSharedMemoryAndRegisters()
+    {
+        var small = new PtxTensorCoreEmitter { WarpTilesM = 2, WarpTilesN = 2, PinWarpTile = true };
+        var large = new PtxTensorCoreEmitter { WarpTilesM = 4, WarpTilesN = 4, PinWarpTile = true };
+
+        small.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+        large.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.True(large.SharedMemoryBytes > small.SharedMemoryBytes);
+        Assert.Equal(16, large.MmaInstructions / 2);       // 16 per body, two bodies
+        Assert.Equal(4, small.MmaInstructions / 2);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
@@ -118,7 +118,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_IssuesFourMmaPerStep()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         Assert.Equal(4, emitter.MmaInstructions);
@@ -127,30 +127,141 @@ public class CodegenTensorCoreStagingTests
     }
 
     /// <summary>
-    /// TWO barriers per K step, and the second is not optional: without it a fast warp
-    /// overwrites the slabs for step k+1 while a slow one is still reading step k out of
-    /// them. That races silently -- plausible magnitudes, a different answer per run.
+    /// SINGLE-buffered staging needs TWO barriers per K step, and the second is not optional:
+    /// without it a fast warp overwrites the slab for step k+1 while a slow one is still
+    /// reading step k out of it. That races silently -- plausible magnitudes, a different
+    /// answer per run.
     /// </summary>
     [Fact]
-    public void StagedKernel_BarriersOnBothSidesOfTheComputation()
+    public void SingleBuffered_BarriersOnBothSidesOfTheComputation()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
-        Assert.Equal(2, CountOccurrences(ptx, "bar.sync 0;"));
+        Assert.True(emitter.Staged);
+        Assert.False(emitter.DoubleBuffered);
+        Assert.Equal(2, emitter.LoopBarriers);
 
         int firstBarrier = ptx.IndexOf("bar.sync 0;", StringComparison.Ordinal);
         int firstMma = ptx.IndexOf("wmma.mma.sync", StringComparison.Ordinal);
         int lastBarrier = ptx.LastIndexOf("bar.sync 0;", StringComparison.Ordinal);
 
         Assert.True(firstBarrier < firstMma, "the staging store must be fenced before any mma");
-        Assert.True(lastBarrier > firstMma, "the slabs must be fenced before being overwritten");
+        Assert.True(lastBarrier > firstMma, "the slab must be fenced before being overwritten");
+    }
+
+    /// <summary>
+    /// DOUBLE buffering removes the second barrier, which is where the overlap comes from:
+    /// the copy for step k+1 targets the buffer nobody is reading, so it needs no fence
+    /// against the readers of step k.
+    /// </summary>
+    [Fact]
+    public void DoubleBuffered_NeedsOneBarrierPerStep()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.DoubleBuffered);
+
+        // Two bodies are emitted per loop iteration, one per buffer, so two barriers cover
+        // TWO K steps -- one each, against the single-buffered form's two each.
+        Assert.Equal(2, emitter.LoopBarriers);
+        Assert.Equal(8, emitter.MmaInstructions);      // 4 per body, two bodies
+    }
+
+    /// <summary>
+    /// The global read for step k+1 must be ISSUED BEFORE the mma work for step k, or its
+    /// latency does not hide behind anything and the second slab buys nothing.
+    /// </summary>
+    [Fact]
+    public void DoubleBuffered_IssuesThePrefetchBeforeTheArithmetic()
+    {
+        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
+        Assert.True(loopStart >= 0);
+
+        string body = ptx.Substring(loopStart);
+        int firstGlobalLoad = body.IndexOf("ld.global.nc.u32", StringComparison.Ordinal);
+        int firstMma = body.IndexOf("wmma.mma.sync", StringComparison.Ordinal);
+        int firstSharedStore = body.IndexOf("st.shared.u32", StringComparison.Ordinal);
+
+        Assert.True(firstGlobalLoad >= 0 && firstMma >= 0 && firstSharedStore >= 0);
+        Assert.True(firstGlobalLoad < firstMma,
+            "the prefetch must be issued before the arithmetic it overlaps with");
+        Assert.True(firstMma < firstSharedStore,
+            "only the shared STORE waits for the arithmetic, not the global load");
+    }
+
+    /// <summary>
+    /// The two buffers must be distinct, and the second must be reserved. A single buffer
+    /// address with a runtime index would defeat the compile-time offsets entirely.
+    /// </summary>
+    [Fact]
+    public void DoubleBuffered_ReservesTwoDistinctBuffers()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.Equal(PtxTensorCoreEmitter.StageBufferBytes * 2, emitter.SharedMemoryBytes);
+        Assert.Contains(".shared .align 16 .b8 stage[8192];", ptx, StringComparison.Ordinal);
+
+        // Buffer 1's slabs sit one whole buffer further along.
+        Assert.Contains("+4096]", ptx, StringComparison.Ordinal);
+        Assert.Contains("+6144]", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The final body prefetches a step past the end of K, so that read must be predicated:
+    /// unguarded it walks off the end of A's last row and outside the allocation.
+    /// </summary>
+    [Fact]
+    public void DoubleBuffered_PredicatesThePrefetchPastTheEnd()
+    {
+        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
+        string body = ptx.Substring(loopStart);
+
+        int guarded = CountOccurrences(body, "@%p"), loads = CountOccurrences(body, "ld.global.nc.u32");
+        Assert.True(loads > 0, "the loop must contain staging loads");
+        Assert.True(guarded >= loads, $"{loads} staging loads but only {guarded} guards");
+    }
+
+    /// <summary>
+    /// An odd step count falls back to single-buffered staging rather than padding K, which
+    /// would change the operator.
+    /// </summary>
+    [Fact]
+    public void OddStepCount_FallsBackToSingleBuffered()
+    {
+        // K = 48 gives three 16-deep steps.
+        Assert.False(PtxTensorCoreEmitter.CanDoubleBuffer(
+            PlanFor(MatMul(64, 48, 64)), out string reason));
+        Assert.Contains("even", reason, StringComparison.Ordinal);
+
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(64, 48, 64), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.Staged);
+        Assert.False(emitter.DoubleBuffered);
+        Assert.Equal(PtxTensorCoreEmitter.StageBufferBytes, emitter.SharedMemoryBytes);
+    }
+
+    /// <summary>A single K step has nothing to overlap with.</summary>
+    [Fact]
+    public void SingleStep_FallsBackToSingleBuffered()
+    {
+        Assert.False(PtxTensorCoreEmitter.CanDoubleBuffer(
+            PlanFor(MatMul(64, 16, 64)), out string reason));
+        Assert.Contains("at least two", reason, StringComparison.Ordinal);
     }
 
     /// <summary>The shared slabs must be reserved, and sized to hold both.</summary>
     [Fact]
     public void StagedKernel_ReservesBothSlabs()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = new PtxTensorCoreEmitter { EnableDoubleBuffering = false };
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         // 64x16 halves of A plus 16x64 of B, two bytes each.

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
@@ -37,6 +37,17 @@ public class CodegenTensorCoreStagingTests
     private static PtxTensorCoreEmitter Tile2x2() =>
         new() { WarpTilesM = 2, WarpTilesN = 2, PinWarpTile = true };
 
+    /// <summary>
+    /// An emitter pinned to 2x2 with REGISTER staging.
+    /// </summary>
+    /// <remarks>
+    /// cp.async is the default where the architecture supports it, so a test about the
+    /// register-staged form -- its ld.global/st.shared pair, its prefetch registers -- has to
+    /// ask for it. That form is still what runs below sm_80.
+    /// </remarks>
+    private static PtxTensorCoreEmitter RegisterStaged() =>
+        new() { WarpTilesM = 2, WarpTilesN = 2, PinWarpTile = true, EnableAsyncCopy = false };
+
     private static CodegenKernelSpec MatMul(
         int m, int k, int n,
         CodegenActivationKind activation = CodegenActivationKind.None,
@@ -190,7 +201,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void DoubleBuffered_IssuesThePrefetchBeforeTheArithmetic()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+        string ptx = RegisterStaged().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
         Assert.True(loopStart >= 0);
@@ -232,7 +243,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void DoubleBuffered_PredicatesThePrefetchPastTheEnd()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+        string ptx = RegisterStaged().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
         int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
         string body = ptx.Substring(loopStart);
@@ -275,7 +286,7 @@ public class CodegenTensorCoreStagingTests
     [Fact]
     public void StagedKernel_ReservesBothSlabs()
     {
-        var emitter = Tile2x2();
+        var emitter = RegisterStaged();
         emitter.EnableDoubleBuffering = false;
         string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
 
@@ -353,19 +364,56 @@ public class CodegenTensorCoreStagingTests
     /// the tensor pipe rises from 26.79% to 35.74%.
     /// </remarks>
     [Theory]
-    [InlineData(128, 128, 4, 4)]      // both divide by 128
-    [InlineData(128, 64, 4, 2)]       // N only reaches 64
+    [InlineData(128, 128, 4, 2)]      // 4x2 leads the ladder: it won most measured shapes
+    [InlineData(128, 64, 4, 2)]
     [InlineData(64, 128, 2, 4)]
     [InlineData(64, 64, 2, 2)]
-    [InlineData(1024, 1024, 4, 4)]
-    public void WarpTileSelection_PicksTheLargestThatFits(int m, int n, int tileM, int tileN)
+    public void WarpTileSelection_FollowsTheLadder(int m, int n, int tileM, int tileN)
     {
+        // K = 64 here, so none of these hit a measured catalog entry: this covers the LADDER.
         var emitter = new PtxTensorCoreEmitter();
         emitter.Emit(MatMul(m, 64, n), Sm86Major, Sm86Minor);
 
         Assert.True(emitter.Staged);
+        Assert.False(emitter.WarpTileWasMeasured);
         Assert.Equal(tileM, emitter.WarpTilesM);
         Assert.Equal(tileN, emitter.WarpTilesN);
+    }
+
+    /// <summary>
+    /// A measured shape takes its MEASURED tile, which at 1024^3 is not the largest that
+    /// fits: 4x2 timed 71.9us against 4x4's 75.0us. This is the case the ladder gets wrong
+    /// and the catalog exists for.
+    /// </summary>
+    [Fact]
+    public void MeasuredShape_OverridesTheLadder()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(1024, 1024, 1024), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.WarpTileWasMeasured);
+        Assert.Equal(4, emitter.WarpTilesM);
+        Assert.Equal(2, emitter.WarpTilesN);
+
+        // The ladder alone would have said 4x4, since 1024 divides 128 both ways.
+        var ladder = TensorCoreWarpTileCatalog.Select(1024, 1024, 64, out bool measured);
+        Assert.False(measured);
+        Assert.Equal(4, ladder.TileM);
+        Assert.Equal(2, ladder.TileN);
+    }
+
+    /// <summary>Every catalog entry must be reachable, or it is a silently dead measurement.</summary>
+    [Fact]
+    public void EveryMeasuredShape_IsReachable()
+    {
+        foreach (var (m, n, k) in TensorCoreWarpTileCatalog.MeasuredShapes)
+        {
+            var emitter = new PtxTensorCoreEmitter();
+            emitter.Emit(MatMul(m, k, n), Sm86Major, Sm86Minor);
+
+            Assert.True(emitter.Staged, $"{m}x{k}x{n} does not stage");
+            Assert.True(emitter.WarpTileWasMeasured, $"{m}x{k}x{n} did not hit its catalog entry");
+        }
     }
 
     /// <summary>A pinned tile is not overridden -- that is what the sweep depends on.</summary>
@@ -395,6 +443,102 @@ public class CodegenTensorCoreStagingTests
         Assert.True(large.SharedMemoryBytes > small.SharedMemoryBytes);
         Assert.Equal(16, large.MmaInstructions / 2);       // 16 per body, two bodies
         Assert.Equal(4, small.MmaInstructions / 2);
+    }
+
+    // ---- cp.async staging ----------------------------------------------------------------
+
+    /// <summary>
+    /// cp.async copies global to shared directly, so the staged words never occupy a register
+    /// and one instruction moves 16 bytes instead of four.
+    /// </summary>
+    /// <remarks>
+    /// This is what took the kernel off its register occupancy limit: at the 4x4 tile the
+    /// register-staged form used 240 registers per thread, allowing 2 blocks per SM and
+    /// 16.41% of peak warps active, with `mio_throttle` the largest remaining stall.
+    /// </remarks>
+    [Fact]
+    public void AsyncCopy_ReplacesTheLoadStorePair()
+    {
+        var emitter = Tile2x2();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.AsyncCopy);
+        Assert.Contains("cp.async.ca.shared.global", ptx, StringComparison.Ordinal);
+        Assert.Contains("cp.async.commit_group;", ptx, StringComparison.Ordinal);
+        Assert.Contains("cp.async.wait_group 0;", ptx, StringComparison.Ordinal);
+
+        // The register round-trip is gone entirely.
+        Assert.DoesNotContain("st.shared.u32", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("ld.global.nc.u32", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The copy must be COMMITTED before the arithmetic and WAITED on after it. Waiting before
+    /// the mma work would serialise exactly what the async form exists to overlap.
+    /// </summary>
+    [Fact]
+    public void AsyncCopy_WaitsAfterTheArithmeticNotBefore()
+    {
+        string ptx = Tile2x2().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
+        string body = ptx.Substring(loopStart);
+
+        int commit = body.IndexOf("cp.async.commit_group;", StringComparison.Ordinal);
+        int mma = body.IndexOf("wmma.mma.sync", StringComparison.Ordinal);
+        int wait = body.IndexOf("cp.async.wait_group 0;", StringComparison.Ordinal);
+
+        Assert.True(commit >= 0 && mma >= 0 && wait >= 0);
+        Assert.True(commit < mma, "the copy must be committed before the arithmetic");
+        Assert.True(mma < wait, "the wait must come after the arithmetic it overlaps with");
+    }
+
+    /// <summary>A copy past the end of K must still be predicated off.</summary>
+    [Fact]
+    public void AsyncCopy_PredicatesThePrefetchPastTheEnd()
+    {
+        string ptx = Tile2x2().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        int loopStart = ptx.IndexOf("KLOOP:", StringComparison.Ordinal);
+        string body = ptx.Substring(loopStart);
+
+        int copies = CountOccurrences(body, "cp.async.ca.shared.global");
+        int guarded = CountOccurrences(body, "@%p") - CountOccurrences(body, "@%p1 bra");
+        Assert.True(copies > 0);
+        Assert.True(guarded >= copies, $"{copies} async copies but only {guarded} guards");
+    }
+
+    /// <summary>
+    /// cp.async is sm_80+. A pre-Ampere target must fall back to register staging rather than
+    /// emitting an instruction the assembler will reject.
+    /// </summary>
+    [Fact]
+    public void AsyncCopy_FallsBackBeforeAmpere()
+    {
+        var emitter = Tile2x2();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), computeMajor: 7, computeMinor: 5);
+
+        Assert.False(emitter.AsyncCopy);
+        Assert.DoesNotContain("cp.async", ptx, StringComparison.Ordinal);
+        Assert.Contains("st.shared.u32", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The catalog records the tile and the staging form TOGETHER, because they interact: at
+    /// 4096^3 the 4x4 tile is faster with registers (45.0 TF) than with cp.async (41.6), while
+    /// 4x2 is much faster with cp.async (47.0) than without (38.4). Picking them independently
+    /// selects 4x4 + cp.async, the worst of those four.
+    /// </summary>
+    [Fact]
+    public void CatalogChoosesTileAndStagingTogether()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(4096, 4096, 4096), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.WarpTileWasMeasured);
+        Assert.Equal(4, emitter.WarpTilesM);
+        Assert.Equal(2, emitter.WarpTilesN);
+        Assert.True(emitter.AsyncCopy);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
@@ -1,0 +1,230 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Shared-memory staging for the tensor-core GEMM.
+//
+// The naive lowering gives one warp one 16x16 tile and lets it stream its own operand bands
+// from global, so nothing is shared between the warps that need the same bands. That measured
+// 11.8 TFLOP/s at 2048^3 and COLLAPSED to 3.0 at 4096^3 once the reused bands outgrew L2.
+//
+// Staging makes a block of four warps own a 64x64 tile and copy the operand slabs into shared
+// memory once per K step, cutting global operand traffic fourfold and fragment loads fourfold
+// again. Measured: 32.7 TFLOP/s at 4096^3, and throughput now RISES with size instead of
+// falling off.
+//
+// The dangerous failure is the second barrier. Without it a fast warp starts overwriting the
+// slabs for step k+1 while a slow one is still reading step k, which produces plausible
+// magnitudes and a different answer per run.
+
+using System;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.Ir;
+using AiDotNet.Tensors.Engines.Compilation.Codegen.Ptx;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Codegen;
+
+public class CodegenTensorCoreStagingTests
+{
+    private const int Sm86Major = 8, Sm86Minor = 6;
+
+    private static CodegenKernelSpec MatMul(
+        int m, int k, int n,
+        CodegenActivationKind activation = CodegenActivationKind.None,
+        bool transposeB = false)
+    {
+        var space = new CodegenIterationSpace(
+            CodegenAxis.Parallel("m", m), CodegenAxis.Parallel("n", n),
+            CodegenAxis.Reduce("k", k));
+
+        var a = new CodegenTensorBinding(0, "a", new[] { m, k },
+            new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(2) },
+            elementType: CodegenElementType.Float16);
+
+        var b = transposeB
+            ? new CodegenTensorBinding(1, "b", new[] { n, k },
+                new[] { CodegenAffineExpr.Axis(1), CodegenAffineExpr.Axis(2) },
+                elementType: CodegenElementType.Float16)
+            : new CodegenTensorBinding(1, "b", new[] { k, n },
+                new[] { CodegenAffineExpr.Axis(2), CodegenAffineExpr.Axis(1) },
+                elementType: CodegenElementType.Float16);
+
+        var output = new CodegenTensorBinding(2, "out", new[] { m, n },
+            new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(1) }, isOutput: true);
+
+        return new CodegenKernelSpec("tc", space, new[] { a, b }, output,
+            new[] { 0, 1 }, CodegenReduceKind.Sum, activation: activation);
+    }
+
+    private static PtxTensorCoreEmitter.Plan PlanFor(CodegenKernelSpec spec)
+    {
+        Assert.True(PtxTensorCoreEmitter.TryPlan(
+            spec, Sm86Major, Sm86Minor, out var plan, out string reason), reason);
+        return plan!;
+    }
+
+    /// <summary>A whole number of 64x64 block tiles is what staging needs.</summary>
+    [Theory]
+    [InlineData(64, 64, 64)]
+    [InlineData(512, 512, 512)]
+    [InlineData(1024, 4096, 1024)]
+    public void WholeBlockTiles_AreEligible(int m, int k, int n)
+    {
+        Assert.True(PtxTensorCoreEmitter.CanStage(PlanFor(MatMul(m, k, n)), out string reason),
+            reason);
+    }
+
+    /// <summary>
+    /// A partial block tile falls back rather than being handled with per-thread bounds tests
+    /// inside the staging loop, which would be a different kernel.
+    /// </summary>
+    [Theory]
+    [InlineData(32, 64, 64)]        // M is a whole wmma tile but not a whole block tile
+    [InlineData(64, 64, 48)]
+    public void PartialBlockTiles_FallBack(int m, int k, int n)
+    {
+        Assert.False(PtxTensorCoreEmitter.CanStage(PlanFor(MatMul(m, k, n)), out string reason));
+        Assert.Contains("block tile", reason, StringComparison.Ordinal);
+
+        // ...and the naive path still handles them, exactly as before.
+        var emitter = new PtxTensorCoreEmitter();
+        emitter.Emit(MatMul(m, k, n), Sm86Major, Sm86Minor);
+        Assert.False(emitter.Staged);
+    }
+
+    /// <summary>A transposed operand cannot be copied as a row-major slab.</summary>
+    [Fact]
+    public void TransposedB_FallsBack()
+    {
+        Assert.False(PtxTensorCoreEmitter.CanStage(
+            PlanFor(MatMul(128, 128, 128, transposeB: true)), out string reason));
+        Assert.Contains("column-wise", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>The staged kernel must load its fragments from SHARED, not global.</summary>
+    [Fact]
+    public void StagedKernel_LoadsFragmentsFromShared()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.True(emitter.Staged);
+        Assert.Contains("wmma.load.a.sync.aligned.row.m16n16k16.shared.f16", ptx, StringComparison.Ordinal);
+        Assert.Contains("wmma.load.b.sync.aligned.row.m16n16k16.shared.f16", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("wmma.load.a.sync.aligned.row.m16n16k16.global.f16", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// FOUR mma instructions per K step from FOUR fragment loads. That two-to-one ratio is
+    /// half the win: the naive lowering issues two fragment loads per single mma.
+    /// </summary>
+    [Fact]
+    public void StagedKernel_IssuesFourMmaPerStep()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.Equal(4, emitter.MmaInstructions);
+        Assert.Equal(2, CountOccurrences(ptx, "wmma.load.a.sync"));
+        Assert.Equal(2, CountOccurrences(ptx, "wmma.load.b.sync"));
+    }
+
+    /// <summary>
+    /// TWO barriers per K step, and the second is not optional: without it a fast warp
+    /// overwrites the slabs for step k+1 while a slow one is still reading step k out of
+    /// them. That races silently -- plausible magnitudes, a different answer per run.
+    /// </summary>
+    [Fact]
+    public void StagedKernel_BarriersOnBothSidesOfTheComputation()
+    {
+        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.Equal(2, CountOccurrences(ptx, "bar.sync 0;"));
+
+        int firstBarrier = ptx.IndexOf("bar.sync 0;", StringComparison.Ordinal);
+        int firstMma = ptx.IndexOf("wmma.mma.sync", StringComparison.Ordinal);
+        int lastBarrier = ptx.LastIndexOf("bar.sync 0;", StringComparison.Ordinal);
+
+        Assert.True(firstBarrier < firstMma, "the staging store must be fenced before any mma");
+        Assert.True(lastBarrier > firstMma, "the slabs must be fenced before being overwritten");
+    }
+
+    /// <summary>The shared slabs must be reserved, and sized to hold both.</summary>
+    [Fact]
+    public void StagedKernel_ReservesBothSlabs()
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        string ptx = emitter.Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        // 64x16 halves of A plus 16x64 of B, two bytes each.
+        Assert.Equal((64 * 16 + 16 * 64) * 2, emitter.SharedMemoryBytes);
+        Assert.Contains(".shared .align 16 .b8 stage[4096];", ptx, StringComparison.Ordinal);
+        Assert.Contains("st.shared.u32", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE GRIDS DIFFER, and not by a little: staged, four warps cover sixteen 16x16 tiles
+    /// rather than four, so a 64x64 output is ONE block staged and FOUR naive. Launching the
+    /// staged kernel on the naive grid would run it four times over, each pass accumulating
+    /// into the same output again.
+    /// </summary>
+    [Theory]
+    [InlineData(64, 64, 1)]
+    [InlineData(128, 128, 4)]
+    [InlineData(1024, 1024, 256)]
+    public void StagedGrid_IsOneBlockPerBlockTile(int m, int n, int expectedBlocks)
+    {
+        var emitter = new PtxTensorCoreEmitter();
+        var plan = PlanFor(MatMul(m, 64, n));
+
+        Assert.Equal(expectedBlocks, emitter.BlockCount(plan));
+        Assert.Equal(128, emitter.BlockThreads);
+    }
+
+    /// <summary>Turning staging off must restore the naive grid, or the A/B measurement lies.</summary>
+    [Fact]
+    public void StagingDisabled_RestoresTheNaiveLowering()
+    {
+        var emitter = new PtxTensorCoreEmitter { EnableStaging = false };
+        var spec = MatMul(512, 512, 512);
+        string ptx = emitter.Emit(spec, Sm86Major, Sm86Minor);
+
+        Assert.False(emitter.Staged);
+        Assert.Equal(0, emitter.SharedMemoryBytes);
+        Assert.Contains("wmma.load.a.sync.aligned.row.m16n16k16.global.f16", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("bar.sync", ptx, StringComparison.Ordinal);
+
+        var plan = PlanFor(spec);
+        Assert.Equal(plan.TileCount / 4, emitter.BlockCount(plan));
+    }
+
+    /// <summary>The fused epilogue must survive staging -- it is the advantage over cuBLAS.</summary>
+    [Fact]
+    public void StagedKernel_KeepsTheFusedEpilogue()
+    {
+        string ptx = new PtxTensorCoreEmitter().Emit(
+            MatMul(512, 512, 512, CodegenActivationKind.ReLU), Sm86Major, Sm86Minor);
+
+        // Once per accumulator register of all four tiles.
+        Assert.Equal(32, CountOccurrences(ptx, "max.f32 %fc"));
+        Assert.True(ptx.IndexOf("max.f32 %fc", StringComparison.Ordinal)
+                  < ptx.IndexOf("wmma.store", StringComparison.Ordinal));
+    }
+
+    /// <summary>All four of the warp's tiles must be stored, not just the first.</summary>
+    [Fact]
+    public void StagedKernel_StoresAllFourTiles()
+    {
+        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(512, 512, 512), Sm86Major, Sm86Minor);
+
+        Assert.Equal(4, CountOccurrences(ptx, "wmma.store.d.sync"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreTests.cs
@@ -23,6 +23,17 @@ public class CodegenTensorCoreTests
 {
     private const int Sm86Major = 8, Sm86Minor = 6;
 
+    /// <summary>
+    /// An emitter pinned to the NAIVE lowering.
+    /// </summary>
+    /// <remarks>
+    /// Staging is the default and is preferred wherever the shape allows it, so a test about
+    /// the naive path has to ask for it. These tests are not obsolete -- the naive lowering is
+    /// still what runs for partial block tiles and transposed operands, which staging cannot
+    /// cover. See CodegenTensorCoreStagingTests for the staged equivalents.
+    /// </remarks>
+    private static PtxTensorCoreEmitter Naive() => new() { EnableStaging = false };
+
     private static CodegenKernelSpec MatMul(
         int m, int k, int n,
         CodegenElementType operands = CodegenElementType.Float16,
@@ -78,7 +89,7 @@ public class CodegenTensorCoreTests
     [Fact]
     public void EmittedKernel_UsesWmma()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(64, 64, 64), Sm86Major, Sm86Minor);
+        string ptx = Naive().Emit(MatMul(64, 64, 64), Sm86Major, Sm86Minor);
 
         Assert.Contains("wmma.load.a.sync.aligned.row.m16n16k16.global.f16", ptx, StringComparison.Ordinal);
         Assert.Contains("wmma.load.b.sync.aligned.row.m16n16k16.global.f16", ptx, StringComparison.Ordinal);
@@ -94,7 +105,7 @@ public class CodegenTensorCoreTests
     [Fact]
     public void TileIndex_ComesFromTheWarp()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(MatMul(64, 64, 64), Sm86Major, Sm86Minor);
+        string ptx = Naive().Emit(MatMul(64, 64, 64), Sm86Major, Sm86Minor);
 
         // tid >> 5 is the warp within the block; every lane of a warp gets the same value,
         // so the tile index and the guard that follows are warp-uniform by construction.
@@ -119,6 +130,7 @@ public class CodegenTensorCoreTests
 
         Assert.False(plan!.BRowMajor);
 
+        // Staging refuses a transposed operand, so this is the naive path either way.
         string ptx = new PtxTensorCoreEmitter().Emit(
             MatMul(64, 64, 64, transposeB: true), Sm86Major, Sm86Minor);
         Assert.Contains("wmma.load.b.sync.aligned.col.m16n16k16", ptx, StringComparison.Ordinal);
@@ -133,7 +145,7 @@ public class CodegenTensorCoreTests
     [Fact]
     public void Activation_IsFusedIntoTheAccumulatorFragment()
     {
-        string ptx = new PtxTensorCoreEmitter().Emit(
+        string ptx = Naive().Emit(
             MatMul(64, 64, 64, activation: CodegenActivationKind.ReLU), Sm86Major, Sm86Minor);
 
         // Once per accumulator register, and before the store.
@@ -150,7 +162,7 @@ public class CodegenTensorCoreTests
     [Fact]
     public void LongContraction_BecomesALoop()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Naive();
         string ptx = emitter.Emit(MatMul(64, 4096, 64), Sm86Major, Sm86Minor);
 
         Assert.False(emitter.Unrolled);
@@ -162,7 +174,7 @@ public class CodegenTensorCoreTests
     [Fact]
     public void ShortContraction_IsUnrolled()
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Naive();
         emitter.Emit(MatMul(64, 128, 64), Sm86Major, Sm86Minor);
 
         Assert.True(emitter.Unrolled);
@@ -276,7 +288,7 @@ public class CodegenTensorCoreTests
     [InlineData(48, 32, 2)]        // 6 tiles  -> 2 blocks, last one partly idle
     public void LaunchGeometry_CoversEveryTile(int m, int n, int expectedBlocks)
     {
-        var emitter = new PtxTensorCoreEmitter();
+        var emitter = Naive();
         Assert.True(PtxTensorCoreEmitter.TryPlan(
             MatMul(m, 64, n), Sm86Major, Sm86Minor, out var plan, out string reason), reason);
 


### PR DESCRIPTION
Follows #886 (merged), which introduced `PtxTensorCoreEmitter`. Rebased onto `main`: one commit, six files.

#886 shipped a tensor-core path that was correct and **not competitive**: 0.35× / 0.23× / **0.05×** against cuBLAS at 1024³ / 2048³ / 4096³, with the cause identified as operand locality rather than instruction selection. This is that named lever, built and measured.

## What changed

The naive lowering gives one warp one 16×16 tile and lets it stream its own operand bands from global, so nothing is shared between the warps that need the same bands. A block of four warps now owns a **64×64** output tile and copies the 64×16 slab of A and the 16×64 slab of B into shared memory once per K step.

| | operand traffic | fragment loads per mma |
|---|---|---|
| naive, 16×16 per warp | `M·N·K / 8` halves | 2 |
| staged, 64×64 per block | `M·N·K / 32` halves | 0.5 |

## Measured

Idle GPU, clocks locked at 1770 MHz, cuBLAS in its CUDA-graph lane, batched timing on both sides.

| shape | naive | **staged** | cuBLAS | was | **now** |
|---|---|---|---|---|---|
| 1024³ | 190.1 µs · 11.3 TF | **83.0 µs · 25.9 TF** | 66.6 µs · 32.2 TF | 0.35× | **0.80×** |
| 2048³ | 1455.4 µs · 11.8 TF | **553.1 µs · 31.1 TF** | 333.8 µs · 51.5 TF | 0.23× | **0.60×** |
| 4096³ | 45810.5 µs · 3.0 TF | **4200.8 µs · 32.7 TF** | 2384.1 µs · 57.6 TF | 0.05× | **0.57×** |

**The collapse is gone.** Throughput now *rises* with size — 25.9 → 31.1 → 32.7 TFLOP/s — where before it fell off a cliff. 4096³ improved **10.9×**.

**This is still a loss and is reported as one:** ~53% of device peak against cuBLAS's 93%. But a different kind of loss — 1.75× away rather than 20×.

## Why this lever was legitimate when the convolution one was not

Shared-memory staging was built and **refuted** earlier in this campaign, on dense 3×3 convolution: it raised L1 from 64.08% to 77.45%, because on NVIDIA hardware shared memory *is* L1TEX, so `ld.shared` is counted by the very metric it was meant to relieve. That lever died because `mio_throttle` sat at 3.03% — the load pipe was never that kernel's bottleneck.

The justification here never rested on a throughput percentage. Throughput **fell fourfold** when the working set outgrew L2, which is a locality statement no stall counter is needed to read. Same lever, different evidence, opposite outcome. This is the blueprint's §2 rule working as intended.

## Two things that would have raced or silently mis-run

- **Two barriers per K step.** Without the second, a fast warp overwrites the slabs for step k+1 while a slow one is still reading step k — plausible magnitudes, a different answer per run.
- **The grids differ.** Staged, four warps cover sixteen 16×16 tiles rather than four, so a 64×64 output is **one** block staged and **four** naive. Launching the staged kernel on the naive grid would run it four times over, each pass re-accumulating into the same output.

Shapes staging cannot cover — partial 64×64 block tiles, transposed operands — fall back to the naive path, which stays correct at every shape. The naive-path tests are pinned to it explicitly rather than deleted, because that path still runs.

## Double buffering — built, measured, under-delivered

Single-buffered staging needs two `bar.sync`s per K step, and between them the global copy and the arithmetic cannot overlap. With two slabs the copy for step k+1 targets the buffer nobody is reading, so it is *issued before* the mma work for step k. One barrier per step.

Measured as a **paired** A/B — both lowerings emitted, launched and timed in the same process and thermal window, three runs — because the effect proved small enough that a cross-run comparison could not separate signal from drift:

| shape | run 1 | run 2 | run 3 | ≈ |
|---|---|---|---|---|
| 1024³ | 1.046× | 1.114× | 1.045× | **1.07×** |
| 2048³ | 1.170× | 1.126× | 1.055× | **1.12×** |
| 4096³ | 1.031× | 1.036× | 1.001× | **1.02×** |

Direction is consistent — all nine paired measurements ≥ 1.0 — but the magnitude is 2–12% and it *shrinks* at the largest shape, which is where the argument for it was strongest. Kept because it is a real win at no correctness cost; **not** the step change the reasoning implied.

### Why, from the profile

`ncu` on the staged 4096³ kernel — which is what should have been read *before* building the lever:

| metric | value | stall | value |
|---|---|---|---|
| **l1tex throughput** | **87.14%** | `long_scoreboard` | 17.85 |
| dram throughput | 52.85% | `short_scoreboard` | 10.22 |
| sm throughput | 32.61% | `mio_throttle` | 7.36 |
| **tensor pipe active** | **25.29%** | **`barrier`** | **5.82** |

**`barrier` is 5.82.** Barriers were never the main cost, so removing one could only ever buy a few percent — which is exactly what it bought. This lever was justified by a structural argument and never by a counter, and the blueprint’s §2 rule exists precisely to stop that. The rule was written on this branch and then not followed on it.

**L1TEX is at 87.14% while the tensor cores idle at 25.29%.** Shared memory *is* L1TEX here, so the `wmma.load.*.shared` traffic feeding the fragments is at a roofline. The kernel is not waiting on global memory — DRAM is 52.85%.

## Next lever — derived, not guessed

A **larger per-warp register tile**, not a larger block tile. Each warp loads two A and two B fragments to issue four mma instructions: one fragment load per mma. A 4×4 warp tile loads four and four to issue sixteen — **half the shared traffic per unit of arithmetic**, aimed at the 87% L1TEX figure.

This is *not* what the earlier revision of this PR proposed. That said “a 128×128 block tile”, which targets global traffic — and DRAM is at 52.85%, not the limiter. The profile changed the answer.

## Promotion

Still **withheld everywhere**. At 0.57–0.84×, routing a caller who could reach cuBLAS to us is still a regression — smaller, but a regression. The capability ships; the promotion does not.

## Gates

```
CodegenTensorCoreStagingTests   18 / 18
codegen suite                  304 / 304
--tensorcore-check              10 / 10   (7 verified at 0.000E+000)
--kernel-verify                  13 / 13  unchanged
--frontend-check                 24 / 24  unchanged
--gather-check                    6 / 6   unchanged
--algebra-check                   5 / 5   unchanged
--multiout-check                  3 / 3   unchanged
net10.0 / net8.0 / net471        all build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared-memory staged tensor-core GEMM lowering for eligible workloads, with support for single- and double-buffered modes.
  - Added configurable warp-tile selection (including pinning) and automatic fallback when staging isn’t applicable.
  - Kept fused activation and scaling behaviors consistent in staged execution.

- **Performance**
  - Expanded tensor-core benchmark reporting to compare single vs double staging and scalar baselines.
  - Added a warp-tile sweep option to explore improved throughput settings.

- **Tests**
  - Introduced dedicated staging-focused PTX codegen tests covering barriers, loads/stores, and buffer layout.

- **Documentation**
  - Updated tensor-core guidance with new measured staging and register-tiling findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
