### PR TITLE
fix: preserve COW isolation in compiled training

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -378,6 +378,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// </remarks>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters)
     {
+        PrepareParametersForTraining(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss: null);
     }
@@ -388,8 +389,20 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters, Tensor<T> explicitLoss)
     {
+        PrepareParametersForTraining(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss);
+    }
+
+    /// <summary>
+    /// Privatizes COW-shared parameters before compilation specializes graph actions or an
+    /// optimizer retains their live backing arrays. Lazy/off-loss-path parameters are included:
+    /// they are valid registered parameters even when this trace does not produce a gradient.
+    /// </summary>
+    private static void PrepareParametersForTraining<T>(Tensor<T>[] parameters)
+    {
+        for (int i = 0; i < parameters.Length; i++)
+            parameters[i].PrepareForInPlaceWrite();
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -2234,6 +2234,14 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     }
 
     /// <summary>
+    /// Declares that an internal subsystem will retain a writable reference to this tensor's
+    /// backing storage. Copy-on-write tensors must be privatized before that reference is
+    /// captured, because a later write through the retained reference cannot pass through the
+    /// normal tensor write guards.
+    /// </summary>
+    internal void PrepareForInPlaceWrite() => EnsureOwnedForWrite();
+
+    /// <summary>
     /// Copy-on-write clone: shares the backing storage at O(1) for the plain dense case and
     /// privatizes on the first write to either side, preserving full deep-copy semantics. Falls
     /// back to an eager <see cref="Clone"/> for any layout that cannot be shared safely. The base

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
@@ -24,6 +24,121 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 public class ConfigureOptimizerParamUpdateTests
 {
     /// <summary>
+    /// Issue #624 follow-up: compiled training is a write-intent use of every registered
+    /// parameter. The parameter must therefore leave COW-shared storage before the plan
+    /// captures live backing arrays; otherwise the fused optimizer mutates the clone too.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamFloat_CowSharedParameterIsPrivatizedBeforePlanCapture()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 4, 3 });
+        var weight = new Tensor<float>(new[] { 3, 2 });
+        var lazyWeight = new Tensor<float>(new[] { 2, 2 });
+        var rng = new System.Random(701);
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < weight.Length; i++) weight[i] = (float)(rng.NextDouble() - 0.5);
+        for (int i = 0; i < lazyWeight.Length; i++) lazyWeight[i] = (float)(rng.NextDouble() - 0.5);
+
+        var peer = (Tensor<float>)weight.CloneShared();
+        var lazyPeer = (Tensor<float>)lazyWeight.CloneShared();
+        var peerBefore = peer.ToArray();
+        var lazyPeerBefore = lazyPeer.ToArray();
+        var weightBefore = weight.ToArray();
+        Assert.True(weight.IsCowShared);
+        Assert.True(peer.IsCowShared);
+        Assert.True(lazyWeight.IsCowShared);
+        Assert.True(lazyPeer.IsCowShared);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorMatMul(input, weight);
+            var squared = engine.TensorMultiply(output, output);
+            var loss = engine.ReduceSum(squared, null);
+            // Lazy/off-loss-path parameters are deliberately accepted by the compiled
+            // optimizer. They still need private storage before its raw-array capture.
+            plan = scope.CompileTraining(new[] { weight, lazyWeight }, loss);
+        }
+
+        // This timing is part of the contract: detaching in ConfigureOptimizer would be too late,
+        // because specialized forward actions may already have pinned the shared backing array.
+        Assert.False(weight.IsCowShared,
+            "CompileTraining must privatize registered COW parameters before plan buffer capture.");
+        Assert.False(lazyWeight.IsCowShared,
+            "CompileTraining must also privatize lazy/off-loss-path registered parameters.");
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            var loss1 = plan.Step()[0];
+            var loss2 = plan.Step()[0];
+            Assert.True(float.IsFinite(loss1));
+            Assert.True(float.IsFinite(loss2));
+            Assert.NotEqual(loss1, loss2);
+        }
+
+        Assert.Equal(peerBefore, peer.ToArray());
+        Assert.Equal(lazyPeerBefore, lazyPeer.ToArray());
+        Assert.NotEqual(weightBefore, weight.ToArray());
+    }
+
+    /// <summary>
+    /// Double-precision coverage for the same COW/compiled-optimizer boundary. The double
+    /// optimizer has a separate live-backing binding implementation and must obey the same rule.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizer_AdamDouble_CowSharedParameterIsPrivatizedBeforePlanCapture()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 4, 3 });
+        var weight = new Tensor<double>(new[] { 3, 2 });
+        var lazyWeight = new Tensor<double>(new[] { 2, 2 });
+        var rng = new System.Random(702);
+        for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < weight.Length; i++) weight[i] = rng.NextDouble() - 0.5;
+        for (int i = 0; i < lazyWeight.Length; i++) lazyWeight[i] = rng.NextDouble() - 0.5;
+
+        var peer = (Tensor<double>)weight.CloneShared();
+        var lazyPeer = (Tensor<double>)lazyWeight.CloneShared();
+        var peerBefore = peer.ToArray();
+        var lazyPeerBefore = lazyPeer.ToArray();
+        var weightBefore = weight.ToArray();
+        Assert.True(weight.IsCowShared);
+        Assert.True(peer.IsCowShared);
+        Assert.True(lazyWeight.IsCowShared);
+        Assert.True(lazyPeer.IsCowShared);
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorMatMul(input, weight);
+            var squared = engine.TensorMultiply(output, output);
+            engine.ReduceSum(squared, null);
+            plan = scope.CompileTraining(new[] { weight, lazyWeight });
+        }
+
+        Assert.False(weight.IsCowShared,
+            "CompileTraining must privatize registered COW parameters before plan buffer capture.");
+        Assert.False(lazyWeight.IsCowShared,
+            "CompileTraining must also privatize lazy/off-loss-path registered parameters.");
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+            var loss1 = plan.Step()[0];
+            var loss2 = plan.Step()[0];
+            Assert.True(double.IsFinite(loss1));
+            Assert.True(double.IsFinite(loss2));
+            Assert.NotEqual(loss1, loss2);
+        }
+
+        Assert.Equal(peerBefore, peer.ToArray());
+        Assert.Equal(lazyPeerBefore, lazyPeer.ToArray());
+        Assert.NotEqual(weightBefore, weight.ToArray());
+    }
+
+    /// <summary>
     /// Issue #350 second-order bug: the AiDotNet consumer's DenseLayer routes
     /// through <c>Engine.FusedLinear(input, weights, bias, FusedActivationType.None)</c>
     /// — a single fused op. After compile + Step + Adam update, the weights

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
@@ -73,8 +73,8 @@ public class ConfigureOptimizerParamUpdateTests
             plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
             var loss1 = plan.Step()[0];
             var loss2 = plan.Step()[0];
