### PR TITLE
fix(compilation): preserve COW parameter views and FP64 training

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -1293,28 +1293,31 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         {
             var step = steps[i];
 
-            // Transpose optimization: use fast Data.Span path when input is contiguous
-            // with zero offset, fall back to eng.TensorTranspose for views/slices
+            // Transpose optimization: operate on exact logical spans so ArrayPool
+            // padding, Memory<T> base offsets, and COW output storage are respected.
+            // Non-contiguous views retain the stride-aware engine fallback.
             if (step.OpType == OpType.TensorTranspose && step.Inputs.Length == 1 && step.Inputs[0].Rank == 2)
             {
                 var capturedInput = step.Inputs[0];
                 var capturedOutput = step.OutputBuffer;
-                bool canUseFastPath = capturedInput.IsContiguous && capturedInput._storageOffset == 0;
+                bool canUseFastPath = capturedInput.IsContiguous && capturedOutput.IsContiguous;
 
                 if (canUseFastPath)
                 {
-                    // Fast path: direct data access (zero-offset contiguous tensor)
+                    // Fast path: exact logical span access (contiguous tensors may
+                    // have non-zero offsets or pool-padded backing storage).
                     int rows = capturedInput._shape[0];
                     int cols = capturedInput._shape[1];
                     specializedSteps[i] = new CompiledStep<T>(
                         step.OpName,
                         (eng, o) =>
                         {
-                            var src = capturedInput.GetDataArray();
-                            var dst = capturedOutput.GetDataArray();
+                            var src = capturedInput.AsSpan();
+                            var dst = capturedOutput.AsWritableSpan();
                             for (int r = 0; r < rows; r++)
                                 for (int c = 0; c < cols; c++)
                                     dst[c * rows + r] = src[r * cols + c];
+                            capturedOutput.IncrementVersion();
                         },
                         step.OutputBuffer,
                         step.Inputs,

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
@@ -195,7 +195,7 @@ public sealed class CompiledModelCache<T> : IDisposable
             // live forward activation and corrupt it on replay (silent zero-gradient / frozen training
             // at large activation sizes). See TensorArena.Suspend.
             using var arenaSuspend = Helpers.TensorArena.Suspend();
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableTraining(parameters);
             var explicitLoss = forwardAndLoss();
             ThrowIfForwardRecordedNothing(scope, explicitLoss);
             var plan = scope.CompileTraining(parameters, explicitLoss);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -485,7 +485,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var tRowSum = new System.Collections.Generic.Dictionary<int, float[]>();
             if (!engine.SupportsGpu)
                 DetectAnalyticLossMatMulBackward(forwardSteps, consumerCount, tempGrad,
-                    tAnalytic, decidedSkippableReduceSum, tAnalyticFwd, tSkipFwd, tRowSum);
+                    tAnalytic, decidedSkippableReduceSum, tAnalyticFwd, tSkipFwd, tRowSum,
+                    decidedFusedSteps);
         }
 
         // ---- Action-space liveness over the decided action stream.
@@ -3543,7 +3544,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         bool multiTensorEligible = true;
         for (int p = 0; p < paramCount; p++)
         {
-            if (paramOffsets[p] != 0 || gradOffsets[p] != 0 || stagedParams[p] || stagedGrads[p])
+            if (paramArrays[p].Length == 0 || gradArrays[p].Length == 0
+                || paramOffsets[p] != 0 || gradOffsets[p] != 0
+                || stagedParams[p] || stagedGrads[p])
             {
                 multiTensorEligible = false;
                 break;
@@ -4546,7 +4549,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // for it, incl. its skippable-ReduceSum, in the action coverage).
         if (typeof(T) == typeof(float) && !preferGenericForGpu)
         {
-            DetectAnalyticLossMatMulBackward(forwardSteps, consumerCount, gradMap, analyticBackwardSpecs, skippableReduceSumIndices, analyticForwardSpecs, skippableReduceSumForwardIndices, sharedRowSumCache);
+            DetectAnalyticLossMatMulBackward(forwardSteps, consumerCount, gradMap,
+                analyticBackwardSpecs, skippableReduceSumIndices, analyticForwardSpecs,
+                skippableReduceSumForwardIndices, sharedRowSumCache, fusedStepIndices);
         }
 
         // Phase G.9: detect MatMul → Slice-prefix-of-last-dim chains where
@@ -5200,10 +5205,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             int K = inputA._shape[aRank - 1];
             int N = inputB._shape[1];
 
-            // Pre-fetch arrays at compile time (bypasses EnsureMaterialized at replay)
-            var cA = (float[])(object)inputA.GetDataArray();
-            var cB = (float[])(object)inputB.GetDataArray();
-            var cOut = (float[])(object)output.GetDataArray();
+            // Bind the verified live arrays. GetDataArray() is not safe for a
+            // cached closure: pool-padded tensors return a detached logical
+            // copy, which would stale-read updated weights or orphan writes.
+            var cA = TryGetLiveFloatBacking(inputA)!;
+            var cB = TryGetLiveFloatBacking(inputB)!;
+            var cOut = TryGetLiveFloatBacking(output)!;
 
             if (N == 1)
             {
@@ -5489,10 +5496,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     var inputLengths = new int[step.Inputs.Length];
                     for (int j = 0; j < step.Inputs.Length; j++)
                     {
-                        inputArrays[j] = (float[])(object)step.Inputs[j].GetDataArray();
+                        inputArrays[j] = TryGetLiveFloatBacking(step.Inputs[j])!;
                         inputLengths[j] = step.Inputs[j].Length;
                     }
-                    var outArr = (float[])(object)step.OutputBuffer.GetDataArray();
+                    var outArr = TryGetLiveFloatBacking(step.OutputBuffer)!;
                     var capturedInputArrays = inputArrays;
                     var capturedLengths = inputLengths;
 
@@ -5518,11 +5525,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var output = step.OutputBuffer;
             var inH = PinAndTrack(GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
             int len = input.Length;
-            float[]? cOut = null;
+            var cOut = TryGetLiveFloatBacking(output)!;
 
             return eng =>
             {
-                cOut ??= (float[])(object)output.GetDataArray();
                 unsafe
                 {
                     float* p = (float*)inH.AddrOfPinnedObject();
@@ -6500,9 +6506,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             int bCols = b.Rank == 1 ? b._shape[0] : b._shape[1];
             if (cols == bCols)
             {
-                var aArr = (float[])(object)a.GetDataArray();
-                var bArr = (float[])(object)b.GetDataArray();
-                var oArr = (float[])(object)o.GetDataArray();
+                var aArr = TryGetLiveFloatBacking(a)!;
+                var bArr = TryGetLiveFloatBacking(b)!;
+                var oArr = TryGetLiveFloatBacking(o)!;
                 if (step.OpType == OpType.TensorBroadcastAdd)
                     return eng => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) oArr[off + c] = aArr[off + c] + bArr[c]; } };
                 else if (step.OpType == OpType.TensorBroadcastSubtract)
@@ -6518,9 +6524,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && typeof(T) == typeof(float))
         {
             var pred = step.Inputs[0]; var target = step.Inputs[1]; var o = step.OutputBuffer;
-            var pArr = (float[])(object)pred.GetDataArray();
-            var tArr = (float[])(object)target.GetDataArray();
-            var oArr = (float[])(object)o.GetDataArray();
+            var pArr = TryGetLiveFloatBacking(pred)!;
+            var tArr = TryGetLiveFloatBacking(target)!;
+            var oArr = TryGetLiveFloatBacking(o)!;
             int len = pred.Length;
             return eng =>
             {
@@ -7147,8 +7153,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             return eng =>
             {
-                var gOutArr = (float[])(object)gradOut.GetDataArray();
-                var gInArr = (float[])(object)gradIn.GetDataArray();
+                var gOutArr = TryGetLiveFloatBacking(gradOut)!;
+                var gInArr = TryGetLiveFloatBacking(gradIn)!;
                 float seed = gOutArr[0];
                 if (seed == 1.0f)
                 {
@@ -7185,9 +7191,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             return eng =>
             {
-                var gOutArr = (float[])(object)gradOut.GetDataArray();
-                var inArr = (float[])(object)input.GetDataArray();
-                var gInArr = (float[])(object)gradIn.GetDataArray();
+                var gOutArr = TryGetLiveFloatBacking(gradOut)!;
+                var inArr = TryGetLiveFloatBacking(input)!;
+                var gInArr = TryGetLiveFloatBacking(gradIn)!;
                 int len = input.Length;
                 unsafe
                 {
@@ -7250,8 +7256,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             return eng =>
             {
-                var gOutArr = (float[])(object)gradOut.GetDataArray();
-                var gInArr = (float[])(object)gradIn.GetDataArray();
+                var gOutArr = TryGetLiveFloatBacking(gradOut)!;
+                var gInArr = TryGetLiveFloatBacking(gradIn)!;
 
                 // Zero-fill the full input grad. The fused-spec backward
                 // for upstream MatMul writes its result via the same
@@ -7304,14 +7310,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // killing ReLU gradient flow. The FillReluBitmask overload
                 // writes into the pre-allocated buffer, preserving the
                 // intended allocation-free replay semantics.
-                var outputData = (float[])(object)output.GetDataArray();
+                var outputData = TryGetLiveFloatBacking(output)!;
                 int len = output.Length;
                 reluBitmask ??= new byte[(len + 7) / 8];
                 ActivationCheckpoint.FillReluBitmask(outputData, reluBitmask, len);
 
                 // Apply backward using bitmask
-                var gradOutData = (float[])(object)gradOut.GetDataArray();
-                var gradInData = (float[])(object)gradIn.GetDataArray();
+                var gradOutData = TryGetLiveFloatBacking(gradOut)!;
+                var gradInData = TryGetLiveFloatBacking(gradIn)!;
                 ActivationCheckpoint.ApplyReluBackwardFromBitmask(gradOutData, reluBitmask, gradInData, len);
                 input.Grad = gradIn;
             };
@@ -8364,71 +8370,91 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool capturedIsGelu = isGeluPattern;
             var capturedPreAct = preActivationBuffer;
 
+            capturedGradMap.TryGetValue(capturedOutput, out var gradOutTensor);
+            capturedGradMap.TryGetValue(capturedW1, out var gradW1Tensor);
+            capturedGradMap.TryGetValue(capturedW2, out var gradW2Tensor);
+            capturedGradMap.TryGetValue(capturedInput, out var gradInputTensor);
+
+            // A fused closure may retain only proven live backing arrays. Pool-padded
+            // tensors intentionally return a detached logical copy from GetDataArray(),
+            // while views require offset/stride-aware addressing. In either case the
+            // ordinary compiled steps are the correct fallback.
+            var inputArray = TryGetLiveFloatBacking(capturedInput);
+            var w1Array = TryGetLiveFloatBacking(capturedW1);
+            var w2Array = TryGetLiveFloatBacking(capturedW2);
+            var outputArray = TryGetLiveFloatBacking(capturedOutput);
+            var activatedArray = TryGetLiveFloatBacking(capturedActivated);
+            var preActivationArray = capturedPreAct is null ? null : TryGetLiveFloatBacking(capturedPreAct);
+            var gradOutArray = gradOutTensor is null ? null : TryGetLiveFloatBacking(gradOutTensor);
+            var gradW1Array = gradW1Tensor is null ? null : TryGetLiveFloatBacking(gradW1Tensor);
+            var gradW2Array = gradW2Tensor is null ? null : TryGetLiveFloatBacking(gradW2Tensor);
+            var gradInputArray = gradInputTensor is null ? null : TryGetLiveFloatBacking(gradInputTensor);
+
+            if (inputArray is null || w1Array is null || w2Array is null
+                || outputArray is null || activatedArray is null
+                || (capturedPreAct is not null && preActivationArray is null)
+                || (gradOutTensor is not null && gradOutArray is null)
+                || (gradW1Tensor is not null && gradW1Array is null)
+                || (gradW2Tensor is not null && gradW2Array is null)
+                || (gradInputTensor is not null && gradInputArray is null))
+            {
+                TensorAllocator.Return(activatedBuffer);
+                if (preActivationBuffer is not null) TensorAllocator.Return(preActivationBuffer);
+                continue;
+            }
+
+            // The fused backward computes every operand gradient. Keep reusable
+            // scratch for operands the caller does not track instead of allocating
+            // a throwaway array on every replay.
+            gradW1Array ??= new float[ck * ch];
+            gradW2Array ??= new float[ch * cn];
+            gradInputArray ??= new float[cm * ck];
+
             // Fused forward: single kernel call replaces 3 steps.
             // GELU path uses SIMD GELU (FusedGemmGeluGemm); ReLU path uses
             // the scalar-Func variant — ReLU is cheap enough that the
             // delegate dispatch isn't a bottleneck.
             fusedForward.Add(eng =>
             {
-                var inA = (float[])(object)capturedInput.GetDataArray();
-                var w1A = (float[])(object)capturedW1.GetDataArray();
-                var w2A = (float[])(object)capturedW2.GetDataArray();
-                var outA = (float[])(object)capturedOutput.GetDataArray();
-                var actA = (float[])(object)capturedActivated.GetDataArray();
                 if (capturedIsGelu)
                 {
-                    var preA = (float[])(object)capturedPreAct!.GetDataArray();
-                    FusedMultiLayerGemm.FusedGemmGeluGemm(inA, w1A, w2A, outA, actA, preA, cm, ck, ch, cn);
+                    FusedMultiLayerGemm.FusedGemmGeluGemm(inputArray, w1Array, w2Array,
+                        outputArray, activatedArray, preActivationArray!, cm, ck, ch, cn);
                 }
                 else
                 {
-                    FusedMultiLayerGemm.FusedGemmActivationGemm(inA, w1A, w2A, outA, actA, cm, ck, ch, cn, activation);
+                    FusedMultiLayerGemm.FusedGemmActivationGemm(inputArray, w1Array, w2Array,
+                        outputArray, activatedArray, cm, ck, ch, cn, activation);
                 }
             });
 
             // Fused backward: pre-allocated workspace, zero alloc during replay
             fusedBackward.Add(eng =>
             {
-                var gradOut = capturedGradMap.ContainsKey(capturedOutput)
-                    ? capturedGradMap[capturedOutput] : null;
-                if (gradOut == null) return;
-
-                var gOutArr = (float[])(object)gradOut.GetDataArray();
-                var inA = (float[])(object)capturedInput.GetDataArray();
-                var w1A = (float[])(object)capturedW1.GetDataArray();
-                var w2A = (float[])(object)capturedW2.GetDataArray();
-                var actA = (float[])(object)capturedActivated.GetDataArray();
-
-                var gW1 = capturedGradMap.ContainsKey(capturedW1)
-                    ? (float[])(object)capturedGradMap[capturedW1].GetDataArray() : new float[ck * ch];
-                var gW2 = capturedGradMap.ContainsKey(capturedW2)
-                    ? (float[])(object)capturedGradMap[capturedW2].GetDataArray() : new float[ch * cn];
-                var gIn = capturedGradMap.ContainsKey(capturedInput)
-                    ? (float[])(object)capturedGradMap[capturedInput].GetDataArray() : new float[cm * ck];
+                if (gradOutArray is null) return;
 
                 Array.Clear(backwardWorkspace, 0, backwardWorkspace.Length);
 
                 if (capturedIsGelu)
                 {
-                    var preA = (float[])(object)capturedPreAct!.GetDataArray();
                     FusedMultiLayerBackward.ComputeGradients(
-                        gOutArr, inA, w1A, w2A, actA, preA,
-                        gW1, gW2, emptyBias, emptyBias, gIn,
+                        gradOutArray, inputArray, w1Array, w2Array, activatedArray, preActivationArray!,
+                        gradW1Array, gradW2Array, emptyBias, emptyBias, gradInputArray,
                         cm, ck, ch, cn, FusedMultiLayerBackward.GELUDerivative,
                         backwardWorkspace);
                 }
                 else
                 {
                     FusedMultiLayerBackward.ComputeGradients(
-                        gOutArr, inA, w1A, w2A, actA,
-                        gW1, gW2, emptyBias, emptyBias, gIn,
+                        gradOutArray, inputArray, w1Array, w2Array, activatedArray,
+                        gradW1Array, gradW2Array, emptyBias, emptyBias, gradInputArray,
                         cm, ck, ch, cn, FusedMultiLayerBackward.ReLUDerivative,
                         backwardWorkspace);
                 }
 
-                capturedW1.Grad = capturedGradMap.ContainsKey(capturedW1) ? capturedGradMap[capturedW1] : null;
-                capturedW2.Grad = capturedGradMap.ContainsKey(capturedW2) ? capturedGradMap[capturedW2] : null;
-                capturedInput.Grad = capturedGradMap.ContainsKey(capturedInput) ? capturedGradMap[capturedInput] : null;
+                capturedW1.Grad = gradW1Tensor;
+                capturedW2.Grad = gradW2Tensor;
+                capturedInput.Grad = gradInputTensor;
             });
 
             consumedIndices.Add(i);
@@ -8489,7 +8515,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         HashSet<int> skippableReduceSumIndices,
         Dictionary<int, Action<IEngine>> analyticForwardSpecs,
         HashSet<int> skippableReduceSumForwardIndices,
-        Dictionary<int, float[]> sharedRowSumCache)
+        Dictionary<int, float[]> sharedRowSumCache,
+        ISet<int>? excludedStepIndices = null)
     {
         if (typeof(T) != typeof(float)) return;
         if (forwardSteps.Count < 2) return;
@@ -8497,6 +8524,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Walk pairs (matmul, reducesum) and check the link.
         for (int i = 0; i + 1 < forwardSteps.Count; i++)
         {
+            // A prior pass owns these actions. Analytic loss replacement cannot
+            // claim a MatMul already consumed by dataflow/cross-layer fusion:
+            // doing so marks its ReduceSum backward skippable and removes the
+            // upstream seed the fused backward requires.
+            if (excludedStepIndices?.Contains(i) == true
+                || excludedStepIndices?.Contains(i + 1) == true)
+                continue;
+
             var matmul = forwardSteps[i];
             var reduce = forwardSteps[i + 1];
 
@@ -8549,6 +8584,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (!gradMap.ContainsKey(reduce.OutputBuffer)) continue;
             var lossGradTensor = gradMap[reduce.OutputBuffer];
 
+            bool enableAnalyticForward = Environment.GetEnvironmentVariable("AIDOTNET_ANALYTIC_FORWARD") == "1";
+            var inputAArray = TryGetLiveFloatBacking(inputA);
+            var inputWArray = TryGetLiveFloatBacking(inputW);
+            var gradAArray = TryGetLiveFloatBacking(gradA);
+            var gradWArray = TryGetLiveFloatBacking(gradW);
+            var lossGradArray = TryGetLiveFloatBacking(lossGradTensor);
+            var lossOutputArray = enableAnalyticForward
+                ? TryGetLiveFloatBacking(reduce.OutputBuffer)
+                : null;
+
+            // The analytic kernels flatten every operand and write gradients/loss
+            // directly. Decline the optimization for views or non-addressable
+            // storage rather than caching a detached materialization.
+            if (inputAArray is null || inputWArray is null
+                || gradAArray is null || gradWArray is null || lossGradArray is null
+                || (enableAnalyticForward && lossOutputArray is null))
+                continue;
+
             // Build the analytic backward closure.
             int cM = M, cK = K, cV = V;
             var capA = inputA;
@@ -8579,7 +8632,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // benefits the downstream backward MatMuls. Keep the
             // infrastructure for future SimdGemm-only environments
             // where MKL isn't available.
-            bool enableAnalyticForward = Environment.GetEnvironmentVariable("AIDOTNET_ANALYTIC_FORWARD") == "1";
             int matmulStepIndex = i;
             int reduceStepIndex = i + 1;
             var capLoss = gradMap.ContainsKey(reduce.OutputBuffer)
@@ -8602,10 +8654,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             if (enableAnalyticForward) analyticForwardSpecs[matmulStepIndex] = eng =>
             {
-                var wArr = (float[])(object)gW.GetDataArray();
-                var aArr = (float[])(object)gA.GetDataArray();
-                var lossArr = (float[])(object)gLoss.GetDataArray();
-
                 // Compute row_sum_W on first call and whenever weights
                 // change (detected via gW.Version increment from the
                 // optimizer's in-place mutators). Frozen-weights workloads
@@ -8618,7 +8666,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     {
                         float s = 0f;
                         int baseIdx = k * gV;
-                        for (int v = 0; v < gV; v++) s += wArr[baseIdx + v];
+                        for (int v = 0; v < gV; v++) s += inputWArray[baseIdx + v];
                         capRowSum[k] = s;
                     }
                     rowSumWVersion = wVersion;
@@ -8631,11 +8679,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 for (int m = 0; m < gM; m++)
                 {
                     int baseIdx = m * gK;
-                    for (int k = 0; k < gK; k++) colSum[k] += aArr[baseIdx + k];
+                    for (int k = 0; k < gK; k++) colSum[k] += inputAArray[baseIdx + k];
                 }
                 float loss = 0f;
                 for (int k = 0; k < gK; k++) loss += capRowSum[k] * colSum[k];
-                lossArr[0] = loss;
+                lossOutputArray![0] = loss;
             };
             // The ReduceSum forward becomes a no-op — its result has
             // already been computed and written by the analytic forward.
@@ -8644,12 +8692,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             analyticBackwardSpecs[i] = eng =>
             {
-                var aArr = (float[])(object)capA.GetDataArray();
-                var wArr = (float[])(object)capW.GetDataArray();
-                var gA = (float[])(object)capGradA.GetDataArray();
-                var gW = (float[])(object)capGradW.GetDataArray();
-                var lossArr = (float[])(object)capLossGrad.GetDataArray();
-                float alpha = lossArr[0];
+                float alpha = lossGradArray[0];
 
                 // Compute row_sums(W): for each row k, sum across all v.
                 //   row_sum_W[k] = sum_v W[k, v]
@@ -8662,7 +8705,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         float s = 0f;
                         int baseIdx = k * cV;
                         // Loop unroll-friendly stride-1 read pattern
-                        for (int v = 0; v < cV; v++) s += wArr[baseIdx + v];
+                        for (int v = 0; v < cV; v++) s += inputWArray[baseIdx + v];
                         rowSumW[k] = alpha * s;
                     }
 
@@ -8671,7 +8714,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     for (int m = 0; m < cM; m++)
                     {
                         int baseIdx = m * cK;
-                        for (int k = 0; k < cK; k++) gA[baseIdx + k] = rowSumW[k];
+                        for (int k = 0; k < cK; k++) gradAArray[baseIdx + k] = rowSumW[k];
                     }
                 }
                 finally
@@ -8690,7 +8733,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     for (int m = 0; m < cM; m++)
                     {
                         int baseIdx = m * cK;
-                        for (int k = 0; k < cK; k++) colSumA[k] += aArr[baseIdx + k];
+                        for (int k = 0; k < cK; k++) colSumA[k] += inputAArray[baseIdx + k];
                     }
                     for (int k = 0; k < cK; k++) colSumA[k] *= alpha;
 
@@ -8699,7 +8742,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     {
                         float c = colSumA[k];
                         int baseIdx = k * cV;
-                        for (int v = 0; v < cV; v++) gW[baseIdx + v] = c;
+                        for (int v = 0; v < cV; v++) gradWArray[baseIdx + v] = c;
                     }
                 }
                 finally
@@ -8785,13 +8828,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var gradW = gradMap[inputW];
             var gradSliceOut = gradMap[sliceOut];
 
-            // Capture for closures
-            var capA = inputA;
-            var capW = inputW;
-            var capSliceOut = sliceOut;
-            var capGradA = gradA;
-            var capGradW = gradW;
-            var capGradSliceOut = gradSliceOut;
+            var inputAArray = TryGetLiveFloatBacking(inputA);
+            var inputWArray = TryGetLiveFloatBacking(inputW);
+            var sliceOutputArray = TryGetLiveFloatBacking(sliceOut);
+            var gradAArray = TryGetLiveFloatBacking(gradA);
+            var gradWArray = TryGetLiveFloatBacking(gradW);
+            var gradSliceOutputArray = TryGetLiveFloatBacking(gradSliceOut);
+            if (inputAArray is null || inputWArray is null || sliceOutputArray is null
+                || gradAArray is null || gradWArray is null || gradSliceOutputArray is null)
+                continue;
+
             int cM = M, cK = K, cNfull = N_full, cNused = N_used;
 
             // Phase G.11: pre-copy W[:, 0:N_used] into a CONTIGUOUS
@@ -8816,13 +8862,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             slicePrefixForwardSpecs[i] = eng =>
             {
-                var aArr = (float[])(object)capA.GetDataArray();
-                var wArr = (float[])(object)capW.GetDataArray();
-                var outArr = (float[])(object)capSliceOut.GetDataArray();
-
                 // Re-copy W[:, 0:N_used] into the contiguous buffer.
                 for (int k = 0; k < cK; k++)
-                    Buffer.BlockCopy(wArr,
+                    Buffer.BlockCopy(inputWArray,
                         (k * cNfull) * sizeof(float),
                         wPacked,
                         (k * cNused) * sizeof(float),
@@ -8830,12 +8872,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
                 // M, N_used, K; lda=K, ldb=N_used (CONTIGUOUS), ldc=N_used.
                 if (!BlasProvider.TryGemm(cM, cNused, cK,
-                        aArr, 0, cK,
+                        inputAArray, 0, cK,
                         wPacked, 0, cNused,
-                        outArr, 0, cNused))
+                        sliceOutputArray, 0, cNused))
                 {
-                    SimdGemm.Sgemm(aArr.AsSpan(0, cM * cK), wPacked.AsSpan(0, cK * cNused),
-                        outArr.AsSpan(0, cM * cNused), cM, cK, cNused);
+                    SimdGemm.Sgemm(inputAArray.AsSpan(0, cM * cK), wPacked.AsSpan(0, cK * cNused),
+                        sliceOutputArray.AsSpan(0, cM * cNused), cM, cK, cNused);
                 }
             };
 
@@ -8845,41 +8887,36 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var dWPackedScratch = new float[cK * cNused];
             slicePrefixBackwardSpecs[i] = eng =>
             {
-                var aArr = (float[])(object)capA.GetDataArray();
-                var dSliceArr = (float[])(object)capGradSliceOut.GetDataArray();
-                var dA = (float[])(object)capGradA.GetDataArray();
-                var dW = (float[])(object)capGradW.GetDataArray();
-
                 // dA = dSliceOut [M, N_used] @ W_q^T [N_used, K]
                 // lda=N_used (compact), ldb=N_used (compact W_q), ldc=K
                 if (!BlasProvider.TryGemmEx(cM, cK, cNused,
-                        dSliceArr, 0, cNused, false,
+                        gradSliceOutputArray, 0, cNused, false,
                         wPacked, 0, cNused, true,
-                        dA, 0, cK))
+                        gradAArray, 0, cK))
                 {
-                    SimdGemm.Sgemm(dSliceArr.AsSpan(0, cM * cNused), cNused, false,
+                    SimdGemm.Sgemm(gradSliceOutputArray.AsSpan(0, cM * cNused), cNused, false,
                         wPacked.AsSpan(0, cK * cNused), cNused, true,
-                        dA.AsSpan(0, cM * cK), cM, cNused, cK);
+                        gradAArray.AsSpan(0, cM * cK), cM, cNused, cK);
                 }
 
                 // dW_packed [K, N_used] = A^T [K, M] @ dSliceOut [M, N_used]
                 // Compute into the contiguous scratch, then scatter into full dW.
                 if (!BlasProvider.TryGemmEx(cK, cNused, cM,
-                        aArr, 0, cK, true,
-                        dSliceArr, 0, cNused, false,
+                        inputAArray, 0, cK, true,
+                        gradSliceOutputArray, 0, cNused, false,
                         dWPackedScratch, 0, cNused))
                 {
-                    SimdGemm.Sgemm(aArr.AsSpan(0, cM * cK), cK, true,
-                        dSliceArr.AsSpan(0, cM * cNused), cNused, false,
+                    SimdGemm.Sgemm(inputAArray.AsSpan(0, cM * cK), cK, true,
+                        gradSliceOutputArray.AsSpan(0, cM * cNused), cNused, false,
                         dWPackedScratch.AsSpan(0, cK * cNused), cK, cM, cNused);
                 }
 
                 // Scatter scratch into dW[:, 0:N_used], zero dW[:, N_used:N_full]
-                Array.Clear(dW, 0, dW.Length);
+                Array.Clear(gradWArray, 0, gradWArray.Length);
                 for (int k = 0; k < cK; k++)
                     Buffer.BlockCopy(dWPackedScratch,
                         (k * cNused) * sizeof(float),
-                        dW,
+                        gradWArray,
                         (k * cNfull) * sizeof(float),
                         cNused * sizeof(float));
             };
@@ -8906,8 +8943,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         public int AOffset;
         public int DyOffset;
         public int DwOffset;
-        public Tensor<T> AStorage;   // source for A^T (use .GetDataArray())
-        public Tensor<T> DyStorage;  // source for dY
+        public float[] AArray;       // live source for A^T
+        public float[] DyArray;      // live source for dY
+        public float[] DwArray;      // live dW destination
         public Tensor<T> DwTensor;   // dW destination (whose Grad we set)
         public Tensor<T> WTensor;    // the weight tensor (for .Grad assignment)
     }
@@ -8985,6 +9023,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var gradOut = gradMap[output];
             var gradW = gradMap[inputW];
 
+            var aBacking = inputA.GetCpuBackingForStridedRead(out int aOffset);
+            var dyBacking = gradOut.GetCpuBackingForStridedRead(out int dyOffset);
+            var dwBacking = gradW.GetCpuBackingForContiguousWrite(out int dwOffset);
+            if (aBacking is null || dyBacking is null || dwBacking is null)
+                continue;
+
             // dW = A^T @ dY → C[K, N].
             // lda_plain=K (A in [M, K] row-major), ldb_dy=N (dY in [M, N]),
             // ldc_dw=N (dW dest [K, N]).
@@ -8992,11 +9036,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 M = M, N = N, K = K,
                 LdaPlain = K, LdaDy = N, LdcDw = N,
-                AOffset = inputA._storageOffset,
-                DyOffset = gradOut._storageOffset,
-                DwOffset = gradW._storageOffset,
-                AStorage = inputA,
-                DyStorage = gradOut,
+                AOffset = aOffset,
+                DyOffset = dyOffset,
+                DwOffset = dwOffset,
+                AArray = (float[])(object)aBacking,
+                DyArray = (float[])(object)dyBacking,
+                DwArray = (float[])(object)dwBacking,
                 DwTensor = gradW,
                 WTensor = inputW,
             });
@@ -9038,28 +9083,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var aOffs = new int[batchSize];
             var bOffs = new int[batchSize];
             var cOffs = new int[batchSize];
+            var aArrs = new float[batchSize][];
+            var bArrs = new float[batchSize][];
+            var cArrs = new float[batchSize][];
             for (int i = 0; i < batchSize; i++)
             {
                 aOffs[i] = captured[i].AOffset;
                 bOffs[i] = captured[i].DyOffset;
                 cOffs[i] = captured[i].DwOffset;
+                aArrs[i] = captured[i].AArray;
+                bArrs[i] = captured[i].DyArray;
+                cArrs[i] = captured[i].DwArray;
             }
 
             backwardActions.Add(eng =>
             {
-                // Resolve underlying float[] for each batch element.
-                // Use storage-based GetDataArray() so views and slices
-                // see the live shape-stable buffer.
-                var aArrs = new float[batchSize][];
-                var bArrs = new float[batchSize][];
-                var cArrs = new float[batchSize][];
-                for (int i = 0; i < batchSize; i++)
-                {
-                    aArrs[i] = (float[])(object)captured[i].AStorage.GetDataArray();
-                    bArrs[i] = (float[])(object)captured[i].DyStorage.GetDataArray();
-                    cArrs[i] = (float[])(object)captured[i].DwTensor.GetDataArray();
-                }
-
                 if (!BlasProvider.TryGemmBatchSameShapeArrays(
                     K, N, M,
                     transA: true, transB: false,
@@ -9127,6 +9165,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             int M = 1;
             for (int d = 0; d < inputA.Rank - 1; d++) M *= inputA._shape[d];
 
+            gradMap.TryGetValue(output, out var gradOutTensor);
+            gradMap.TryGetValue(W1, out var gradW1Tensor);
+            gradMap.TryGetValue(W2, out var gradW2Tensor);
+            gradMap.TryGetValue(inputA, out var gradInputTensor);
+
+            var inputArray = TryGetLiveFloatBacking(inputA);
+            var w1Data = TryGetLiveFloatBacking(W1);
+            var w2Data = TryGetLiveFloatBacking(W2);
+            var outputArray = TryGetLiveFloatBacking(output);
+            var gradOutArray = gradOutTensor is null ? null : TryGetLiveFloatBacking(gradOutTensor);
+            var gradW1Array = gradW1Tensor is null ? null : TryGetLiveFloatBacking(gradW1Tensor);
+            var gradW2Array = gradW2Tensor is null ? null : TryGetLiveFloatBacking(gradW2Tensor);
+            var gradInputArray = gradInputTensor is null ? null : TryGetLiveFloatBacking(gradInputTensor);
+
+            if (inputArray is null || w1Data is null || w2Data is null || outputArray is null
+                || (gradOutTensor is not null && gradOutArray is null)
+                || (gradW1Tensor is not null && gradW1Array is null)
+                || (gradW2Tensor is not null && gradW2Array is null)
+                || (gradInputTensor is not null && gradInputArray is null))
+                continue;
+
             // Allocate W_fused buffer at compile time. Population is
             // deferred to the first forward call and refreshed whenever
             // W1.Version or W2.Version changes (training loops mutate
@@ -9134,8 +9193,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // stale fused weights and silently produce wrong forward
             // outputs). For frozen-weights workloads, the GEMM only runs
             // once and is then reused forever.
-            var w1Data = (float[])(object)W1.GetDataArray();
-            var w2Data = (float[])(object)W2.GetDataArray();
             var wFused = new float[K * N];
 
             // Forward: single MatMul input @ W_fused → output. Skip
@@ -9163,11 +9220,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     wFusedW1Version = v1;
                     wFusedW2Version = v2;
                 }
-                var inArr = (float[])(object)capturedInput.GetDataArray();
-                var outArr = (float[])(object)capturedOutput.GetDataArray();
-                if (!BlasProvider.TryGemm(cM, cN, cK, inArr, 0, cK, cWFused, 0, cN, outArr, 0, cN))
-                    SimdGemm.Sgemm(inArr.AsSpan(0, cM * cK), cWFused.AsSpan(0, cK * cN),
-                        outArr.AsSpan(0, cM * cN), cM, cK, cN);
+                if (!BlasProvider.TryGemm(cM, cN, cK, inputArray, 0, cK, cWFused, 0, cN, outputArray, 0, cN))
+                    SimdGemm.Sgemm(inputArray.AsSpan(0, cM * cK), cWFused.AsSpan(0, cK * cN),
+                        outputArray.AsSpan(0, cM * cN), cM, cK, cN);
             });
 
             // Pre-allocate dW_fused scratch (compile-time, reused per call).
@@ -9175,69 +9230,62 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             fusedBackward.Add(eng =>
             {
-                if (!capturedGradMap.TryGetValue(capturedOutput, out var gradOut)) return;
-                var gOutArr = (float[])(object)gradOut.GetDataArray();
-                var inArr = (float[])(object)capturedInput.GetDataArray();
-                var w1Arr = (float[])(object)capturedW1.GetDataArray();
-                var w2Arr = (float[])(object)capturedW2.GetDataArray();
+                if (gradOutArray is null) return;
 
                 // dW_fused = input^T @ gradOut  [K, N]
                 if (!BlasProvider.TryGemmEx(cK, cN, cM,
-                        inArr, 0, cK, true,
-                        gOutArr, 0, cN, false,
+                        inputArray, 0, cK, true,
+                        gradOutArray, 0, cN, false,
                         dWFused, 0, cN))
                 {
-                    SimdGemm.Sgemm(inArr.AsSpan(0, cM * cK), cK, true,
-                        gOutArr.AsSpan(0, cM * cN), cN, false,
+                    SimdGemm.Sgemm(inputArray.AsSpan(0, cM * cK), cK, true,
+                        gradOutArray.AsSpan(0, cM * cN), cN, false,
                         dWFused.AsSpan(0, cK * cN), cK, cM, cN);
                 }
 
                 // dW1 = dW_fused @ W2^T  [K, H]  (chain rule on W_fused = W1 @ W2)
-                if (capturedGradMap.TryGetValue(capturedW1, out var gW1Tensor))
+                if (gradW1Array is not null)
                 {
-                    var gW1 = (float[])(object)gW1Tensor.GetDataArray();
                     if (!BlasProvider.TryGemmEx(cK, cH, cN,
                             dWFused, 0, cN, false,
-                            w2Arr, 0, cN, true,
-                            gW1, 0, cH))
+                            w2Data, 0, cN, true,
+                            gradW1Array, 0, cH))
                     {
                         SimdGemm.Sgemm(dWFused.AsSpan(0, cK * cN), cN, false,
-                            w2Arr.AsSpan(0, cH * cN), cN, true,
-                            gW1.AsSpan(0, cK * cH), cK, cN, cH);
+                            w2Data.AsSpan(0, cH * cN), cN, true,
+                            gradW1Array.AsSpan(0, cK * cH), cK, cN, cH);
                     }
-                    capturedW1.Grad = gW1Tensor;
+                    capturedW1.Grad = gradW1Tensor;
                 }
 
                 // dW2 = W1^T @ dW_fused  [H, N]
-                if (capturedGradMap.TryGetValue(capturedW2, out var gW2Tensor))
+                if (gradW2Array is not null)
                 {
-                    var gW2 = (float[])(object)gW2Tensor.GetDataArray();
                     if (!BlasProvider.TryGemmEx(cH, cN, cK,
-                            w1Arr, 0, cH, true,
+                            w1Data, 0, cH, true,
                             dWFused, 0, cN, false,
-                            gW2, 0, cN))
+                            gradW2Array, 0, cN))
                     {
-                        SimdGemm.Sgemm(w1Arr.AsSpan(0, cK * cH), cH, true,
+                        SimdGemm.Sgemm(w1Data.AsSpan(0, cK * cH), cH, true,
                             dWFused.AsSpan(0, cK * cN), cN, false,
-                            gW2.AsSpan(0, cH * cN), cH, cK, cN);
+                            gradW2Array.AsSpan(0, cH * cN), cH, cK, cN);
                     }
-                    capturedW2.Grad = gW2Tensor;
+                    capturedW2.Grad = gradW2Tensor;
                 }
 
                 // dInput = gradOut @ W_fused^T  [M, K]
-                if (capturedGradMap.TryGetValue(capturedInput, out var gInTensor))
+                if (gradInputArray is not null)
                 {
-                    var gIn = (float[])(object)gInTensor.GetDataArray();
                     if (!BlasProvider.TryGemmEx(cM, cK, cN,
-                            gOutArr, 0, cN, false,
+                            gradOutArray, 0, cN, false,
                             cWFused, 0, cN, true,
-                            gIn, 0, cK))
+                            gradInputArray, 0, cK))
                     {
-                        SimdGemm.Sgemm(gOutArr.AsSpan(0, cM * cN), cN, false,
+                        SimdGemm.Sgemm(gradOutArray.AsSpan(0, cM * cN), cN, false,
                             cWFused.AsSpan(0, cK * cN), cN, true,
-                            gIn.AsSpan(0, cM * cK), cM, cN, cK);
+                            gradInputArray.AsSpan(0, cM * cK), cM, cN, cK);
                     }
-                    capturedInput.Grad = gInTensor;
+                    capturedInput.Grad = gradInputTensor;
                 }
             });
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -92,6 +92,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private bool _graphStepEligible;
     private const int GraphWarmupSteps = 3;   // eager first so cuBLAS workspace / lazy buffers stabilize
     private readonly Tensor<T>[] _parameters;
