### PR TITLE
fix(autodiff): elementwise backwards threw on a rank-0 operand vs a rank-1 seed gradient

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Tensors.Engines.Simd;
+using AiDotNet.Tensors.Engines.Simd;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -110,6 +110,9 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        // See AlignGradRank: a rank-0 operand paired with a rank-1 [1] seed would otherwise throw.
+        gradOutput = AlignGradRank(engine, gradOutput, inputs[0]);
+
         var gradA = engine.TensorMultiply(gradOutput, inputs[1]);
         var gradB = engine.TensorMultiply(gradOutput, inputs[0]);
         if (DifferentiableOps.AccumulateGradPoolable(grads, inputs[0], gradA, engine))
@@ -119,10 +122,37 @@ internal static class BackwardFunctions<T>
     }
 
     /// <summary>d(a/b)/da = grad/b, d(a/b)/db = -grad*a/(b*b)</summary>
+    /// <summary>
+    /// Reshapes an upstream gradient to an operand's shape when the two describe the SAME number of
+    /// elements but different ranks, e.g. a rank-1 <c>[1]</c> seed against a rank-0 <c>[]</c> operand.
+    /// </summary>
+    /// <remarks>
+    /// Elementwise backward functions divide/multiply the upstream gradient by an operand directly,
+    /// which requires matching shapes. A rank-0 result (any full reduction with
+    /// <c>keepDims: false</c>) receives a rank-1 <c>[1]</c> seed gradient from the tape, so those ops
+    /// threw "Tensor shapes must match. Got [1] and []" from inside ComputeGradients -- turning a
+    /// perfectly valid loss into an exception mid-training-step. Because the element count is
+    /// identical, a reshape is exact and loses nothing; anything that is NOT a pure rank mismatch is
+    /// left untouched so genuine shape errors still surface.
+    /// </remarks>
+    private static Tensor<T> AlignGradRank(IEngine engine, Tensor<T> grad, Tensor<T> operand)
+    {
+        if (grad.Shape.Length == operand.Shape.Length || grad.Length != operand.Length)
+        {
+            return grad;
+        }
+
+        return engine.Reshape(grad, (int[])operand._shape.Clone());
+    }
+
     internal static void DivideBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        // The forward divide requires a and b to share a shape, so aligning against inputs[0] is
+        // enough to make every product/quotient below shape-consistent.
+        gradOutput = AlignGradRank(engine, gradOutput, inputs[0]);
+
         var gradA = engine.TensorDivide(gradOutput, inputs[1]);
         var bSquared = engine.TensorMultiply(inputs[1], inputs[1]);
         var posGradA = engine.TensorMultiply(gradOutput, inputs[0]);
@@ -145,6 +175,7 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        gradOutput = AlignGradRank(engine, gradOutput, output);
         var grad = engine.TensorMultiply(gradOutput, output);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
@@ -154,6 +185,7 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        gradOutput = AlignGradRank(engine, gradOutput, inputs[0]);
         var grad = engine.TensorDivide(gradOutput, inputs[0]);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], grad, engine);
     }
@@ -4480,6 +4512,9 @@ internal static class BackwardFunctions<T>
     {
         var numOps = MathHelper.GetNumericOperations<T>();
         var two = numOps.FromDouble(2.0);
+        // See AlignGradRank: same rank-0-operand / rank-1-seed hazard as the other elementwise
+        // backwards. Found by sweeping all 245 backward functions for this pattern.
+        gradOutput = AlignGradRank(engine, gradOutput, inputs[0]);
         var gradReal = engine.TensorMultiplyScalar(engine.TensorMultiply(gradOutput, inputs[0]), two);
         var gradImag = engine.TensorMultiplyScalar(engine.TensorMultiply(gradOutput, inputs[1]), two);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradReal, engine);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RankZeroLossBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RankZeroLossBackwardTests.cs
@@ -62,7 +62,7 @@ public class RankZeroLossBackwardTests
         var ga = grads[a];
         for (int i = 0; i < ga.Length; i++)
         {
-            Assert.True(double.IsFinite(ga[i]), $"grad a[{i}] not finite: {ga[i]}");
+            Assert.True(!double.IsNaN(ga[i]) && !double.IsInfinity(ga[i]), $"grad a[{i}] not finite: {ga[i]}");
             Assert.True(Math.Abs(ga[i] - 0.25) < 1e-9, $"grad a[{i}]={ga[i]}, expected 0.25");
         }
 