-            Assert.True(float.IsFinite(loss1));
-            Assert.True(float.IsFinite(loss2));
+            Assert.False(float.IsNaN(loss1) || float.IsInfinity(loss1));
+            Assert.False(float.IsNaN(loss2) || float.IsInfinity(loss2));
             Assert.NotEqual(loss1, loss2);
         }
 
@@ -128,8 +128,8 @@ public class ConfigureOptimizerParamUpdateTests
             plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
             var loss1 = plan.Step()[0];
             var loss2 = plan.Step()[0];
-            Assert.True(double.IsFinite(loss1));
-            Assert.True(double.IsFinite(loss2));
+            Assert.False(double.IsNaN(loss1) || double.IsInfinity(loss1));
+            Assert.False(double.IsNaN(loss2) || double.IsInfinity(loss2));
             Assert.NotEqual(loss1, loss2);
         }
 


### PR DESCRIPTION
## Summary

- privatize copy-on-write shared parameters before compiled training specializes graph actions or retains writable backing arrays
- expose a narrow internal write-intent boundary on `TensorBase<T>`
- cover both float and double compiled Adam paths and both `CompileTraining` overloads
- retain support for lazy/off-loss-path registered parameters without disabling fused compiled training

## Root cause

The fused compiled optimizer binds each registered parameter's live CPU backing array for in-place updates. That raw-array path bypasses the normal tensor write accessors that call the COW privatization guard.

Parameters exercised by some graph topologies were detached incidentally during compilation, but lazy/off-loss-path registered parameters could remain COW-shared when the plan captured their storage. Detaching later in `ConfigureOptimizer` is not a safe lifecycle boundary because compiled actions may already retain backing references.

This change makes compiled training itself the write-intent boundary and privatizes every registered COW parameter before plan compilation and buffer capture.

## Impact

COW model clones remain O(1) for inference and other read-only use. A clone pays the required copy only when it enters compiled training, ensuring optimizer writes cannot leak into the peer model. Fused compiled training remains enabled.

This addresses the clone-training isolation problem observed while diagnosing AiDotNet PR [#1789](https://github.com/ooples/AiDotNet/pull/1789).

## Validation

- confirmed both new float and double regressions fail before the fix
- Release focused COW/compiled optimizer tests: 40 passed
- Linux GitHub-runner simulation (4 CPUs, 16 GB RAM, Workstation GC): 40 passed
- loaded the fixed Release DLL into AiDotNet and ran:
  - `InstructionNERTests.MoreData_ShouldNotDegrade`
  - `PubMedBERTNERTests.MoreData_ShouldNotDegrade`
- constrained Linux AiDotNet verification: 2 passed