+    // Present only when the caller registered tied weights more than once.
+    // Each original slot maps to its canonical physical parameter slot.
+    private readonly int[]? _originalParameterToUnique;
     private readonly Tensor<T>[] _gradients;
     private readonly Tensor<T>[] _preAllocatedGrads;
     private readonly Tensor<T> _lossGradSeed;
@@ -152,6 +155,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         Tensor<T>[] preAllocatedGrads,
         Tensor<T>[] gradients,
         Tensor<T> lossGradSeed,
+        int[]? originalParameterToUnique = null,
         int[]? genericGradIndices = null,
         Tensor<T>? lossGradDest = null,
         List<GCHandle>? pinnedHandles = null,
@@ -173,6 +177,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _lossOutput = lossOutput;
         _engine = engine;
         _parameters = parameters;
+        _originalParameterToUnique = originalParameterToUnique;
         _preAllocatedGrads = preAllocatedGrads;
         _gradients = gradients;
         _lossGradSeed = lossGradSeed;
@@ -1074,6 +1079,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
     {
+        using var graphModeSuspension = GraphMode.SuspendRecording();
+
         // Opt-in CUDA-graph replay of the whole compiled step. Narrowly gated:
         // float + CUDA backend + no grad-norm clip (a per-step host read) + no
         // checkpointing + an all-GPU-pure action set (_graphStepEligible — host-only
@@ -1536,6 +1543,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         long t3 = _profileStepEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
         if (stepTiming) StepTiming.RecordBackward(Stopwatch.GetTimestamp() - bwdStart);
 
+        // Some generic CPU backward primitives produce a deferred tensor and
+        // attach it to the plan's pre-allocated parameter-gradient slot. The
+        // optimizer owns raw backing-array references, so it must never run
+        // before that deferred producer has committed its values to live
+        // storage. Specialized delegates already write synchronously and pay
+        // only the null check here.
+        if (_optimizerUpdate is not null && _engine is not Engines.DirectGpuTensorEngine)
+        {
+            for (int p = 0; p < _gradients.Length; p++)
+            {
+                var gradient = _gradients[p];
+                if (gradient is not null && gradient.LazySource is not null)
+                    _ = gradient.AsSpan();
+            }
+        }
+
         // Global gradient L2-norm clipping. Applied between backward and the
         // fused optimizer update so the optimizer sees the clipped gradients.
         // Mirrors PyTorch's torch.nn.utils.clip_grad_norm_ semantics: one
@@ -1716,9 +1739,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         if (paramToGroup is null) throw new ArgumentNullException(nameof(paramToGroup));
         if (groupSchedules.Count == 0)
             throw new ArgumentException("groupSchedules must contain at least one schedule.", nameof(groupSchedules));
-        if (paramToGroup.Count != _parameters.Length)
+        bool suppliedCanonicalGroups = paramToGroup.Count == _parameters.Length;
+        bool suppliedOriginalGroups = _originalParameterToUnique is not null
+            && paramToGroup.Count == _originalParameterToUnique.Length;
+        if (!suppliedCanonicalGroups && !suppliedOriginalGroups)
             throw new ArgumentException(
-                $"paramToGroup.Count ({paramToGroup.Count}) must equal the compiled parameter count ({_parameters.Length}).",
+                $"paramToGroup.Count ({paramToGroup.Count}) must equal the canonical compiled parameter count " +
+                $"({_parameters.Length})" +
+                (_originalParameterToUnique is null
+                    ? "."
+                    : $" or the original registered parameter count ({_originalParameterToUnique.Length})."),
                 nameof(paramToGroup));
         // Validate every schedule slot up front — the grouped hot path
         // evaluates GetLr() on ALL of them per step, not just the ones
@@ -1736,6 +1766,29 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 throw new ArgumentOutOfRangeException(
                     nameof(paramToGroup),
                     $"paramToGroup[{i}]={g} is out of range [0, {groupSchedules.Count}).");
+        }
+
+        System.Collections.Generic.IReadOnlyList<int> canonicalParamToGroup = paramToGroup;
+        if (suppliedOriginalGroups && !suppliedCanonicalGroups)
+        {
+            var collapsed = new int[_parameters.Length];
+            for (int i = 0; i < collapsed.Length; i++) collapsed[i] = -1;
+
+            for (int originalIndex = 0; originalIndex < _originalParameterToUnique!.Length; originalIndex++)
+            {
+                int canonicalIndex = _originalParameterToUnique[originalIndex];
+                int group = paramToGroup[originalIndex];
+                int existing = collapsed[canonicalIndex];
+                if (existing >= 0 && existing != group)
+                {
+                    throw new ArgumentException(
+                        $"Tied parameter slots map to conflicting optimizer groups ({existing} and {group}). " +
+                        "Every registration of the same physical parameter must use the same group.",
+                        nameof(paramToGroup));
+                }
+                collapsed[canonicalIndex] = group;
+            }
+            canonicalParamToGroup = collapsed;
         }
         // GPU residency only matters for float (the GPU configure branch is
         // float-gated); detect any GPU-backed parameter so the gate can reject
@@ -1761,12 +1814,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         ex.Validate();
         if (typeof(T) == typeof(float))
         {
-            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay, ex);
+            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, ex);
             return;
         }
         if (typeof(T) == typeof(double))
         {
-            ConfigureOptimizerDoubleGrouped(optimizerType, groupSchedules, paramToGroup, beta1, beta2, eps, weightDecay);
+            ConfigureOptimizerDoubleGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay);
             return;
         }
         throw new NotSupportedException("Fused optimizer updates support float and double parameters.");
@@ -4098,6 +4151,35 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     internal static CompiledTrainingPlan<T> Compile(
         LazyTensorScope scope, IEngine engine, Tensor<T>[] parameters, Tensor<T>? explicitLoss)
     {
+        int[]? originalParameterToUnique = null;
+
+        // Tied/shared weights may legitimately appear more than once while a
+        // model walks its layer graph. Canonicalize by object identity so the
+        // backward graph and optimizer own one slot and apply one update per
+        // physical parameter.
+        if (parameters.Length > 1)
+        {
+            var seenParameters = new Dictionary<Tensor<T>, int>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+            var uniqueParameters = new List<Tensor<T>>(parameters.Length);
+            var aliasMap = new int[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (!seenParameters.TryGetValue(parameters[i], out int uniqueIndex))
+                {
+                    uniqueIndex = uniqueParameters.Count;
+                    seenParameters.Add(parameters[i], uniqueIndex);
+                    uniqueParameters.Add(parameters[i]);
+                }
+                aliasMap[i] = uniqueIndex;
+            }
+
+            if (uniqueParameters.Count != parameters.Length)
+            {
+                originalParameterToUnique = aliasMap;
+                parameters = uniqueParameters.ToArray();
+            }
+        }
+
         var compiler = new LazyGraphCompiler();
         var optimized = compiler.Compile(scope.Nodes);
 
@@ -4741,6 +4823,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             allGrads.ToArray(),
             gradients,
             lossGradSeed,
+            originalParameterToUnique,
             genericGradIndices,
             gradMap.ContainsKey(lossOutput) ? gradMap[lossOutput] : null,
             pinnedHandles,
@@ -4847,9 +4930,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private static float[] GetPinnableFloatBacking(Tensor<float> t)
         => t.GetLiveBackingArrayAllowingPaddingOrNull() ?? t.GetDataArray();
 
-    /// <summary>FP64 counterpart of <see cref="GetPinnableFloatBacking"/>.</summary>
-    private static double[] GetPinnableDoubleBacking(Tensor<double> t)
-        => t.GetLiveBackingArrayAllowingPaddingOrNull() ?? t.GetDataArray();
+    /// <summary>
+    /// Returns the live FP64 backing required by a specialized kernel, or
+    /// <see langword="null"/> when the tensor layout cannot be addressed as a
+    /// zero-offset dense array. Specialized writers must never fall back to
+    /// <c>GetDataArray()</c>, which may intentionally materialize a copy.
+    /// </summary>
+    private static double[]? TryGetLiveDoubleBacking(Tensor<T> tensor)
+        => ((Tensor<double>)(object)tensor).GetLiveBackingArrayAllowingPaddingOrNull();
 
     internal static unsafe Action<IEngine>? TryBuildSpecializedForward(
         CompiledStep<T> step,
@@ -4881,10 +4969,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var output = step.OutputBuffer;
             int M = inputA._shape[0], K = inputA._shape[1], N = inputB._shape[1];
 
-            // Pre-fetch arrays at compile time (bypasses EnsureMaterialized at replay)
-            var cA = (double[])(object)inputA.GetDataArray();
-            var cB = (double[])(object)inputB.GetDataArray();
-            var cOut = (double[])(object)output.GetDataArray();
+            // Bind only verified live storage. A copied output would make the
+            // kernel appear successful while leaving the tensor unchanged.
+            var cA = TryGetLiveDoubleBacking(inputA);
+            var cB = TryGetLiveDoubleBacking(inputB);
+            var cOut = TryGetLiveDoubleBacking(output);
+            if (cA is null || cB is null || cOut is null)
+                return null;
 
             // Note: no Path-A pre-pack cache for double yet (SimdGemm has no
             // DgemmWithCachedB), so the inference vs training distinction
@@ -6580,16 +6671,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             int Md = inputAd._shape[0], Kd = inputAd._shape[1], Nd = inputBd._shape[1];
 
-            double[]? cdDC = null, cdA = null, cdB = null, cdDestA = null, cdDestB = null;
+            var cdDC = TryGetLiveDoubleBacking(gradOutD);
+            var cdA = TryGetLiveDoubleBacking(inputAd);
+            var cdB = TryGetLiveDoubleBacking(inputBd);
+            var cdDestA = TryGetLiveDoubleBacking(gradAd);
+            var cdDestB = TryGetLiveDoubleBacking(gradBd);
+            if (cdDC is null || cdA is null || cdB is null || cdDestA is null || cdDestB is null)
+                return null;
 
             return eng =>
             {
-                cdDC ??= (double[])(object)gradOutD.GetDataArray();
-                cdA ??= (double[])(object)inputAd.GetDataArray();
-                cdB ??= (double[])(object)inputBd.GetDataArray();
-                cdDestA ??= (double[])(object)gradAd.GetDataArray();
-                cdDestB ??= (double[])(object)gradBd.GetDataArray();
-
                 // dA = dC @ B^T — double-precision BLAS with engine fallback
                 if (!BlasProvider.TryGemmEx(Md, Kd, Nd, cdDC, 0, Nd, false, cdB, 0, Nd, true, cdDestA, 0, Kd))
                 {
@@ -7893,7 +7984,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // the kernels that depend on it.
             if (typeof(T) == typeof(double))
             {
-                if (!BlasProvider.HasNativeDgemm)
+                // The FP64 fusion below implements ReLU. GELU requires its
+                // pre-activation for the exact backward derivative, so retain
+                // the ordinary compiled GELU steps instead of silently applying
+                // ReLU semantics to a GELU graph.
+                if (!isReluPattern || !BlasProvider.HasNativeDgemm)
                 {
                     TensorAllocator.Return(activatedBuffer);
                     continue;
@@ -7907,85 +8002,91 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 int cmD = m, ckD = k, chD = h, cnD = n;
                 var capturedGradMapD = gradMap;
 
+                capturedGradMapD.TryGetValue(capturedOutputD, out var gradOutD);
+                capturedGradMapD.TryGetValue(capturedW1D, out var gW1TensorD);
+                capturedGradMapD.TryGetValue(capturedW2D, out var gW2TensorD);
+                capturedGradMapD.TryGetValue(capturedInputD, out var gInTensorD);
+
+                var inArrayD = TryGetLiveDoubleBacking(capturedInputD);
+                var w1ArrayD = TryGetLiveDoubleBacking(capturedW1D);
+                var w2ArrayD = TryGetLiveDoubleBacking(capturedW2D);
+                var outArrayD = TryGetLiveDoubleBacking(capturedOutputD);
+                var activatedArrayD = TryGetLiveDoubleBacking(capturedActivatedD);
+                var gradOutArrayD = gradOutD is null ? null : TryGetLiveDoubleBacking(gradOutD);
+                var gW1ArrayD = gW1TensorD is null ? null : TryGetLiveDoubleBacking(gW1TensorD);
+                var gW2ArrayD = gW2TensorD is null ? null : TryGetLiveDoubleBacking(gW2TensorD);
+                var gInArrayD = gInTensorD is null ? null : TryGetLiveDoubleBacking(gInTensorD);
+
+                if (inArrayD is null || w1ArrayD is null || w2ArrayD is null
+                    || outArrayD is null || activatedArrayD is null || gradOutArrayD is null
+                    || (gW1TensorD is not null && gW1ArrayD is null)
+                    || (gW2TensorD is not null && gW2ArrayD is null)
+                    || (gInTensorD is not null && gInArrayD is null))
+                {
+                    TensorAllocator.Return(activatedBuffer);
+                    continue;
+                }
+
                 fusedForward.Add(eng =>
                 {
-                    var inA = (double[])(object)capturedInputD.GetDataArray();
-                    var w1A = (double[])(object)capturedW1D.GetDataArray();
-                    var w2A = (double[])(object)capturedW2D.GetDataArray();
-                    var outA = (double[])(object)capturedOutputD.GetDataArray();
-                    var actA = (double[])(object)capturedActivatedD.GetDataArray();
-
-                    BlasProvider.TryGemm(cmD, chD, ckD, inA, 0, ckD, w1A, 0, chD, actA, 0, chD);
+                    BlasProvider.TryGemm(cmD, chD, ckD,
+                        inArrayD, 0, ckD, w1ArrayD, 0, chD, activatedArrayD, 0, chD);
 
                     int activatedLen = cmD * chD;
                     for (int idx = 0; idx < activatedLen; idx++)
-                        if (actA[idx] < 0.0) actA[idx] = 0.0;
+                        if (activatedArrayD[idx] < 0.0) activatedArrayD[idx] = 0.0;
 
-                    BlasProvider.TryGemm(cmD, cnD, chD, actA, 0, chD, w2A, 0, cnD, outA, 0, cnD);
+                    BlasProvider.TryGemm(cmD, cnD, chD,
+                        activatedArrayD, 0, chD, w2ArrayD, 0, cnD, outArrayD, 0, cnD);
                 });
 
                 fusedBackward.Add(eng =>
                 {
-                    if (!capturedGradMapD.TryGetValue(capturedOutputD, out var gradOut)) return;
-
-                    var gOutArr = (double[])(object)gradOut.GetDataArray();
-                    var inA = (double[])(object)capturedInputD.GetDataArray();
-                    var w1A = (double[])(object)capturedW1D.GetDataArray();
-                    var w2A = (double[])(object)capturedW2D.GetDataArray();
-                    var actA = (double[])(object)capturedActivatedD.GetDataArray();
-
-                    capturedGradMapD.TryGetValue(capturedW1D, out var gW1Tensor);
-                    capturedGradMapD.TryGetValue(capturedW2D, out var gW2Tensor);
-                    capturedGradMapD.TryGetValue(capturedInputD, out var gInTensor);
-
                     // dW2 = activated^T @ gradOut → [h, n]
-                    if (gW2Tensor is not null)
+                    if (gW2ArrayD is not null)
                     {
-                        var gW2 = (double[])(object)gW2Tensor.GetDataArray();
                         BlasProvider.TryGemmEx(chD, cnD, cmD,
-                            actA, 0, chD, transA: true,
-                            gOutArr, 0, cnD, transB: false,
-                            gW2, 0, cnD);
+                            activatedArrayD, 0, chD, transA: true,
+                            gradOutArrayD, 0, cnD, transB: false,
+                            gW2ArrayD, 0, cnD);
                     }
 
                     // gradH = gradOut @ w2^T → [m, h]
                     var gradH = ArrayPool<double>.Shared.Rent(cmD * chD);
                     Array.Clear(gradH, 0, cmD * chD);
                     BlasProvider.TryGemmEx(cmD, chD, cnD,
-                        gOutArr, 0, cnD, transA: false,
-                        w2A, 0, cnD, transB: true,
+                        gradOutArrayD, 0, cnD, transA: false,
+                        w2ArrayD, 0, cnD, transB: true,
                         gradH, 0, chD);
 
                     // ReLU backward: gradH *= (activated > 0 ? 1 : 0)
                     int gradHLen = cmD * chD;
                     for (int idx = 0; idx < gradHLen; idx++)
-                        if (actA[idx] <= 0.0) gradH[idx] = 0.0;
+                        if (activatedArrayD[idx] <= 0.0) gradH[idx] = 0.0;
 
                     // dW1 = input^T @ gradH → [k, h]
-                    if (gW1Tensor is not null)
+                    if (gW1ArrayD is not null)
                     {
-                        var gW1 = (double[])(object)gW1Tensor.GetDataArray();
                         BlasProvider.TryGemmEx(ckD, chD, cmD,
-                            inA, 0, ckD, transA: true,
+                            inArrayD, 0, ckD, transA: true,
                             gradH, 0, chD, transB: false,
-                            gW1, 0, chD);
+                            gW1ArrayD, 0, chD);
                     }
 
                     // dInput = gradH @ w1^T → [m, k]
-                    if (gInTensor is not null)
+                    if (gInArrayD is not null)
                     {
-                        var gIn = (double[])(object)gInTensor.GetDataArray();
                         BlasProvider.TryGemmEx(cmD, ckD, chD,
                             gradH, 0, chD, transA: false,
-                            w1A, 0, chD, transB: true,
-                            gIn, 0, ckD);
+                            w1ArrayD, 0, chD, transB: true,
+                            gInArrayD, 0, ckD);
                     }
 
                     ArrayPool<double>.Shared.Return(gradH);
 
-                    capturedW1D.Grad = gW1Tensor;
-                    capturedW2D.Grad = gW2Tensor;
-                    capturedInputD.Grad = gInTensor;
+                    capturedW1D.Grad = gW1TensorD;
+                    capturedW2D.Grad = gW2TensorD;
+                    capturedInputD.Grad = gInTensorD;
                 });
 
                 consumedIndices.Add(i);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1445,14 +1445,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // the first Step() of any double-precision compiled plan
                 // whose parameters happen to round-up the bucket (e.g.
                 // GraFPrint's 53-layer BN pyramid).
-                gradArrays[i] = _preAllocatedGrads[i].GetLiveBackingArrayAllowingPaddingOrNull()
-                    ?? _preAllocatedGrads[i].GetDataArray();
+                gradArrays[i] = BindInternalStepBuffer(
+                    _preAllocatedGrads[i], $"preallocated gradient {i}");
             }
             _cachedGradArrays = gradArrays;
-            _cachedLossGradSeedArray = _lossGradSeed.GetLiveBackingArrayAllowingPaddingOrNull()
-                ?? _lossGradSeed.GetDataArray();
-            _cachedLossGradDestArray = _lossGradDest?.GetLiveBackingArrayAllowingPaddingOrNull()
-                ?? _lossGradDest?.GetDataArray();
+            _cachedLossGradSeedArray = BindInternalStepBuffer(_lossGradSeed, "loss gradient seed");
+            _cachedLossGradDestArray = _lossGradDest is null
+                ? null
+                : BindInternalStepBuffer(_lossGradDest, "loss gradient destination");
         }
 
         // Only zero gradient buffers used by generic (accumulating) backward delegates.
@@ -1902,6 +1902,93 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         }
     }
 
