### PR TITLE
fix(compilation): replay stop-gradient forward values

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6792,6 +6792,10 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        // Preserve the caller's tensor/view for transparent replay. The eager copy below
+        // may need a contiguous snapshot, but closing over that snapshot would freeze a
+        // non-contiguous view at trace time instead of observing later source mutations.
+        var tracedInput = tensor;
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
         // Copy data to a new tensor with no tape connection.
@@ -6800,7 +6804,7 @@ public partial class CpuEngine : ITensorLevelEngine
         tensor.AsSpan().CopyTo(result.AsWritableSpan());
         // Transparent inference tracing has the same forward-dependency contract as
         // GraphMode, while remaining outside the autodiff tape.
-        { var c = tensor; AutoTracer.RecordOp("StopGradient", result, eng => eng.StopGradient(c)); }
+        { var c = tracedInput; AutoTracer.RecordOp("StopGradient", result, eng => eng.StopGradient(c)); }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6766,13 +6766,41 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> StopGradient<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+
+        // Detaching blocks BACKWARD traversal; it does not make the value a
+        // compile-time constant. Keep the input in the lazy forward graph and
+        // deliberately omit a backward function so replay refreshes the value
+        // while gradient propagation terminates at this node.
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                scope.BindEngineIfUnset(this);
+                var captured = tensor;
+                return scope.RecordUnary(
+                    LazyNodeType.Custom,
+                    "StopGradient",
+                    tensor,
+                    tensor._shape,
+                    (eng, output) =>
+                    {
+                        var source = captured.IsContiguous ? captured : captured.Contiguous();
+                        DirectGpuTensorEngine.CopyResultInto(eng, source, output);
+                    },
+                    backwardFn: null);
+            }
+        }
+
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
         // Copy data to a new tensor with no tape connection.
         // Intentionally does NOT call DifferentiableOps.Record — this is the whole point.
         var result = AutoTensorCache.RentOrAllocate<T>(tensor._shape);
         tensor.AsSpan().CopyTo(result.AsWritableSpan());
+        // Transparent inference tracing has the same forward-dependency contract as
+        // GraphMode, while remaining outside the autodiff tape.
+        { var c = tensor; AutoTracer.RecordOp("StopGradient", result, eng => eng.StopGradient(c)); }
         return result;
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -23440,6 +23440,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> StopGradient<T>(Tensor<T> tensor)
     {
+        // The compiled graph must retain StopGradient as a forward dependency.
+        // Bypassing CpuEngine here would eagerly snapshot a lazy input and replay
+        // stale data, so let the base implementation record the no-backward node.
+        if (Compilation.GraphMode.IsActive) return base.StopGradient(tensor);
+
         try
         {
             if (TryGetBackend(out var backend))

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledStopGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledStopGradientTests.cs
@@ -1,0 +1,101 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+[Collection("CompilationGlobalState")]
+public sealed class CompiledStopGradientTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+
+    public CompiledStopGradientTests()
+    {
+        AiDotNetEngine.Current = new CpuEngine();
+    }
+
+    public void Dispose()
+    {
+        AiDotNetEngine.Current = _priorEngine;
+    }
+
+    [Fact]
+    public void InferenceReplay_RefreshesDetachedForwardValue()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 2.0f }, new[] { 1 });
+        var bias = new Tensor<float>(new[] { 10.0f }, new[] { 1 });
+
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var negated = engine.TensorNegate(input);
+            var detached = engine.StopGradient(negated);
+            var output = engine.TensorAdd(detached, bias);
+            plan = scope.CompileInference<float>(output, input);
+        }
+
+        using (plan)
+        {
+            Assert.Equal(8.0f, plan.Execute()[0]);
+
+            input[0] = 4.0f;
+            Assert.Equal(6.0f, plan.Execute()[0]);
+        }
+    }
+
+    [Fact]
+    public void InferenceReplay_RefreshesDetachedNonContiguousView()
+    {
+        var engine = new CpuEngine();
+        var source = new Tensor<float>(new[] { 1.0f, 2.0f, 3.0f, 4.0f }, new[] { 2, 2 });
+        var transposed = source.Transpose(new[] { 1, 0 });
+        Assert.False(transposed.IsContiguous);
+
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var detached = engine.StopGradient(transposed);
+            plan = scope.CompileInference<float>(detached, source);
+        }
+
+        using (plan)
+        {
+            Assert.Equal(new[] { 1.0f, 3.0f, 2.0f, 4.0f }, plan.Execute().ToArray());
+
+            source[1] = 20.0f;
+            Assert.Equal(new[] { 1.0f, 3.0f, 20.0f, 4.0f }, plan.Execute().ToArray());
+        }
+    }
+
+    [Fact]
+    public void TrainingReplay_RefreshesStraightThroughCorrectionWithoutBackpropagatingIt()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 3.0f }, new[] { 1 });
+        var parameter = new Tensor<float>(new[] { 2.0f }, new[] { 1 });
+        var two = new Tensor<float>(new[] { 2.0f }, new[] { 1 });
+        var parameters = new[] { parameter };
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.EnableTraining(parameters))
+        {
+            var primitive = engine.TensorMultiply(parameter, input);
+            var stableForward = engine.TensorMultiply(primitive, two);
+            var correction = engine.StopGradient(engine.TensorSubtract(stableForward, primitive));
+            var loss = engine.ReduceSum(engine.TensorAdd(primitive, correction), null);
+            plan = scope.CompileTraining(parameters, loss);
+        }
+
+        using (plan)
+        {
+            Assert.Equal(12.0f, plan.Step()[0]);
+            Assert.Equal(3.0f, plan.Gradients[0][0]);
+
+            input[0] = 4.0f;
+            Assert.Equal(16.0f, plan.Step()[0]);
+            Assert.Equal(4.0f, plan.Gradients[0][0]);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- records `StopGradient` as a lazy forward graph node during compilation
- replays the current input value instead of snapshotting an unmaterialized buffer at trace time
- keeps the node detached by providing no backward function
- routes the direct-GPU override through the graph-aware base implementation while compiling
- adds inference, non-contiguous-view, and straight-through-estimator training coverage

## Root cause

The eager implementation copied `StopGradient` immediately and correctly omitted autodiff recording. In graph mode, however, its input could still be lazy and unmaterialized. Compiled plans therefore captured whatever happened to be in that buffer: clean memory appeared as zero, while reused allocator memory could produce NaNs. This corrupted compiled losses such as cross-entropy-with-logits' straight-through correction.

## Impact

Compiled inference and training now preserve the live detached forward value while gradients continue only through the intended primitive branch. This fixes allocator-history-dependent NaNs without disabling fused compiled training or weakening copy-on-write parameter isolation.

## Validation

- `CompiledStopGradientTests`: 3/3 on `net10.0`
- `CompiledStopGradientTests`: 3/3 on `net471`
- AiDotNet `ELECTRANERTests.MoreData_ShouldNotDegrade`: passes with normal pooled allocations
- AiDotNet Generated D-F retained run: 3,596 existing passes; the two unrelated timeout failures pass after fixture bounds under a 16 GB/4-CPU Linux profile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `StopGradient` behavior in compiled graph execution.
  * Detached values now refresh correctly when source tensors change.
  * Fixed handling of non-contiguous tensor views during replay.
  * Ensured detached correction paths do not contribute to backpropagated gradients.

* **Tests**
  * Added coverage for inference and training scenarios involving compiled `StopGradient` graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->