@@ -70,7 +70,7 @@ public class RankZeroLossBackwardTests
         var gb = grads[b];
         for (int i = 0; i < gb.Length; i++)
         {
-            Assert.True(double.IsFinite(gb[i]), $"grad b[{i}] not finite: {gb[i]}");
+            Assert.True(!double.IsNaN(gb[i]) && !double.IsInfinity(gb[i]), $"grad b[{i}] not finite: {gb[i]}");
             Assert.True(Math.Abs(gb[i] + 0.375) < 1e-9, $"grad b[{i}]={gb[i]}, expected -0.375");
         }
     }
@@ -113,7 +113,7 @@ public class RankZeroLossBackwardTests
         var ga = grads[a];
         for (int i = 0; i < ga.Length; i++)
         {
-            Assert.True(double.IsFinite(ga[i]));
+            Assert.True(!double.IsNaN(ga[i]) && !double.IsInfinity(ga[i]));
             Assert.True(Math.Abs(ga[i] - 0.25) < 1e-9, $"grad a[{i}]={ga[i]}, expected 0.25");
         }
     }
@@ -135,7 +135,7 @@ public class RankZeroLossBackwardTests
         var ga = grads[a];
         for (int i = 0; i < ga.Length; i++)
         {
-            Assert.True(double.IsFinite(ga[i]));
+            Assert.True(!double.IsNaN(ga[i]) && !double.IsInfinity(ga[i]));
             // 1e-6 matches the tolerance the neighbouring AbsSoftplusGradientRepro tests use: the
             // engine evaluates exp at ~float32 precision (measured 2.117000102996826 against the
             // exact 2.117000016612675), which is a precision characteristic, not a gradient error.
@@ -168,7 +168,7 @@ public class RankZeroLossBackwardTests
         var ga = grads[a];
         for (int i = 0; i < ga.Length; i++)
         {
-            Assert.True(double.IsFinite(ga[i]));
+            Assert.True(!double.IsNaN(ga[i]) && !double.IsInfinity(ga[i]));
             Assert.True(Math.Abs(ga[i] - 2.0) < 1e-9, $"grad a[{i}]={ga[i]}, expected 2");
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RankZeroLossBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RankZeroLossBackwardTests.cs
@@ -1,0 +1,202 @@
+using System;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Guards backpropagation through a RANK-0 loss — the shape produced by any full reduction with
+/// <c>keepDims: false</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ORIGIN: AiDotNet's DiceLoss reduced over all axes with <c>keepDims: false</c> (giving rank-0
+/// <c>[]</c> tensors) and then divided them. The FORWARD divide was fine, but the BACKWARD was not:
+/// the tape seeds a rank-1 <c>[1]</c> gradient, and <c>DivideBackward</c> passed that straight into
+/// <c>TensorDivide</c> against a rank-0 operand, throwing
+/// "Tensor shapes must match. Got [1] and []" from inside <c>ComputeGradients</c>.
+/// </para>
+/// <para>
+/// That made the loss unusable for TRAINING, and the failure mode was badly misleading: the
+/// exception surfaces mid-training-step, so callers saw "no parameters changed after training" and
+/// blamed the model or the gradients rather than the loss. A sweep of all 245 backward functions
+/// found the same unguarded pattern in Multiply, Log, Exp and ComplexMagnitudeSquared; all are now
+/// routed through AlignGradRank.
+/// </para>
+/// <para>
+/// Each test asserts gradients are produced, FINITE, and numerically CORRECT — not merely that no
+/// exception is thrown, so a future "fix" that silently zeroes the gradient still fails here.
+/// </para>
+/// </remarks>
+[Collection("EngineCurrentGlobalState")]
+public class RankZeroLossBackwardTests
+{
+    private readonly IEngine _engine = AiDotNetEngine.Current;
+
+    private static Tensor<double> Param(params double[] values)
+        => new Tensor<double>(values, new[] { values.Length });
+
+    /// <summary>Full reduction with keepDims:false — the shape that triggered the bug.</summary>
+    private Tensor<double> Rank0Sum(Tensor<double> t)
+        => _engine.ReduceSum(t, new[] { 0 }, keepDims: false);
+
+    [Fact]
+    public void Divide_WithRankZeroOperands_Backpropagates()
+    {
+        var a = Param(2.0, 4.0);
+        var b = Param(1.0, 3.0);
+
+        using var tape = new GradientTape<double>();
+        var num = Rank0Sum(a);                            // 6, shape []
+        var den = Rank0Sum(b);                            // 4, shape []
+        var loss = _engine.TensorDivide(num, den);        // 1.5
+
+        Assert.Equal(0, loss.Shape.Length);
+
+        var grads = tape.ComputeGradients(loss, new[] { a, b });
+
+        // d(sum(a)/sum(b))/da_i = 1/sum(b) = 0.25
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+        {
+            Assert.True(double.IsFinite(ga[i]), $"grad a[{i}] not finite: {ga[i]}");
+            Assert.True(Math.Abs(ga[i] - 0.25) < 1e-9, $"grad a[{i}]={ga[i]}, expected 0.25");
+        }
+
+        // d/db_i = -sum(a)/sum(b)^2 = -6/16 = -0.375
+        var gb = grads[b];
+        for (int i = 0; i < gb.Length; i++)
+        {
+            Assert.True(double.IsFinite(gb[i]), $"grad b[{i}] not finite: {gb[i]}");
+            Assert.True(Math.Abs(gb[i] + 0.375) < 1e-9, $"grad b[{i}]={gb[i]}, expected -0.375");
+        }
+    }
+
+    [Fact]
+    public void Multiply_WithRankZeroOperands_Backpropagates()
+    {
+        var a = Param(2.0, 3.0);
+        var b = Param(4.0, 1.0);
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.TensorMultiply(Rank0Sum(a), Rank0Sum(b));   // 5 * 5 = 25
+
+        Assert.Equal(0, loss.Shape.Length);
+
+        var grads = tape.ComputeGradients(loss, new[] { a, b });
+
+        // d(sum(a)*sum(b))/da_i = sum(b) = 5, and symmetrically for b.
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+            Assert.True(Math.Abs(ga[i] - 5.0) < 1e-9, $"grad a[{i}]={ga[i]}, expected 5");
+        var gb = grads[b];
+        for (int i = 0; i < gb.Length; i++)
+            Assert.True(Math.Abs(gb[i] - 5.0) < 1e-9, $"grad b[{i}]={gb[i]}, expected 5");
+    }
+
+    [Fact]
+    public void Log_WithRankZeroOperand_Backpropagates()
+    {
+        var a = Param(1.0, 3.0);
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.TensorLog(Rank0Sum(a));    // ln 4
+
+        Assert.Equal(0, loss.Shape.Length);
+
+        var grads = tape.ComputeGradients(loss, new[] { a });
+
+        // d(log(sum(a)))/da_i = 1/sum(a) = 0.25
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+        {
+            Assert.True(double.IsFinite(ga[i]));
+            Assert.True(Math.Abs(ga[i] - 0.25) < 1e-9, $"grad a[{i}]={ga[i]}, expected 0.25");
+        }
+    }
+
+    [Fact]
+    public void Exp_WithRankZeroOperand_Backpropagates()
+    {
+        var a = Param(0.5, 0.25);
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.TensorExp(Rank0Sum(a));    // e^0.75
+
+        Assert.Equal(0, loss.Shape.Length);
+
+        var grads = tape.ComputeGradients(loss, new[] { a });
+
+        // d(exp(sum(a)))/da_i = exp(sum(a))
+        double expected = Math.Exp(0.75);
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+        {
+            Assert.True(double.IsFinite(ga[i]));
+            // 1e-6 matches the tolerance the neighbouring AbsSoftplusGradientRepro tests use: the
+            // engine evaluates exp at ~float32 precision (measured 2.117000102996826 against the
+            // exact 2.117000016612675), which is a precision characteristic, not a gradient error.
+            Assert.True(Math.Abs(ga[i] - expected) < 1e-6, $"grad a[{i}]={ga[i]}, expected {expected}");
+        }
+    }
+
+    /// <summary>
+    /// The composite shape that broke AiDotNet's SAM/SAM2: one loss term reduces to rank-1 <c>[1]</c>
+    /// (FocalLoss) and another to rank-0 <c>[]</c> (DiceLoss), and the two are summed.
+    /// </summary>
+    [Fact]
+    public void MixedRankLossTerms_CanBeCombinedAndBackpropagated()
+    {
+        var a = Param(1.0, 2.0, 3.0);
+
+        using var tape = new GradientTape<double>();
+        var rank0 = Rank0Sum(a);                                        // shape []
+        var rank1 = _engine.ReduceSum(a, new[] { 0 }, keepDims: true);  // shape [1]
+
+        Assert.Equal(0, rank0.Shape.Length);
+        Assert.Equal(1, rank1.Shape.Length);
+
+        // Aligning then combining is exactly what a composite objective must do.
+        var loss = _engine.TensorAdd(_engine.Reshape(rank0, new[] { 1 }), rank1);   // 2 * sum(a)
+
+        var grads = tape.ComputeGradients(loss, new[] { a });
+
+        // d(2*sum(a))/da_i = 2
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+        {
+            Assert.True(double.IsFinite(ga[i]));
+            Assert.True(Math.Abs(ga[i] - 2.0) < 1e-9, $"grad a[{i}]={ga[i]}, expected 2");
+        }
+    }
+
+    /// <summary>
+    /// A rank-0 loss reached through a CHAIN (divide then log), so the aligned gradient has to
+    /// survive more than one backward hop.
+    /// </summary>
+    [Fact]
+    public void ChainedRankZeroOps_Backpropagate()
+    {
+        var a = Param(2.0, 2.0);
+        var b = Param(1.0, 1.0);
+
+        using var tape = new GradientTape<double>();
+        var ratio = _engine.TensorDivide(Rank0Sum(a), Rank0Sum(b));   // 4/2 = 2
+        var loss = _engine.TensorLog(ratio);                          // ln 2
+
+        Assert.Equal(0, loss.Shape.Length);
+
+        var grads = tape.ComputeGradients(loss, new[] { a, b });
+
+        // d(log(sum(a)/sum(b)))/da_i = 1/sum(a) = 0.25 ; d/db_i = -1/sum(b) = -0.5
+        var ga = grads[a];
+        for (int i = 0; i < ga.Length; i++)
+            Assert.True(Math.Abs(ga[i] - 0.25) < 1e-9, $"grad a[{i}]={ga[i]}, expected 0.25");
+        var gb = grads[b];
+        for (int i = 0; i < gb.Length; i++)
+            Assert.True(Math.Abs(gb[i] + 0.5) < 1e-9, $"grad b[{i}]={gb[i]}, expected -0.5");
+    }
+}


### PR DESCRIPTION
## Problem

Any full reduction with `keepDims: false` produces a **rank-0 `[]`** tensor. The tape seeds a **rank-1 `[1]`** gradient, and several elementwise backward functions passed that seed straight into an elementwise op against a rank-0 operand, so `CpuEngine` threw:

```
Tensor shapes must match. Got [1] and []
```

...from **inside** `GradientTape.ComputeGradients`.

The impact is worse than a shape error, because of *where* it surfaces. The exception fires mid-training-step, so callers see "no parameters changed after training" and blame the model or the gradients. Downstream in AiDotNet this made `DiceLoss` **completely unusable for training**, and it cost three wrong diagnoses on SAM2 (vanishing gradients at p=0.5, a severed tape, sigmoid saturation) before the stack trace pointed at `DivideBackward`.

## Fix

`AlignGradRank`: when the gradient and the operand describe the **same element count** but different ranks, reshape the gradient to the operand's shape. The reshape is exact (no data change), and anything that is *not* a pure rank mismatch is left untouched so genuine shape errors still surface.

I **swept all 245 backward functions** for the pattern (an elementwise op pairing `gradOutput` with `inputs[..]`/`output` without alignment). Five needed it:

- `DivideBackward`
- `MultiplyBackward`
- `LogBackward`
- `ExpBackward`
- `ComplexMagnitudeSquaredBackward`

No others matched, so this closes the class of bug rather than patching the one reported site.

## Tests

New `RankZeroLossBackwardTests` — 6 cases covering the trigger and its neighbours:

| Case | Why it exists |
|---|---|
| divide, **both** operands rank-0 | the exact `DiceLoss` shape that broke |
| multiply, both rank-0 | sibling op with the same hazard |
| log / exp of a rank-0 value | the other two swept ops |
| **mixed-rank `[1]` + `[]`** combined into one loss | the composite-objective shape (focal `[1]` + dice `[]`) |
| **chained** rank-0 path (divide → log) | the aligned gradient must survive multiple backward hops |

Each asserts the gradient is produced, **finite**, and **numerically equal to the closed-form derivative** — not merely that no exception was thrown, so a future change that silently zeroes a gradient still fails here.

## Verification

- **2836 passed / 0 failed** across the Autodiff, Backward, GradientTape and OpParity suites (3178 total, 342 GPU-skipped) — up from 2830 by exactly the 6 new tests.
- Re-verified on this `main`-based branch: OpParity + the new tests, 1399 passed / 0 failed.

One note on tolerance: the exp case initially failed at 8.6e-8 (`2.117000102996826` vs the exact `2.117000016612675`). That is the engine evaluating exp at ~float32 precision, not a gradient error, so the assertion uses the same `1e-6` tolerance the neighbouring `AbsSoftplusGradientRepro` tests already use, with the measurement recorded in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)