+    /// <summary>
+    /// Binds an internal compiled-step buffer whose generated delegates require
+    /// zero-based live storage. These tensors are allocated by the plan itself;
+    /// accepting a detached copy here would silently discard backward writes.
+    /// </summary>
+    private static T[] BindInternalStepBuffer(Tensor<T> tensor, string role)
+    {
+        var backing = tensor.GetCpuBackingForContiguousWrite(out int offset);
+        if (backing is null || offset != 0 || backing.Length < tensor.Length)
+            throw new InvalidOperationException(
+                $"Compiled {role} must expose zero-offset writable CPU storage; " +
+                $"shape=[{string.Join(",", tensor.Shape)}], offset={offset}, " +
+                $"backingLength={backing?.Length ?? 0}.");
+        return backing;
+    }
+
+    /// <summary>
+    /// Binds a CPU optimizer operand without losing view addressing. Contiguous
+    /// managed storage stays zero-copy and carries an explicit base offset;
+    /// non-contiguous or non-array storage uses a persistent logical staging
+    /// buffer that is refreshed/committed around each optimizer step.
+    /// </summary>
+    private static T[] BindCpuOptimizerTensor(
+        Tensor<T> tensor, out int offset, out bool requiresStaging)
+    {
+        if (tensor.Device != TensorDevice.CPU)
+            throw new InvalidOperationException(
+                $"A fused CPU optimizer cannot stage tensor shape [{string.Join(",", tensor.Shape)}] " +
+                $"from device {tensor.Device} without an attached backend buffer.");
+        if (tensor.IsSparse)
+            throw new NotSupportedException(
+                "Compiled fused optimizers do not support sparse parameter or gradient storage.");
+        if (tensor.IsReadOnlyOptimizerStorage)
+            throw new InvalidOperationException(
+                "Compiled fused optimizers cannot update read-only memory-mapped storage.");
+
+        var backing = tensor.GetCpuBackingForContiguousWrite(out offset);
+        if (backing is not null)
+        {
+            // Preserve the existing lazy/streaming convention: an empty live
+            // backing means the parameter was not materialized/exercised and
+            // the fused updater skips it without forcing residency.
+            if (backing.Length == 0)
+            {
+                offset = 0;
+                requiresStaging = false;
+                return backing;
+            }
+
+            if (offset < 0 || offset > backing.Length - tensor.Length)
+                throw new InvalidOperationException(
+                    $"Tensor shape [{string.Join(",", tensor.Shape)}] exposes invalid optimizer backing " +
+                    $"bounds: offset={offset}, logicalLength={tensor.Length}, backingLength={backing.Length}.");
+
+            requiresStaging = false;
+            return backing;
+        }
+
+        var staged = new T[tensor.Length];
+        tensor.CopyLogicalTo(staged);
+        offset = 0;
+        requiresStaging = true;
+        return staged;
+    }
+
+    private static void RefreshOptimizerStaging(
+        Tensor<T>[] tensors, T[][] buffers, bool[] requiresStaging)
+    {
+        for (int i = 0; i < buffers.Length; i++)
+        {
+            if (!requiresStaging[i] || buffers[i].Length == 0)
+                continue;
+            tensors[i].CopyLogicalTo(buffers[i]);
+        }
+    }
+
+    private static void CommitOptimizerStaging(
+        Tensor<T>[] tensors, T[][] buffers, bool[] requiresStaging)
+    {
+        for (int i = 0; i < buffers.Length; i++)
+        {
+            if (!requiresStaging[i] || buffers[i].Length == 0)
+                continue;
+            tensors[i].CopyFromArray(buffers[i]);
+        }
+    }
+
     private unsafe void ConfigureOptimizerFloat(
         OptimizerType optimizerType, LrSchedule schedule, float beta1, float beta2, float eps, float weightDecay,
         FusedOptimizerExtras extras)
@@ -1924,6 +2011,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         int paramCount = _parameters.Length;
         var paramArrays = new float[paramCount][];
         var gradArrays = new float[paramCount][];
+        var paramOffsets = new int[paramCount];
+        var gradOffsets = new int[paramCount];
+        var stagedParams = new bool[paramCount];
+        var stagedGrads = new bool[paramCount];
         var lengths = new int[paramCount];
 
         // Momentum / first moment buffers (Adam, SGD+momentum, etc.)
@@ -1969,6 +2060,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuVScales = new Engines.DirectGpu.IGpuBuffer?[paramCount];
         var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
+        var gpuGradUploadScratch = new float[paramCount][];
 
         // Issue #350: GetDataArray() returns a COPY when the parameter tensor's
         // backing storage is pool-padded (e.g. logical length 6 on a 16-slot
@@ -2034,11 +2126,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         // Gradient is CPU-resident — bind its live CPU
                         // backing as gradArrays[p]; the per-step closure
                         // will upload it to a GPU staging buffer.
-                        var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                        if (liveGrad is not null)
-                            gradArrays[p] = (float[])(object)liveGrad;
-                        else
-                            gradArrays[p] = Array.Empty<float>();
+                        var boundGrad = BindCpuOptimizerTensor(
+                            _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                        gradArrays[p] = (float[])(object)boundGrad;
                     }
                 }
                 else
@@ -2107,32 +2197,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 mScales[p] = Array.Empty<double>();
                 vScales[p] = Array.Empty<double>();
                 paramArrays[p] = Array.Empty<float>();
+                paramOffsets[p] = 0;
                 continue;
             }
 
-            // CPU path. For non-trivial layouts (views, non-zero offset)
-            // the live-backing accessor returns null and we throw — that's
-            // a "should never happen for params registered with
-            // CompileTraining" condition and a silent fallback to a copy
-            // would just resurrect the Issue #350 stale-buffer bug.
-            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
-            if (liveParam is null)
-                throw new InvalidOperationException(
-                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset). " +
-                    $"ConfigureOptimizer requires either a contiguous CPU tensor or a GPU-resident tensor with " +
-                    $"a backend-attached buffer (TryGetGpuBuffer() returns non-null). For non-contiguous views, " +
-                    $"call .Contiguous() before registering with CompileTraining.");
-            paramArrays[p] = (float[])(object)liveParam;
+            // CPU path. Preserve view semantics: contiguous views bind their
+            // real backing plus an explicit offset; non-contiguous/native-memory
+            // views use a persistent gather/update/scatter staging buffer.
+            var boundParam = BindCpuOptimizerTensor(
+                _parameters[p], out paramOffsets[p], out stagedParams[p]);
+            paramArrays[p] = (float[])(object)boundParam;
             if (_gradients[p] is not null)
             {
-                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                if (liveGrad is null)
-                    throw new InvalidOperationException(
-                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
-                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage so the fused " +
-                        $"optimizer step reads the current gradient values produced by each plan.Step()'s backward pass.");
-                gradArrays[p] = (float[])(object)liveGrad;
+                var boundGrad = BindCpuOptimizerTensor(
+                    _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                gradArrays[p] = (float[])(object)boundGrad;
             }
             else
             {
@@ -2212,22 +2291,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             for (int p = 0; p < paramCount; p++)
             {
                 if (paramArrays[p].Length == 0) continue; // GPU-resident: gate rejects this combo
-                Array.Copy(paramArrays[p], m[p], lengths[p]); // z ← param₀
-                Array.Copy(paramArrays[p], v[p], lengths[p]); // x ← param₀
+                Array.Copy(paramArrays[p], paramOffsets[p], m[p], 0, lengths[p]); // z ← param₀
+                Array.Copy(paramArrays[p], paramOffsets[p], v[p], 0, lengths[p]); // x ← param₀
             }
             float sfBeta = extras.SfBeta;
             _preForwardParamTransform = () =>
             {
+                RefreshOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
                 for (int p = 0; p < paramCount; p++)
                 {
                     int lenY = lengths[p];
                     if (paramArrays[p].Length == 0) continue;
-                    fixed (float* pY = paramArrays[p], pZ = m[p], pX = v[p])
+                    fixed (float* pY = &paramArrays[p][paramOffsets[p]], pZ = m[p], pX = v[p])
                         FusedOptimizer.ScheduleFreeYUpdateSimd(pY, pZ, pX, lenY, sfBeta);
                     // Pre-forward y-write also mutates the live backing → keep the resident GPU
                     // buffer coherent so the forward reads y, not stale pre-step weights (#739 review).
                     MarkHostWeightMutated(p);
                 }
+                CommitOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
             };
         }
         _optimizerRuntimeState = new FusedOptimizerRuntimeState
@@ -2265,6 +2346,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         _optimizerUpdate = () =>
         {
+            RefreshOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+            RefreshOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            try
+            {
             _optimizerStep++;
             float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
             float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
@@ -2293,7 +2378,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 {
                     if (gradArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
-                    fixed (float* pGrad = gradArrays[p], pPrev = m[p])
+                    fixed (float* pGrad = &gradArrays[p][gradOffsets[p]], pPrev = m[p])
                         for (int i = 0; i < len2; i++) inner += (double)pGrad[i] * pPrev[i];
                 }
                 scalarState.HypergradientAdjustment += exHyperLr * (float)inner;
@@ -2303,7 +2388,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // Skip params with no gradient OR no materialized weight backing (#1738).
                     if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
-                    fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p], pPrev = m[p])
+                    fixed (float* pParam = &paramArrays[p][paramOffsets[p]],
+                           pGrad = &gradArrays[p][gradOffsets[p]], pPrev = m[p])
                         for (int i = 0; i < len2; i++) { pParam[i] -= newLr * pGrad[i]; pPrev[i] = pGrad[i]; }
                     MarkHostWeightMutated(p);
                 }
@@ -2318,7 +2404,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 {
                     if (gradArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
-                    fixed (float* pGrad = gradArrays[p], pS = m[p])
+                    fixed (float* pGrad = &gradArrays[p][gradOffsets[p]], pS = m[p])
                         for (int i = 0; i < len2; i++)
                         {
                             pS[i] += gamma * pGrad[i];
@@ -2336,7 +2422,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // Skip params with no gradient OR no materialized weight backing (#1738).
                     if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
-                    fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p])
+                    fixed (float* pParam = &paramArrays[p][paramOffsets[p]],
+                           pGrad = &gradArrays[p][gradOffsets[p]])
                         for (int i = 0; i < len2; i++) pParam[i] -= gammaNew * pGrad[i];
                     MarkHostWeightMutated(p);
                 }
@@ -2357,10 +2444,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 {
                     if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                     int len2 = lengths[p];
-                    fixed (float* pZ = m[p], pX = v[p], pGrad = gradArrays[p])
+                    fixed (float* pZ = m[p], pX = v[p],
+                           pGrad = &gradArrays[p][gradOffsets[p]])
                         wsNext = FusedOptimizer.ScheduleFreeSgdUpdateSimd(
                             pZ, pX, pGrad, len2, lr, scalarState.ScheduleFreeWeightSum);
-                    Array.Copy(v[p], paramArrays[p], len2); // live backing ← x (eval copy)
+                    Array.Copy(v[p], 0, paramArrays[p], paramOffsets[p], len2); // live backing ← x (eval copy)
                     MarkHostWeightMutated(p);
                 }
                 scalarState.ScheduleFreeWeightSum = wsNext;
@@ -2485,11 +2573,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         float[] hostGrad = gradArrays[p];
                         if (hostGrad.Length == 0)
                         {
-                            var liveGrad = _gradients[p]?.GetLiveBackingArrayAllowingPaddingOrNull();
-                            hostGrad = liveGrad is not null ? (float[])(object)liveGrad : Array.Empty<float>();
+                            if (_gradients[p] is not null)
+                            {
+                                var rebound = BindCpuOptimizerTensor(
+                                    _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                                hostGrad = (float[])(object)rebound;
+                                gradArrays[p] = hostGrad;
+                                if (stagedGrads[p] && hostGrad.Length != 0)
+                                    _gradients[p].CopyLogicalTo((T[])(object)hostGrad);
+                            }
                         }
                         if (hostGrad.Length == 0) continue; // no grad recorded
-                        gradBuf = gpuBe.AllocateBuffer(hostGrad);
+                        float[] uploadGrad = hostGrad;
+                        if (gradOffsets[p] != 0)
+                        {
+                            uploadGrad = gpuGradUploadScratch[p] ??= new float[len];
+                            hostGrad.AsSpan(gradOffsets[p], len).CopyTo(uploadGrad);
+                        }
+                        gradBuf = gpuBe.AllocateBuffer(uploadGrad);
                         gradTransient = true;
                     }
                     bool diagAU = p == 0 && _optimizerStep == 6 && System.Environment.GetEnvironmentVariable("AIDOTNET_OPT_DIAG") == "1";
@@ -2625,7 +2726,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // ~17× slower eager autograd tape — the exact UnifiedMultimodal regression.
                 if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
 
-                fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
+                fixed (float* pParam = &paramArrays[p][paramOffsets[p]],
+                       pGrad = &gradArrays[p][gradOffsets[p]],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
@@ -2783,6 +2885,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // resident buffer makes the next forward re-upload the updated host weights.
                 MarkHostWeightMutated(p);
             }
+            }
+            finally
+            {
+                CommitOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+                CommitOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            }
         };
     }
 
@@ -2808,6 +2916,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         int groupCount = groupSchedules.Count;
         var paramArrays = new float[paramCount][];
         var gradArrays = new float[paramCount][];
+        var paramOffsets = new int[paramCount];
+        var gradOffsets = new int[paramCount];
+        var stagedParams = new bool[paramCount];
+        var stagedGrads = new bool[paramCount];
         var lengths = new int[paramCount];
         var m = new float[paramCount][];
         var v = new float[paramCount][];
@@ -2845,6 +2957,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuVScales = new Engines.DirectGpu.IGpuBuffer?[paramCount];
         var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
+        var gpuGradUploadScratch = new float[paramCount][];
 
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
@@ -2885,8 +2998,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     }
                     else
                     {
-                        var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                        gradArrays[p] = liveGrad is not null ? (float[])(object)liveGrad : Array.Empty<float>();
+                        var boundGrad = BindCpuOptimizerTensor(
+                            _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                        gradArrays[p] = (float[])(object)boundGrad;
                     }
                 }
                 else
@@ -2954,25 +3068,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 mScales[p] = Array.Empty<double>();
                 vScales[p] = Array.Empty<double>();
                 paramArrays[p] = Array.Empty<float>();
+                paramOffsets[p] = 0;
                 continue;
             }
 
