### PR TITLE
fix(autodiff): gather backward must scatter-add for repeated indices

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1832,7 +1832,7 @@ internal static class BackwardFunctions<T>
 
             if (DifferentiableOps.GetSparseEmbeddingGradsFor(inputs[0]) is null)
             {
-                var dense = engine.ScatterAddBackward(gradOutput, indices, inputShape, axis);
+                var dense = engine.ScatterAdd(gradOutput, indices, axis, inputShape[axis]);
                 DifferentiableOps.AccumulateGrad(grads, inputs[0], dense, engine);
             }
             return;
@@ -1842,7 +1842,20 @@ internal static class BackwardFunctions<T>
         // Generalizing SparseEmbeddingGradient to N-D / arbitrary-axis gathers is a
         // forward-ledger surface change for a future PR. For now, the perf win we
         // care about (embedding-table lookups) is covered.
-        var grad = engine.ScatterAddBackward(gradOutput, indices, inputShape, axis);
+        //
+        // Uses ScatterAdd (output[indices[i]] += source[i]) and NOT ScatterAddBackward.
+        // Despite the name, ScatterAddBackward is the backward of a SCATTER-ADD forward with
+        // respect to that op's `src` input, which is a GATHER:
+        // gradSource[s] = gradOutput[indices[s]], with `indices` indexed by SOURCE position.
+        // Gather's backward is the opposite - it must ACCUMULATE gradOutput[i] into source slice
+        // indices[i], because gather indices routinely REPEAT (duplicate tokens in an embedding
+        // lookup; relative-position-bias tables where many (i, j) window positions share a
+        // bucket), so a slice selected k times must receive k contributions. Borrowing the
+        // gather-shaped helper here also read `indices` OUT OF RANGE whenever the source extent
+        // exceeded the index count, because it wrapped via `indices[d % indices.Length]`: a 4-row
+        // source gathered by 3 indices produced uniform garbage instead of per-occurrence sums,
+        // and never-selected slices came back nonzero when they must be exactly 0.
+        var grad = engine.ScatterAdd(gradOutput, indices, axis, inputShape[axis]);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GatherBackwardRepeatedIndicesTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GatherBackwardRepeatedIndicesTests.cs
@@ -1,0 +1,102 @@
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Gradient-correctness guards for Gather's backward when indices REPEAT.
+///
+/// Gather backward must scatter-ADD: position k of the gathered result came from source slice
+/// indices[k], so a slice selected k times must receive k contributions. Accumulation is not an
+/// optimization - repeated indices are the norm rather than the exception:
+///   * embedding lookups, where the same token appears many times in a batch
+///   * relative-position-bias tables (Swin), where many (i, j) window positions map to the same
+///     relative-position bucket
+///
+/// The original ScatterAddBackward looped over the SOURCE dim and did
+///     gradInput[d] = gradOutput[indices[d % len]]
+/// which walked the wrong axis, ASSIGNED instead of accumulating, and bounds-checked the target
+/// index against the OUTPUT extent although it indexes the SOURCE. With an all-ones upstream
+/// gradient it wrote 1 into every slot it touched - including never-selected slices, which must be
+/// exactly 0. Downstream that produced analytical gradients too small by a non-uniform factor and
+/// with signs that need not match the true sum (AiDotNet SwinTransformerBlockLayer disagreed with
+/// finite differences on 6/6 sampled scalars).
+/// </summary>
+public class GatherBackwardRepeatedIndicesTests
+{
+    [Fact]
+    public void GatherBackward_WithRepeatedIndices_AccumulatesPerOccurrence()
+    {
+        var engine = AiDotNetEngine.Current;
+
+        // 4 source rows, gather 3 of them as [0, 0, 1]. The source deliberately has MORE rows than
+        // the gather count so grad-wrt-source [4,2] and grad-wrt-output [3,2] have DIFFERENT
+        // shapes: with equal shapes an all-ones result is ambiguous, since it is also exactly
+        // d(loss)/d(gathered).
+        var table = new Tensor<double>(new[] { 4, 2 });
+        for (int i = 0; i < table.Length; i++) table[i] = i + 1;
+
+        var indices = new Tensor<int>(new[] { 3 });
+        indices[0] = 0;
+        indices[1] = 0;
+        indices[2] = 1;
+
+        using var tape = new GradientTape<double>();
+        var gathered = engine.TensorGather(table, indices, axis: 0);
+        var allAxes = new int[gathered.Shape.Length];
+        for (int i = 0; i < allAxes.Length; i++) allAxes[i] = i;
+        var loss = engine.ReduceSum(gathered, allAxes, keepDims: false);
+
+        var grads = tape.ComputeGradients(loss, new[] { table });
+        Assert.True(grads.TryGetValue(table, out var grad) && grad is not null,
+            "no gradient was produced for the gathered source table");
+
+        Assert.Equal(new[] { 4, 2 }, grad!.Shape.ToArray());
+
+        // loss = sum(gathered) => d(loss)/d(table[r, :]) == number of times row r was selected.
+        double[] expectedPerRow = { 2.0, 1.0, 0.0, 0.0 };
+        for (int r = 0; r < 4; r++)
+        {
+            for (int c = 0; c < 2; c++)
+            {
+                Assert.Equal(expectedPerRow[r], grad[r * 2 + c], precision: 10);
+            }
+        }
+    }
+
+    [Fact]
+    public void GatherBackward_WithoutRepeats_IsUnchanged()
+    {
+        var engine = AiDotNetEngine.Current;
+
+        // Regression guard for the non-repeating case the old code happened to get right, so the
+        // accumulation fix cannot silently double-count.
+        var table = new Tensor<double>(new[] { 4, 2 });
+        for (int i = 0; i < table.Length; i++) table[i] = i + 1;
+
+        var indices = new Tensor<int>(new[] { 2 });
+        indices[0] = 2;
+        indices[1] = 0;
+
+        using var tape = new GradientTape<double>();
+        var gathered = engine.TensorGather(table, indices, axis: 0);
+        var allAxes = new int[gathered.Shape.Length];
+        for (int i = 0; i < allAxes.Length; i++) allAxes[i] = i;
+        var loss = engine.ReduceSum(gathered, allAxes, keepDims: false);
+
+        var grads = tape.ComputeGradients(loss, new[] { table });
+        Assert.True(grads.TryGetValue(table, out var grad) && grad is not null,
+            "no gradient was produced for the gathered source table");
+
+        double[] expectedPerRow = { 1.0, 0.0, 1.0, 0.0 };
+        for (int r = 0; r < 4; r++)
+        {
+            for (int c = 0; c < 2; c++)
+            {
+                Assert.Equal(expectedPerRow[r], grad![r * 2 + c], precision: 10);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`GatherBackward` delegated to `engine.ScatterAddBackward`, which — despite the name — is the backward of a **ScatterAdd forward** with respect to that op's `src` input, and that is a **gather**:

```
gradSource[s] = gradOutput[indices[s]]     // `indices` indexed by SOURCE
```

Gather's backward is the opposite. Position `i` of the gathered result came from source slice `indices[i]`, so it must **accumulate**:

```
gradSource[indices[i]] += gradOutput[i]    // `indices` indexed by OUTPUT
```

Accumulation is mandatory, not an optimization. Gather indices routinely **repeat** — duplicate tokens in an embedding lookup, and relative-position-bias tables where many `(i, j)` window positions map to the same bucket. A slice selected *k* times must receive *k* contributions.

Borrowing the gather-shaped helper also read `indices` **out of range** whenever the source extent exceeded the index count, because it wrapped via `indices[d % indices.Length]`. A 4-row source gathered by 3 indices therefore produced uniform garbage instead of per-occurrence sums, and never-selected slices came back nonzero when they must be exactly `0`.

## Fix

Use `ScatterAdd` (`output[indices[i]] += source[i]`) with `outputSize = inputShape[axis]`, at the real site.

**`ScatterAddBackward` and every GPU kernel (CUDA / HIP / Metal / OpenCL) are deliberately left alone** — they correctly implement their own op's contract. The OpParity fixture pins that contract down: `gradOutput [4,6]`, `indices` length 3, `sourceShape [3,6]`, i.e. `indices.Length == sourceRows != outputRows`, which is only consistent with the gather reading. Changing *that* op instead breaks `Parity_ScatterAddBackward`, and CPU/GPU agreeing there was never the bug.

## Verification

- Gather/Scatter/Embedding suite **177/177** on net10.0, including `Parity_ScatterAddBackward` (CPU vs GPU, bit-exact) — confirming no GPU kernel change is required.
- New `GatherBackwardRepeatedIndicesTests` **2/2 on net10.0 and net471**: gathering `[0,0,1]` from a 4x2 table now yields per-row gradients `[2,1,0,0]`.
  - The source deliberately has **more rows than the gather count** so `grad-wrt-source [4,2]` and `grad-wrt-output [3,2]` differ in shape. With equal shapes an all-ones result is ambiguous, being *also* exactly `d(loss)/d(gathered)`, and cannot distinguish "backward ignores the indices" from "gradient returned for the wrong tensor".
  - A second case guards the non-repeating path against double-counting.

## Downstream impact

Found via AiDotNet, which consumed this branch packed as `0.119.0-gatherfix2`:

`SwinTransformerBlockLayerTests.TapeGradient_ShouldMatchNumericalGradient` now **passes**. It had disagreed with finite differences on **6/6** sampled trainable scalars — analytical gradients 3-100x too small with frequent sign flips — while its forward was provably clean (all window-partition / cyclic-shift / QKV / relative-position-bias ops already go through recorded `Engine.*` calls). The non-uniform error factor is the signature of dropped repeated-index contributions rather than a mis-scaled backward. AiDotNet's full tape-gradient suite goes 157/1 -> **158/158**.

Scope worth noting: Swin was simply the first consumer whose gradient check was strict enough to catch this. Any gather-based lookup with repeated indices had silently wrong gradients, embedding tables included, since duplicate tokens in a batch are normal rather than exceptional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)