-            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
-            if (liveParam is null)
-                throw new InvalidOperationException(
-                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset). " +
-                    $"ConfigureOptimizerGrouped requires either a contiguous CPU tensor or a GPU-resident tensor with " +
-                    $"a backend-attached buffer (TryGetGpuBuffer() returns non-null).");
-            paramArrays[p] = (float[])(object)liveParam;
+            var boundParam = BindCpuOptimizerTensor(
+                _parameters[p], out paramOffsets[p], out stagedParams[p]);
+            paramArrays[p] = (float[])(object)boundParam;
             if (_gradients[p] is not null)
             {
-                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                if (liveGrad is null)
-                    throw new InvalidOperationException(
-                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
-                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
-                gradArrays[p] = (float[])(object)liveGrad;
+                var boundGrad = BindCpuOptimizerTensor(
+                    _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                gradArrays[p] = (float[])(object)boundGrad;
             }
             else
             {
@@ -3060,6 +3167,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         _optimizerUpdate = () =>
         {
+            RefreshOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+            RefreshOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            try
+            {
             _optimizerStep++;
             float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
             float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
@@ -3097,7 +3208,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     if (gradBuf is null)
                     {
                         if (gradArrays[p].Length == 0) continue;
-                        gradBuf = gpuBe.AllocateBuffer(gradArrays[p]);
+                        float[] hostGrad = gradArrays[p];
+                        if (gradOffsets[p] != 0)
+                        {
+                            float[] scratch = gpuGradUploadScratch[p] ??= new float[len];
+                            hostGrad.AsSpan(gradOffsets[p], len).CopyTo(scratch);
+                            hostGrad = scratch;
+                        }
+                        gradBuf = gpuBe.AllocateBuffer(hostGrad);
                         gradTransient = true;
                     }
                     try
@@ -3206,7 +3324,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // unexercised layers; see the same guard in ConfigureOptimizerFloat). #1738.
                 if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
 
-                fixed (float* pParam = paramArrays[p], pGrad = gradArrays[p],
+                fixed (float* pParam = &paramArrays[p][paramOffsets[p]],
+                       pGrad = &gradArrays[p][gradOffsets[p]],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
@@ -3342,6 +3461,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // bypassed under a resident/capture scope, so the bump alone is insufficient).
                 MarkHostWeightMutated(p);
             }
+            }
+            finally
+            {
+                CommitOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+                CommitOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            }
         };
     }
 
@@ -3365,6 +3490,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         int paramCount = _parameters.Length;
         var paramArrays = new double[paramCount][];
         var gradArrays = new double[paramCount][];
+        var paramOffsets = new int[paramCount];
+        var gradOffsets = new int[paramCount];
+        var stagedParams = new bool[paramCount];
+        var stagedGrads = new bool[paramCount];
         var lengths = new int[paramCount];
         var m = new double[paramCount][];
         var v = new double[paramCount][];
@@ -3379,23 +3508,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // straight through to _parameters[p].
         for (int p = 0; p < paramCount; p++)
         {
-            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
-            if (liveParam is null)
-                throw new InvalidOperationException(
-                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
-                    $"ConfigureOptimizer requires every registered parameter to be a contiguous CPU tensor so " +
-                    $"the fused optimizer step can mutate the caller's tensor in place.");
-            paramArrays[p] = (double[])(object)liveParam;
+            var boundParam = BindCpuOptimizerTensor(
+                _parameters[p], out paramOffsets[p], out stagedParams[p]);
+            paramArrays[p] = (double[])(object)boundParam;
             if (_gradients[p] is not null)
             {
-                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
-                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                if (liveGrad is null)
-                    throw new InvalidOperationException(
-                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
-                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
-                gradArrays[p] = (double[])(object)liveGrad;
+                var boundGrad = BindCpuOptimizerTensor(
+                    _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                gradArrays[p] = (double[])(object)boundGrad;
             }
             else
             {
@@ -3418,6 +3538,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
             v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+        }
+
+        bool multiTensorEligible = true;
+        for (int p = 0; p < paramCount; p++)
+        {
+            if (paramOffsets[p] != 0 || gradOffsets[p] != 0 || stagedParams[p] || stagedGrads[p])
+            {
+                multiTensorEligible = false;
+                break;
+            }
         }
 
         _optimizerStep = 0;
@@ -3447,6 +3577,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         _optimizerUpdate = () =>
         {
+            RefreshOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+            RefreshOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            try
+            {
             _optimizerStep++;
             // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
             // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
@@ -3461,16 +3595,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // loop below (same math, same per-tensor SIMD/scalar-tail split). This
             // (non-grouped double) path is pure CPU fp32-moment AdamW — no GPU-resident
             // or bf16/int8 branch to preserve — so the fast path is unconditional here.
-            if (optType == OptimizerType.AdamW)
+            if (multiTensorEligible && optType == OptimizerType.AdamW)
             {
                 FusedOptimizer.AdamWUpdateSimdMulti(paramArrays, gradArrays, m, v, lengths, paramCount,
                     lr, b1, b2, epsVal, wd, stepBc1, stepBc2);
+                for (int p = 0; p < paramCount; p++) MarkHostWeightMutated(p);
                 return;
             }
-            if (optType == OptimizerType.Adam)
+            if (multiTensorEligible && optType == OptimizerType.Adam)
             {
                 FusedOptimizer.AdamUpdateSimdMulti(paramArrays, gradArrays, m, v, lengths, paramCount,
                     lr, b1, b2, epsVal, stepBc1, stepBc2);
+                for (int p = 0; p < paramCount; p++) MarkHostWeightMutated(p);
                 return;
             }
             for (int p = 0; p < paramCount; p++)
@@ -3478,7 +3614,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // Skip params with no gradient OR no materialized weight backing (#1738).
                 if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                 int len = lengths[p];
-                fixed (double* pParam = paramArrays[p], pGrad = gradArrays[p],
+                fixed (double* pParam = &paramArrays[p][paramOffsets[p]],
+                       pGrad = &gradArrays[p][gradOffsets[p]],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
@@ -3513,6 +3650,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                 $"Supported: SGD, Adam, AdamW. Apply gradients manually for other types.");
                     }
                 }
+                MarkHostWeightMutated(p);
+            }
+            }
+            finally
+            {
+                CommitOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+                CommitOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
             }
         };
     }
@@ -3535,6 +3679,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         int groupCount = groupSchedules.Count;
         var paramArrays = new double[paramCount][];
         var gradArrays = new double[paramCount][];
+        var paramOffsets = new int[paramCount];
+        var gradOffsets = new int[paramCount];
+        var stagedParams = new bool[paramCount];
+        var stagedGrads = new bool[paramCount];
         var lengths = new int[paramCount];
         var m = new double[paramCount][];
         var v = new double[paramCount][];
@@ -3549,22 +3697,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
         {
-            var liveParam = _parameters[p].GetLiveBackingArrayAllowingPaddingOrNull();
-            if (liveParam is null)
-                throw new InvalidOperationException(
-                    $"Parameter {p} (shape [{string.Join(",", _parameters[p].Shape)}]) has a layout that does not expose " +
-                    $"a live CPU backing array (non-contiguous view, non-zero storageOffset, or non-CPU device). " +
-                    $"ConfigureOptimizerGrouped requires every registered parameter to be a contiguous CPU tensor.");
-            paramArrays[p] = (double[])(object)liveParam;
+            var boundParam = BindCpuOptimizerTensor(
+                _parameters[p], out paramOffsets[p], out stagedParams[p]);
+            paramArrays[p] = (double[])(object)boundParam;
             if (_gradients[p] is not null)
             {
-                // Fail fast on copy-fallback (see ConfigureOptimizerFloat for full rationale).
-                var liveGrad = _gradients[p].GetLiveBackingArrayAllowingPaddingOrNull();
-                if (liveGrad is null)
-                    throw new InvalidOperationException(
-                        $"Gradient {p} (shape [{string.Join(",", _gradients[p].Shape)}]) has a layout that does not expose " +
-                        $"a live CPU backing array. ConfigureOptimizer requires live gradient storage.");
-                gradArrays[p] = (double[])(object)liveGrad;
+                var boundGrad = BindCpuOptimizerTensor(
+                    _gradients[p], out gradOffsets[p], out stagedGrads[p]);
+                gradArrays[p] = (double[])(object)boundGrad;
             }
             else
             {
@@ -3617,6 +3757,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         _optimizerUpdate = () =>
         {
+            RefreshOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+            RefreshOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
+            try
+            {
             _optimizerStep++;
             // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
             // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
@@ -3633,7 +3777,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 int len = lengths[p];
                 double lr = groupLrs[paramGroup[p]];
 
-                fixed (double* pParam = paramArrays[p], pGrad = gradArrays[p],
+                fixed (double* pParam = &paramArrays[p][paramOffsets[p]],
+                       pGrad = &gradArrays[p][gradOffsets[p]],
                        pM = m[p], pV = v[p], pVMax = vMax[p])
                 {
                     switch (optType)
@@ -3668,6 +3813,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                 $"Supported: SGD, Adam, AdamW.");
                     }
                 }
+                MarkHostWeightMutated(p);
+            }
+            }
+            finally
+            {
+                CommitOptimizerStaging(_parameters, (T[][])(object)paramArrays, stagedParams);
+                CommitOptimizerStaging(_gradients, (T[][])(object)gradArrays, stagedGrads);
             }
         };
     }
@@ -4912,10 +5064,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// <see cref="LinearAlgebra.TensorBase{T}.GetLiveBackingArrayAllowingPaddingOrNull"/>
     /// which returns the actual pool-padded backing array, so pins point at the live
     /// storage and writes through the pin are visible to subsequent
-    /// <c>tensor.AsSpan()</c> / <c>tensor[i]</c> reads. Falls back to
-    /// <c>GetDataArray()</c> for non-contiguous / non-zero-offset / non-CPU tensors
-    /// (where GetDataArray returns a COPY) — those are filtered out by callers'
-    /// <c>IsContiguous</c> gates, so the fallback should never fire in practice.
+    /// <c>tensor.AsSpan()</c> / <c>tensor[i]</c> reads. Non-contiguous,
+    /// non-zero-offset, or non-CPU tensors are rejected: callers must select
+    /// the stride-aware engine fallback instead of pinning a detached copy.
     /// <para>
     /// The bug was: <c>GetDataArray()</c> returns a COPY when the tensor is
     /// ArrayPool-padded (logical Length=1 on a 16-slot bucket, for instance).
@@ -4928,7 +5079,18 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// </para>
     /// </summary>
     private static float[] GetPinnableFloatBacking(Tensor<float> t)
-        => t.GetLiveBackingArrayAllowingPaddingOrNull() ?? t.GetDataArray();
+        => t.GetLiveBackingArrayAllowingPaddingOrNull()
+            ?? throw new InvalidOperationException(
+                "A compiled specialization attempted to bind a tensor without zero-offset live FP32 storage.");
+
+    /// <summary>
+    /// Returns the live FP32 backing required by a specialized kernel, or
+    /// <see langword="null"/> when the tensor layout cannot be addressed as a
+    /// zero-offset dense array. A specialized writer must fall back to the
+    /// stride-aware engine path instead of binding a materialized copy.
+    /// </summary>
+    private static float[]? TryGetLiveFloatBacking(Tensor<T> tensor)
+        => ((Tensor<float>)(object)tensor).GetLiveBackingArrayAllowingPaddingOrNull();
 
     /// <summary>
     /// Returns the live FP64 backing required by a specialized kernel, or
@@ -4954,6 +5116,29 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // (the consumer ViT-Base in PR #1224) hit the compiled-replay fast
         // path on their hottest op.
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return null;
+
+        // Every specialization below captures raw arrays or pins them for later
+        // replay. Enforce that contract once, centrally: views, sliced Memory<T>
+        // instances with a nonzero underlying array offset, GPU tensors, and
+        // other non-addressable layouts must use the stride-aware engine path.
+        // Falling back is both correct and intentionally preferable to binding
+        // a materialized copy that can stale-read a parameter or orphan writes.
+        if (typeof(T) == typeof(float))
+        {
+            if (TryGetLiveFloatBacking(step.OutputBuffer) is null)
+                return null;
+            for (int i = 0; i < step.Inputs.Length; i++)
+                if (TryGetLiveFloatBacking(step.Inputs[i]) is null)
+                    return null;
+        }
+        else
+        {
+            if (TryGetLiveDoubleBacking(step.OutputBuffer) is null)
+                return null;
+            for (int i = 0; i < step.Inputs.Length; i++)
+                if (TryGetLiveDoubleBacking(step.Inputs[i]) is null)
+                    return null;
+        }
 
         // MatMul forward (double): direct BLAS into output buffer.
         // Mirrors the float branch below but with double[] arrays and
@@ -5228,10 +5413,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var input = step.Inputs[0];
             var output = step.OutputBuffer;
-            float[]? cOut = null;
-
             if (typeof(T) == typeof(float) && input.IsContiguous)
             {
+                var cOut = TryGetLiveFloatBacking(output);
+                if (cOut is null)
+                    return null;
                 // Pinned path: GCHandle once at compile time
                 var inH = PinAndTrack(
                     GetPinnableFloatBacking((Tensor<float>)(object)input), handleTracker);
@@ -5245,7 +5431,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     var partials = new float[numChunks];
                     return eng =>
                     {
-                        cOut ??= (float[])(object)output.GetDataArray();
                         unsafe
                         {
                             float* p = (float*)inH.AddrOfPinnedObject();
@@ -5265,7 +5450,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
                 return eng =>
                 {
-                    cOut ??= (float[])(object)output.GetDataArray();
                     unsafe { cOut[0] = SimdKernels.SumUnsafe((float*)inH.AddrOfPinnedObject(), len); }
                 };
             }
@@ -5527,11 +5711,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 ? act : FusedActivationType.None;
             int M = input._shape[0], K = input._shape[1], N = weights._shape[1];
 
-            // Pre-fetch arrays at compile time — bypass EnsureMaterialized at replay
-            var inArr = (float[])(object)input.GetDataArray();
-            var wArr = (float[])(object)weights.GetDataArray();
-            var bArr = (float[])(object)bias.GetDataArray();
-            var oArr = (float[])(object)o.GetDataArray();
+            // Bind only live zero-offset storage. GetDataArray() may materialize a
+            // copy for pool-padded tensors and views. A copied output silently drops
+            // every replay write (AiDotNet#1346/Tensors#396); copied inputs also go
+            // stale after the trace. Unsupported layouts use the generic engine path.
+            var inArr = TryGetLiveFloatBacking(input);
+            var wArr = TryGetLiveFloatBacking(weights);
+            var bArr = TryGetLiveFloatBacking(bias);
+            var oArr = TryGetLiveFloatBacking(o);
+            if (inArr is null || wArr is null || bArr is null || oArr is null)
+                return null;
 
             var fusedAllowCachedB = allowCachedB;
             return eng =>
@@ -6087,13 +6276,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             && step.OutputBuffer.Length == 1)
         {
             var inp = step.Inputs[0]; var o = step.OutputBuffer;
+            var cOut = TryGetLiveFloatBacking(o);
+            if (cOut is null)
+                return null;
             var inHandle = PinAndTrack(
                 GetPinnableFloatBacking((Tensor<float>)(object)inp), handleTracker);
-            float[]? cOut = null;
             int len = inp.Length;
             return eng =>
             {
-                cOut ??= (float[])(object)o.GetDataArray();
                 unsafe
                 {
                     float* pIn = (float*)inHandle.AddrOfPinnedObject();
@@ -6372,8 +6562,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (ps is null || ps.Length != gradients.Length) return false;
             var pt = ps[p];
             if (pt is null) return true;
-            var pa = pt.GetLiveBackingArrayAllowingPaddingOrNull();
-            return pa is null || pa.Length == 0;
+            return !pt.HasMaterializedOptimizerStorage;
         }
 
         // CodeRabbit #425 review: detect GPU-resident gradients before the CPU
@@ -6421,19 +6610,27 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var tensor = gradients[p];
             if (tensor == null || SkipUnexercised(p)) continue;
-            var arr = tensor.GetLiveBackingArrayAllowingPaddingOrNull() ?? tensor.GetDataArray();
             int len = tensor.Length;
+            var arr = tensor.GetCpuBackingForStridedRead(out int offset);
             // SIMD fast path for the two dominant element types (float/double): the
             // norm is a per-step, full-gradient pass over the ENTIRE parameter set,
             // and the previous scalar loop with a per-element numOps.ToDouble virtual
             // call was ~19% of a large-model fused training step (PerfView). Only the
             // logical [0,len) region is read, so the pool-padding tail never leaks.
-            if (arr is double[] dNorm) totalNormSq += SumSquaresVectorized(dNorm, len);
-            else if (arr is float[] fNorm) totalNormSq += SumSquaresVectorized(fNorm, len);
+            if (tensor.IsContiguous && offset == 0 && arr is double[] dNorm)
+                totalNormSq += SumSquaresVectorized(dNorm, len);
+            else if (tensor.IsContiguous && offset == 0 && arr is float[] fNorm)
+                totalNormSq += SumSquaresVectorized(fNorm, len);
+            else if (tensor.IsContiguous && arr is not null)
+                for (int i = 0; i < len; i++)
+                {
+                    double v = numOps.ToDouble(arr[offset + i]);
+                    totalNormSq += v * v;
+                }
             else
                 for (int i = 0; i < len; i++)
                 {
-                    double v = numOps.ToDouble(arr[i]);
+                    double v = numOps.ToDouble(tensor.GetFlat(i));
                     totalNormSq += v * v;
                 }
         }
@@ -6447,13 +6644,20 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var tensor = gradients[p];
             if (tensor == null || SkipUnexercised(p)) continue;
-            var arr = tensor.GetLiveBackingArrayAllowingPaddingOrNull() ?? tensor.GetDataArray();
             int len = tensor.Length;
-            if (arr is double[] dScale) ScaleInPlaceVectorized(dScale, len, maxNorm / (totalNorm + 1e-6));
-            else if (arr is float[] fScale) ScaleInPlaceVectorized(fScale, len, (float)(maxNorm / (totalNorm + 1e-6)));
+            var arr = tensor.GetCpuBackingForContiguousWrite(out int offset);
+            if (offset == 0 && arr is double[] dScale)
+            {
+                ScaleInPlaceVectorized(dScale, len, maxNorm / (totalNorm + 1e-6));
+                tensor.IncrementVersion();
+            }
+            else if (offset == 0 && arr is float[] fScale)
+            {
+                ScaleInPlaceVectorized(fScale, len, (float)(maxNorm / (totalNorm + 1e-6)));
+                tensor.IncrementVersion();
+            }
             else
-                for (int i = 0; i < len; i++)
-                    arr[i] = numOps.Multiply(arr[i], scale);
+                tensor.ScaleLogicalInPlace(scale);
         }
     }
 
@@ -6649,6 +6853,29 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // dominant backward op (matmul backward = ~30% of typical
         // transformer train wall-clock).
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return null;
+
+        // Specialized backward delegates capture raw zero-based arrays. Apply
+        // the same centralized eligibility contract as specialized forward:
+        // parameter views, Memory<T> slices with a base offset, and native/GPU
+        // storage remain fully supported through the stride-aware compiled
+        // fallback, but must never be rebound to detached GetDataArray copies.
+        bool HasSpecializedBacking(Tensor<T> tensor) => typeof(T) == typeof(float)
+            ? TryGetLiveFloatBacking(tensor) is not null
+            : TryGetLiveDoubleBacking(tensor) is not null;
+
+        if (!HasSpecializedBacking(step.OutputBuffer))
+            return null;
+        for (int i = 0; i < step.Inputs.Length; i++)
+            if (!HasSpecializedBacking(step.Inputs[i]))
+                return null;
+
+        if (gradMap.TryGetValue(step.OutputBuffer, out var outputGrad)
+            && !HasSpecializedBacking(outputGrad))
+            return null;
+        for (int i = 0; i < step.Inputs.Length; i++)
+            if (gradMap.TryGetValue(step.Inputs[i], out var inputGrad)
+                && !HasSpecializedBacking(inputGrad))
+                return null;
 
         // MatMul backward (double): dA = dC @ B^T, dB = A^T @ dC — transposed BLAS, zero alloc.
         // Mirrors the float branch with cblas_dgemm via TryGemmEx's double overload;

--- a/src/AiDotNet.Tensors/Engines/Compilation/GradientClipping.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GradientClipping.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
-using AiDotNet.Tensors.Engines.Simd;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Compilation;
@@ -29,70 +28,68 @@ public static class GradientClipping
     /// <returns>The total gradient norm before clipping.</returns>
     public static unsafe float ClipGradNorm(Tensor<float>[] gradients, float maxNorm)
     {
+        if (float.IsNaN(maxNorm) || maxNorm < 0f)
+            throw new ArgumentOutOfRangeException(nameof(maxNorm), maxNorm,
+                "Maximum gradient norm must be non-negative and not NaN.");
         if (gradients is null || gradients.Length == 0) return 0f;
 
         // Step 1: Compute total L2 norm across all gradient tensors
-        float totalNormSq = 0f;
+        // Squaring a finite float around 1e20 overflows float. Double covers
+        // the entire float domain and still uses SIMD in SumSquares below.
+        double totalNormSq = 0d;
         for (int g = 0; g < gradients.Length; g++)
         {
             if (gradients[g] is null) continue;
-            // Ensure contiguous — GetDataArray may return a copy for views
-            var grad = gradients[g].IsContiguous ? gradients[g] : gradients[g].Contiguous();
-            var data = grad.GetDataArray();
-            int len = data.Length;
-            int i = 0;
-
-#if NET5_0_OR_GREATER
-            if (Fma.IsSupported && len >= 8)
+            var grad = gradients[g];
+            if (grad.TryGetContiguousSpan(out var logical))
             {
-                var acc = Vector256<float>.Zero;
-                int simdLen = len & ~7;
-                fixed (float* p = data)
-                {
-                    for (; i < simdLen; i += 8)
-                    {
-                        var v = Avx.LoadVector256(p + i);
-                        acc = Fma.MultiplyAdd(v, v, acc);
-                    }
-                }
-                totalNormSq += SimdKernels.HorizontalSum(acc);
+                totalNormSq += SumSquares(logical);
             }
-#endif
-            for (; i < len; i++)
-                totalNormSq += data[i] * data[i];
+            else
+            {
+                // Non-contiguous views cannot expose one logical span. Copy into a
+                // pooled scratch buffer so stride traversal remains correct without
+                // creating a persistent tensor or a full-size GC allocation.
+                var scratch = System.Buffers.ArrayPool<float>.Shared.Rent(grad.Length);
+                try
+                {
+                    var logicalCopy = scratch.AsSpan(0, grad.Length);
+                    grad.CopyLogicalTo(logicalCopy);
+                    totalNormSq += SumSquares(logicalCopy);
+                }
+                finally
+                {
+                    System.Buffers.ArrayPool<float>.Shared.Return(scratch);
+                }
+            }
         }
 
-        float totalNorm = MathF.Sqrt(totalNormSq);
+        double totalNorm = Math.Sqrt(totalNormSq);
 
         // Step 2: If norm exceeds maxNorm, scale all gradients down
         if (totalNorm > maxNorm)
         {
-            float scale = maxNorm / (totalNorm + 1e-6f);
+            float scale = (float)(maxNorm / (totalNorm + 1e-6d));
             for (int g = 0; g < gradients.Length; g++)
             {
                 if (gradients[g] is null) continue;
-                var data = gradients[g].GetDataArray();
-                int len = data.Length;
-                int i = 0;
-
-#if NET5_0_OR_GREATER
-                if (Avx.IsSupported && len >= 8)
+                var grad = gradients[g];
+                if (grad.IsContiguous)
                 {
-                    var vScale = Vector256.Create(scale);
-                    int simdLen = len & ~7;
-                    fixed (float* p = data)
-                    {
-                        for (; i < simdLen; i += 8)
-                            Avx.Store(p + i, Avx.Multiply(Avx.LoadVector256(p + i), vScale));
-                    }
+                    // AsWritableSpan is the single write-intent gate: it applies COW,
+                    // respects a view's offset, excludes ArrayPool padding, and works
+                    // for managed and native CPU storage.
+                    Scale(grad.AsWritableSpan(), scale);
+                    grad.IncrementVersion();
                 }
-#endif
-                for (; i < len; i++)
-                    data[i] *= scale;
+                else
+                {
+                    grad.ScaleLogicalInPlace(scale);
+                }
             }
         }
 
-        return totalNorm;
+        return (float)totalNorm;
     }
 
     /// <summary>
@@ -104,13 +101,23 @@ public static class GradientClipping
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void ClipGradValue(Tensor<float>[] gradients, float clipValue)
     {
+        if (float.IsNaN(clipValue) || clipValue < 0f)
+            throw new ArgumentOutOfRangeException(nameof(clipValue), clipValue,
+                "Gradient clip value must be non-negative and not NaN.");
         if (gradients is null) return;
         float negClip = -clipValue;
 
         for (int g = 0; g < gradients.Length; g++)
         {
             if (gradients[g] is null) continue;
-            var data = gradients[g].GetDataArray();
+            var grad = gradients[g];
+            if (!grad.IsContiguous)
+            {
+                grad.ClampLogicalInPlace(negClip, clipValue);
+                continue;
+            }
+
+            var data = grad.AsWritableSpan();
             int len = data.Length;
             int i = 0;
 
@@ -120,7 +127,7 @@ public static class GradientClipping
                 var vMax = Vector256.Create(clipValue);
                 var vMin = Vector256.Create(negClip);
                 int simdLen = len & ~7;
-                fixed (float* p = data)
+                fixed (float* p = &data.GetPinnableReference())
                 {
                     for (; i < simdLen; i += 8)
                     {
@@ -137,6 +144,72 @@ public static class GradientClipping
                 if (data[i] > clipValue) data[i] = clipValue;
                 else if (data[i] < negClip) data[i] = negClip;
             }
+            grad.IncrementVersion();
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe double SumSquares(ReadOnlySpan<float> data)
+    {
+        double result = 0d;
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && data.Length >= 8)
+        {
+            var lowerAccumulator = Vector256<double>.Zero;
+            var upperAccumulator = Vector256<double>.Zero;
+            int simdLength = data.Length & ~7;
+            fixed (float* p = &data.GetPinnableReference())
+            {
+                for (; i < simdLength; i += 8)
+                {
+                    var value = Avx.LoadVector256(p + i);
+                    var lower = Avx.ConvertToVector256Double(value.GetLower());
+                    var upper = Avx.ConvertToVector256Double(value.GetUpper());
+                    if (Fma.IsSupported)
+                    {
+                        lowerAccumulator = Fma.MultiplyAdd(lower, lower, lowerAccumulator);
+                        upperAccumulator = Fma.MultiplyAdd(upper, upper, upperAccumulator);
+                    }
+                    else
+                    {
+                        lowerAccumulator = Avx.Add(
+                            lowerAccumulator, Avx.Multiply(lower, lower));
+                        upperAccumulator = Avx.Add(
+                            upperAccumulator, Avx.Multiply(upper, upper));
+                    }
+                }
+            }
+            var lanes = stackalloc double[4];
+            Avx.Store(lanes, Avx.Add(lowerAccumulator, upperAccumulator));
+            result = lanes[0] + lanes[1] + lanes[2] + lanes[3];
+        }
+#endif
+        for (; i < data.Length; i++)
+        {
+            double value = data[i];
+            result += value * value;
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void Scale(Span<float> data, float scale)
+    {
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && data.Length >= 8)
+        {
+            var vectorScale = Vector256.Create(scale);
+            int simdLength = data.Length & ~7;
+            fixed (float* p = &data.GetPinnableReference())
+            {
+                for (; i < simdLength; i += 8)
+                    Avx.Store(p + i, Avx.Multiply(Avx.LoadVector256(p + i), vectorScale));
+            }
+        }
+#endif
+        for (; i < data.Length; i++)
+            data[i] *= scale;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Compilation;
 
@@ -41,6 +42,55 @@ internal static class GraphMode
         var scope = new LazyTensorScope(_current);
         _current = scope;
         return scope;
+    }
+
+    /// <summary>
+    /// Enables graph mode for a training trace. Copy-on-write parameters are
+    /// privatized before any graph node or parameter-derived view can capture
+    /// their storage. Every production training compiler must enter through
+    /// this method rather than <see cref="Enable"/>.
+    /// </summary>
+    internal static LazyTensorScope EnableTraining<T>(Tensor<T>[] parameters)
+    {
+        if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i] is null)
+                throw new ArgumentException("Training parameters cannot contain null tensors.", nameof(parameters));
+            parameters[i].PrepareForInPlaceWrite();
+        }
+
+        var scope = new LazyTensorScope(_current, trainingParametersPreparedBeforeTrace: true);
+        _current = scope;
+        return scope;
+    }
+
+    /// <summary>
+    /// Temporarily disables graph recording while a compiled plan replays.
+    /// Generic plan delegates call ordinary engine operations; without this
+    /// boundary they can accidentally append to an ambient trace instead of
+    /// executing, producing silent zero or stale gradients.
+    /// </summary>
+    internal static RecordingSuspension SuspendRecording()
+    {
+        var previous = _current;
+        _current = null;
+        return new RecordingSuspension(previous);
+    }
+
+    internal readonly struct RecordingSuspension : IDisposable
+    {
+        private readonly LazyTensorScope? _previous;
+
+        internal RecordingSuspension(LazyTensorScope? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            _current = _previous;
+        }
     }
 
     /// <summary>Sets the current scope (used by LazyTensorScope.Dispose).</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -176,6 +176,27 @@ internal sealed class LazyTensorScope : IDisposable
     }
 
     /// <summary>
+    /// Records a unary operation whose caller has already materialized the output tensor during
+    /// tracing. Replay still executes <paramref name="execute"/> because the output owns storage
+    /// independent of the input. This is the materializing counterpart to <see cref="RecordView"/>.
+    /// </summary>
+    internal Tensor<T> RecordMaterializedUnary<T>(
+        LazyNodeType opType,
+        string opName,
+        Tensor<T> input,
+        Tensor<T> output,
+        Action<IEngine, Tensor<T>> execute,
+        BackwardFunction<T>? backwardFn = null,
+        object[]? savedState = null)
+    {
+        var node = new LazyNode<T>(
+            opType, opName, input, output, execute, backwardFn, savedState);
+        output.LazySource = node;
+        _nodes.Add(node);
+        return output;
+    }
+
+    /// <summary>
     /// Records an IN-PLACE operation that mutates an already-existing tensor.
     /// Unlike <see cref="RecordUnary"/> / <see cref="RecordBinary"/> /
     /// <see cref="RecordVariadic"/>, the "output" of the lazy node IS the
@@ -384,7 +405,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// </remarks>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters)
     {
-        ValidateTrainingParametersWerePrepared(parameters);
+        EnsureTrainingParametersPrepared(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss: null);
     }
@@ -395,7 +416,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters, Tensor<T> explicitLoss)
     {
-        ValidateTrainingParametersWerePrepared(parameters);
+        EnsureTrainingParametersPrepared(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss);
     }
@@ -405,7 +426,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// optimizer retains their live backing arrays. Lazy/off-loss-path parameters are included:
     /// they are valid registered parameters even when this trace does not produce a gradient.
     /// </summary>
-    private void ValidateTrainingParametersWerePrepared<T>(Tensor<T>[] parameters)
+    private void EnsureTrainingParametersPrepared<T>(Tensor<T>[] parameters)
     {
         if (parameters is null) throw new ArgumentNullException(nameof(parameters));
         for (int i = 0; i < parameters.Length; i++)

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -21,10 +21,12 @@ internal sealed class LazyTensorScope : IDisposable
     private bool _engineExplicitlyBound;
     private bool _disposed;
     private bool _realized;
+    private readonly bool _trainingParametersPreparedBeforeTrace;
 
-    internal LazyTensorScope(LazyTensorScope? parent)
+    internal LazyTensorScope(LazyTensorScope? parent, bool trainingParametersPreparedBeforeTrace = false)
     {
         _parent = parent;
+        _trainingParametersPreparedBeforeTrace = trainingParametersPreparedBeforeTrace;
         // Default to AiDotNetEngine.Current; the first op recorded into the
         // scope will rebind via BindEngineIfUnset to the engine instance the
         // user actually invoked the op on. This matters because the global
@@ -158,12 +160,16 @@ internal sealed class LazyTensorScope : IDisposable
         LazyNodeType opType,
         string opName,
         Tensor<T> input,
-        Tensor<T> view)
+        Tensor<T> view,
+        BackwardFunction<T>? backwardFn = null,
+        object[]? savedState = null)
     {
         // The caller already built the view with shared storage — we just
         // attach it to the graph so the compile step sees a producing node.
         var node = new LazyNode<T>(opType, opName, input, view,
-            execute: (_, _) => { /* storage is shared; nothing to compute */ });
+            execute: (_, _) => { /* storage is shared; nothing to compute */ },
+            backwardFn,
+            savedState);
         view.LazySource = node;
         _nodes.Add(node);
         return view;
@@ -378,7 +384,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// </remarks>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters)
     {
-        PrepareParametersForTraining(parameters);
+        ValidateTrainingParametersWerePrepared(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss: null);
     }
@@ -389,7 +395,7 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters, Tensor<T> explicitLoss)
     {
-        PrepareParametersForTraining(parameters);
+        ValidateTrainingParametersWerePrepared(parameters);
         MarkCompiled();
         return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss);
     }
@@ -399,10 +405,30 @@ internal sealed class LazyTensorScope : IDisposable
     /// optimizer retains their live backing arrays. Lazy/off-loss-path parameters are included:
     /// they are valid registered parameters even when this trace does not produce a gradient.
     /// </summary>
-    private static void PrepareParametersForTraining<T>(Tensor<T>[] parameters)
+    private void ValidateTrainingParametersWerePrepared<T>(Tensor<T>[] parameters)
     {
+        if (parameters is null) throw new ArgumentNullException(nameof(parameters));
         for (int i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i] is null)
+                throw new ArgumentException("Training parameters cannot contain null tensors.", nameof(parameters));
+
+            // A plain graph scope remains valid for unshared tensors (including
+            // existing internal tests). A COW parameter, however, must have
+            // detached before tracing: doing it here is too late because graph
+            // nodes may already retain parameter-derived storage views.
+            if (!_trainingParametersPreparedBeforeTrace && parameters[i].IsCowShared)
+            {
+                throw new InvalidOperationException(
+                    "Copy-on-write parameters must be prepared before a training graph is traced. " +
+                    "Create the scope with GraphMode.EnableTraining(parameters), not GraphMode.Enable().");
+            }
+
+            // Defensive idempotent guard for unshared tensors and callers that
+            // entered through EnableTraining. This also protects future backing
+            // capture added during compilation itself.
             parameters[i].PrepareForInPlaceWrite();
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/TrainingPlanReader.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/TrainingPlanReader.cs
@@ -180,7 +180,7 @@ internal static class TrainingPlanReader
         for (int i = 0; i < tensorTable.Length; i++)
             liveTensors[i] = tensorTable[i];
 
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(callerParameters))
         {
             for (int i = 0; i < rawOps.Length; i++)
             {

--- a/src/AiDotNet.Tensors/Engines/Compilation/TensorCodec.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/TensorCodec.cs
@@ -88,7 +88,7 @@ internal static class TensorCodec
         TensorCodecOptions.SetCurrent(opts);
         try
         {
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableTraining(parameters);
             computation();
             return scope.CompileTraining(parameters);
         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -43723,7 +43723,7 @@ public partial class CpuEngine : ITensorLevelEngine
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Narrow", tensor._shape); if (ac is not null) return ac.Execute(); }
 
-        var result = tensor.Slice(dim, start, start + length);
+        var result = tensor.CreateNarrowView(dim, start, start + length, recordAutodiff: false);
         DifferentiableOps.RecordUnary("Narrow", result, tensor, BackwardFunctions<T>.NarrowBackward,
             savedState: new object[] { dim, start, length });
         AutoTracer.RecordOp("Narrow", result, eng => eng.TensorNarrow(tensor, dim, start, length));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -30798,6 +30798,11 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> ReduceMean<T>(Tensor<T> input, int[] axes, bool keepDims)
     {
+        // Match ReduceSum and the eager reduction contract: null means reduce
+        // every axis. Normalize before graph-shape construction so tracing does
+        // not enumerate a null array even though the eager path supports it.
+        axes ??= Enumerable.Range(0, input.Rank).ToArray();
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;

--- a/src/AiDotNet.Tensors/Engines/Training/DpSgdFusedStep.cs
+++ b/src/AiDotNet.Tensors/Engines/Training/DpSgdFusedStep.cs
@@ -145,7 +145,7 @@ public sealed class DpSgdFusedStep<T> : IDisposable
             {
                 CopySlotData(firstExample);
                 using var arenaSuspend = TensorArena.Suspend();
-                using var scope = GraphMode.Enable();
+                using var scope = GraphMode.EnableTraining(_cachedParameters);
                 var pred = forward(_persistentSlots);
                 var loss = computeLoss(pred, _persistentSlots);
                 _plan = scope.CompileTraining(_cachedParameters, loss);

--- a/src/AiDotNet.Tensors/Engines/Training/MultiSlotFusedStep.cs
+++ b/src/AiDotNet.Tensors/Engines/Training/MultiSlotFusedStep.cs
@@ -175,7 +175,7 @@ public sealed class MultiSlotFusedStep<T> : IDisposable
             if (_plan is null)
             {
                 using var arenaSuspend = TensorArena.Suspend();
-                using var scope = GraphMode.Enable();
+                using var scope = GraphMode.EnableTraining(_cachedParameters);
                 var pred = forward(_persistentSlots);
                 var loss = computeLoss(pred, _persistentSlots);
                 _plan = scope.CompileTraining(_cachedParameters, loss);

--- a/src/AiDotNet.Tensors/Engines/Training/WganGpFusedStep.cs
+++ b/src/AiDotNet.Tensors/Engines/Training/WganGpFusedStep.cs
@@ -138,7 +138,7 @@ public sealed class WganGpFusedStep<T> : IDisposable
             if (_plan is null)
             {
                 using var arenaSuspend = TensorArena.Suspend();
-                using var scope = GraphMode.Enable();
+                using var scope = GraphMode.EnableTraining(_cachedParameters);
                 var loss = BuildWganGpLoss(discForward, gradientPenaltyWeight);
                 _plan = scope.CompileTraining(_cachedParameters, loss);
             }

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -156,12 +156,13 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// </summary>
     private Tensor<T> CreateStorageView(int[] shape, int[] strides, int storageOffset)
     {
-        // Exposing a retained alias is semantically a write-capability escape:
-        // future writes through either tensor bypass the other's COW gate. Make
-        // this tensor private first so the new view can never remain attached
-        // to an unrelated COW peer after either peer detaches.
-        EnsureOwnedForWrite();
-        var view = new Tensor<T>(_data, shape, strides, storageOffset, _storage);
+        // A normal tensor takes the allocation-free direct path. COW tensors coordinate the
+        // vector/storage snapshot and family registration under the detach lock; otherwise a
+        // concurrent writer could swap storage between evaluation of the two constructor args.
+        var view = HasCowAliasFamily
+            ? CreateViewInCowAliasFamily(
+                () => new Tensor<T>(_data, shape, strides, storageOffset, _storage))
+            : new Tensor<T>(_data, shape, strides, storageOffset, _storage);
         if (_device == TensorDevice.CPU || _gpuBuffer is null || _gpuBackend is null)
             return view;
 
@@ -188,7 +189,10 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// </summary>
     private Tensor<T> FinalizeReshapeLikeView(Tensor<T> view, string opName)
     {
-        var originalShape = _shape.ToArray();
+        if (!IsDifferentiableRecordingActive)
+            return view;
+
+        var originalShape = (int[])_shape.Clone();
         return FinalizeDifferentiableView(
             view,
             Engines.Compilation.LazyNodeType.Reshape,
@@ -200,6 +204,9 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// <summary>Attaches inverse-permutation gradients to a storage view.</summary>
     private Tensor<T> FinalizePermuteView(Tensor<T> view, int[] permutation)
     {
+        if (!IsDifferentiableRecordingActive)
+            return view;
+
         var savedPermutation = (int[])permutation.Clone();
         return FinalizeDifferentiableView(
             view,
@@ -207,6 +214,59 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             "Transpose",
             Engines.Autodiff.BackwardFunctions<T>.PermuteBackward,
             new object[] { savedPermutation });
+    }
+
+    /// <summary>
+    /// True only while eager or compiled autodiff is recording. Keeping this check ahead of
+    /// saved-state construction makes ordinary metadata views allocation-free beyond their
+    /// required shape/stride descriptors.
+    /// </summary>
+    private static bool IsDifferentiableRecordingActive =>
+        Engines.Autodiff.GradientTape<T>.Current is not null ||
+        Engines.Compilation.GraphMode.Current is not null;
+
+    /// <summary>
+    /// Records a storage-materializing contiguous copy as a real unary edge. Unlike a metadata
+    /// view, replay must copy the input's current logical values into the independent output.
+    /// </summary>
+    private Tensor<T> FinalizeContiguousCopy(Tensor<T> result)
+    {
+        if (!IsDifferentiableRecordingActive)
+            return result;
+
+        var savedState = new object[] { (int[])_shape.Clone() };
+        Engines.Autodiff.BackwardFunction<T> backward =
+            Engines.Autodiff.BackwardFunctions<T>.ReshapeBackward;
+        if (Engines.Autodiff.GradientTape<T>.Current is { } tape)
+        {
+            var node = Engines.Autodiff.GradNodePool<T>.Rent();
+            node.OwningTape = tape;
+            node.Backward = backward;
+            node.Output = result;
+            node.Input0 = this;
+            node.InputCount = 1;
+            node.SavedState = savedState;
+            result.GradFn = node;
+        }
+
+        var graphScope = Engines.Compilation.GraphMode.Current;
+        if (graphScope is not null)
+        {
+            return graphScope.RecordMaterializedUnary(
+                Engines.Compilation.LazyNodeType.Custom,
+                "Contiguous",
+                this,
+                result,
+                (_, output) =>
+                {
+                    CopyTo(output.AsWritableSpan());
+                    output.IncrementVersion();
+                },
+                backward,
+                savedState);
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -336,7 +396,7 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         {
             // Contiguous with offset — simple bulk copy
             _data.AsSpan().Slice(_storageOffset, Length).CopyTo(dstSpan);
-            return result;
+            return FinalizeContiguousCopy(result);
         }
 
         // Non-contiguous materialization — "odometer" stride walk.
@@ -351,7 +411,7 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         var srcSpan = _data.AsSpan();
         int rank = Rank;
         int length = Length;
-        if (rank == 0 || length == 0) return result;
+        if (rank == 0 || length == 0) return FinalizeContiguousCopy(result);
 
         Span<int> counter = stackalloc int[rank];
         int srcIdx = _storageOffset;
@@ -372,7 +432,7 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             }
         }
 
-        return result;
+        return FinalizeContiguousCopy(result);
     }
 
     /// <summary>
@@ -894,15 +954,22 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (indices.Length > Rank)
             throw new ArgumentException("Number of indices exceeds tensor dimensions.");
 
+        // Validate against the original leading dimensions before constructing any view. This
+        // keeps failures atomic: a later invalid index cannot leave a partially-built view chain
+        // (and its storage refcounts / graph nodes) behind.
+        for (int i = 0; i < indices.Length; i++)
+        {
+            if (indices[i] < 0 || indices[i] >= _shape[i])
+                throw new ArgumentOutOfRangeException(nameof(indices),
+                    $"Index {indices[i]} is out of range for dimension {i} with size {_shape[i]}.");
+        }
+
         // Express a leading-dimension sub-tensor as a chain of axis-zero views.
         // Besides sharing storage, this gives each removed dimension the exact
         // slice-scatter backward in eager and compiled training.
         Tensor<T> result = this;
         for (int i = 0; i < indices.Length; i++)
         {
-            if (indices[i] < 0 || indices[i] >= result._shape[0])
-                throw new ArgumentOutOfRangeException(nameof(indices),
-                    $"Index {indices[i]} is out of range for dimension {i} with size {_shape[i]}.");
             result = result.GetSliceAlongDimension(indices[i], 0);
         }
 
@@ -1780,21 +1847,20 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             throw new ArgumentException(
                 $"Cannot reshape tensor with {Length} elements to shape [{string.Join(", ", newShape)}] ({newTotal} elements).");
 
-        Tensor<T> result;
         if (IsContiguous)
         {
             // O(1) view: same storage, new shape, row-major strides, same offset.
             // Guaranteed zero-copy for contiguous tensors (PyTorch can't always guarantee this).
             var newStrides = ComputeRowMajorStrides(newShape);
-            result = CreateStorageView(newShape, newStrides, _storageOffset);
-        }
-        else
-        {
-            // Non-contiguous view: must materialize first, then reshape the contiguous result
-            result = Contiguous().Reshape(newShape);
+            return FinalizeReshapeLikeView(
+                CreateStorageView(newShape, newStrides, _storageOffset),
+                "Reshape");
         }
 
-        return FinalizeReshapeLikeView(result, "Reshape");
+        // Non-contiguous input: Contiguous() records the storage-materialization edge and the
+        // recursive call records exactly one metadata reshape. Do not finalize again here—the
+        // former double-finalization replaced the inner GradFn and duplicated the lazy graph.
+        return Contiguous().Reshape(newShape);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -156,6 +156,11 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// </summary>
     private Tensor<T> CreateStorageView(int[] shape, int[] strides, int storageOffset)
     {
+        // Exposing a retained alias is semantically a write-capability escape:
+        // future writes through either tensor bypass the other's COW gate. Make
+        // this tensor private first so the new view can never remain attached
+        // to an unrelated COW peer after either peer detaches.
+        EnsureOwnedForWrite();
         var view = new Tensor<T>(_data, shape, strides, storageOffset, _storage);
         if (_device == TensorDevice.CPU || _gpuBuffer is null || _gpuBackend is null)
             return view;
@@ -176,6 +181,73 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         return view;
     }
 
+    /// <summary>
+    /// Completes a reshape-like view by attaching the same inverse reshape
+    /// edge to eager GradientTape and compiled GraphMode. Keeping both paths
+    /// here prevents metadata-only APIs from silently becoming gradient stops.
+    /// </summary>
+    private Tensor<T> FinalizeReshapeLikeView(Tensor<T> view, string opName)
+    {
+        var originalShape = _shape.ToArray();
+        return FinalizeDifferentiableView(
+            view,
+            Engines.Compilation.LazyNodeType.Reshape,
+            opName,
+            Engines.Autodiff.BackwardFunctions<T>.ReshapeBackward,
+            new object[] { originalShape });
+    }
+
+    /// <summary>Attaches inverse-permutation gradients to a storage view.</summary>
+    private Tensor<T> FinalizePermuteView(Tensor<T> view, int[] permutation)
+    {
+        var savedPermutation = (int[])permutation.Clone();
+        return FinalizeDifferentiableView(
+            view,
+            Engines.Compilation.LazyNodeType.Transpose,
+            "Transpose",
+            Engines.Autodiff.BackwardFunctions<T>.PermuteBackward,
+            new object[] { savedPermutation });
+    }
+
+    /// <summary>
+    /// Applies the common eager/compiled autodiff contract to a metadata-only
+    /// storage view. All public storage-sharing paths must pass through this
+    /// method so view APIs cannot silently become gradient stops.
+    /// </summary>
+    private Tensor<T> FinalizeDifferentiableView(
+        Tensor<T> view,
+        Engines.Compilation.LazyNodeType nodeType,
+        string opName,
+        Engines.Autodiff.BackwardFunction<T> backward,
+        object[] savedState)
+    {
+        if (Engines.Autodiff.GradientTape<T>.Current is { } tape)
+        {
+            var node = Engines.Autodiff.GradNodePool<T>.Rent();
+            node.OwningTape = tape;
+            node.Backward = backward;
+            node.Output = view;
+            node.Input0 = this;
+            node.InputCount = 1;
+            node.SavedState = savedState;
+            view.GradFn = node;
+        }
+
+        var graphScope = Engines.Compilation.GraphMode.Current;
+        if (graphScope is not null)
+        {
+            return graphScope.RecordView(
+                nodeType,
+                opName,
+                this,
+                view,
+                backward,
+                savedState);
+        }
+
+        return view;
+    }
+
     /// <inheritdoc/>
     public override TensorBase<T> CloneShared()
     {
@@ -192,7 +264,8 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         // EnsureMaterialized can realize a lazy node or rehydrate a paged-out weight and swap storage
         // or device — re-validate the layout before sharing.
         if (!IsContiguous || _storageOffset != 0 || _storage.Length != Length
-            || _storage.IsReadOnlyMapped || _device != TensorDevice.CPU)
+            || _storage.IsReadOnlyMapped || _device != TensorDevice.CPU
+            || _storage.RefCount != 1)
         {
             return CloneDeepCopy();
         }
@@ -424,7 +497,9 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             }
         }
 
-        return CreateStorageView(newShape, newStrides, _storageOffset);
+        return FinalizeReshapeLikeView(
+            CreateStorageView(newShape, newStrides, _storageOffset),
+            "ExpandDims");
     }
 
     /// <summary>
@@ -457,18 +532,9 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             }
         }
 
-        var result = CreateStorageView(newShape, newStrides, _storageOffset);
-
-        // Record the view under GraphMode so the compiler sees the caller's
-        // final tensor when a forward ends in Squeeze (issue #228).
-        var graphScope = Engines.Compilation.GraphMode.Current;
-        if (graphScope is not null)
-        {
-            return graphScope.RecordView(
-                Engines.Compilation.LazyNodeType.Reshape, "Squeeze", this, result);
-        }
-
-        return result;
+        return FinalizeReshapeLikeView(
+            CreateStorageView(newShape, newStrides, _storageOffset),
+            "Squeeze");
     }
 
     /// <summary>
@@ -500,17 +566,9 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             }
         }
 
-        var result = CreateStorageView(newShape, newStrides, _storageOffset);
-
-        // Record the view under GraphMode — see Squeeze(int) for rationale.
-        var graphScope = Engines.Compilation.GraphMode.Current;
-        if (graphScope is not null)
-        {
-            return graphScope.RecordView(
-                Engines.Compilation.LazyNodeType.Reshape, "Squeeze", this, result);
-        }
-
-        return result;
+        return FinalizeReshapeLikeView(
+            CreateStorageView(newShape, newStrides, _storageOffset),
+            "Squeeze");
     }
 
     /// <summary>
@@ -836,23 +894,19 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (indices.Length > Rank)
             throw new ArgumentException("Number of indices exceeds tensor dimensions.");
 
-        // O(1) view: fix leading dimensions by advancing offset, drop those dimensions.
-        int newRank = Rank - indices.Length;
-        var newShape = new int[newRank];
-        var newStrides = new int[newRank];
-        Array.Copy(_shape, indices.Length, newShape, 0, newRank);
-        Array.Copy(_strides, indices.Length, newStrides, 0, newRank);
-
-        int newOffset = _storageOffset;
+        // Express a leading-dimension sub-tensor as a chain of axis-zero views.
+        // Besides sharing storage, this gives each removed dimension the exact
+        // slice-scatter backward in eager and compiled training.
+        Tensor<T> result = this;
         for (int i = 0; i < indices.Length; i++)
         {
-            if (indices[i] < 0 || indices[i] >= _shape[i])
+            if (indices[i] < 0 || indices[i] >= result._shape[0])
                 throw new ArgumentOutOfRangeException(nameof(indices),
                     $"Index {indices[i]} is out of range for dimension {i} with size {_shape[i]}.");
-            newOffset += indices[i] * _strides[i];
+            result = result.GetSliceAlongDimension(indices[i], 0);
         }
 
-        return new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
+        return result;
     }
 
     /// <summary>
@@ -1451,7 +1505,9 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             newStrides[i] = _strides[permutation[i]];
         }
 
-        return CreateStorageView(newShape, newStrides, _storageOffset);
+        return FinalizePermuteView(
+            CreateStorageView(newShape, newStrides, _storageOffset),
+            permutation);
     }
 
     /// <summary>
@@ -1738,38 +1794,7 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
             result = Contiguous().Reshape(newShape);
         }
 
-        // Propagate gradient chain: if a GradientTape is active, set GradFn on the
-        // result so gradients flow through Reshape during backward pass.
-        // Without this, any layer using tensor.Reshape() silently breaks the gradient tape.
-        if (Engines.Autodiff.GradientTape<T>.Current != null)
-        {
-            var originalShape = _shape.ToArray();
-            // Issue #319 Phase 3: pooled GradNode rental, stamped with
-            // the current tape so cleanup only Returns nodes it owns.
-            var reshapeNode = Engines.Autodiff.GradNodePool<T>.Rent();
-            reshapeNode.OwningTape = Engines.Autodiff.GradientTape<T>.Current;
-            reshapeNode.Backward = Engines.Autodiff.BackwardFunctions<T>.ReshapeBackward;
-            reshapeNode.Output = result;
-            reshapeNode.Input0 = this;
-            reshapeNode.InputCount = 1;
-            reshapeNode.SavedState = new object[] { originalShape };
-            result.GradFn = reshapeNode;
-        }
-
-        // Record the view in the active lazy graph so a forward lambda ending
-        // in Reshape (or routing through Reshape in a host-side branch) hands
-        // CompiledInferencePlan.Compile a tensor with a LazySource — issue #228.
-        // The view shares storage with `this`, so the recorded node's execute
-        // step is a no-op: writes to the producer buffer are live-visible
-        // through the view at replay time.
-        var graphScope = Engines.Compilation.GraphMode.Current;
-        if (graphScope is not null)
-        {
-            return graphScope.RecordView(
-                Engines.Compilation.LazyNodeType.Reshape, "Reshape", this, result);
-        }
-
-        return result;
+        return FinalizeReshapeLikeView(result, "Reshape");
     }
 
     /// <summary>
@@ -3245,29 +3270,12 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         }
 
         int newOffset = _storageOffset + index * _strides[dimension];
-        var result = new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
-
-        // Propagate the gradient chain: if a GradientTape is active, set GradFn on
-        // the result so gradients flow through the slice during backward. Without
-        // this, GetSliceAlongDimension was a raw storage-sharing view with no
-        // recorded backward — any layer that slices a tape tensor per-timestep
-        // (recurrent / sequence layers) leaked wrong input gradients via aliasing.
-        // The view is preserved (zero-copy) for the inference path where no tape
-        // is active; only training pays the node record. Mirrors Reshape above.
-        if (Engines.Autodiff.GradientTape<T>.Current != null)
-        {
-            var sliceNode = Engines.Autodiff.GradNodePool<T>.Rent();
-            sliceNode.OwningTape = Engines.Autodiff.GradientTape<T>.Current;
-            sliceNode.Backward = Engines.Autodiff.BackwardFunctions<T>.SliceAxisBackward;
-            sliceNode.Output = result;
-            sliceNode.Input0 = this;
-            sliceNode.InputCount = 1;
-            // SliceAxisBackward reads SavedState as { axis, index }.
-            sliceNode.SavedState = new object[] { dimension, index };
-            result.GradFn = sliceNode;
-        }
-
-        return result;
+        return FinalizeDifferentiableView(
+            CreateStorageView(newShape, newStrides, newOffset),
+            Engines.Compilation.LazyNodeType.Slice,
+            "SliceAxis",
+            Engines.Autodiff.BackwardFunctions<T>.SliceAxisBackward,
+            new object[] { dimension, index });
     }
 
     /// <summary>
@@ -3805,7 +3813,10 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         if (_shape.Length <= 1)
         {
             // 0D/1D tensor: transpose is identity. Return view with same data.
-            return new Tensor<T>(_data, (int[])_shape.Clone(), (int[])_strides.Clone(), _storageOffset, _storage);
+            var identity = new int[Rank];
+            for (int i = 0; i < identity.Length; i++)
+                identity[i] = i;
+            return Transpose(identity);
         }
         else if (_shape.Length == 2)
         {
@@ -4125,6 +4136,17 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
     /// </remarks>
     public Tensor<T> Slice(int axis, int start, int? end = null)
     {
+        return CreateNarrowView(axis, start, end, recordAutodiff: true);
+    }
+
+    /// <summary>
+    /// Creates the range view used by both the public tensor API and
+    /// <c>IEngine.TensorNarrow</c>. The engine path records its own named tape
+    /// entry, so it requests only the storage-safe raw view to avoid duplicate
+    /// pooled gradient nodes.
+    /// </summary>
+    internal Tensor<T> CreateNarrowView(int axis, int start, int? end, bool recordAutodiff)
+    {
         ThrowIfSparse();
         if (axis < 0 || axis >= Rank)
             throw new ArgumentException($"Invalid axis. Must be between 0 and {Rank - 1}.");
@@ -4145,7 +4167,15 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         newShape[axis] = sliceSize;
         int newOffset = _storageOffset + start * _strides[axis];
 
-        return new Tensor<T>(_data, newShape, newStrides, newOffset, _storage);
+        var view = CreateStorageView(newShape, newStrides, newOffset);
+        return recordAutodiff
+            ? FinalizeDifferentiableView(
+                view,
+                Engines.Compilation.LazyNodeType.Slice,
+                "Narrow",
+                Engines.Autodiff.BackwardFunctions<T>.NarrowBackward,
+                new object[] { axis, start, sliceSize })
+            : view;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -2159,9 +2159,10 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     internal void ScaleLogicalInPlace(T scale)
     {
         EnsureMaterialized();
-        EnsureOwnedForWrite();
         if (Length == 0)
             return;
+        EnsureNonOverlappingWritableLayout();
+        EnsureOwnedForWrite();
 
         var destination = _storage.AsWritableSpan();
         if (IsContiguous)
@@ -2180,6 +2181,105 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         }
 
         IncrementVersion();
+    }
+
+    /// <summary>
+    /// Clamps every logical element in place while preserving strided-view and
+    /// copy-on-write semantics. The operation touches only the tensor's logical
+    /// region; storage padding and unrelated elements surrounding a view are left
+    /// unchanged.
+    /// </summary>
+    internal void ClampLogicalInPlace(T min, T max)
+    {
+        EnsureMaterialized();
+        if (Length == 0)
+            return;
+        EnsureNonOverlappingWritableLayout();
+        EnsureOwnedForWrite();
+
+        var destination = _storage.AsWritableSpan();
+        if (IsContiguous)
+        {
+            ClampSpan(destination.Slice(_storageOffset, Length), min, max);
+        }
+        else
+        {
+            for (int i = 0; i < Length; i++)
+            {
+                int storageIndex = FlatIndexToStorageIndex(i);
+                T value = destination[storageIndex];
+                destination[storageIndex] = _numOps.GreaterThan(value, max)
+                    ? max
+                    : _numOps.LessThan(value, min) ? min : value;
+            }
+        }
+
+        IncrementVersion();
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private void ClampSpan(Span<T> destination, T min, T max)
+    {
+        for (int i = 0; i < destination.Length; i++)
+        {
+            T value = destination[i];
+            destination[i] = _numOps.GreaterThan(value, max)
+                ? max
+                : _numOps.LessThan(value, min) ? min : value;
+        }
+    }
+
+    /// <summary>
+    /// Rejects in-place logical operations on layouts where multiple logical
+    /// coordinates address the same storage element. Applying a scale or clamp
+    /// once per logical coordinate would otherwise mutate zero-stride/broadcast
+    /// storage repeatedly and make the result traversal-order dependent.
+    /// </summary>
+    private void EnsureNonOverlappingWritableLayout()
+    {
+        if (IsContiguous || Length <= 1 || Rank == 0)
+            return;
+
+        Span<int> dimensions = Rank <= 16 ? stackalloc int[Rank] : new int[Rank];
+        int dimensionCount = 0;
+        for (int d = 0; d < Rank; d++)
+        {
+            if (_shape[d] <= 1)
+                continue;
+            if (_strides[d] == 0)
+                throw new InvalidOperationException(
+                    "In-place logical mutation is not defined for overlapping tensor views " +
+                    "(a non-singleton dimension has stride zero). Materialize the view first.");
+            dimensions[dimensionCount++] = d;
+        }
+
+        // Sort active dimensions by absolute stride. A dimension is safely
+        // non-overlapping only when its stride begins at or beyond the complete
+        // storage span covered by every faster-varying dimension.
+        for (int i = 1; i < dimensionCount; i++)
+        {
+            int value = dimensions[i];
+            long stride = Math.Abs((long)_strides[value]);
+            int j = i - 1;
+            while (j >= 0 && Math.Abs((long)_strides[dimensions[j]]) > stride)
+            {
+                dimensions[j + 1] = dimensions[j];
+                j--;
+            }
+            dimensions[j + 1] = value;
+        }
+
+        long coveredSpan = 1;
+        for (int i = 0; i < dimensionCount; i++)
+        {
+            int dimension = dimensions[i];
+            long stride = Math.Abs((long)_strides[dimension]);
+            if (stride < coveredSpan)
+                throw new InvalidOperationException(
+                    "In-place logical mutation is not defined for overlapping tensor views. " +
+                    "Materialize the view first.");
+            coveredSpan = checked(coveredSpan + ((long)_shape[dimension] - 1L) * stride);
+        }
     }
 
     // ================================================================
@@ -2308,44 +2408,160 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     }
 
     // ================================================================
-    // Copy-on-write clone (issue #624 — Stage 1: primitive + write-gate)
+    // Copy-on-write clone (issue #624 — alias-family ownership + write gate)
     // ================================================================
 
     /// <summary>
-    /// True when this tensor shares its backing storage with a copy-on-write peer (see
-    /// <see cref="CloneShared"/>). While set, the next in-place write privatizes this tensor's
-    /// storage (<see cref="EnsureOwnedForWrite"/>) so neither side observes the other's mutation.
-    /// Normal tensors never set it — so the write-path guards are a single predictable branch.
+    /// The alias family this tensor belongs to while its storage is shared with an independent
+    /// copy-on-write peer. Metadata views join their creator's family so ordinary source/view
+    /// aliasing survives the family-level detach. Normal tensors leave this null, keeping the
+    /// write-path guard to one predictable branch.
     /// </summary>
-    private bool _cowShared;
+    private CowAliasFamily? _cowFamily;
 
     /// <summary>Diagnostic: whether this tensor is currently a live COW storage sharer.</summary>
-    internal bool IsCowShared => _cowShared;
-
-    /// <summary>Marks this tensor as a COW sharer. Called only by <see cref="CloneShared"/>.</summary>
-    internal void MarkCowShared() => _cowShared = true;
+    internal bool IsCowShared => _cowFamily?.RequiresDetach == true;
 
     /// <summary>
-    /// Privatizes copy-on-write storage before an in-place write. No-op unless this tensor was
-    /// produced by (or is the source of) a <see cref="CloneShared"/> and still shares storage.
-    /// When storage is still shared (<c>RefCount &gt; 1</c>) the backing buffer is deep-copied into
-    /// fresh sole-owned storage; when we are already the only ref we just clear the flag. Must be
-    /// called at the top of every in-place write path — the isolation test is the completeness guard.
+    /// Starts an independent COW alias family for this tensor. The source and clone each receive
+    /// their own family; views created from either side subsequently join that side's family.
+    /// </summary>
+    internal void MarkCowShared()
+    {
+        var family = new CowAliasFamily();
+        family.Add(this);
+    }
+
+    /// <summary>True when view construction must coordinate with a pending COW detach.</summary>
+    protected bool HasCowAliasFamily => _cowFamily is not null;
+
+    /// <summary>
+    /// Constructs and registers a metadata view while holding this tensor's alias-family lock.
+    /// This makes the creator's vector/storage pair an atomic snapshot relative to first-write
+    /// detach. Callers should use their direct allocation path when <see cref="HasCowAliasFamily"/>
+    /// is false so ordinary view construction does not allocate a delegate.
+    /// </summary>
+    protected TView CreateViewInCowAliasFamily<TView>(Func<TView> factory)
+        where TView : TensorBase<T>
+    {
+        var family = _cowFamily;
+        return family is null ? factory() : family.CreateView(this, factory);
+    }
+
+    /// <summary>
+    /// Privatizes a complete copy-on-write alias family before an in-place write. No-op unless
+    /// this tensor was produced by (or is the source of) a <see cref="CloneShared"/> and still
+    /// shares storage with an independent family. Moving the whole family preserves the normal
+    /// rule that writes through a source or any of its metadata views remain mutually visible.
     /// </summary>
     protected void EnsureOwnedForWrite()
     {
-        if (!_cowShared) return;
-        if (_storage.RefCount > 1)
+        var family = _cowFamily;
+        if (family is null) return;
+        family.DetachForWrite(this);
+    }
+
+    /// <summary>
+    /// Tracks one logical alias family using weak members so discarded views do
+    /// not stay alive. A family-level detach preserves ordinary source/view
+    /// aliasing while isolating the independent family created for a COW peer.
+    /// </summary>
+    private sealed class CowAliasFamily
+    {
+        private readonly object _sync = new object();
+        private readonly System.Collections.Generic.List<WeakReference<TensorBase<T>>> _members =
+            new System.Collections.Generic.List<WeakReference<TensorBase<T>>>();
+        private int _requiresDetach = 1;
+
+        internal bool RequiresDetach => Volatile.Read(ref _requiresDetach) != 0;
+
+        internal void Add(TensorBase<T> member)
         {
-            EnsureMaterialized();
-            var fresh = _data.Clone();                  // independent copy of the shared buffer
-            var oldStorage = _storage;
-            _data = fresh;
-            _storage = new TensorStorage<T>(fresh);     // sole owner (RefCount 1)
-            oldStorage.Release();                       // drop our shared ref; peer keeps theirs
-            IncrementVersion();
+            lock (_sync)
+            {
+                if (_requiresDetach == 0)
+                    return;
+                member._cowFamily = this;
+                _members.Add(new WeakReference<TensorBase<T>>(member));
+            }
         }
-        _cowShared = false;
+
+        /// <summary>
+        /// Atomically captures the creator's current vector/storage pair and attaches the new
+        /// metadata view to this family when a detach is still pending.
+        /// </summary>
+        internal TView CreateView<TView>(TensorBase<T> creator, Func<TView> factory)
+            where TView : TensorBase<T>
+        {
+            lock (_sync)
+            {
+                var view = factory();
+                if (_requiresDetach != 0 && ReferenceEquals(creator._cowFamily, this))
+                {
+                    view._cowFamily = this;
+                    _members.Add(new WeakReference<TensorBase<T>>(view));
+                    return view;
+                }
+                return view;
+            }
+        }
+
+        internal void DetachForWrite(TensorBase<T> requester)
+        {
+            lock (_sync)
+            {
+                if (_requiresDetach == 0)
+                {
+                    requester._cowFamily = null;
+                    return;
+                }
+
+                requester.EnsureMaterialized();
+                var liveMembers = new System.Collections.Generic.List<TensorBase<T>>(_members.Count);
+                for (int i = 0; i < _members.Count; i++)
+                {
+                    if (_members[i].TryGetTarget(out var member)
+                        && !member._disposed
+                        && ReferenceEquals(member._cowFamily, this)
+                        && ReferenceEquals(member._storage, requester._storage))
+                    {
+                        liveMembers.Add(member);
+                    }
+                }
+                if (!liveMembers.Contains(requester))
+                    liveMembers.Add(requester);
+
+                // When every remaining storage reference belongs to this family,
+                // no independent peer remains. Clear the pending COW state without
+                // copying, matching the former sole-owner fast path.
+                if (requester._storage.RefCount == liveMembers.Count)
+                {
+                    for (int i = 0; i < liveMembers.Count; i++)
+                        liveMembers[i]._cowFamily = null;
+                    Volatile.Write(ref _requiresDetach, 0);
+                    _members.Clear();
+                    return;
+                }
+
+                var fresh = requester._data.Clone();
+                var privateStorage = new TensorStorage<T>(fresh);
+                for (int i = 0; i < liveMembers.Count; i++)
+                {
+                    var member = liveMembers[i];
+                    if (i > 0)
+                        privateStorage.AddRef();
+                    var oldStorage = member._storage;
+                    member._data = fresh;
+                    member._storage = privateStorage;
+                    member._cowFamily = null;
+                    oldStorage.Release();
+                    member.IncrementVersion();
+                }
+
+                Volatile.Write(ref _requiresDetach, 0);
+                _members.Clear();
+            }
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -2002,7 +2002,10 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         // before the caller touches the buffer.
         if (_device != TensorDevice.CPU)
             return null;
-        return _storage.GetDataArray();
+        return _storage.TryGetBackingArraySegment(out var array, out int baseOffset)
+            && baseOffset == 0
+            ? array
+            : null;
     }
 
     /// <summary>
@@ -2015,10 +2018,12 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// MUST NOT read or write past index <c>Length - 1</c> (the tail
     /// is pool padding and may alias another tensor's storage).
     ///
-    /// <para>Returns <c>null</c> only for views (non-contiguous, non-zero
-    /// offset) and non-CPU tensors — the cases where there is no single
-    /// CPU-side backing array that mutating the tensor through would be
-    /// well-defined. For pooled-padded layouts the live backing IS
+    /// <para>Returns <c>null</c> for views (non-contiguous or non-zero tensor
+    /// offset), non-CPU tensors, non-array memory managers, and sliced
+    /// <see cref="Memory{T}"/> instances whose underlying array begins at a
+    /// non-zero base offset. In those cases a zero-offset array-only kernel
+    /// cannot address the tensor correctly. For pooled-padded layouts whose
+    /// underlying array begins at zero, the live backing IS
     /// well-defined as "first Length elements", which is what the fused
     /// optimizer's per-parameter <c>fixed (T* p = …)</c> + <c>length</c>
     /// pin contract has always relied on.</para>
@@ -2038,8 +2043,21 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             return null;
         if (_device != TensorDevice.CPU)
             return null;
-        return _storage.GetDataArray();
+        return _storage.TryGetBackingArraySegment(out var array, out int baseOffset)
+            && baseOffset == 0
+            ? array
+            : null;
     }
+
+    /// <summary>
+    /// Reports whether logical optimizer storage is currently materialized
+    /// without rehydrating a streaming weight. Unlike live-array accessors,
+    /// this remains true for views and native/memory-mapped CPU storage.
+    /// </summary>
+    internal bool HasMaterializedOptimizerStorage => Length == 0 || _storage.Length != 0;
+
+    /// <summary>Whether optimizer writes are prohibited by mapped storage.</summary>
+    internal bool IsReadOnlyOptimizerStorage => _storage.IsReadOnlyMapped;
 
     /// <summary>
     /// Returns the raw CPU backing array together with this view's storage offset,
@@ -2048,8 +2066,11 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// returned array is the shared backing store: the caller MUST only read, and
     /// MUST honour <see cref="Strides"/> + <paramref name="storageOffset"/> when
     /// addressing elements (the view may be permuted/sliced). Returns <c>null</c>
-    /// for GPU-resident tensors (no authoritative CPU array) — the caller should
-    /// then fall back to <see cref="Contiguous"/>. Triggers the same materialization
+    /// for GPU-resident tensors (no authoritative CPU array) and CPU storage
+    /// not backed by a managed array — the caller should then fall back to
+    /// <see cref="Contiguous"/>. The returned offset includes both the tensor
+    /// view offset and any underlying <see cref="Memory{T}"/> slice offset.
+    /// Triggers the same materialization
     /// guard as the span accessors so a lazy node is realized and a paged-out
     /// streaming weight rehydrated first. This is a READ-ONLY accessor (it does NOT
     /// privatize a copy-on-write clone): routing a write through the returned array
@@ -2063,8 +2084,102 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             storageOffset = 0;
             return null;
         }
-        storageOffset = _storageOffset;
-        return _storage.GetDataArray();
+        if (_storage.TryGetBackingArraySegment(out var array, out int baseOffset))
+        {
+            storageOffset = checked(baseOffset + _storageOffset);
+            return array;
+        }
+
+        storageOffset = 0;
+        return null;
+    }
+
+    /// <summary>
+    /// Returns writable managed-array storage for a contiguous CPU tensor and
+    /// the absolute offset of its first logical element. Unlike the legacy
+    /// array-only live accessors, this preserves both tensor-view offsets and
+    /// the base offset of sliced <see cref="Memory{T}"/> storage.
+    /// </summary>
+    /// <remarks>
+    /// The accessor does not force streaming materialization. A dropped or
+    /// unmaterialized parameter therefore continues to expose its current
+    /// (possibly empty) storage and can retain the existing skip semantics.
+    /// Copy-on-write peers are privatized before a writable alias escapes.
+    /// </remarks>
+    internal T[]? GetCpuBackingForContiguousWrite(out int storageOffset)
+    {
+        EnsureOwnedForWrite();
+        if (_device != TensorDevice.CPU || !IsContiguous || _storage.IsReadOnlyMapped)
+        {
+            storageOffset = 0;
+            return null;
+        }
+
+        if (_storage.TryGetBackingArraySegment(out var array, out int baseOffset))
+        {
+            storageOffset = checked(baseOffset + _storageOffset);
+            return array;
+        }
+
+        storageOffset = 0;
+        return null;
+    }
+
+    /// <summary>
+    /// Copies logical tensor elements into caller-owned contiguous storage
+    /// without allocating. Supports non-contiguous views.
+    /// </summary>
+    internal void CopyLogicalTo(Span<T> destination)
+    {
+        EnsureMaterialized();
+        if (destination.Length != Length)
+            throw new ArgumentException(
+                $"Destination length ({destination.Length}) must match tensor length ({Length}).",
+                nameof(destination));
+
+        if (Length == 0)
+            return;
+
+        var source = _storage.AsSpan();
+        if (IsContiguous)
+        {
+            source.Slice(_storageOffset, Length).CopyTo(destination);
+            return;
+        }
+
+        for (int i = 0; i < Length; i++)
+            destination[i] = source[FlatIndexToStorageIndex(i)];
+    }
+
+    /// <summary>
+    /// Scales every logical element in place while preserving strided-view and
+    /// copy-on-write semantics. This is the allocation-free fallback used when
+    /// a caller cannot safely obtain a contiguous managed-array alias.
+    /// </summary>
+    internal void ScaleLogicalInPlace(T scale)
+    {
+        EnsureMaterialized();
+        EnsureOwnedForWrite();
+        if (Length == 0)
+            return;
+
+        var destination = _storage.AsWritableSpan();
+        if (IsContiguous)
+        {
+            var logical = destination.Slice(_storageOffset, Length);
+            for (int i = 0; i < logical.Length; i++)
+                logical[i] = _numOps.Multiply(logical[i], scale);
+        }
+        else
+        {
+            for (int i = 0; i < Length; i++)
+            {
+                int storageIndex = FlatIndexToStorageIndex(i);
+                destination[storageIndex] = _numOps.Multiply(destination[storageIndex], scale);
+            }
+        }
+
+        IncrementVersion();
     }
 
     // ================================================================

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -242,6 +242,14 @@ internal sealed class TensorStorage<T>
         return _data.GetDataArray();
     }
 
+    /// <summary>
+    /// Gets the actual managed backing array and the base offset of this
+    /// storage without materializing a copy.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetBackingArraySegment(out T[]? array, out int offset)
+        => _data.TryGetBackingArraySegment(out array, out offset);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfReadOnlyMapped()
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
@@ -363,16 +363,41 @@ public abstract class VectorBase<T>
     /// </summary>
     internal T[]? GetBackingArrayUnsafe()
     {
-        if (_cachedArray is not null)
-            return _cachedArray;
+        return TryGetBackingArraySegment(out var array, out int offset) && offset == 0
+            ? array
+            : null;
+    }
 
-        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<T>)_memory, out var segment)
-            && segment.Array is not null && segment.Offset == 0)
+    /// <summary>
+    /// Gets the actual managed backing array and the offset at which this
+    /// vector's logical memory begins, without materializing or copying.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="Memory{T}"/> may be a slice whose underlying
+    /// <see cref="ArraySegment{T}.Offset"/> is nonzero. Returning only the
+    /// array in that case loses essential addressing information and has
+    /// historically caused compiled kernels to bind a copied snapshot.
+    /// </remarks>
+    internal bool TryGetBackingArraySegment(out T[]? array, out int offset)
+    {
+        if (_cachedArray is not null)
         {
-            return segment.Array;
+            array = _cachedArray;
+            offset = 0;
+            return true;
         }
 
-        return null;
+        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<T>)_memory, out var segment)
+            && segment.Array is not null)
+        {
+            array = segment.Array;
+            offset = segment.Offset;
+            return true;
+        }
+
+        array = null;
+        offset = 0;
+        return false;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledFp64LiveBackingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledFp64LiveBackingTests.cs
@@ -1,0 +1,158 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public class CompiledFp64LiveBackingTests
+{
+    private const int PooledLength = 262_145;
+
+    [Fact]
+    public void CompiledMatMul_UsesLivePoolPaddedFp64Output()
+    {
+        var engine = new CpuEngine();
+        var left = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var rightData = new double[PooledLength];
+        Fill(rightData, 3.0);
+        var right = new Tensor<double>(rightData, new[] { 1, PooledLength });
+
+        Tensor<double> output;
+        ICompiledPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            output = engine.TensorMatMul(left, right);
+            plan = scope.CompileInference<double>(output, left._shape);
+        }
+
+        using (plan)
+        {
+            var replayed = plan.Execute();
+            var live = replayed.GetLiveBackingArrayAllowingPaddingOrNull();
+
+            Assert.NotNull(live);
+            Assert.True(live!.Length > replayed.Length,
+                "The regression requires a genuinely pool-padded output buffer.");
+            Assert.Equal(6.0, replayed[0], precision: 12);
+            Assert.Equal(6.0, replayed[PooledLength / 2], precision: 12);
+            Assert.Equal(6.0, replayed[PooledLength - 1], precision: 12);
+        }
+    }
+
+    [Fact]
+    public void CompiledTraining_PoolPaddedFp64GradientUpdatesLiveParameter()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 1.0 }, new[] { 1, 1 });
+        var weightData = new double[PooledLength];
+        Fill(weightData, 0.5);
+        var weight = new Tensor<double>(weightData, new[] { 1, PooledLength });
+        var parameters = new[] { weight };
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var output = engine.TensorMatMul(input, weight);
+        var lossTensor = engine.ReduceSum(output, null);
+        using var plan = scope.CompileTraining(parameters, lossTensor);
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0.0001f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        var compiledPlan = Assert.IsType<CompiledTrainingPlan<double>>(plan);
+        double loss = plan.Step()[0];
+
+        Assert.True(IsFinite(loss));
+        Assert.InRange(loss, PooledLength * 0.499, PooledLength * 0.501);
+        Assert.NotNull(weight.Grad);
+        var liveGradient = weight.Grad!.GetLiveBackingArrayAllowingPaddingOrNull();
+        Assert.NotNull(liveGradient);
+        Assert.True(liveGradient!.Length > weight.Grad.Length,
+            "The regression requires a genuinely pool-padded gradient destination.");
+        Assert.Equal(1.0, weight.Grad[0], precision: 12);
+        Assert.Equal(1.0, compiledPlan.Gradients[0][0], precision: 12);
+        Assert.InRange(weight[0], 0.49989, 0.49991);
+        Assert.True(IsFinite(weight[PooledLength - 1]));
+    }
+
+    [Fact]
+    public unsafe void Fp64SgdKernel_UpdatesLargeArrayIncludingScalarTail()
+    {
+        var parameter = new double[PooledLength];
+        var gradient = new double[PooledLength];
+        Fill(parameter, 0.5);
+        Fill(gradient, 1.0);
+
+        fixed (double* parameterPtr = parameter)
+        fixed (double* gradientPtr = gradient)
+        {
+            FusedOptimizer.SgdUpdateSimd(parameterPtr, gradientPtr, parameter.Length, 0.0001);
+        }
+
+        Assert.InRange(parameter[0], 0.49989, 0.49991);
+        Assert.InRange(parameter[PooledLength - 1], 0.49989, 0.49991);
+    }
+
+    [Fact]
+    public void CompiledMatMul_NonContiguousFp64InputFallsBackWithExactResult()
+    {
+        var engine = new CpuEngine();
+        var storage = new Tensor<double>(new[] { 1.0, 2.0, 3.0, 4.0 }, new[] { 2, 2 });
+        var leftView = storage.Transpose(new[] { 1, 0 });
+        var right = new Tensor<double>(new[] { 5.0, 6.0, 7.0, 8.0 }, new[] { 2, 2 });
+
+        ICompiledPlan<double> plan;
+        Tensor<double> output;
+        using (var scope = GraphMode.Enable())
+        {
+            output = engine.TensorMatMul(leftView, right);
+            plan = scope.CompileInference(output, leftView);
+        }
+
+        using (plan)
+        {
+            var actual = plan.Execute().ToArray();
+            Assert.Equal(new[] { 26.0, 30.0, 38.0, 44.0 }, actual);
+        }
+    }
+
+    [Fact]
+    public void CompiledFp64GeluChain_PreservesGeluSemantics()
+    {
+        const int hiddenSize = 128;
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { -1.0 }, new[] { 1, 1 });
+        var w1Data = new double[hiddenSize];
+        var w2Data = new double[hiddenSize];
+        Fill(w1Data, 1.0);
+        Fill(w2Data, 1.0);
+        var w1 = new Tensor<double>(w1Data, new[] { 1, hiddenSize });
+        var w2 = new Tensor<double>(w2Data, new[] { hiddenSize, 1 });
+        var parameters = new[] { w1, w2 };
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var hidden = engine.TensorMatMul(input, w1);
+        var activated = engine.GELU(hidden);
+        var output = engine.TensorMatMul(activated, w2);
+        var lossTensor = engine.ReduceSum(output, null);
+        using var plan = scope.CompileTraining(parameters, lossTensor);
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        double loss = plan.Step()[0];
+        double expectedPerElement = 0.5 * -1.0 *
+            (1.0 + Math.Tanh(Math.Sqrt(2.0 / Math.PI) * (-1.0 + 0.044715 * -1.0)));
+
+        Assert.True(loss < 0.0, "GELU(-1) is negative; ReLU substitution would return zero.");
+        Assert.Equal(hiddenSize * expectedPerElement, loss, precision: 8);
+    }
+
+    private static void Fill(double[] values, double value)
+    {
+        for (int i = 0; i < values.Length; i++)
+        {
+            values[i] = value;
+        }
+    }
+
+    private static bool IsFinite(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
@@ -1,0 +1,76 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+[Collection("CompilationGlobalState")]
+public sealed class CompiledInferenceStorageContractTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+
+    public CompiledInferenceStorageContractTests()
+    {
+        AiDotNetEngine.Current = new CpuEngine();
+    }
+
+    public void Dispose()
+    {
+        AiDotNetEngine.Current = _priorEngine;
+    }
+
+    [Fact]
+    public void Transpose_OffsetInputAndPaddedOutput_UsesLiveLogicalStorageAcrossReplay()
+    {
+        var engine = new CpuEngine();
+        var inputBacking = new[] { 777f, 1f, 2f, 3f, 4f, 5f, 6f, 888f };
+        var input = Tensor<float>.FromMemory(
+            new Memory<float>(inputBacking, 1, 6), new[] { 2, 3 });
+
+        var outputBacking = new float[12];
+        for (int i = 0; i < outputBacking.Length; i++)
+            outputBacking[i] = 999f;
+        var outputStorage = Tensor<float>.FromMemory(
+            new Memory<float>(outputBacking, 2, 6), new[] { 3, 2 });
+
+        ICompiledPlan<float> plan;
+        Tensor<float> capturedOutput;
+        using (var scope = GraphMode.Enable())
+        {
+            capturedOutput = engine.TensorTranspose(input);
+            // Force the plan's final output onto an offset, padded backing before
+            // specialization. Legacy GetDataArray() wrote a detached six-element
+            // copy and left this storage unchanged.
+            capturedOutput.RebindStorageFrom(outputStorage);
+            plan = scope.CompileInference<float>();
+        }
+
+        using (plan)
+        {
+            var first = plan.Execute();
+            Assert.Equal(new[] { 1f, 4f, 2f, 5f, 3f, 6f }, first.AsSpan().ToArray());
+            AssertSentinels(outputBacking);
+
+            input[0] = 10f;
+            input[1] = 20f;
+            input[2] = 30f;
+            input[3] = 40f;
+            input[4] = 50f;
+            input[5] = 60f;
+
+            var second = plan.Execute();
+            Assert.Equal(new[] { 10f, 40f, 20f, 50f, 30f, 60f }, second.AsSpan().ToArray());
+            AssertSentinels(outputBacking);
+        }
+    }
+
+    private static void AssertSentinels(float[] backing)
+    {
+        Assert.Equal(999f, backing[0]);
+        Assert.Equal(999f, backing[1]);
+        for (int i = 8; i < backing.Length; i++)
+            Assert.Equal(999f, backing[i]);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOptimizerParameterViewTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOptimizerParameterViewTests.cs
@@ -1,0 +1,174 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Integration coverage for compiled fused optimizers over parameter views.
+/// View addressing must survive graph compilation, gradient clipping, grouped
+/// dispatch, COW isolation, and both supported floating-point precisions.
+/// </summary>
+public sealed class CompiledOptimizerParameterViewTests
+{
+    private static ICompiledTrainingPlan<T> CompileReduceSum<T>(CpuEngine engine, Tensor<T> parameter)
+    {
+        using var scope = GraphMode.Enable();
+        engine.ReduceSum(parameter, null);
+        return scope.CompileTraining(new[] { parameter });
+    }
+
+    [Fact]
+    public void FloatSgd_ContiguousMemorySlice_UpdatesOnlyLogicalWindow()
+    {
+        var engine = new CpuEngine();
+        var backing = new[] { 91f, 1f, 2f, 92f };
+        var parameter = Tensor<float>.FromMemory(new Memory<float>(backing, 1, 2), new[] { 2 });
+
+        using var plan = CompileReduceSum(engine, parameter);
+        plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+        plan.Step();
+
+        Assert.Equal(91f, backing[0]);
+        Assert.Equal(0.9f, backing[1], 6);
+        Assert.Equal(1.9f, backing[2], 6);
+        Assert.Equal(92f, backing[3]);
+    }
+
+    [Fact]
+    public void FloatGroupedSgd_NonContiguousView_PreservesCowPeerAndGroupRates()
+    {
+        var engine = new CpuEngine();
+        var source = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        var peer = (Tensor<float>)source.CloneShared();
+        var transposedParameter = source.Transpose(new[] { 1, 0 });
+        var slicedBacking = new[] { 71f, 10f, 20f, 72f };
+        var slicedParameter = Tensor<float>.FromMemory(
+            new Memory<float>(slicedBacking, 1, 2), new[] { 2 });
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var viewLoss = engine.ReduceSum(transposedParameter, null);
+            var sliceLoss = engine.ReduceSum(slicedParameter, null);
+            engine.TensorAdd(viewLoss, sliceLoss);
+            plan = scope.CompileTraining(new[] { transposedParameter, slicedParameter });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.2), LrSchedule.Constant(0.1) },
+                new[] { 0, 1 });
+            for (int step = 0; step < 3; step++)
+                plan.Step();
+        }
+
+        var expectedSource = new[] { 0.4f, 1.4f, 2.4f, 3.4f };
+        var actualSource = source.ToArray();
+        for (int i = 0; i < expectedSource.Length; i++)
+            Assert.Equal(expectedSource[i], actualSource[i], 5);
+        Assert.Equal(new[] { 1f, 2f, 3f, 4f }, peer.ToArray());
+        Assert.Equal(71f, slicedBacking[0]);
+        Assert.Equal(9.7f, slicedBacking[1], 5);
+        Assert.Equal(19.7f, slicedBacking[2], 5);
+        Assert.Equal(72f, slicedBacking[3]);
+    }
+
+    [Fact]
+    public void DoubleAdam_OffsetParameter_MatchesDenseMultiTensorSemantics()
+    {
+        var engine = new CpuEngine();
+        var dense = new Tensor<double>(new[] { 3.0, -2.0 }, new[] { 2 });
+        var backing = new[] { 101.0, 3.0, -2.0, 102.0 };
+        var offset = Tensor<double>.FromMemory(new Memory<double>(backing, 1, 2), new[] { 2 });
+
+        using var densePlan = CompileReduceSum(engine, dense);
+        using var offsetPlan = CompileReduceSum(engine, offset);
+        densePlan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+        offsetPlan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.01f);
+
+        densePlan.Step();
+        offsetPlan.Step();
+
+        Assert.Equal(dense.ToArray()[0], backing[1], 12);
+        Assert.Equal(dense.ToArray()[1], backing[2], 12);
+        Assert.Equal(101.0, backing[0]);
+        Assert.Equal(102.0, backing[3]);
+    }
+
+    [Fact]
+    public void DoubleGroupedSgd_NonContiguousView_UpdatesUnderlyingLogicalElements()
+    {
+        var engine = new CpuEngine();
+        var source = new Tensor<double>(new[] { 2.0, 4.0, 6.0, 8.0 }, new[] { 2, 2 });
+        var view = source.Transpose(new[] { 1, 0 });
+        var dense = new Tensor<double>(new[] { 10.0, 20.0 }, new[] { 2 });
+
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var viewLoss = engine.ReduceSum(view, null);
+            var denseLoss = engine.ReduceSum(dense, null);
+            engine.TensorAdd(viewLoss, denseLoss);
+            plan = scope.CompileTraining(new[] { view, dense });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.05), LrSchedule.Constant(0.2) },
+                new[] { 0, 1 });
+            plan.Step();
+        }
+
+        Assert.Equal(new[] { 1.95, 3.95, 5.95, 7.95 }, source.ToArray());
+        Assert.Equal(new[] { 9.8, 19.8 }, dense.ToArray());
+    }
+
+    [Fact]
+    public void GradientClip_DoesNotClassifyParameterViewAsUnmaterialized()
+    {
+        var engine = new CpuEngine();
+        var source = new Tensor<float>(new[] { 1f, 1f, 1f, 1f }, new[] { 2, 2 });
+        var view = source.Transpose(new[] { 1, 0 });
+
+        using var plan = CompileReduceSum(engine, view);
+        plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+        plan.SetMaxGradNorm(1.0);
+        plan.Step();
+
+        // ||[1,1,1,1]||₂=2, so clipping to 1 scales every gradient to ~0.5.
+        foreach (float value in source.ToArray())
+            Assert.Equal(0.95f, value, 5);
+    }
+
+    [Fact]
+    public void MatMulForwardBackward_NonContiguousParameter_UsesStrideAwareFallback()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1f, 0f, 0f, 1f }, new[] { 2, 2 });
+        var source = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        var parameterView = source.Transpose(new[] { 1, 0 });
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var output = engine.TensorMatMul(input, parameterView);
+            engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(new[] { parameterView });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+            plan.Step();
+        }
+
+        Assert.Equal(new[] { 0.9f, 1.9f, 2.9f, 3.9f }, source.ToArray());
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOptimizerParameterViewTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOptimizerParameterViewTests.cs
@@ -47,14 +47,15 @@ public sealed class CompiledOptimizerParameterViewTests
         var slicedBacking = new[] { 71f, 10f, 20f, 72f };
         var slicedParameter = Tensor<float>.FromMemory(
             new Memory<float>(slicedBacking, 1, 2), new[] { 2 });
+        var parameters = new[] { transposedParameter, slicedParameter };
 
         ICompiledTrainingPlan<float> plan;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(parameters))
         {
             var viewLoss = engine.ReduceSum(transposedParameter, null);
             var sliceLoss = engine.ReduceSum(slicedParameter, null);
             engine.TensorAdd(viewLoss, sliceLoss);
-            plan = scope.CompileTraining(new[] { transposedParameter, slicedParameter });
+            plan = scope.CompileTraining(parameters);
         }
 
         using (plan)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledStorageContractFusionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledStorageContractFusionTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Buffers;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// End-to-end storage-contract coverage for compiled closures that retain raw arrays.
+/// A closure must bind live storage or decline the optimization; retaining a logical
+/// <c>GetDataArray()</c> materialization silently stale-reads inputs and drops writes
+/// for pool-padded tensors and views.
+/// </summary>
+[Collection("CompilationGlobalState")]
+public sealed class CompiledStorageContractFusionTests
+{
+    [Fact]
+    public void DataflowFusion_PoolPaddedOperands_ReplayUsesLiveStorageAndGradients()
+    {
+        const int m = 2, k = 3, h = 128, n = 3;
+        var input = PooledTensor(new[] { m, k }, 1.0f);
+        var w1 = PooledTensor(new[] { k, h }, 1.0f);
+        var w2 = PooledTensor(new[] { h, n }, 1.0f);
+        AssertPoolPadded(input, w1, w2);
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        var previousOptions = TensorCodecOptions.Current;
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions
+        {
+            EnableDataflowFusion = true,
+            EnableBackwardGradientPooling = false,
+        });
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { w1, w2 };
+            CompiledTrainingPlan<float> plan;
+            Tensor<float> output;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var hidden = engine.ReLU(engine.TensorMatMul(input, w1));
+                output = engine.TensorMatMul(hidden, w2);
+                var loss = engine.ReduceSum(output, axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                Fill(w1, 2.0f); // mutate after closure construction
+                var loss = plan.Step();
+
+                Assert.Equal(4608.0f, loss[0], 3);
+                Assert.NotNull(output.Grad);
+                AssertAllClose(output.Grad!, 1.0f);
+                Assert.Same(plan.Gradients[0], w1.Grad);
+                Assert.Same(plan.Gradients[1], w2.Grad);
+                AssertAllClose(plan.Gradients[0], 6.0f);
+                AssertAllClose(plan.Gradients[1], 12.0f);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            TensorCodecOptions.SetCurrent(previousOptions);
+            TensorAllocator.Return(input);
+            TensorAllocator.Return(w1);
+            TensorAllocator.Return(w2);
+        }
+    }
+
+    [Fact]
+    public void DataflowFusion_OffsetParameterView_DeclinesAndFallbackUsesCorrectSlice()
+    {
+        const int m = 2, k = 3, h = 128, n = 3;
+        var input = new Tensor<float>(new float[m * k], new[] { m, k });
+        Fill(input, 1.0f);
+        var backing = new float[k * h + 2];
+        backing[0] = 12345.0f;
+        backing[^1] = -12345.0f;
+        var w1 = Tensor<float>.FromMemory(
+            new Memory<float>(backing, 1, k * h), new[] { k, h });
+        var w2 = new Tensor<float>(new float[h * n], new[] { h, n });
+        Fill(w1, 2.0f);
+        Fill(w2, 1.0f);
+        Assert.Null(w1.GetLiveBackingArrayAllowingPaddingOrNull());
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        var previousOptions = TensorCodecOptions.Current;
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions
+        {
+            EnableDataflowFusion = true,
+            EnableBackwardGradientPooling = false,
+        });
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { w1, w2 };
+            CompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var hidden = engine.ReLU(engine.TensorMatMul(input, w1));
+                var output = engine.TensorMatMul(hidden, w2);
+                var loss = engine.ReduceSum(output, axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                Assert.Equal(4608.0f, plan.Step()[0], 3);
+                AssertAllClose(plan.Gradients[0], 6.0f);
+            }
+
+            Assert.Equal(12345.0f, backing[0]);
+            Assert.Equal(-12345.0f, backing[^1]);
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            TensorCodecOptions.SetCurrent(previousOptions);
+        }
+    }
+
+    [Fact]
+    public void AnalyticMatMulLoss_PoolPaddedReplay_WritesLiveLossAndGradients()
+    {
+        const int m = 3, k = 5, n = 7;
+        var input = PooledTensor(new[] { m, k }, 1.0f);
+        var weight = PooledTensor(new[] { k, n }, 1.0f);
+        AssertPoolPadded(input, weight);
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        string? previousAnalytic = Environment.GetEnvironmentVariable("AIDOTNET_ANALYTIC_FORWARD");
+        Environment.SetEnvironmentVariable("AIDOTNET_ANALYTIC_FORWARD", "1");
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { weight };
+            CompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var output = engine.TensorMatMul(input, weight);
+                var loss = engine.ReduceSum(output, axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                Fill(weight, 2.0f);
+                Assert.Equal(210.0f, plan.Step()[0], 3);
+                AssertAllClose(plan.Gradients[0], 3.0f);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            Environment.SetEnvironmentVariable("AIDOTNET_ANALYTIC_FORWARD", previousAnalytic);
+            TensorAllocator.Return(input);
+            TensorAllocator.Return(weight);
+        }
+    }
+
+    [Fact]
+    public void SlicePrefixFusion_PoolPaddedReplay_WritesLiveLossAndGradientPrefix()
+    {
+        const int m = 2, k = 3, nFull = 5, nUsed = 2;
+        var input = PooledTensor(new[] { m, k }, 1.0f);
+        var weight = PooledTensor(new[] { k, nFull }, 1.0f);
+        AssertPoolPadded(input, weight);
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        var previousOptions = TensorCodecOptions.Current;
+        string? previousSlice = Environment.GetEnvironmentVariable("AIDOTNET_SLICE_PREFIX_FUSION");
+        Environment.SetEnvironmentVariable("AIDOTNET_SLICE_PREFIX_FUSION", "1");
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableBackwardGradientPooling = false });
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { weight };
+            CompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var full = engine.TensorMatMul(input, weight);
+                var prefix = engine.TensorSlice(full, new[] { 0, 0 }, new[] { m, nUsed });
+                var loss = engine.ReduceSum(prefix, axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                Fill(weight, 2.0f);
+                Assert.Equal(24.0f, plan.Step()[0], 3);
+                var gradient = plan.Gradients[0].AsSpan();
+                for (int row = 0; row < k; row++)
+                for (int col = 0; col < nFull; col++)
+                    Assert.Equal(col < nUsed ? 2.0f : 0.0f, gradient[row * nFull + col], 3);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            TensorCodecOptions.SetCurrent(previousOptions);
+            Environment.SetEnvironmentVariable("AIDOTNET_SLICE_PREFIX_FUSION", previousSlice);
+            TensorAllocator.Return(input);
+            TensorAllocator.Return(weight);
+        }
+    }
+
+    [Fact]
+    public void CrossLayerMatMulFusion_PoolPaddedReplay_WritesLiveLossAndGradients()
+    {
+        const int m = 2, k = 3, h = 4, n = 5;
+        var input = PooledTensor(new[] { m, k }, 1.0f);
+        var w1 = PooledTensor(new[] { k, h }, 1.0f);
+        var w2 = PooledTensor(new[] { h, n }, 1.0f);
+        AssertPoolPadded(input, w1, w2);
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        var previousOptions = TensorCodecOptions.Current;
+        string? previousCross = Environment.GetEnvironmentVariable("AIDOTNET_CROSS_LAYER_FUSION");
+        Environment.SetEnvironmentVariable("AIDOTNET_CROSS_LAYER_FUSION", "1");
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions
+        {
+            EnableDataflowFusion = true,
+            EnableBackwardGradientPooling = false,
+        });
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { w1, w2 };
+            CompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var hidden = engine.TensorMatMul(input, w1);
+                var output = engine.TensorMatMul(hidden, w2);
+                var loss = engine.ReduceMean(output, axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                Fill(w1, 2.0f);
+                Assert.Equal(24.0f, plan.Step()[0], 3);
+                AssertAllClose(plan.Gradients[0], 1.0f);
+                AssertAllClose(plan.Gradients[1], 1.2f);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            TensorCodecOptions.SetCurrent(previousOptions);
+            Environment.SetEnvironmentVariable("AIDOTNET_CROSS_LAYER_FUSION", previousCross);
+            TensorAllocator.Return(input);
+            TensorAllocator.Return(w1);
+            TensorAllocator.Return(w2);
+        }
+    }
+
+    [Fact]
+    public void BatchedWeightGradients_PoolPaddedDestinations_WriteLiveStorage_WhenAvailable()
+    {
+        if (!BlasProvider.IsMklBatchedAvailable) return;
+
+        const int m = 2, k = 3, n = 5;
+        var x1 = PooledTensor(new[] { m, k }, 1.0f);
+        var x2 = PooledTensor(new[] { m, k }, 2.0f);
+        var w1 = PooledTensor(new[] { k, n }, 1.0f);
+        var w2 = PooledTensor(new[] { k, n }, 1.0f);
+        AssertPoolPadded(x1, x2, w1, w2);
+
+        var engine = new CpuEngine();
+        var previousEngine = AiDotNetEngine.Current;
+        var previousOptions = TensorCodecOptions.Current;
+        string? previousBatch = Environment.GetEnvironmentVariable("AIDOTNET_DW_BATCHING");
+        Environment.SetEnvironmentVariable("AIDOTNET_DW_BATCHING", "1");
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions
+        {
+            EnableDataflowFusion = false,
+            EnableBackwardGradientPooling = false,
+        });
+        AiDotNetEngine.Current = engine;
+
+        try
+        {
+            var parameters = new[] { w1, w2 };
+            CompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.EnableTraining(parameters))
+            {
+                var y1 = engine.TensorMatMul(x1, w1);
+                var y2 = engine.TensorMatMul(x2, w2);
+                var loss = engine.ReduceSum(engine.TensorAdd(y1, y2), axes: null, keepDims: false);
+                plan = scope.CompileTraining(parameters, loss);
+            }
+
+            using (plan)
+            {
+                _ = plan.Step();
+                AssertAllClose(plan.Gradients[0], 2.0f);
+                AssertAllClose(plan.Gradients[1], 4.0f);
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previousEngine;
+            TensorCodecOptions.SetCurrent(previousOptions);
+            Environment.SetEnvironmentVariable("AIDOTNET_DW_BATCHING", previousBatch);
+            TensorAllocator.Return(x1);
+            TensorAllocator.Return(x2);
+            TensorAllocator.Return(w1);
+            TensorAllocator.Return(w2);
+        }
+    }
+
+    private static Tensor<float> PooledTensor(int[] shape, float value)
+    {
+        int length = 1;
+        for (int i = 0; i < shape.Length; i++) length *= shape[i];
+        var backing = ArrayPool<float>.Shared.Rent(length);
+        Array.Clear(backing, 0, backing.Length);
+        var tensor = Tensor<float>.FromPooledMemory(
+            new Memory<float>(backing, 0, length), shape, backing);
+        Fill(tensor, value);
+        return tensor;
+    }
+
+    private static void Fill(Tensor<float> tensor, float value)
+    {
+        var span = tensor.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++) span[i] = value;
+    }
+
+    private static void AssertPoolPadded(params Tensor<float>[] tensors)
+    {
+        foreach (var tensor in tensors)
+        {
+            var live = tensor.GetLiveBackingArrayAllowingPaddingOrNull();
+            Assert.NotNull(live);
+            Assert.True(live!.Length > tensor.Length,
+                $"Test shape [{string.Join(",", tensor._shape)}] did not receive padded storage.");
+        }
+    }
+
+    private static void AssertAllClose(Tensor<float> tensor, float expected)
+    {
+        var span = tensor.AsSpan();
+        for (int i = 0; i < span.Length; i++)
+            Assert.True(MathF.Abs(span[i] - expected) <= 1e-3f,
+                $"Gradient[{i}] was {span[i]:R}; expected {expected:R}.");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
@@ -187,27 +187,67 @@ public class CompiledTrainingCowIsolationTests
     [Fact]
     public async Task ConcurrentCowPeers_CompileAndTrainWithoutCrossMutation()
     {
-        var untouched = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
-        var first = (Tensor<double>)untouched.CloneShared();
-        var second = (Tensor<double>)untouched.CloneShared();
+        var first = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var second = (Tensor<double>)first.CloneShared();
+        using var bothPlansReady = new System.Threading.Barrier(2);
 
-        async Task TrainAsync(Tensor<double> parameter, double learningRate)
+        Task TrainAsync(Tensor<double> parameter, double learningRate)
         {
-            await Task.Yield();
-            var engine = new CpuEngine();
-            var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
-            var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
-            using var plan = CompileSquaredError(engine, input, target, parameter, new[] { parameter });
-            plan.ConfigureOptimizer(OptimizerType.SGD, (float)learningRate, 0.9f, 0.999f, 1e-8f, 0f);
-            plan.Step();
+            return Task.Run(() =>
+            {
+                var engine = new CpuEngine();
+                var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+                var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+                var parameters = new[] { parameter };
+
+                // GraphMode is thread-static. Each concurrent worker owns and disposes its scope
+                // entirely on that worker rather than relying on an async continuation's thread.
+                using var scope = GraphMode.EnableTraining(parameters);
+                var parameterView = parameter.Reshape(1, 1);
+                var prediction = engine.TensorMatMul(input, parameterView);
+                var error = engine.TensorSubtract(prediction, target);
+                var loss = engine.ReduceSum(engine.TensorMultiply(error, error), null);
+                using var plan = scope.CompileTraining(parameters, loss);
+                plan.ConfigureOptimizer(
+                    OptimizerType.SGD, (float)learningRate, 0.9f, 0.999f, 1e-8f, 0f);
+
+                Assert.True(
+                    bothPlansReady.SignalAndWait(TimeSpan.FromSeconds(30)),
+                    "Both concurrent training plans should reach the step barrier.");
+                plan.Step();
+            });
         }
 
         await Task.WhenAll(TrainAsync(first, 0.1), TrainAsync(second, 0.05));
 
-        Assert.Equal(1.0, untouched[0]);
         Assert.NotEqual(1.0, first[0]);
         Assert.NotEqual(1.0, second[0]);
         Assert.NotEqual(first[0], second[0]);
+    }
+
+    [Theory]
+    [InlineData(OptimizerType.Adam)]
+    [InlineData(OptimizerType.AdamW)]
+    public void MultiTensorOptimizer_SkipsMissingAndEmptyGradients(OptimizerType optimizerType)
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+        var active = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var unused = new Tensor<double>(new[] { 7.0 }, new[] { 1 });
+        var empty = new Tensor<double>(Array.Empty<double>(), new[] { 0 });
+
+        using var plan = CompileSquaredError(
+            engine, input, target, active, new[] { active, unused, empty });
+        // Keep weight decay at zero so this test isolates missing/empty-gradient routing. AdamW
+        // legitimately decays a registered zero-gradient parameter when decay is nonzero.
+        plan.ConfigureOptimizer(optimizerType, 0.01f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        plan.Step();
+
+        Assert.NotEqual(1.0, active[0]);
+        Assert.Equal(7.0, unused[0]);
+        Assert.Equal(0, empty.Length);
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
@@ -1,0 +1,277 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public class CompiledTrainingCowIsolationTests
+{
+    [Fact]
+    public void TrainingTrace_DetachesCowParameterBeforeCapturingDerivedView()
+    {
+        var engine = new CpuEngine();
+        var peer = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var trainable = (Tensor<double>)peer.CloneShared();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+
+        using var plan = CompileSquaredError(engine, input, target, trainable, new[] { trainable });
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0.1f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        var loss = plan.Step()[0];
+
+        Assert.True(!double.IsNaN(loss) && !double.IsInfinity(loss));
+        Assert.True(loss > 0.0);
+        Assert.NotEqual(1.0, trainable[0]);
+        Assert.Equal(1.0, peer[0]);
+    }
+
+    [Fact]
+    public void SequentialCowPeers_CompileAndTrainIndependently()
+    {
+        var engine = new CpuEngine();
+        var first = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var second = (Tensor<double>)first.CloneShared();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+
+        using (var firstPlan = CompileSquaredError(engine, input, target, first, new[] { first }))
+        {
+            firstPlan.ConfigureOptimizer(OptimizerType.SGD, 0.1f, 0.9f, 0.999f, 1e-8f, 0f);
+            firstPlan.Step();
+        }
+
+        double firstAfterOwnStep = first[0];
+        Assert.Equal(1.0, second[0]);
+
+        using (var secondPlan = CompileSquaredError(engine, input, target, second, new[] { second }))
+        {
+            secondPlan.ConfigureOptimizer(OptimizerType.SGD, 0.05f, 0.9f, 0.999f, 1e-8f, 0f);
+            secondPlan.Step();
+        }
+
+        Assert.Equal(firstAfterOwnStep, first[0]);
+        Assert.NotEqual(1.0, second[0]);
+    }
+
+    [Fact]
+    public void CachedTrainingPlan_DoesNotRetraceOrRedetachOnCacheHit()
+    {
+        var engine = new CpuEngine();
+        var peer = new Tensor<double>(new[] { 1.0 }, new[] { 1, 1 });
+        var trainable = (Tensor<double>)peer.CloneShared();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+        int traceCount = 0;
+
+        using var cache = new CompiledModelCache<double>();
+        Tensor<double> Trace()
+        {
+            traceCount++;
+            var prediction = engine.TensorMatMul(input, trainable);
+            var error = engine.TensorSubtract(prediction, target);
+            return engine.ReduceSum(engine.TensorMultiply(error, error), null);
+        }
+
+        var firstPlan = cache.GetOrCompileTraining(input._shape, Trace, new[] { trainable });
+        var cachedPlan = cache.GetOrCompileTraining(input._shape, Trace, new[] { trainable });
+
+        Assert.Same(firstPlan, cachedPlan);
+        Assert.Equal(1, traceCount);
+        Assert.False(trainable.IsCowShared);
+        Assert.Equal(1.0, peer[0]);
+    }
+
+    [Fact]
+    public void FailedTrainingTrace_LeavesPreparedParameterIsolated()
+    {
+        var peer = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var trainable = (Tensor<double>)peer.CloneShared();
+        var parameters = new[] { trainable };
+
+        Assert.Throws<InvalidOperationException>((Action)(() =>
+        {
+            using var scope = GraphMode.EnableTraining(parameters);
+            throw new InvalidOperationException("synthetic trace failure");
+        }));
+
+        trainable[0] = 7.0;
+        Assert.Equal(1.0, peer[0]);
+    }
+
+    [Fact]
+    public void PlainGraphScope_RejectsUnpreparedCowTrainingParameter()
+    {
+        var engine = new CpuEngine();
+        var peer = new Tensor<double>(new[] { 1.0 }, new[] { 1, 1 });
+        var trainable = (Tensor<double>)peer.CloneShared();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var scope = GraphMode.Enable();
+        try
+        {
+            var output = engine.TensorMatMul(input, trainable);
+            var loss = engine.ReduceSum(output, null);
+
+            var error = Assert.Throws<InvalidOperationException>(
+                () => scope.CompileTraining(new[] { trainable }, loss));
+            Assert.Contains("EnableTraining", error.Message);
+        }
+        finally
+        {
+            scope.MarkCompiled();
+            scope.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DuplicateTiedParameter_IsUpdatedExactlyOnce()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+        var single = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var tied = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+
+        using var singlePlan = CompileSquaredError(engine, input, target, single, new[] { single });
+        using var tiedPlan = CompileSquaredError(engine, input, target, tied, new[] { tied, tied });
+        singlePlan.ConfigureOptimizer(OptimizerType.SGD, 0.1f, 0.9f, 0.999f, 1e-8f, 0f);
+        tiedPlan.ConfigureOptimizer(OptimizerType.SGD, 0.1f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        singlePlan.Step();
+        tiedPlan.Step();
+
+        Assert.Equal(single[0], tied[0], precision: 12);
+    }
+
+    [Fact]
+    public void DuplicateTiedParameter_GroupedOptimizerAcceptsOriginalRegistrationMap()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+        var single = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var tied = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+
+        using var singlePlan = CompileSquaredError(engine, input, target, single, new[] { single });
+        using var tiedPlan = CompileSquaredError(engine, input, target, tied, new[] { tied, tied });
+        var schedules = new[] { LrSchedule.Constant(0.1) };
+        singlePlan.ConfigureOptimizerGrouped(OptimizerType.SGD, schedules, new[] { 0 });
+        tiedPlan.ConfigureOptimizerGrouped(OptimizerType.SGD, schedules, new[] { 0, 0 });
+
+        singlePlan.Step();
+        tiedPlan.Step();
+
+        Assert.Equal(single[0], tied[0], precision: 12);
+    }
+
+    [Fact]
+    public void DuplicateTiedParameter_GroupedOptimizerRejectsConflictingGroups()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+        var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+        var tied = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+
+        using var plan = CompileSquaredError(engine, input, target, tied, new[] { tied, tied });
+        var error = Assert.Throws<ArgumentException>(() =>
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.1), LrSchedule.Constant(0.01) },
+                new[] { 0, 1 }));
+
+        Assert.Contains("conflicting optimizer groups", error.Message);
+    }
+
+    [Fact]
+    public async Task ConcurrentCowPeers_CompileAndTrainWithoutCrossMutation()
+    {
+        var untouched = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        var first = (Tensor<double>)untouched.CloneShared();
+        var second = (Tensor<double>)untouched.CloneShared();
+
+        async Task TrainAsync(Tensor<double> parameter, double learningRate)
+        {
+            await Task.Yield();
+            var engine = new CpuEngine();
+            var input = new Tensor<double>(new[] { 2.0 }, new[] { 1, 1 });
+            var target = new Tensor<double>(new[] { 0.0 }, new[] { 1, 1 });
+            using var plan = CompileSquaredError(engine, input, target, parameter, new[] { parameter });
+            plan.ConfigureOptimizer(OptimizerType.SGD, (float)learningRate, 0.9f, 0.999f, 1e-8f, 0f);
+            plan.Step();
+        }
+
+        await Task.WhenAll(TrainAsync(first, 0.1), TrainAsync(second, 0.05));
+
+        Assert.Equal(1.0, untouched[0]);
+        Assert.NotEqual(1.0, first[0]);
+        Assert.NotEqual(1.0, second[0]);
+        Assert.NotEqual(first[0], second[0]);
+    }
+
+    [Fact]
+    public void MetadataViewChain_CompiledBackwardUpdatesRegisteredCowParameter()
+    {
+        var engine = new CpuEngine();
+        var peer = new Tensor<double>(new[] { 2.0, 3.0 }, new[] { 1, 2 });
+        var parameter = (Tensor<double>)peer.CloneShared();
+        var parameters = new[] { parameter };
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var expanded = parameter.ExpandDims(0);
+        var squeezed = expanded.Squeeze(0);
+        var permuted = squeezed.Transpose(new[] { 1, 0 });
+        var loss = engine.ReduceSum(engine.TensorMultiply(permuted, permuted), null);
+        using var plan = scope.CompileTraining(parameters, loss);
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0.01f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        plan.Step();
+
+        Assert.NotEqual(2.0, parameter[0]);
+        Assert.NotEqual(3.0, parameter[1]);
+        Assert.Equal(new[] { 2.0, 3.0 }, peer.ToArray());
+    }
+
+    [Fact]
+    public void SliceViewChain_CompiledBackwardUpdatesOnlySelectedCowParameterRegion()
+    {
+        var engine = new CpuEngine();
+        var peer = new Tensor<double>(new[] { 1.0, 2.0, 3.0, 4.0 }, new[] { 2, 2 });
+        var parameter = (Tensor<double>)peer.CloneShared();
+        var parameters = new[] { parameter };
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var row = parameter.SubTensor(1);
+        var selected = row.Slice(axis: 0, start: 0, end: 1);
+        var loss = engine.ReduceSum(engine.TensorMultiply(selected, selected), null);
+        using var plan = scope.CompileTraining(parameters, loss);
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0.01f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        plan.Step();
+
+        Assert.Same(scope, GraphMode.Current);
+        var compiled = Assert.IsType<CompiledTrainingPlan<double>>(plan);
+        Assert.Equal(new[] { 0.0, 0.0, 6.0, 0.0 }, compiled.Gradients[0].ToArray());
+        Assert.Equal(1.0, parameter[0]);
+        Assert.Equal(2.0, parameter[1]);
+        Assert.NotEqual(3.0, parameter[2]);
+        Assert.Equal(4.0, parameter[3]);
+        Assert.Equal(new[] { 1.0, 2.0, 3.0, 4.0 }, peer.ToArray());
+    }
+
+    private static ICompiledTrainingPlan<double> CompileSquaredError(
+        CpuEngine engine,
+        Tensor<double> input,
+        Tensor<double> target,
+        Tensor<double> parameter,
+        Tensor<double>[] parameters)
+    {
+        using var scope = GraphMode.EnableTraining(parameters);
+        var parameterView = parameter.Reshape(1, 1);
+        var prediction = engine.TensorMatMul(input, parameterView);
+        var error = engine.TensorSubtract(prediction, target);
+        var loss = engine.ReduceSum(engine.TensorMultiply(error, error), null);
+        return scope.CompileTraining(parameters, loss);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerParamUpdateTests.cs
@@ -50,23 +50,24 @@ public class ConfigureOptimizerParamUpdateTests
         Assert.True(lazyWeight.IsCowShared);
         Assert.True(lazyPeer.IsCowShared);
 
+        var parameters = new[] { weight, lazyWeight };
         ICompiledTrainingPlan<float> plan;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(parameters))
         {
             var output = engine.TensorMatMul(input, weight);
             var squared = engine.TensorMultiply(output, output);
             var loss = engine.ReduceSum(squared, null);
             // Lazy/off-loss-path parameters are deliberately accepted by the compiled
             // optimizer. They still need private storage before its raw-array capture.
-            plan = scope.CompileTraining(new[] { weight, lazyWeight }, loss);
+            plan = scope.CompileTraining(parameters, loss);
         }
 
         // This timing is part of the contract: detaching in ConfigureOptimizer would be too late,
         // because specialized forward actions may already have pinned the shared backing array.
         Assert.False(weight.IsCowShared,
-            "CompileTraining must privatize registered COW parameters before plan buffer capture.");
+            "EnableTraining must privatize registered COW parameters before graph tracing.");
         Assert.False(lazyWeight.IsCowShared,
-            "CompileTraining must also privatize lazy/off-loss-path registered parameters.");
+            "EnableTraining must also privatize lazy/off-loss-path registered parameters.");
 
         using (plan)
         {
@@ -109,19 +110,20 @@ public class ConfigureOptimizerParamUpdateTests
         Assert.True(lazyWeight.IsCowShared);
         Assert.True(lazyPeer.IsCowShared);
 
+        var parameters = new[] { weight, lazyWeight };
         ICompiledTrainingPlan<double> plan;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(parameters))
         {
             var output = engine.TensorMatMul(input, weight);
             var squared = engine.TensorMultiply(output, output);
             engine.ReduceSum(squared, null);
-            plan = scope.CompileTraining(new[] { weight, lazyWeight });
+            plan = scope.CompileTraining(parameters);
         }
 
         Assert.False(weight.IsCowShared,
-            "CompileTraining must privatize registered COW parameters before plan buffer capture.");
+            "EnableTraining must privatize registered COW parameters before graph tracing.");
         Assert.False(lazyWeight.IsCowShared,
-            "CompileTraining must also privatize lazy/off-loss-path registered parameters.");
+            "EnableTraining must also privatize lazy/off-loss-path registered parameters.");
 
         using (plan)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/EnableCheckpointingInterfaceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/EnableCheckpointingInterfaceTests.cs
@@ -68,20 +68,22 @@ public class EnableCheckpointingInterfaceTests
         var weightBaseline = Tensor<float>.CreateRandom([3, 2]);
         var weightCheckpointed = weightBaseline.Clone();
 
+        var baselineParameters = new[] { weightBaseline };
         ICompiledTrainingPlan<float> baseline;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(baselineParameters))
         {
             var output = engine.TensorMatMul(input, weightBaseline);
             engine.ReduceSum(output, null);
-            baseline = scope.CompileTraining(new[] { weightBaseline });
+            baseline = scope.CompileTraining(baselineParameters);
         }
 
+        var checkpointedParameters = new[] { weightCheckpointed };
         ICompiledTrainingPlan<float> checkpointed;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(checkpointedParameters))
         {
             var output = engine.TensorMatMul(input, weightCheckpointed);
             engine.ReduceSum(output, null);
-            checkpointed = scope.CompileTraining(new[] { weightCheckpointed });
+            checkpointed = scope.CompileTraining(checkpointedParameters);
         }
 
         using (baseline)
@@ -165,7 +167,7 @@ public class EnableCheckpointingInterfaceTests
         }
 
         ICompiledTrainingPlan<float> baseline;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(baselineWeights))
         {
             var h = input;
             for (int i = 0; i < depth; i++)
@@ -175,7 +177,7 @@ public class EnableCheckpointingInterfaceTests
         }
 
         ICompiledTrainingPlan<float> checkpointed;
-        using (var scope = GraphMode.Enable())
+        using (var scope = GraphMode.EnableTraining(checkpointedWeights))
         {
             var h = input;
             for (int i = 0; i < depth; i++)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GradientClippingStorageContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/GradientClippingStorageContractTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Buffers;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Storage-contract coverage for standalone CPU gradient clipping. These cases
+/// deliberately exercise layouts for which GetDataArray() is not a writable
+/// alias of the tensor's logical region.
+/// </summary>
+public sealed class GradientClippingStorageContractTests
+{
+    [Fact]
+    public void ClipGradNorm_PoolPaddedTensor_IgnoresPaddingAndPreservesTail()
+    {
+        var backing = ArrayPool<float>.Shared.Rent(3);
+        var gradient = Tensor<float>.FromPooledMemory(
+            new Memory<float>(backing, 0, 3), new[] { 3 }, backing);
+
+        try
+        {
+            Assert.True(backing.Length > gradient.Length);
+            gradient[0] = 3f;
+            gradient[1] = 4f;
+            gradient[2] = 0f;
+            for (int i = gradient.Length; i < backing.Length; i++)
+                backing[i] = 1000f + i;
+            var expectedTail = backing.AsSpan(gradient.Length).ToArray();
+            int versionBefore = gradient.Version;
+
+            float norm = GradientClipping.ClipGradNorm(new[] { gradient }, 2.5f);
+
+            Assert.Equal(5f, norm, 5);
+            Assert.Equal(1.5f, gradient[0], 4);
+            Assert.Equal(2f, gradient[1], 4);
+            Assert.Equal(0f, gradient[2]);
+            Assert.Equal(expectedTail, backing.AsSpan(gradient.Length).ToArray());
+            Assert.True(gradient.Version > versionBefore);
+        }
+        finally
+        {
+            TensorAllocator.Return(gradient);
+        }
+    }
+
+    [Fact]
+    public void ClipGradNorm_OffsetView_WritesOnlyLogicalSlice()
+    {
+        var backing = new[] { 777f, 3f, 4f, 888f };
+        var gradient = Tensor<float>.FromMemory(
+            new Memory<float>(backing, 1, 2), new[] { 2 });
+
+        float norm = GradientClipping.ClipGradNorm(new[] { gradient }, 1f);
+
+        float scale = 1f / (5f + 1e-6f);
+        Assert.Equal(5f, norm, 5);
+        Assert.Equal(777f, backing[0]);
+        Assert.Equal(3f * scale, backing[1], 5);
+        Assert.Equal(4f * scale, backing[2], 5);
+        Assert.Equal(888f, backing[3]);
+    }
+
+    [Fact]
+    public void ClipGradNorm_LargeFiniteValues_DoesNotOverflowScaleToZero()
+    {
+        var gradient = new Tensor<float>(new[] { 1e20f, 1e20f }, new[] { 2 });
+
+        float norm = GradientClipping.ClipGradNorm(new[] { gradient }, 1f);
+
+        Assert.False(float.IsNaN(norm));
+        Assert.False(float.IsInfinity(norm));
+        Assert.Equal(MathF.Sqrt(2f) * 1e20f, norm, precision: 5);
+        Assert.Equal(1f / MathF.Sqrt(2f), gradient[0], precision: 5);
+        Assert.Equal(1f / MathF.Sqrt(2f), gradient[1], precision: 5);
+    }
+
+    [Fact]
+    public void ClipGradValue_NonContiguousView_UpdatesUnderlyingStorage()
+    {
+        var source = new Tensor<float>(
+            new[] { 100f, -3f, 2f, -4f, 5f, -100f }, new[] { 2, 3 });
+        var transposedView = source.Transpose();
+        Assert.False(transposedView.IsContiguous);
+
+        GradientClipping.ClipGradValue(new[] { transposedView }, 2f);
+
+        Assert.Equal(new[] { 2f, -2f, 2f, -2f, 2f, -2f }, source.AsSpan().ToArray());
+    }
+
+    [Fact]
+    public void ClipGradValue_CopyOnWriteClone_PrivatizesBeforeMutation()
+    {
+        var untouchedPeer = new Tensor<float>(new[] { -5f, 0.5f, 7f }, new[] { 3 });
+        var gradient = (Tensor<float>)untouchedPeer.CloneShared();
+        Assert.True(gradient.IsCowShared);
+
+        GradientClipping.ClipGradValue(new[] { gradient }, 1f);
+
+        Assert.Equal(new[] { -1f, 0.5f, 1f }, gradient.AsSpan().ToArray());
+        Assert.Equal(new[] { -5f, 0.5f, 7f }, untouchedPeer.AsSpan().ToArray());
+        Assert.False(gradient.IsCowShared);
+    }
+
+    [Fact]
+    public void ClipGradValue_OverlappingZeroStrideView_ThrowsWithoutMutation()
+    {
+        var source = new Tensor<float>(new[] { 3f, -4f }, new[] { 2 });
+        var overlappingView = new Tensor<float>(
+            source.DataVector,
+            new[] { 2, 2 },
+            new[] { 0, 1 },
+            storageOffset: 0,
+            parentStorage: source._storage);
+        int versionBefore = source.Version;
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            GradientClipping.ClipGradValue(new[] { overlappingView }, 1f));
+
+        Assert.Contains("overlapping tensor views", error.Message);
+        Assert.Equal(new[] { 3f, -4f }, source.ToArray());
+        Assert.Equal(versionBefore, source.Version);
+    }
+
+    [Theory]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    public void ClipGradNorm_InvalidMaximum_Throws(float maxNorm)
+    {
+        var gradient = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            GradientClipping.ClipGradNorm(new[] { gradient }, maxNorm));
+    }
+
+    [Fact]
+    public void ClipGradNorm_InvalidMaximumWithEmptyInput_StillThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            GradientClipping.ClipGradNorm(Array.Empty<Tensor<float>>(), float.NaN));
+    }
+
+    [Theory]
+    [InlineData(-1f)]
+    [InlineData(float.NaN)]
+    public void ClipGradValue_InvalidMaximum_Throws(float clipValue)
+    {
+        var gradient = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            GradientClipping.ClipGradValue(new[] { gradient }, clipValue));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -35,6 +35,134 @@ public class PoolPaddedLossReadoutTests
     public PoolPaddedLossReadoutTests(ITestOutputHelper output) { _output = output; }
 
     [Fact]
+    public void SpecializedFusedLinear_PoolPaddedOutput_WritesLiveBacking()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new float[] { 2.0f }, new[] { 1, 1 });
+        var weights = new Tensor<float>(new float[] { 3.0f }, new[] { 1, 1 });
+        var bias = new Tensor<float>(new float[] { 4.0f }, new[] { 1 });
+        var pooledOutput = ArrayPool<float>.Shared.Rent(1);
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(pooledOutput, 0, 1), new[] { 1, 1 }, pooledOutput);
+
+        try
+        {
+            var live = output.GetLiveBackingArrayAllowingPaddingOrNull();
+            Assert.NotNull(live);
+            Assert.True(live!.Length > output.Length,
+                "The regression requires a pool-padded output backing.");
+            Array.Clear(live, 0, live.Length);
+
+            var step = new CompiledStep<float>(
+                "FusedLinear",
+                (eng, destination) => { },
+                output,
+                new[] { input, weights, bias },
+                savedState: new object[] { FusedActivationType.None });
+
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+            specialized!(engine);
+
+            Assert.Equal(10.0f, output[0]);
+            Assert.Equal(10.0f, live[0]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+        }
+    }
+
+    [Theory]
+    [InlineData("ReduceSum", 6.0f)]
+    [InlineData("ReduceMean", 2.0f)]
+    public void SpecializedScalarReduction_PoolPaddedOutput_WritesLiveBacking(
+        string opName, float expected)
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new float[] { 1.0f, 2.0f, 3.0f }, new[] { 3 });
+        var pooledOutput = ArrayPool<float>.Shared.Rent(1);
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(pooledOutput, 0, 1), new[] { 1 }, pooledOutput);
+
+        try
+        {
+            var live = output.GetLiveBackingArrayAllowingPaddingOrNull();
+            Assert.NotNull(live);
+            Assert.True(live!.Length > output.Length);
+            Array.Clear(live, 0, live.Length);
+
+            var step = new CompiledStep<float>(
+                opName,
+                (eng, destination) => { },
+                output,
+                new[] { input });
+
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+            specialized!(engine);
+
+            Assert.Equal(expected, output[0]);
+            Assert.Equal(expected, live[0]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+        }
+    }
+
+    [Fact]
+    public void OffsetBackedParameterView_RejectsRawArraySpecialization_AndFallbackReadsCorrectSlice()
+    {
+        var engine = new CpuEngine();
+        var parameterBacking = new float[] { 999.0f, 1.0f, 2.0f, 999.0f };
+        var parameterView = Tensor<float>.FromMemory(
+            new Memory<float>(parameterBacking, 1, 2), new[] { 2 });
+        var addend = new Tensor<float>(new float[] { 10.0f, 20.0f }, new[] { 2 });
+        var output = new Tensor<float>(new[] { 2 });
+
+        Assert.True(parameterView.IsContiguous);
+        Assert.Null(parameterView.GetLiveBackingArrayAllowingPaddingOrNull());
+        var raw = parameterView.GetCpuBackingForStridedRead(out int storageOffset);
+        Assert.Same(parameterBacking, raw);
+        Assert.Equal(1, storageOffset);
+
+        var step = new CompiledStep<float>(
+            "TensorAdd",
+            (eng, destination) => eng.TensorAddInto(destination, parameterView, addend),
+            output,
+            new[] { parameterView, addend });
+
+        Assert.Null(CompiledTrainingPlan<float>.TryBuildSpecializedForward(step));
+        step.Execute(engine, output);
+
+        Assert.Equal(11.0f, output[0]);
+        Assert.Equal(22.0f, output[1]);
+    }
+
+    [Fact]
+    public void OffsetBackedOutputView_RejectsRawArraySpecialization_AndFallbackWritesCorrectSlice()
+    {
+        var engine = new CpuEngine();
+        var left = new Tensor<float>(new float[] { 1.0f, 2.0f }, new[] { 2 });
+        var right = new Tensor<float>(new float[] { 10.0f, 20.0f }, new[] { 2 });
+        var outputBacking = new float[] { 999.0f, 0.0f, 0.0f, 999.0f };
+        var outputView = Tensor<float>.FromMemory(
+            new Memory<float>(outputBacking, 1, 2), new[] { 2 });
+
+        var step = new CompiledStep<float>(
+            "TensorAdd",
+            (eng, destination) => eng.TensorAddInto(destination, left, right),
+            outputView,
+            new[] { left, right });
+
+        Assert.Null(CompiledTrainingPlan<float>.TryBuildSpecializedForward(step));
+        step.Execute(engine, outputView);
+
+        Assert.Equal(new float[] { 999.0f, 11.0f, 22.0f, 999.0f }, outputBacking);
+    }
+
+    [Fact]
     public void NegateForward_PoolPaddedOutput_PropagatesNaN_NotSilentZero()
     {
         // Pre-pad the ArrayPool<float> Length-1 bucket by renting + returning

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -112,6 +112,180 @@ public class PoolPaddedLossReadoutTests
     }
 
     [Fact]
+    public void SpecializedReduceMax_PoolPaddedOutput_WritesLiveBacking()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { -3.0f, 7.0f, 2.0f }, new[] { 3 });
+        var pooled = ArrayPool<float>.Shared.Rent(1);
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(pooled, 0, 1), new[] { 1 }, pooled);
+
+        try
+        {
+            Array.Clear(pooled, 0, pooled.Length);
+            Assert.True(pooled.Length > output.Length);
+            var step = new CompiledStep<float>(
+                "ReduceMax", (eng, destination) => { }, output, new[] { input });
+
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+            specialized!(engine);
+
+            Assert.Equal(7.0f, output[0]);
+            Assert.Equal(7.0f, pooled[0]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+        }
+    }
+
+    [Fact]
+    public void SpecializedMseLoss_PoolPaddedOutput_WritesLiveBacking()
+    {
+        var engine = new CpuEngine();
+        var predicted = new Tensor<float>(new[] { 1.0f, 4.0f }, new[] { 2 });
+        var target = new Tensor<float>(new[] { 3.0f, 2.0f }, new[] { 2 });
+        var pooled = ArrayPool<float>.Shared.Rent(1);
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(pooled, 0, 1), new[] { 1 }, pooled);
+
+        try
+        {
+            Array.Clear(pooled, 0, pooled.Length);
+            Assert.True(pooled.Length > output.Length);
+            var step = new CompiledStep<float>(
+                "MSELoss", (eng, destination) => { }, output, new[] { predicted, target });
+
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+            specialized!(engine);
+
+            Assert.Equal(4.0f, output[0]);
+            Assert.Equal(4.0f, pooled[0]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+        }
+    }
+
+    [Fact]
+    public void SpecializedBroadcastAdd_PoolPaddedInputAndOutput_StayLiveAcrossReplay()
+    {
+        var engine = new CpuEngine();
+        var inputBacking = ArrayPool<float>.Shared.Rent(2);
+        var outputBacking = ArrayPool<float>.Shared.Rent(2);
+        var input = Tensor<float>.FromPooledMemory(
+            new Memory<float>(inputBacking, 0, 2), new[] { 1, 2 }, inputBacking);
+        var addend = new Tensor<float>(new[] { 10.0f, 20.0f }, new[] { 2 });
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(outputBacking, 0, 2), new[] { 1, 2 }, outputBacking);
+
+        try
+        {
+            Assert.True(inputBacking.Length > input.Length);
+            Assert.True(outputBacking.Length > output.Length);
+            input[0] = 1.0f;
+            input[1] = 2.0f;
+            Array.Clear(outputBacking, 0, outputBacking.Length);
+
+            var step = new CompiledStep<float>(
+                "TensorBroadcastAdd", (eng, destination) => { }, output, new[] { input, addend });
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+
+            // Mutate after closure creation. A cached GetDataArray() copy would
+            // keep reading 1,2 instead of the live 3,4 values.
+            input[0] = 3.0f;
+            input[1] = 4.0f;
+            specialized!(engine);
+
+            Assert.Equal(new[] { 13.0f, 24.0f }, output.AsSpan().ToArray());
+            Assert.Equal(13.0f, outputBacking[0]);
+            Assert.Equal(24.0f, outputBacking[1]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+            TensorAllocator.Return(input);
+        }
+    }
+
+    [Fact]
+    public void SpecializedNdMatMul_PoolPaddedWeightAndOutput_StayLiveAcrossReplay()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1.0f, 2.0f, 3.0f, 4.0f }, new[] { 1, 2, 2 });
+        var weightBacking = ArrayPool<float>.Shared.Rent(2);
+        var outputBacking = ArrayPool<float>.Shared.Rent(2);
+        var weight = Tensor<float>.FromPooledMemory(
+            new Memory<float>(weightBacking, 0, 2), new[] { 2, 1 }, weightBacking);
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(outputBacking, 0, 2), new[] { 1, 2, 1 }, outputBacking);
+
+        try
+        {
+            Assert.True(weightBacking.Length > weight.Length);
+            Assert.True(outputBacking.Length > output.Length);
+            weight[0] = 1.0f;
+            weight[1] = 1.0f;
+            var step = new CompiledStep<float>(
+                "TensorMatMul", (eng, destination) => { }, output, new[] { input, weight });
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+
+            weight[0] = 2.0f;
+            weight[1] = 3.0f;
+            specialized!(engine);
+
+            Assert.Equal(new[] { 8.0f, 18.0f }, output.AsSpan().ToArray());
+            Assert.Equal(8.0f, outputBacking[0]);
+            Assert.Equal(18.0f, outputBacking[1]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+            TensorAllocator.Return(weight);
+        }
+    }
+
+    [Fact]
+    public void SpecializedConcat_PoolPaddedInputAndOutput_StayLiveAcrossReplay()
+    {
+        var engine = new CpuEngine();
+        var leftBacking = ArrayPool<float>.Shared.Rent(1);
+        var outputBacking = ArrayPool<float>.Shared.Rent(2);
+        var left = Tensor<float>.FromPooledMemory(
+            new Memory<float>(leftBacking, 0, 1), new[] { 1 }, leftBacking);
+        var right = new Tensor<float>(new[] { 5.0f }, new[] { 1 });
+        var output = Tensor<float>.FromPooledMemory(
+            new Memory<float>(outputBacking, 0, 2), new[] { 2 }, outputBacking);
+
+        try
+        {
+            left[0] = 1.0f;
+            var step = new CompiledStep<float>(
+                "Concatenate", (eng, destination) => { }, output, new[] { left, right },
+                savedState: new object[] { 0 });
+            var specialized = CompiledTrainingPlan<float>.TryBuildSpecializedForward(step);
+            Assert.NotNull(specialized);
+
+            left[0] = 9.0f;
+            specialized!(engine);
+
+            Assert.Equal(new[] { 9.0f, 5.0f }, output.AsSpan().ToArray());
+            Assert.Equal(9.0f, outputBacking[0]);
+            Assert.Equal(5.0f, outputBacking[1]);
+        }
+        finally
+        {
+            TensorAllocator.Return(output);
+            TensorAllocator.Return(left);
+        }
+    }
+
+    [Fact]
     public void OffsetBackedParameterView_RejectsRawArraySpecialization_AndFallbackReadsCorrectSlice()
     {
         var engine = new CpuEngine();

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Optimization;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -164,5 +166,57 @@ public class ReshapeGradientTests
         Assert.Equal(
             new[] { 0f, 1f, 1f, 0f, 1f, 1f },
             gradients[parameter].ToArray());
+    }
+
+    [Fact]
+    public void NonContiguousReshape_RecordsMaterializationAndViewAsDistinctEdges()
+    {
+        var engine = new CpuEngine();
+        var parameter = new Tensor<float>(
+            new[] { 1f, 2f, 3f, 4f, 5f, 6f }, new[] { 2, 3 });
+
+        using var tape = new GradientTape<float>();
+        var transposed = parameter.Transpose();
+        var reshaped = transposed.Reshape(6);
+        var loss = engine.ReduceSum(reshaped, null);
+
+        var reshapeNode = Assert.IsType<GradNode<float>>(reshaped.GradFn);
+        var materialized = Assert.IsType<Tensor<float>>(reshapeNode.Input0);
+        Assert.NotSame(transposed, materialized);
+        Assert.Same(transposed, Assert.IsType<GradNode<float>>(materialized.GradFn).Input0);
+
+        var gradients = tape.ComputeGradients(loss);
+        Assert.Equal(new[] { 1f, 1f, 1f, 1f, 1f, 1f }, gradients[parameter].ToArray());
+    }
+
+    [Fact]
+    public void NonContiguousReshape_CompiledReplayPreservesGradientChain()
+    {
+        var engine = new CpuEngine();
+        var parameter = new Tensor<float>(
+            new[] { 1f, 2f, 3f, 4f, 5f, 6f }, new[] { 2, 3 });
+        var parameters = new[] { parameter };
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var reshaped = parameter.Transpose().Reshape(6);
+        var loss = engine.ReduceSum(engine.TensorMultiply(reshaped, reshaped), null);
+        using var plan = scope.CompileTraining(parameters, loss);
+        plan.ConfigureOptimizer(OptimizerType.SGD, 0.01f, 0.9f, 0.999f, 1e-8f, 0f);
+
+        plan.Step();
+
+        var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
+        Assert.Equal(new[] { 2f, 4f, 6f, 8f, 10f, 12f }, compiled.Gradients[0].ToArray());
+    }
+
+    [Fact]
+    public void SubTensor_InvalidLaterIndex_DoesNotConstructPartialViews()
+    {
+        var tensor = new Tensor<float>(new float[8], new[] { 2, 2, 2 });
+        int refCountBefore = tensor._storage.RefCount;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => tensor.SubTensor(1, 2));
+
+        Assert.Equal(refCountBefore, tensor._storage.RefCount);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/ReshapeGradientTests.cs
@@ -107,4 +107,62 @@ public class ReshapeGradientTests
         Assert.True(grads.ContainsKey(input),
             "Input gradient must flow through reshape");
     }
+
+    [Fact]
+    public void MetadataViewChain_ExpandSqueezeAndPermute_PropagatesGradient()
+    {
+        var engine = new CpuEngine();
+        var parameter = new Tensor<float>(new[] { 2f, 3f }, new[] { 1, 2 });
+
+        using var tape = new GradientTape<float>();
+        var expanded = parameter.ExpandDims(0);       // [1,1,2]
+        var squeezed = expanded.Squeeze(0);          // [1,2]
+        var permuted = squeezed.Transpose(new[] { 1, 0 }); // [2,1]
+        var loss = engine.ReduceSum(permuted, null);
+
+        Assert.NotNull(expanded.GradFn);
+        Assert.NotNull(squeezed.GradFn);
+        Assert.NotNull(permuted.GradFn);
+
+        var gradients = tape.ComputeGradients(loss);
+
+        Assert.True(gradients.ContainsKey(parameter));
+        Assert.Equal(new[] { 1f, 1f }, gradients[parameter].ToArray());
+    }
+
+    [Fact]
+    public void SubTensorViewChain_ScattersGradientToFixedLeadingIndices()
+    {
+        var engine = new CpuEngine();
+        var parameter = new Tensor<float>(
+            new[] { 1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f },
+            new[] { 2, 2, 2 });
+
+        using var tape = new GradientTape<float>();
+        var selected = parameter.SubTensor(1, 0);
+        var loss = engine.ReduceSum(selected, null);
+        var gradients = tape.ComputeGradients(loss);
+
+        Assert.Equal(
+            new[] { 0f, 0f, 0f, 0f, 1f, 1f, 0f, 0f },
+            gradients[parameter].ToArray());
+    }
+
+    [Fact]
+    public void NarrowView_ScattersGradientToSelectedRange()
+    {
+        var engine = new CpuEngine();
+        var parameter = new Tensor<float>(
+            new[] { 1f, 2f, 3f, 4f, 5f, 6f },
+            new[] { 2, 3 });
+
+        using var tape = new GradientTape<float>();
+        var selected = parameter.Slice(axis: 1, start: 1, end: 3);
+        var loss = engine.ReduceSum(selected, null);
+        var gradients = tape.ComputeGradients(loss);
+
+        Assert.Equal(
+            new[] { 0f, 1f, 1f, 0f, 1f, 1f },
+            gradients[parameter].ToArray());
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCowCloneTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCowCloneTests.cs
@@ -141,7 +141,7 @@ public class TensorCowCloneTests
         var src = MakeTensor();
         var clone = (Tensor<float>)src.Clone();
 
-        // O(1) proof: CloneShared only flags _cowShared when it actually shared storage (the eager
+        // O(1) proof: CloneShared only attaches a COW family when it actually shared storage (the eager
         // CloneDeepCopy fallback never does), so IsCowShared==true means no full-buffer copy happened.
         Assert.True(clone.IsCowShared, "Clone() must share storage (O(1)) by default");
         Assert.True(src.IsCowShared, "the source is flagged COW too");
@@ -211,12 +211,17 @@ public class TensorCowCloneTests
         var source = MakeTensor();
         var clone = (Tensor<float>)source.CloneShared();
 
-        // Creating a retained alias is an alias-exposure barrier. It must
-        // privatize source before the view captures storage.
+        // Metadata view creation remains O(1): source and view form one alias family while the
+        // independent clone is a second family over the same storage.
         var sourceView = source.Reshape(6);
 
-        Assert.False(source.IsCowShared);
+        Assert.True(source.IsCowShared);
+        Assert.True(sourceView.IsCowShared);
+        Assert.Same(source._storage, sourceView._storage);
+        Assert.Same(source._storage, clone._storage);
         sourceView[2] = 52f;
+        Assert.False(source.IsCowShared);
+        Assert.False(sourceView.IsCowShared);
         Assert.Equal(52f, source[2]);
         Assert.Equal(Original[2], clone[2]);
 
@@ -231,10 +236,59 @@ public class TensorCowCloneTests
         var clone = (Tensor<float>)source.CloneShared();
 
         var cloneView = clone.Transpose(new[] { 1, 0 });
+        Assert.True(clone.IsCowShared);
+        Assert.True(cloneView.IsCowShared);
         cloneView[0] = 84f;
 
         Assert.Equal(84f, clone[0]);
         Assert.Equal(Original[0], source[0]);
+    }
+
+    [Fact]
+    public void SourceWrite_AfterCowViewCreation_MovesWholeAliasFamily()
+    {
+        var source = MakeTensor();
+        var peer = (Tensor<float>)source.CloneShared();
+        var sourceView = source.Reshape(6);
+
+        source[4] = 95f;
+
+        Assert.Equal(95f, sourceView[4]);
+        Assert.Equal(Original[4], peer[4]);
+        Assert.False(source.IsCowShared);
+        Assert.False(sourceView.IsCowShared);
+    }
+
+    [Fact]
+    public async Task ViewCreation_ConcurrentWithFirstWrite_RemainsInSourceAliasFamily()
+    {
+        for (int iteration = 0; iteration < 32; iteration++)
+        {
+            var source = MakeTensor();
+            var peer = (Tensor<float>)source.CloneShared();
+            using var start = new System.Threading.ManualResetEventSlim(false);
+            Tensor<float> sourceView = null!;
+
+            var createView = Task.Run(() =>
+            {
+                start.Wait();
+                sourceView = source.Reshape(6);
+            });
+            var firstWrite = Task.Run(() =>
+            {
+                start.Wait();
+                source[0] = 100f + iteration;
+            });
+
+            start.Set();
+            await Task.WhenAll(createView, firstWrite);
+
+            var retainedView = Assert.IsType<Tensor<float>>(sourceView);
+            source[1] = 200f + iteration;
+            Assert.Equal(source[1], retainedView[1]);
+            Assert.Equal(Original[0], peer[0]);
+            Assert.Equal(Original[1], peer[1]);
+        }
     }
 
     [Fact]
@@ -287,6 +341,8 @@ public class TensorCowCloneTests
         var peer = (Tensor<float>)source.CloneShared();
 
         var view = createView(source);
+        Assert.True(source.IsCowShared);
+        Assert.True(view.IsCowShared);
         view[0] = 123f;
 
         Assert.False(source.IsCowShared);

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCowCloneTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCowCloneTests.cs
@@ -185,4 +185,112 @@ public class TensorCowCloneTests
         eager[0] = 55f;
         Assert.Equal(Original, src.ToArray());
     }
+
+    [Fact]
+    public void CloneShared_SourceWithRetainedView_UsesEagerIndependentCopy()
+    {
+        var source = MakeTensor();
+        var retainedView = source.Reshape(6);
+
+        var clone = (Tensor<float>)source.CloneShared();
+
+        Assert.False(source.IsCowShared);
+        Assert.False(clone.IsCowShared);
+
+        retainedView[0] = 41f;
+        Assert.Equal(41f, source[0]);
+        Assert.Equal(Original[0], clone[0]);
+
+        clone[1] = 73f;
+        Assert.Equal(Original[1], retainedView[1]);
+    }
+
+    [Fact]
+    public void ViewCreatedAfterCloneShared_AliasesRequestedSource_NotCowPeer()
+    {
+        var source = MakeTensor();
+        var clone = (Tensor<float>)source.CloneShared();
+
+        // Creating a retained alias is an alias-exposure barrier. It must
+        // privatize source before the view captures storage.
+        var sourceView = source.Reshape(6);
+
+        Assert.False(source.IsCowShared);
+        sourceView[2] = 52f;
+        Assert.Equal(52f, source[2]);
+        Assert.Equal(Original[2], clone[2]);
+
+        clone[3] = 63f;
+        Assert.Equal(Original[3], sourceView[3]);
+    }
+
+    [Fact]
+    public void ViewCreatedFromClone_AfterCloneShared_AliasesCloneOnly()
+    {
+        var source = MakeTensor();
+        var clone = (Tensor<float>)source.CloneShared();
+
+        var cloneView = clone.Transpose(new[] { 1, 0 });
+        cloneView[0] = 84f;
+
+        Assert.Equal(84f, clone[0]);
+        Assert.Equal(Original[0], source[0]);
+    }
+
+    [Fact]
+    public void ThirdClone_WhileTwoCowPeersExist_IsIndependentEagerCopy()
+    {
+        var source = MakeTensor();
+        var firstClone = (Tensor<float>)source.CloneShared();
+
+        var secondClone = (Tensor<float>)source.CloneShared();
+
+        Assert.False(secondClone.IsCowShared);
+        firstClone[0] = 91f;
+        source[1] = 92f;
+        Assert.Equal(Original, secondClone.ToArray());
+    }
+
+    [Fact]
+    public void SubTensorView_FromCowSource_AliasesOnlyRequestedSource()
+    {
+        AssertViewExposureIsolatesPeer(tensor => tensor.SubTensor(1), sourceFlatIndex: 3);
+    }
+
+    [Fact]
+    public void AxisSliceView_FromCowSource_AliasesOnlyRequestedSource()
+    {
+        AssertViewExposureIsolatesPeer(
+            tensor => tensor.GetSliceAlongDimension(1, 1),
+            sourceFlatIndex: 1);
+    }
+
+    [Fact]
+    public void NarrowView_FromCowSource_AliasesOnlyRequestedSource()
+    {
+        AssertViewExposureIsolatesPeer(
+            tensor => tensor.Slice(axis: 1, start: 1, end: 3),
+            sourceFlatIndex: 1);
+    }
+
+    [Fact]
+    public void ParameterlessTransposeView_FromCowSource_AliasesOnlyRequestedSource()
+    {
+        AssertViewExposureIsolatesPeer(tensor => tensor.Transpose(), sourceFlatIndex: 0);
+    }
+
+    private static void AssertViewExposureIsolatesPeer(
+        Func<Tensor<float>, Tensor<float>> createView,
+        int sourceFlatIndex)
+    {
+        var source = MakeTensor();
+        var peer = (Tensor<float>)source.CloneShared();
+
+        var view = createView(source);
+        view[0] = 123f;
+
+        Assert.False(source.IsCowShared);
+        Assert.Equal(123f, source[sourceFlatIndex]);
+        Assert.Equal(Original[sourceFlatIndex], peer[sourceFlatIndex]);
+    }
 }


### PR DESCRIPTION
## Summary
- prepare copy-on-write training parameters before graph tracing and reject unsafe plain training scopes
- preserve writable-view isolation across COW peers while adding eager and compiled gradients for metadata, slice, and narrow views
- bind FP64 compiled kernels only to verified live backing arrays, materialize deferred CPU gradients before optimization, and preserve exact GELU semantics
- canonicalize tied parameters so each identity is updated once while accepting original registration group maps and rejecting conflicts
- support contiguous offset and non-contiguous parameter views in grouped/ungrouped FP32 and FP64 fused optimizers
- use zero-copy backing+offset binding for contiguous storage and reusable gather/scatter staging for strided/native storage
- keep dense SIMD and multi-tensor fast paths while routing unsupported view layouts through stride-aware compiled forward/backward fallbacks
- make gradient clipping view-aware and distinguish views from unmaterialized streaming weights
- suspend ambient graph recording while executing a compiled training step

## Why
AiDotNet PR ooples/AiDotNet#1789 exposed silent FP64 training corruption and clone divergence in several learnability shards. The defects crossed storage ownership, graph capture, pooled backing arrays, deferred gradients, parameter views, and tied parameters, so fixing only a model or disabling fusion would hide the underlying failures.

## Validation
- Release build: AiDotNet.Tensors.Tests, net471 - passed with 0 errors
- Release build: AiDotNet.Tensors.Tests, net10.0 - passed with 0 errors
- final focused COW/view/optimizer/FP64/GPU-mock/checkpointing regression set - 179 passed, 0 failed
- new parameter-view integration tests - 6 passed, covering offset sentinels, repeated strided staging, COW peers, MatMul fallback, grouped FP32/FP64, Adam multi-tensor fallback, and clipping
- prior CI's four stale COW-scope failures migrated to the safe GraphMode.EnableTraining(parameters) contract
- git diff --check - clean

The full test suite was not repeated locally; CI supplies the broader matrix while local validation stays focused on affected paths.

## Design note
Dense parameters remain zero-allocation and retain SIMD/multi-tensor fusion. Contiguous views carry explicit base offsets without copying. Non-contiguous or non-array CPU views use one persistent logical staging buffer per operand, refreshed and committed each step; GPU offset uploads likewise reuse scratch storage. Read-only, sparse, or unattached non-CPU storage fails fast. Specialized kernels bind only verified zero-offset live arrays, while other layouts remain supported by stride-aware compiled fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training compilation and replay reliability, including safer handling of shared parameters and tied parameters.
  * Fixed gradient propagation through reshape, transpose, slice, narrow, and sub-tensor views.
  * Improved optimizer updates and gradient clipping for offset, non-contiguous, and pooled tensor storage.
  * Corrected CUDA graph replay boundaries and deferred gradient materialization.
  * Improved FP64 and GELU training behavior, including reliable fallback handling for non-contiguous data.

* **Tests**
  * Added comprehensive coverage for copy-on-write isolation, optimizer parameter views, live tensor storage, gradient propagation, and pooled outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->