### PR TITLE
fix(gpu): correct LSTM forward+backward GPU kernels + POCL cpu-opencl parity gate

### DIFF
--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -52,20 +52,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each entry is a --filter fragment run in its OWN job/runner (fresh POCL). Keep each group
-        # small enough to stay under POCL's per-process kernel-compile ceiling; split further if a
-        # group still exhausts. `name` is only for a readable job label.
+        # Each entry runs in its OWN job/runner (fresh POCL) so no single process compiles too many
+        # kernels. The two big classes are single [Theory]s over the op registry (~550 forward, ~430
+        # tape-gradient); AIDOTNET_PARITY_SHARD=k/N partitions each into sub-shards via ParityShard so
+        # each POCL process stays under its per-process kernel-compile ceiling. `name` is the job label.
         include:
-          - name: lstm
-            filter: "FullyQualifiedName~GpuMissingKernelsParityTests.LstmSequence"
-          - name: missing-kernels
-            filter: "FullyQualifiedName~GpuMissingKernelsParityTests&FullyQualifiedName!~LstmSequence"
-          - name: op-forward
-            filter: "FullyQualifiedName~Engines.OpParity.OpParityTests"
-          - name: tape-gradient
-            filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests"
-          - name: scan-kernels
-            filter: "FullyQualifiedName~ScanGpuParityTests|FullyQualifiedName~Rwkv4WkvGpuParityTests"
+          - { name: lstm,            filter: "FullyQualifiedName~GpuMissingKernelsParityTests.LstmSequence" }
+          - { name: missing-kernels, filter: "FullyQualifiedName~GpuMissingKernelsParityTests&FullyQualifiedName!~LstmSequence" }
+          - { name: scan-kernels,    filter: "FullyQualifiedName~ScanGpuParityTests|FullyQualifiedName~Rwkv4WkvGpuParityTests" }
+          - { name: op-forward-1, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "1/6" }
+          - { name: op-forward-2, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "2/6" }
+          - { name: op-forward-3, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "3/6" }
+          - { name: op-forward-4, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "4/6" }
+          - { name: op-forward-5, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "5/6" }
+          - { name: op-forward-6, filter: "FullyQualifiedName~Engines.OpParity.OpParityTests", shard: "6/6" }
+          - { name: tape-grad-1,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "1/6" }
+          - { name: tape-grad-2,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "2/6" }
+          - { name: tape-grad-3,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "3/6" }
+          - { name: tape-grad-4,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "4/6" }
+          - { name: tape-grad-5,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "5/6" }
+          - { name: tape-grad-6,  filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests", shard: "6/6" }
     name: gpu-parity-pocl (${{ matrix.name }})
     steps:
     - uses: actions/checkout@v4
@@ -92,6 +98,8 @@ jobs:
       env:
         AIDOTNET_OPENCL_ALLOW_CPU: '1'
         AIDOTNET_REQUIRE_GPU_TESTS: '1'
+        # Empty for the non-partitioned shards (unset => full set); "k/N" for the op-registry sub-shards.
+        AIDOTNET_PARITY_SHARD: ${{ matrix.shard }}
         AIDOTNET_OPPARITY_REPORT_DIR: ${{ runner.temp }}/opparity
       run: |
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj \

--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -2,30 +2,28 @@ name: GPU Parity (POCL / CPU-OpenCL)
 
 # Why this lane exists
 # --------------------
-# The CPU-vs-GPU op-parity suites (Engines.OpParity.*, GpuMissingKernelsParityTests,
-# TapeGradientParity, *GpuParityTests) construct a real DirectGpuTensorEngine and compare
-# every op against the trusted CPU oracle. On a GPU-less runner they *skip* — which is why a
-# genuine GPU kernel bug (the LSTM seq-major-vs-batch-major layout defect) shipped in a
-# release: nothing ever executed the kernels in CI.
+# The CPU-vs-GPU op-parity suites construct a real DirectGpuTensorEngine and compare every op
+# against the trusted CPU oracle. On a GPU-less runner they *skip* — which is why a genuine GPU
+# kernel bug (the LSTM seq-major-vs-batch-major layout defect) shipped in a release: nothing ever
+# executed the kernels in CI. POCL (Portable Computing Language) exposes a CPU OpenCL device, so
+# the DirectGpu OpenCL kernels can actually EXECUTE and be parity-checked on a stock ubuntu runner.
+#   * AIDOTNET_OPENCL_ALLOW_CPU=1  — lets the OpenCL backend bind a CPU device as a fallback when no
+#                                    GPU is present (default off; GPU always preferred).
+#   * AIDOTNET_REQUIRE_GPU_TESTS=1 — turns "no GPU device" from a silent Skip into a hard failure.
 #
-# POCL (Portable Computing Language) exposes a CPU OpenCL device, so the DirectGpu OpenCL
-# kernels can actually EXECUTE and be parity-checked on a stock ubuntu runner with no GPU
-# hardware. Two opt-in env flags make the backend use it:
-#   * AIDOTNET_OPENCL_ALLOW_CPU=1  — lets the OpenCL backend bind a CPU device as a fallback
-#                                    when no GPU is present (default off; GPU always preferred,
-#                                    so this changes nothing on real-GPU machines).
-#   * AIDOTNET_REQUIRE_GPU_TESTS=1 — turns "no GPU device" from a silent Skip into a hard
-#                                    failure, so a broken POCL setup fails loudly here instead
-#                                    of quietly skipping the whole gate.
+# SHARDED: a single-process run of the full parity surface exhausts POCL partway through (it
+# JIT-compiles every kernel it touches; after ~150 the OpenCL context is lost and later tests fail
+# "no DirectGpu backend available"). So each parity class group runs as its OWN matrix job — a fresh
+# runner + fresh POCL process per shard, so POCL never accumulates across groups. Only the
+# backend-agnostic OpenCL-routed classes are included; the other GPU backends (Cuda/Hip/Metal/
+# Vulkan/WebGpu) and the GPU-feature-specific OpenCL kernels (FlashDecode/PagedAttention/QuantGemm/
+# RopeGqa) are excluded — POCL can't provide those devices/features, so they'd fail "unavailable".
 #
-# STATUS: informational / experimental, NOT a required check. On GitHub-hosted runners POCL has
-# proven unreliable as a hard gate: (1) a single-process run of the full parity surface exhausts it
-# partway (it JIT-compiles every kernel it touches; after ~150 the OpenCL context is lost), and
-# (2) even a tiny scoped run intermittently fails DirectGpu init outright ("no GPU available"),
-# unreproducibly. So the parity step is `continue-on-error` — it runs and uploads a divergence
-# report for diagnostics, but never blocks. The RELIABLE gate for GPU-vs-CPU parity is real GPU
-# hardware (the LSTM parity passes 234/234 on a local AMD RX 5500 XT); promoting this to required
-# needs either a self-hosted GPU runner or the run sharded across fresh POCL processes.
+# STATUS: informational (continue-on-error), NOT required. POCL has also shown intermittent
+# DirectGpu-init failures on hosted runners that are unreproducible without POCL hardware locally.
+# This runs + uploads a per-shard divergence report but never blocks. Promote a shard to required
+# in branch protection only once it is reliably green here. The fully reliable gate remains real GPU
+# hardware (the LSTM parity passes 234/234 on a local AMD RX 5500 XT).
 
 on:
   push:
@@ -37,9 +35,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: this lane only needs to read the repo to check out + build + test. It never
-# writes to the repo, comments, or touches deployments, so the GITHUB_TOKEN is read-only. This
-# matters most on pull_request runs of fork/untrusted branches.
+# Least privilege: this lane only reads the repo to check out + build + test.
 permissions:
   contents: read
 
@@ -50,12 +46,27 @@ env:
 
 jobs:
   gpu-parity-pocl:
-    # Skip on the release-please Release PR and on the release merge-commit push — the code is
-    # identical to the feature PRs that already ran this gate (mirrors build.yml). A job skipped
-    # via an `if:` conditional reports SUCCESS to branch protection, so a future required check
-    # is still satisfied on the Release PR.
+    # Skip on the release-please Release PR and the release merge-commit push (mirrors build.yml).
     if: "${{ !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release')) && !startsWith(github.head_ref, 'release-please--') }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry is a --filter fragment run in its OWN job/runner (fresh POCL). Keep each group
+        # small enough to stay under POCL's per-process kernel-compile ceiling; split further if a
+        # group still exhausts. `name` is only for a readable job label.
+        include:
+          - name: lstm
+            filter: "FullyQualifiedName~GpuMissingKernelsParityTests.LstmSequence"
+          - name: missing-kernels
+            filter: "FullyQualifiedName~GpuMissingKernelsParityTests&FullyQualifiedName!~LstmSequence"
+          - name: op-forward
+            filter: "FullyQualifiedName~Engines.OpParity.OpParityTests"
+          - name: tape-gradient
+            filter: "FullyQualifiedName~Engines.OpParity.TapeGradientParityTests"
+          - name: scan-kernels
+            filter: "FullyQualifiedName~ScanGpuParityTests|FullyQualifiedName~Rwkv4WkvGpuParityTests"
+    name: gpu-parity-pocl (${{ matrix.name }})
     steps:
     - uses: actions/checkout@v4
 
@@ -68,56 +79,30 @@ jobs:
     - name: Install POCL (CPU OpenCL device) + ICD loader
       run: |
         sudo apt-get update
-        # ocl-icd-opencl-dev provides libOpenCL.so (the ICD loader + unversioned symlink that
-        # [DllImport("OpenCL")] resolves to); pocl-opencl-icd registers a CPU device under
-        # /etc/OpenCL/vendors/pocl.icd; clinfo lets us confirm discovery in the log.
         sudo apt-get install -y ocl-icd-opencl-dev pocl-opencl-icd clinfo
-        echo "=== clinfo: OpenCL platforms/devices visible to the ICD loader ==="
-        clinfo || echo "::warning::clinfo failed — POCL may not be registered; the parity step will fail loudly (AIDOTNET_REQUIRE_GPU_TESTS=1)."
+        echo "=== clinfo: OpenCL platforms/devices ==="
+        clinfo || echo "::warning::clinfo failed — POCL may not be registered."
 
     - name: Build tests (net10.0)
       run: dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --framework net10.0
 
-    - name: Run CPU-vs-GPU parity on the POCL CPU device
-      # Informational only: POCL is unreliable as a hard gate on hosted runners (see the header).
-      # This step runs the parity + uploads a divergence report, but does not block the PR.
+    - name: Run CPU-vs-GPU parity on POCL (shard ${{ matrix.name }})
+      # Informational only: POCL is not yet reliable as a hard gate on hosted runners (see header).
       continue-on-error: true
       env:
         AIDOTNET_OPENCL_ALLOW_CPU: '1'
         AIDOTNET_REQUIRE_GPU_TESTS: '1'
         AIDOTNET_OPPARITY_REPORT_DIR: ${{ runner.temp }}/opparity
       run: |
-        # Scope: the LSTM forward+backward CPU-vs-GPU parity — the exact regression this lane guards
-        # (a GPU LSTM kernel bug that shipped because GPU parity SKIPS on GPU-less CI). These run the
-        # DirectGpuTensorEngine (OpenCL -> POCL here) against the trusted CPU oracle.
-        #
-        # Why not the full parity surface yet: a single-process run of ALL GPU parity classes
-        # exhausts POCL partway through (it JIT-compiles every kernel it touches and the process runs
-        # out of resources after ~150 distinct kernels, after which the OpenCL context goes away and
-        # every later test fails "no DirectGpu backend available" — a POCL process-scale limit, NOT a
-        # parity divergence: the ops that ran matched the CPU oracle). Broadening this gate to the full
-        # surface needs the run sharded across fresh processes so POCL never accumulates past its limit;
-        # tracked as a follow-up. This LSTM-scoped gate compiles only a handful of kernels and stays
-        # well under that limit, so it is reliably green while still catching the class of bug it exists for.
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj \
           --configuration Release --no-build --framework net10.0 \
-          --filter "FullyQualifiedName~GpuMissingKernelsParityTests.LstmSequence" \
+          --filter "(${{ matrix.filter }})&Category!=Benchmark&Category!=Performance" \
           --blame-hang --blame-hang-timeout 600s --blame-crash
 
     - name: Upload parity divergence report
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: opparity-pocl-report
+        name: opparity-pocl-${{ matrix.name }}
         path: ${{ runner.temp }}/opparity/**
-        if-no-files-found: ignore
-
-    - name: Upload hang/crash dumps
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: pocl-blame-dumps
-        path: |
-          **/*.dmp
-          **/Sequence_*.xml
         if-no-files-found: ignore

--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -18,9 +18,14 @@ name: GPU Parity (POCL / CPU-OpenCL)
 #                                    failure, so a broken POCL setup fails loudly here instead
 #                                    of quietly skipping the whole gate.
 #
-# Not yet a required check. Promote it in branch protection only after the first green run
-# confirms POCL compiles + runs the kernel cache in CI; until then it is a live, diagnostic
-# gate whose job status reflects real CPU-vs-GPU divergence.
+# STATUS: informational / experimental, NOT a required check. On GitHub-hosted runners POCL has
+# proven unreliable as a hard gate: (1) a single-process run of the full parity surface exhausts it
+# partway (it JIT-compiles every kernel it touches; after ~150 the OpenCL context is lost), and
+# (2) even a tiny scoped run intermittently fails DirectGpu init outright ("no GPU available"),
+# unreproducibly. So the parity step is `continue-on-error` — it runs and uploads a divergence
+# report for diagnostics, but never blocks. The RELIABLE gate for GPU-vs-CPU parity is real GPU
+# hardware (the LSTM parity passes 234/234 on a local AMD RX 5500 XT); promoting this to required
+# needs either a self-hosted GPU runner or the run sharded across fresh POCL processes.
 
 on:
   push:
@@ -74,6 +79,9 @@ jobs:
       run: dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --framework net10.0
 
     - name: Run CPU-vs-GPU parity on the POCL CPU device
+      # Informational only: POCL is unreliable as a hard gate on hosted runners (see the header).
+      # This step runs the parity + uploads a divergence report, but does not block the PR.
+      continue-on-error: true
       env:
         AIDOTNET_OPENCL_ALLOW_CPU: '1'
         AIDOTNET_REQUIRE_GPU_TESTS: '1'

--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -74,15 +74,10 @@ jobs:
         AIDOTNET_OPPARITY_REPORT_DIR: ${{ runner.temp }}/opparity
       run: |
         # Scope: the suites that actually run a DirectGpuTensorEngine against the CPU oracle.
-        #
-        # EXCLUSION — LstmSequenceBackward: its OpenCL BPTT kernel is a known-incomplete
-        # implementation (C#/kernel arg-order mismatch, missing recurrent weight-gradient
-        # terms, and a non-atomic gradHInit accumulation race). Its rewrite is tracked
-        # separately; the LSTM *forward* parity is fixed and runs here. Remove this
-        # `!~LstmSequenceBackward` clause when the backward rewrite lands so the gate covers it.
+        # LSTM forward AND backward are both fixed and covered here -- no ops are excluded.
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj \
           --configuration Release --no-build --framework net10.0 \
-          --filter "(FullyQualifiedName~Engines.DirectGpu|FullyQualifiedName~Engines.OpParity|FullyQualifiedName~GpuParity|FullyQualifiedName~TapeGradientParity)&FullyQualifiedName!~LstmSequenceBackward&Category!=Benchmark&Category!=Performance" \
+          --filter "(FullyQualifiedName~Engines.DirectGpu|FullyQualifiedName~Engines.OpParity|FullyQualifiedName~GpuParity|FullyQualifiedName~TapeGradientParity)&Category!=Benchmark&Category!=Performance" \
           --blame-hang --blame-hang-timeout 600s --blame-crash
 
     - name: Upload parity divergence report

--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -32,6 +32,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this lane only needs to read the repo to check out + build + test. It never
+# writes to the repo, comments, or touches deployments, so the GITHUB_TOKEN is read-only. This
+# matters most on pull_request runs of fork/untrusted branches.
+permissions:
+  contents: read
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -73,11 +79,21 @@ jobs:
         AIDOTNET_REQUIRE_GPU_TESTS: '1'
         AIDOTNET_OPPARITY_REPORT_DIR: ${{ runner.temp }}/opparity
       run: |
-        # Scope: the suites that actually run a DirectGpuTensorEngine against the CPU oracle.
-        # LSTM forward AND backward are both fixed and covered here -- no ops are excluded.
+        # Scope: the LSTM forward+backward CPU-vs-GPU parity — the exact regression this lane guards
+        # (a GPU LSTM kernel bug that shipped because GPU parity SKIPS on GPU-less CI). These run the
+        # DirectGpuTensorEngine (OpenCL -> POCL here) against the trusted CPU oracle.
+        #
+        # Why not the full parity surface yet: a single-process run of ALL GPU parity classes
+        # exhausts POCL partway through (it JIT-compiles every kernel it touches and the process runs
+        # out of resources after ~150 distinct kernels, after which the OpenCL context goes away and
+        # every later test fails "no DirectGpu backend available" — a POCL process-scale limit, NOT a
+        # parity divergence: the ops that ran matched the CPU oracle). Broadening this gate to the full
+        # surface needs the run sharded across fresh processes so POCL never accumulates past its limit;
+        # tracked as a follow-up. This LSTM-scoped gate compiles only a handful of kernels and stays
+        # well under that limit, so it is reliably green while still catching the class of bug it exists for.
         dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj \
           --configuration Release --no-build --framework net10.0 \
-          --filter "(FullyQualifiedName~Engines.DirectGpu|FullyQualifiedName~Engines.OpParity|FullyQualifiedName~GpuParity|FullyQualifiedName~TapeGradientParity)&Category!=Benchmark&Category!=Performance" \
+          --filter "FullyQualifiedName~GpuMissingKernelsParityTests.LstmSequence" \
           --blame-hang --blame-hang-timeout 600s --blame-crash
 
     - name: Upload parity divergence report

--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -1,0 +1,104 @@
+name: GPU Parity (POCL / CPU-OpenCL)
+
+# Why this lane exists
+# --------------------
+# The CPU-vs-GPU op-parity suites (Engines.OpParity.*, GpuMissingKernelsParityTests,
+# TapeGradientParity, *GpuParityTests) construct a real DirectGpuTensorEngine and compare
+# every op against the trusted CPU oracle. On a GPU-less runner they *skip* — which is why a
+# genuine GPU kernel bug (the LSTM seq-major-vs-batch-major layout defect) shipped in a
+# release: nothing ever executed the kernels in CI.
+#
+# POCL (Portable Computing Language) exposes a CPU OpenCL device, so the DirectGpu OpenCL
+# kernels can actually EXECUTE and be parity-checked on a stock ubuntu runner with no GPU
+# hardware. Two opt-in env flags make the backend use it:
+#   * AIDOTNET_OPENCL_ALLOW_CPU=1  — lets the OpenCL backend bind a CPU device as a fallback
+#                                    when no GPU is present (default off; GPU always preferred,
+#                                    so this changes nothing on real-GPU machines).
+#   * AIDOTNET_REQUIRE_GPU_TESTS=1 — turns "no GPU device" from a silent Skip into a hard
+#                                    failure, so a broken POCL setup fails loudly here instead
+#                                    of quietly skipping the whole gate.
+#
+# Not yet a required check. Promote it in branch protection only after the first green run
+# confirms POCL compiles + runs the kernel cache in CI; until then it is a live, diagnostic
+# gate whose job status reflects real CPU-vs-GPU divergence.
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  gpu-parity-pocl:
+    # Skip on the release-please Release PR and on the release merge-commit push — the code is
+    # identical to the feature PRs that already ran this gate (mirrors build.yml). A job skipped
+    # via an `if:` conditional reports SUCCESS to branch protection, so a future required check
+    # is still satisfied on the Release PR.
+    if: "${{ !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release')) && !startsWith(github.head_ref, 'release-please--') }}"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+        dotnet-quality: 'preview'
+
+    - name: Install POCL (CPU OpenCL device) + ICD loader
+      run: |
+        sudo apt-get update
+        # ocl-icd-opencl-dev provides libOpenCL.so (the ICD loader + unversioned symlink that
+        # [DllImport("OpenCL")] resolves to); pocl-opencl-icd registers a CPU device under
+        # /etc/OpenCL/vendors/pocl.icd; clinfo lets us confirm discovery in the log.
+        sudo apt-get install -y ocl-icd-opencl-dev pocl-opencl-icd clinfo
+        echo "=== clinfo: OpenCL platforms/devices visible to the ICD loader ==="
+        clinfo || echo "::warning::clinfo failed — POCL may not be registered; the parity step will fail loudly (AIDOTNET_REQUIRE_GPU_TESTS=1)."
+
+    - name: Build tests (net10.0)
+      run: dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj --configuration Release --framework net10.0
+
+    - name: Run CPU-vs-GPU parity on the POCL CPU device
+      env:
+        AIDOTNET_OPENCL_ALLOW_CPU: '1'
+        AIDOTNET_REQUIRE_GPU_TESTS: '1'
+        AIDOTNET_OPPARITY_REPORT_DIR: ${{ runner.temp }}/opparity
+      run: |
+        # Scope: the suites that actually run a DirectGpuTensorEngine against the CPU oracle.
+        #
+        # EXCLUSION — LstmSequenceBackward: its OpenCL BPTT kernel is a known-incomplete
+        # implementation (C#/kernel arg-order mismatch, missing recurrent weight-gradient
+        # terms, and a non-atomic gradHInit accumulation race). Its rewrite is tracked
+        # separately; the LSTM *forward* parity is fixed and runs here. Remove this
+        # `!~LstmSequenceBackward` clause when the backward rewrite lands so the gate covers it.
+        dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj \
+          --configuration Release --no-build --framework net10.0 \
+          --filter "(FullyQualifiedName~Engines.DirectGpu|FullyQualifiedName~Engines.OpParity|FullyQualifiedName~GpuParity|FullyQualifiedName~TapeGradientParity)&FullyQualifiedName!~LstmSequenceBackward&Category!=Benchmark&Category!=Performance" \
+          --blame-hang --blame-hang-timeout 600s --blame-crash
+
+    - name: Upload parity divergence report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: opparity-pocl-report
+        path: ${{ runner.temp }}/opparity/**
+        if-no-files-found: ignore
+
+    - name: Upload hang/crash dumps
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: pocl-blame-dumps
+        path: |
+          **/*.dmp
+          **/Sequence_*.xml
+        if-no-files-found: ignore

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalResidentKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalResidentKernels.cs
@@ -1329,7 +1329,7 @@ kernel void lstm_forward_sequence(
     uint gid [[thread_position_in_grid]])
 {
     if (gid >= batch) return; uint stateSize = batch * hiddenSize;
-    for (uint t = 0; t < sequence; ++t) { uint inputOffset = t * batch * inputSize + gid * inputSize, previousOffset = t * stateSize + gid * hiddenSize, currentOffset = (t + 1u) * stateSize + gid * hiddenSize, outputOffset = t * stateSize + gid * hiddenSize, gateOffset = (t * batch + gid) * hiddenSize * 4u;
+    for (uint t = 0; t < sequence; ++t) { uint inputOffset = (gid * sequence + t) * inputSize, previousOffset = t * stateSize + gid * hiddenSize, currentOffset = (t + 1u) * stateSize + gid * hiddenSize, outputOffset = (gid * sequence + t) * hiddenSize, gateOffset = (t * batch + gid) * hiddenSize * 4u;
         for (uint h = 0; h < hiddenSize; ++h) { float activated[4];
             for (uint gate = 0; gate < 4u; ++gate) { uint gateRow = gate * hiddenSize + h; float sum = biasIh[gateRow] + biasHh[gateRow]; for (uint i = 0; i < inputSize; ++i) sum += weightsIh[gateRow * inputSize + i] * input[inputOffset + i]; for (uint hp = 0; hp < hiddenSize; ++hp) sum += weightsHh[gateRow * hiddenSize + hp] * allH[previousOffset + hp]; activated[gate] = gate == 2u ? tanh(sum) : resident_stable_sigmoid(sum); }
             for (uint gate = 0; gate < 4u; ++gate) gates[gateOffset + h * 4u + gate] = activated[gate];
@@ -1352,12 +1352,12 @@ kernel void lstm_backward_sequence_serial(
     for (uint i = 0; i < sequence * batch * inputSize; ++i) gradInput[i] = 0.0f;
     for (uint i = 0; i < stateSize; ++i) { gradHInit[i] = 0.0f; gradCInit[i] = 0.0f; nextH[i] = 0.0f; nextC[i] = 0.0f; }
     for (uint i = 0; i < gateRows * inputSize; ++i) gradWeightsIh[i] = 0.0f; for (uint i = 0; i < gateRows * hiddenSize; ++i) gradWeightsHh[i] = 0.0f; for (uint i = 0; i < gateRows; ++i) gradBias[i] = 0.0f;
-    for (int time = int(sequence) - 1; time >= 0; --time) { uint t = uint(time), inputOffsetBase = t * batch * inputSize, previousBase = t * stateSize, currentBase = (t + 1u) * stateSize, outputBase = t * stateSize, gateBase = t * batch * hiddenSize * 4u;
+    for (int time = int(sequence) - 1; time >= 0; --time) { uint t = uint(time), previousBase = t * stateSize, currentBase = (t + 1u) * stateSize, gateBase = t * batch * hiddenSize * 4u;
         for (uint b = 0; b < batch; ++b) for (uint h = 0; h < hiddenSize; ++h) { uint cache = gateBase + b * hiddenSize * 4u + h * 4u, state = b * hiddenSize + h; float inputGate = gates[cache], forgetGate = gates[cache + 1u], candidate = gates[cache + 2u], outputGate = gates[cache + 3u], previousCell = allC[previousBase + state], currentCell = allC[currentBase + state];
-            float dHidden = gradOutput[outputBase + state] + nextH[state], tanhCell = tanh(currentCell), dOutput = dHidden * tanhCell, dCell = dHidden * outputGate * (1.0f - tanhCell * tanhCell) + nextC[state];
+            float dHidden = gradOutput[(b * sequence + t) * hiddenSize + h] + nextH[state], tanhCell = tanh(currentCell), dOutput = dHidden * tanhCell, dCell = dHidden * outputGate * (1.0f - tanhCell * tanhCell) + nextC[state];
             float raw[4] = { dCell * candidate * inputGate * (1.0f - inputGate), dCell * previousCell * forgetGate * (1.0f - forgetGate), dCell * inputGate * (1.0f - candidate * candidate), dOutput * outputGate * (1.0f - outputGate) };
-            for (uint gate = 0; gate < 4u; ++gate) { uint row = gate * hiddenSize + h; gradBias[row] += raw[gate]; for (uint i = 0; i < inputSize; ++i) gradWeightsIh[row * inputSize + i] += raw[gate] * input[inputOffsetBase + b * inputSize + i]; for (uint hp = 0; hp < hiddenSize; ++hp) gradWeightsHh[row * hiddenSize + hp] += raw[gate] * allH[previousBase + b * hiddenSize + hp]; }
-            for (uint i = 0; i < inputSize; ++i) { float sum = 0.0f; for (uint gate = 0; gate < 4u; ++gate) sum += raw[gate] * weightsIh[(gate * hiddenSize + h) * inputSize + i]; gradInput[inputOffsetBase + b * inputSize + i] += sum; }
+            for (uint gate = 0; gate < 4u; ++gate) { uint row = gate * hiddenSize + h; gradBias[row] += raw[gate]; for (uint i = 0; i < inputSize; ++i) gradWeightsIh[row * inputSize + i] += raw[gate] * input[(b * sequence + t) * inputSize + i]; for (uint hp = 0; hp < hiddenSize; ++hp) gradWeightsHh[row * hiddenSize + hp] += raw[gate] * allH[previousBase + b * hiddenSize + hp]; }
+            for (uint i = 0; i < inputSize; ++i) { float sum = 0.0f; for (uint gate = 0; gate < 4u; ++gate) sum += raw[gate] * weightsIh[(gate * hiddenSize + h) * inputSize + i]; gradInput[(b * sequence + t) * inputSize + i] += sum; }
             for (uint hp = 0; hp < hiddenSize; ++hp) { float sum = 0.0f; for (uint gate = 0; gate < 4u; ++gate) sum += raw[gate] * weightsHh[(gate * hiddenSize + hp) * hiddenSize + h]; if (t > 0u) nextH[b * hiddenSize + hp] = sum; else gradHInit[b * hiddenSize + hp] += sum; }
             float previousCellGradient = dCell * forgetGate; if (t > 0u) nextC[state] = previousCellGradient; else gradCInit[state] = previousCellGradient;
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
@@ -244,15 +244,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             // Find devices of a given type across all platforms and select by global index.
             // GPU is always attempted first; the CPU pass below runs only under the opt-in
-            // flag when no GPU exists, so production selection is unchanged.
-            bool TrySelectDevice(ulong deviceType)
+            // flag when no GPU DEVICE EXISTS AT ALL, so production selection is unchanged.
+            // anyDevicesOfType reports whether the platform exposed >=1 device of the type, which
+            // is distinct from "the requested index was in range" — an out-of-range index against
+            // an existing GPU must NOT silently fall through to a CPU device.
+            bool TrySelectDevice(ulong deviceType, out bool anyDevicesOfType)
             {
+                anyDevicesOfType = false;
                 int currentIndex = 0;
                 foreach (var platform in platforms)
                 {
                     int e = OpenClNativeBindings.GetDeviceIDs(platform, deviceType, 0, null, out uint numDevices);
                     if (e == OpenClNativeBindings.CL_SUCCESS && numDevices > 0)
                     {
+                        anyDevicesOfType = true;
                         var devices = new IntPtr[numDevices];
                         e = OpenClNativeBindings.GetDeviceIDs(platform, deviceType, numDevices, devices, out _);
                         if (e == OpenClNativeBindings.CL_SUCCESS)
@@ -271,12 +276,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 return false;
             }
 
-            if (!TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_GPU)
-                && OpenClNativeBindings.AllowCpuOpenClDevice)
+            bool gpuSelected = TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_GPU, out bool anyGpu);
+            if (!gpuSelected && !anyGpu && OpenClNativeBindings.AllowCpuOpenClDevice)
             {
-                // No GPU present, but AIDOTNET_OPENCL_ALLOW_CPU=1 — bind a CPU OpenCL device
-                // (e.g. POCL) so the DirectGpu kernels EXECUTE for CPU-vs-GPU parity in CI.
-                TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_CPU);
+                // No GPU device exists AT ALL, but AIDOTNET_OPENCL_ALLOW_CPU=1 — bind a CPU OpenCL
+                // device (e.g. POCL) so the DirectGpu kernels EXECUTE for CPU-vs-GPU parity in CI.
+                // Guarded by !anyGpu so an out-of-range index on a real GPU throws below instead of
+                // silently binding a CPU device.
+                TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_CPU, out _);
             }
 
             if (_device == IntPtr.Zero)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
@@ -200,6 +200,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         totalDevices += (int)numDevices;
                     }
                 }
+                // Opt-in CI fallback: count CPU OpenCL devices (POCL) only when no GPU exists
+                // and AIDOTNET_OPENCL_ALLOW_CPU=1, matching the selection fallback in Initialize.
+                if (totalDevices == 0 && OpenClNativeBindings.AllowCpuOpenClDevice)
+                {
+                    foreach (var platform in platforms)
+                    {
+                        err = OpenClNativeBindings.GetDeviceIDs(platform, OpenClNativeBindings.CL_DEVICE_TYPE_CPU, 0, null, out uint numCpu);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                        {
+                            totalDevices += (int)numCpu;
+                        }
+                    }
+                }
                 return totalDevices;
             }
             catch
@@ -229,31 +242,48 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to get OpenCL platforms: {err}");
 
-            // Find GPU devices across all platforms and select by index
-            int currentIndex = 0;
-            foreach (var platform in platforms)
+            // Find devices of a given type across all platforms and select by global index.
+            // GPU is always attempted first; the CPU pass below runs only under the opt-in
+            // flag when no GPU exists, so production selection is unchanged.
+            bool TrySelectDevice(ulong deviceType)
             {
-                err = OpenClNativeBindings.GetDeviceIDs(platform, OpenClNativeBindings.CL_DEVICE_TYPE_GPU, 0, null, out uint numDevices);
-                if (err == OpenClNativeBindings.CL_SUCCESS && numDevices > 0)
+                int currentIndex = 0;
+                foreach (var platform in platforms)
                 {
-                    var devices = new IntPtr[numDevices];
-                    err = OpenClNativeBindings.GetDeviceIDs(platform, OpenClNativeBindings.CL_DEVICE_TYPE_GPU, numDevices, devices, out _);
-                    if (err == OpenClNativeBindings.CL_SUCCESS)
+                    int e = OpenClNativeBindings.GetDeviceIDs(platform, deviceType, 0, null, out uint numDevices);
+                    if (e == OpenClNativeBindings.CL_SUCCESS && numDevices > 0)
                     {
-                        // Check if the requested device index is within this platform's devices
-                        if (deviceIndex >= currentIndex && deviceIndex < currentIndex + (int)numDevices)
+                        var devices = new IntPtr[numDevices];
+                        e = OpenClNativeBindings.GetDeviceIDs(platform, deviceType, numDevices, devices, out _);
+                        if (e == OpenClNativeBindings.CL_SUCCESS)
                         {
-                            _platform = platform;
-                            _device = devices[deviceIndex - currentIndex];
-                            break;
+                            // Check if the requested device index is within this platform's devices
+                            if (deviceIndex >= currentIndex && deviceIndex < currentIndex + (int)numDevices)
+                            {
+                                _platform = platform;
+                                _device = devices[deviceIndex - currentIndex];
+                                return true;
+                            }
+                            currentIndex += (int)numDevices;
                         }
-                        currentIndex += (int)numDevices;
                     }
                 }
+                return false;
+            }
+
+            if (!TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_GPU)
+                && OpenClNativeBindings.AllowCpuOpenClDevice)
+            {
+                // No GPU present, but AIDOTNET_OPENCL_ALLOW_CPU=1 — bind a CPU OpenCL device
+                // (e.g. POCL) so the DirectGpu kernels EXECUTE for CPU-vs-GPU parity in CI.
+                TrySelectDevice(OpenClNativeBindings.CL_DEVICE_TYPE_CPU);
             }
 
             if (_device == IntPtr.Zero)
-                throw new InvalidOperationException("No GPU devices found");
+                throw new InvalidOperationException(
+                    OpenClNativeBindings.AllowCpuOpenClDevice
+                        ? "No OpenCL GPU or CPU devices found"
+                        : "No GPU devices found");
 
             // Get device info
             DeviceName = OpenClNativeBindings.GetDeviceInfoString(_device, OpenClNativeBindings.CL_DEVICE_NAME);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
@@ -394,7 +394,6 @@ __kernel void lstm_backward_dgates(
     __global const float* cacheGates,  // [seqLen, batch, hidden, 4]   (slots: i,f,g,o)
     __global const float* weightsIh,   // [4*hidden, inputSize]
     __global const float* weightsHh,   // [4*hidden, hidden]
-    __global const float* input,       // [batch, seqLen, inputSize] (batch-major) -- unused here
     __global float* dGates,            // [seqLen, batch, 4*hidden]  (out: gate-preact grads)
     __global float* gradInput,         // [batch, seqLen, inputSize] (batch-major, out)
     __global float* gradHInit,         // [batch, hidden] (out; also the reverse-time dH carry)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
@@ -166,8 +166,11 @@ __kernel void lstm_forward_sequence(
             float sumG = biasIh[2 * hiddenSize + h] + biasHh[2 * hiddenSize + h];
             float sumO = biasIh[3 * hiddenSize + h] + biasHh[3 * hiddenSize + h];
 
-            // Input contribution at this timestep
-            int inputOffset = t * batch * inputSize + b * inputSize;
+            // Input contribution at this timestep. The engine feeds the input in its native
+            // [batch, seq, in] (batch-major) layout — element (b, t) is at (b*seqLen + t) — so the
+            // offset must be batch-major too. It was seq-major (t*batch + b), which reads the wrong
+            // element whenever batch != seq and grossly corrupted the forward output.
+            int inputOffset = (b * seqLen + t) * inputSize;
             for (int j = 0; j < inputSize; j++) {
                 float inVal = input[inputOffset + j];
                 sumI += inVal * weightsIh[h * inputSize + j];
@@ -197,8 +200,11 @@ __kernel void lstm_forward_sequence(
             // Hidden state update
             float newH = o * tanh(newC);
 
-            // Store output
-            int outIdx = t * batch * hiddenSize + gid;
+            // Store output in the engine's native [batch, seq, hidden] (batch-major) layout —
+            // element (b, t, h) at (b*seqLen + t)*hidden + h — matching how the C# side reads bufOut
+            // as [B, S, Hd] with no permute. The previous seq-major index (t*batch + b) transposed
+            // the sequence whenever batch != seq.
+            int outIdx = (b * seqLen + t) * hiddenSize + h;
             output[outIdx] = newH;
 
             // Store all states for backward pass

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/LstmKernels.cs
@@ -377,331 +377,164 @@ __kernel void lstm_backward_prevh(
 }
 
 // ===========================================================================
-// LSTM BACKWARD SEQUENCE KERNEL
+// LSTM BACKWARD SEQUENCE (correct, race-free BPTT) -- two kernels
 // ===========================================================================
-// Processes backward pass through entire sequence.
-// Iterates in reverse through timesteps for proper BPTT.
+// The forward caches (allH/allC [(S+1),B,H], cacheGates [S,B,H,4] gate order i,f,g,o) are
+// seq-major; gradOutput/input/gradInput are the engine's native batch-major [B,S,*]. The
+// recurrence over t is inherently sequential, so kernel A runs ONE work-item per batch element
+// (each independent -> no barriers, no cross-work-item writes) and emits the gate-preactivation
+// gradients dGates[S,B,4H], grad_input, and the initial-state grads (gradHInit/gradCInit double
+// as the reverse-time carry). Kernel B then sums dGates into the weight/bias gradients with one
+// work-item per output element -- each an independent reduction over (t,b), so no atomics.
 
-__kernel void lstm_backward_sequence(
-    __global const float* gradOutput,  // [seqLen, batch, hidden_size]
-    __global const float* allH,        // [seqLen + 1, batch, hidden_size]
-    __global const float* allC,        // [seqLen + 1, batch, hidden_size]
-    __global const float* cacheGates,  // [seqLen, batch, hidden_size, 4]
-    __global const float* weightsIh,   // [4 * hidden_size, input_size]
-    __global const float* weightsHh,   // [4 * hidden_size, hidden_size]
-    __global float* gradInput,         // [seqLen, batch, input_size]
-    __global float* gradHInit,         // [batch, hidden_size]
-    __global float* gradCInit,         // [batch, hidden_size]
-    __global float* gradWeightsIh,     // [4 * hidden_size, input_size] - accumulated
-    __global float* gradWeightsHh,     // [4 * hidden_size, hidden_size] - accumulated
-    __global float* gradBiasIh,        // [4 * hidden_size] - accumulated
-    __global float* gradBiasHh,        // [4 * hidden_size] - accumulated
-    __global const float* input,       // [seqLen, batch, input_size]
+// Kernel A: per-(batch) reverse-time BPTT. global size = batch.
+__kernel void lstm_backward_dgates(
+    __global const float* gradOutput,  // [batch, seqLen, hidden] (batch-major)
+    __global const float* allC,        // [seqLen + 1, batch, hidden]  (allC[0]=c0, allC[t+1]=c_t)
+    __global const float* cacheGates,  // [seqLen, batch, hidden, 4]   (slots: i,f,g,o)
+    __global const float* weightsIh,   // [4*hidden, inputSize]
+    __global const float* weightsHh,   // [4*hidden, hidden]
+    __global const float* input,       // [batch, seqLen, inputSize] (batch-major) -- unused here
+    __global float* dGates,            // [seqLen, batch, 4*hidden]  (out: gate-preact grads)
+    __global float* gradInput,         // [batch, seqLen, inputSize] (batch-major, out)
+    __global float* gradHInit,         // [batch, hidden] (out; also the reverse-time dH carry)
+    __global float* gradCInit,         // [batch, hidden] (out; also the reverse-time dC carry)
     const int seqLen,
     const int batch,
     const int inputSize,
     const int hiddenSize)
 {
-    int gid = get_global_id(0);
-    int totalElements = batch * hiddenSize;
-    int b = gid / hiddenSize;
-    int h = gid % hiddenSize;
-    int isValid = (gid < totalElements) ? 1 : 0;
+    int b = get_global_id(0);
+    if (b >= batch) return;
 
-    // Initialize gradients
-    float dH = 0.0f;  // Gradient w.r.t. hidden state (accumulated from next timestep)
-    float dC = 0.0f;  // Gradient w.r.t. cell state (accumulated from next timestep)
+    int H = hiddenSize;
+    int G = 4 * H;
 
-    // Initialize gradHInit buffer for use as intermediate storage during BPTT
-    if (isValid) {
-        gradHInit[gid] = 0.0f;
+    // Carries start at zero: h_{S-1}/c_{S-1} receive no gradient from beyond the sequence end.
+    for (int h = 0; h < H; h++) {
+        gradHInit[b * H + h] = 0.0f;
+        gradCInit[b * H + h] = 0.0f;
     }
-    barrier(CLK_GLOBAL_MEM_FENCE);
 
-    // Process timesteps in reverse
     for (int t = seqLen - 1; t >= 0; t--) {
-        if (isValid) {
-            // Read accumulated recurrent gradient from previous iteration (if any)
-            if (t < seqLen - 1) {
-                dH = gradHInit[gid];
-                gradHInit[gid] = 0.0f;  // Clear for next accumulation
-            }
-        }
-        barrier(CLK_GLOBAL_MEM_FENCE);
+        int goBase   = (b * seqLen + t) * H;              // gradOutput[b, t, :]
+        int cCurr    = ((t + 1) * batch + b) * H;         // allC[t+1] = c_t
+        int cPrev    = (t * batch + b) * H;               // allC[t]   = c_{t-1}
+        int gateBase = ((t * batch + b) * H) * 4;         // cacheGates[t, b, :, :]
+        int dgBase   = (t * batch + b) * G;               // dGates[t, b, :]
 
-        if (isValid) {
-            // Add gradient from output at this timestep
-            int outIdx = t * batch * hiddenSize + gid;
-            dH += gradOutput[outIdx];
+        // Phase 1: per hidden unit -> gate-preactivation gradients; update the dC carry.
+        for (int h = 0; h < H; h++) {
+            float dh = gradOutput[goBase + h] + gradHInit[b * H + h];   // upstream + recurrent
+            int gI = gateBase + h * 4;
+            float i = cacheGates[gI + 0];
+            float f = cacheGates[gI + 1];
+            float g = cacheGates[gI + 2];
+            float o = cacheGates[gI + 3];
+            float cT    = allC[cCurr + h];
+            float cPrv  = allC[cPrev + h];
+            float tanhC = tanh(cT);
 
-            // Load cached gate values
-            int gateIdx = (t * batch * hiddenSize + gid) * 4;
-            float i = cacheGates[gateIdx + 0];
-            float f = cacheGates[gateIdx + 1];
-            float g = cacheGates[gateIdx + 2];
-            float o = cacheGates[gateIdx + 3];
+            float dO    = dh * tanhC;
+            float dPreO = dO * o * (1.0f - o);
+            float dc    = gradCInit[b * H + h] + dh * o * (1.0f - tanhC * tanhC);
+            float dI    = dc * g;
+            float dPreI = dI * i * (1.0f - i);
+            float dG    = dc * i;
+            float dPreG = dG * (1.0f - g * g);
+            float dF    = dc * cPrv;
+            float dPreF = dF * f * (1.0f - f);
 
-            // Load cell states
-            int prevStateIdx = t * batch * hiddenSize + gid;
-            int currStateIdx = (t + 1) * batch * hiddenSize + gid;
-            float cPrev = allC[prevStateIdx];
-            float cCurr = allC[currStateIdx];
+            // dc flows to the previous (earlier) timestep; at t==0 this becomes grad w.r.t. c0.
+            gradCInit[b * H + h] = dc * f;
 
-            float tanhC = tanh(cCurr);
-
-            // Gradient through output gate
-            float dO = dH * tanhC * sigmoid_derivative(o);
-
-            // Gradient to cell state (from hidden gradient + next timestep cell gradient)
-            dC += dH * o * tanh_derivative(tanhC);
-
-            // Gradients through gates
-            float dF = dC * cPrev * sigmoid_derivative(f);
-            float dI = dC * g * sigmoid_derivative(i);
-            float dG = dC * i * tanh_derivative(g);
-
-            // Gradient to previous cell state for next iteration
-            float dCPrev = dC * f;
-
-            // Gradient to previous hidden state for BPTT
-            // dH_prev[j] = sum_k (dGate[k] * Wh[k, j]) for all four gates
-            // Each thread k contributes its gate gradients to all hidden units j
-            // Note: Using simpler accumulation pattern - within work group this relies on
-            // sequential execution of contributions. For production, use proper float atomic add.
-            for (int j = 0; j < hiddenSize; j++) {
-                // Contribution from gate derivatives at position h to hidden unit j
-                // Wh layout: [4*hiddenSize, hiddenSize], so Wh[k, j] = Wh[k * hiddenSize + j]
-                float contrib = dI * weightsHh[h * hiddenSize + j];
-                contrib += dF * weightsHh[(hiddenSize + h) * hiddenSize + j];
-                contrib += dG * weightsHh[(2 * hiddenSize + h) * hiddenSize + j];
-                contrib += dO * weightsHh[(3 * hiddenSize + h) * hiddenSize + j];
-                // Simple accumulation - relies on single work group execution
-                // For multi-group, would need atomic operations or reduction kernel
-                gradHInit[b * hiddenSize + j] += contrib;
-            }
-
-            // Update dC for next iteration
-            dC = dCPrev;
+            // Store gate-preact grads; row = gate*H + h, gate order i,f,g,o (matches the weights).
+            dGates[dgBase + 0 * H + h] = dPreI;
+            dGates[dgBase + 1 * H + h] = dPreF;
+            dGates[dgBase + 2 * H + h] = dPreG;
+            dGates[dgBase + 3 * H + h] = dPreO;
         }
 
-        barrier(CLK_GLOBAL_MEM_FENCE);
-    }
+        // Phase 2a: recurrent dh for the previous step: dh_prev[hh] = sum_row dPre[row] * Whh[row, hh].
+        // Overwrites gradHInit (Phase 1 already consumed the old value for every h).
+        for (int hh = 0; hh < H; hh++) {
+            float s = 0.0f;
+            for (int row = 0; row < G; row++) {
+                s += dGates[dgBase + row] * weightsHh[row * H + hh];
+            }
+            gradHInit[b * H + hh] = s;   // at t==0 this becomes grad w.r.t. h0
+        }
 
-    // Store initial state gradients
-    // gradHInit already contains accumulated gradient for h_init
-    if (isValid) {
-        gradCInit[gid] = dC;
+        // Phase 2b: grad_input[b, t, j] = sum_row dPre[row] * Wih[row, j].
+        int giBase = (b * seqLen + t) * inputSize;
+        for (int j = 0; j < inputSize; j++) {
+            float s = 0.0f;
+            for (int row = 0; row < G; row++) {
+                s += dGates[dgBase + row] * weightsIh[row * inputSize + j];
+            }
+            gradInput[giBase + j] = s;
+        }
     }
 }
 
-// ===========================================================================
-// LSTM WEIGHT GRADIENT ACCUMULATION KERNELS
-// ===========================================================================
-
-__kernel void lstm_accumulate_weight_gradients_ih(
-    __global const float* input,        // [seqLen, batch, input_size]
-    __global const float* allH,         // [seqLen + 1, batch, hidden_size]
-    __global const float* allC,         // [seqLen + 1, batch, hidden_size]
-    __global const float* cacheGates,   // [seqLen, batch, hidden_size, 4]
-    __global const float* gradOutput,   // [seqLen, batch, hidden_size]
-    __global float* gradWeightsIh,      // [4 * hidden_size, input_size]
+// Kernel B: weight + bias gradients from the precomputed dGates. One work-item per output
+// element across the concatenated ranges [dWih | dWhh | dBias]; each is an independent sum.
+__kernel void lstm_backward_dweights(
+    __global const float* dGates,      // [seqLen, batch, 4*hidden]
+    __global const float* input,       // [batch, seqLen, inputSize] (batch-major)
+    __global const float* allH,        // [seqLen + 1, batch, hidden]  (allH[t] = h_{t-1})
+    __global float* gradWeightsIh,     // [4*hidden, inputSize]
+    __global float* gradWeightsHh,     // [4*hidden, hidden]
+    __global float* gradBiasIh,        // [4*hidden]
+    __global float* gradBiasHh,        // [4*hidden]
     const int seqLen,
     const int batch,
     const int inputSize,
     const int hiddenSize)
 {
     int gid = get_global_id(0);
-    int totalWeights = 4 * hiddenSize * inputSize;
+    int H = hiddenSize;
+    int G = 4 * H;
+    int nWih = G * inputSize;
+    int nWhh = G * H;
 
-    if (gid >= totalWeights) return;
-
-    int gateIdx = gid / (hiddenSize * inputSize);  // Which gate (0-3)
-    int remainder = gid % (hiddenSize * inputSize);
-    int h = remainder / inputSize;
-    int j = remainder % inputSize;
-
-    float gradSum = 0.0f;
-
-    // Accumulate gradients over all timesteps and batch elements
-    // Note: This requires computing gate gradients inline
-    for (int t = 0; t < seqLen; t++) {
-        for (int b = 0; b < batch; b++) {
-            int batchHiddenIdx = b * hiddenSize + h;
-
-            // Load cached values
-            int cacheIdx = (t * batch * hiddenSize + batchHiddenIdx) * 4;
-            float i = cacheGates[cacheIdx + 0];
-            float f = cacheGates[cacheIdx + 1];
-            float g = cacheGates[cacheIdx + 2];
-            float o = cacheGates[cacheIdx + 3];
-
-            // Cell states
-            int prevStateIdx = t * batch * hiddenSize + batchHiddenIdx;
-            int currStateIdx = (t + 1) * batch * hiddenSize + batchHiddenIdx;
-            float cPrev = allC[prevStateIdx];
-            float cCurr = allC[currStateIdx];
-
-            // Get output gradient (simplified - full impl needs accumulated dH, dC)
-            float dH = gradOutput[t * batch * hiddenSize + batchHiddenIdx];
-            float tanhC = tanh(cCurr);
-
-            // Compute gate gradients
-            float dO = dH * tanhC * sigmoid_derivative(o);
-            float dC = dH * o * tanh_derivative(tanhC);
-            float dF = dC * cPrev * sigmoid_derivative(f);
-            float dI = dC * g * sigmoid_derivative(i);
-            float dG = dC * i * tanh_derivative(g);
-
-            // Get input value
-            float inputVal = input[t * batch * inputSize + b * inputSize + j];
-
-            // Accumulate based on gate index
-            if (gateIdx == 0) {
-                gradSum += dI * inputVal;
-            } else if (gateIdx == 1) {
-                gradSum += dF * inputVal;
-            } else if (gateIdx == 2) {
-                gradSum += dG * inputVal;
-            } else {
-                gradSum += dO * inputVal;
+    if (gid < nWih) {
+        // dWih[row, j] = sum_{t,b} dGates[t,b,row] * input[b,t,j]
+        int row = gid / inputSize;
+        int j   = gid % inputSize;
+        float s = 0.0f;
+        for (int t = 0; t < seqLen; t++) {
+            for (int b = 0; b < batch; b++) {
+                s += dGates[(t * batch + b) * G + row] * input[(b * seqLen + t) * inputSize + j];
             }
         }
-    }
-
-    gradWeightsIh[gid] = gradSum;
-}
-
-__kernel void lstm_accumulate_weight_gradients_hh(
-    __global const float* allH,         // [seqLen + 1, batch, hidden_size]
-    __global const float* allC,         // [seqLen + 1, batch, hidden_size]
-    __global const float* cacheGates,   // [seqLen, batch, hidden_size, 4]
-    __global const float* gradOutput,   // [seqLen, batch, hidden_size]
-    __global float* gradWeightsHh,      // [4 * hidden_size, hidden_size]
-    const int seqLen,
-    const int batch,
-    const int hiddenSize)
-{
-    int gid = get_global_id(0);
-    int totalWeights = 4 * hiddenSize * hiddenSize;
-
-    if (gid >= totalWeights) return;
-
-    int gateIdx = gid / (hiddenSize * hiddenSize);  // Which gate (0-3)
-    int remainder = gid % (hiddenSize * hiddenSize);
-    int h = remainder / hiddenSize;
-    int j = remainder % hiddenSize;
-
-    float gradSum = 0.0f;
-
-    for (int t = 0; t < seqLen; t++) {
-        for (int b = 0; b < batch; b++) {
-            int batchHiddenIdx = b * hiddenSize + h;
-
-            // Load cached values
-            int cacheIdx = (t * batch * hiddenSize + batchHiddenIdx) * 4;
-            float i = cacheGates[cacheIdx + 0];
-            float f = cacheGates[cacheIdx + 1];
-            float g = cacheGates[cacheIdx + 2];
-            float o = cacheGates[cacheIdx + 3];
-
-            // Cell states
-            int prevStateIdx = t * batch * hiddenSize + batchHiddenIdx;
-            int currStateIdx = (t + 1) * batch * hiddenSize + batchHiddenIdx;
-            float cPrev = allC[prevStateIdx];
-            float cCurr = allC[currStateIdx];
-
-            // Get output gradient
-            float dH = gradOutput[t * batch * hiddenSize + batchHiddenIdx];
-            float tanhC = tanh(cCurr);
-
-            // Compute gate gradients
-            float dO = dH * tanhC * sigmoid_derivative(o);
-            float dC = dH * o * tanh_derivative(tanhC);
-            float dF = dC * cPrev * sigmoid_derivative(f);
-            float dI = dC * g * sigmoid_derivative(i);
-            float dG = dC * i * tanh_derivative(g);
-
-            // Get previous hidden value
-            float hPrev = allH[t * batch * hiddenSize + b * hiddenSize + j];
-
-            // Accumulate based on gate index
-            if (gateIdx == 0) {
-                gradSum += dI * hPrev;
-            } else if (gateIdx == 1) {
-                gradSum += dF * hPrev;
-            } else if (gateIdx == 2) {
-                gradSum += dG * hPrev;
-            } else {
-                gradSum += dO * hPrev;
+        gradWeightsIh[row * inputSize + j] = s;
+    } else if (gid < nWih + nWhh) {
+        // dWhh[row, hh] = sum_{t,b} dGates[t,b,row] * h_{t-1}[b,hh]   (h_{t-1} = allH[t])
+        int k   = gid - nWih;
+        int row = k / H;
+        int hh  = k % H;
+        float s = 0.0f;
+        for (int t = 0; t < seqLen; t++) {
+            for (int b = 0; b < batch; b++) {
+                s += dGates[(t * batch + b) * G + row] * allH[(t * batch + b) * H + hh];
             }
         }
-    }
-
-    gradWeightsHh[gid] = gradSum;
-}
-
-__kernel void lstm_accumulate_bias_gradients(
-    __global const float* allC,         // [seqLen + 1, batch, hidden_size]
-    __global const float* cacheGates,   // [seqLen, batch, hidden_size, 4]
-    __global const float* gradOutput,   // [seqLen, batch, hidden_size]
-    __global float* gradBias,           // [4 * hidden_size]
-    const int seqLen,
-    const int batch,
-    const int hiddenSize)
-{
-    int gid = get_global_id(0);
-    int totalBiases = 4 * hiddenSize;
-
-    if (gid >= totalBiases) return;
-
-    int gateIdx = gid / hiddenSize;  // Which gate (0-3)
-    int h = gid % hiddenSize;
-
-    float gradSum = 0.0f;
-
-    for (int t = 0; t < seqLen; t++) {
-        for (int b = 0; b < batch; b++) {
-            int batchHiddenIdx = b * hiddenSize + h;
-
-            // Load cached values
-            int cacheIdx = (t * batch * hiddenSize + batchHiddenIdx) * 4;
-            float i = cacheGates[cacheIdx + 0];
-            float f = cacheGates[cacheIdx + 1];
-            float g = cacheGates[cacheIdx + 2];
-            float o = cacheGates[cacheIdx + 3];
-
-            // Cell states
-            int prevStateIdx = t * batch * hiddenSize + batchHiddenIdx;
-            int currStateIdx = (t + 1) * batch * hiddenSize + batchHiddenIdx;
-            float cPrev = allC[prevStateIdx];
-            float cCurr = allC[currStateIdx];
-
-            // Get output gradient
-            float dH = gradOutput[t * batch * hiddenSize + batchHiddenIdx];
-            float tanhC = tanh(cCurr);
-
-            // Compute gate gradients
-            float dO = dH * tanhC * sigmoid_derivative(o);
-            float dC = dH * o * tanh_derivative(tanhC);
-            float dF = dC * cPrev * sigmoid_derivative(f);
-            float dI = dC * g * sigmoid_derivative(i);
-            float dG = dC * i * tanh_derivative(g);
-
-            // Accumulate based on gate index
-            if (gateIdx == 0) {
-                gradSum += dI;
-            } else if (gateIdx == 1) {
-                gradSum += dF;
-            } else if (gateIdx == 2) {
-                gradSum += dG;
-            } else {
-                gradSum += dO;
+        gradWeightsHh[row * H + hh] = s;
+    } else if (gid < nWih + nWhh + G) {
+        // dBih[row] = dBhh[row] = sum_{t,b} dGates[t,b,row]   (both biases share the gate grad)
+        int row = gid - nWih - nWhh;
+        float s = 0.0f;
+        for (int t = 0; t < seqLen; t++) {
+            for (int b = 0; b < batch; b++) {
+                s += dGates[(t * batch + b) * G + row];
             }
         }
+        gradBiasIh[row] = s;
+        gradBiasHh[row] = s;
     }
-
-    gradBias[gid] = gradSum;
 }
+
 ";
     }
 
@@ -717,10 +550,8 @@ __kernel void lstm_accumulate_bias_gradients(
             "lstm_cell_backward",
             "lstm_backward_input",
             "lstm_backward_prevh",
-            "lstm_backward_sequence",
-            "lstm_accumulate_weight_gradients_ih",
-            "lstm_accumulate_weight_gradients_hh",
-            "lstm_accumulate_bias_gradients"
+            "lstm_backward_dgates",
+            "lstm_backward_dweights"
         };
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -183,7 +183,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // against the CPU runtime, costing 2-3 GB of process RSS for nothing.
             // AIDOTNET_DISABLE_OPENCL=1 forces this branch even on machines with a
             // real GPU. See AiDotNet.Tensors#436 (P2 — OpenCL kernel cache RSS).
-            if (!DirectOpenClContext.IsGpuAvailable)
+            //
+            // Opt-in CI escape: when AIDOTNET_OPENCL_ALLOW_CPU=1, proceed even if this
+            // GPU presence probe reports nothing, so a CPU OpenCL device (POCL) can back
+            // the parity lane. Deferring here is deliberate — DirectOpenClContext.Initialize
+            // below does the authoritative device selection (prefers a GPU, falls back to a
+            // CPU device, and throws if neither exists), so we must not let this earlier,
+            // redundant probe short-circuit the fallback. Default (flag unset) is unchanged:
+            // no GPU -> bail here without touching the kernel cache.
+            if (!DirectOpenClContext.IsGpuAvailable && !OpenClNativeBindings.AllowCpuOpenClDevice)
             {
                 IsAvailable = false;
                 DeviceName = "None";

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -13264,27 +13264,30 @@ KERNEL VARIANTS (A/B testing):
             using var dGates = AllocateBuffer(seqLen * batch * gateCount);
 
             // --- Kernel A: sequential BPTT recurrence, global size = batch ---
+            // (input is not read by kernel A — grad_input is Wih^T . dGates, no x needed.)
             kGates.SetArg(0u, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
             kGates.SetArg(1u, ((DirectOpenClGpuBuffer)allC).Buffer.Handle);
             kGates.SetArg(2u, ((DirectOpenClGpuBuffer)cacheGates).Buffer.Handle);
             kGates.SetArg(3u, ((DirectOpenClGpuBuffer)weightsIh).Buffer.Handle);
             kGates.SetArg(4u, ((DirectOpenClGpuBuffer)weightsHh).Buffer.Handle);
-            kGates.SetArg(5u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            kGates.SetArg(6u, ((DirectOpenClGpuBuffer)dGates).Buffer.Handle);
-            kGates.SetArg(7u, ((DirectOpenClGpuBuffer)gradInput).Buffer.Handle);
-            kGates.SetArg(8u, ((DirectOpenClGpuBuffer)gradHInit).Buffer.Handle);
-            kGates.SetArg(9u, ((DirectOpenClGpuBuffer)gradCInit).Buffer.Handle);
-            kGates.SetArg(10u, seqLen);
-            kGates.SetArg(11u, batch);
-            kGates.SetArg(12u, inputSize);
-            kGates.SetArg(13u, hiddenSize);
+            kGates.SetArg(5u, ((DirectOpenClGpuBuffer)dGates).Buffer.Handle);
+            kGates.SetArg(6u, ((DirectOpenClGpuBuffer)gradInput).Buffer.Handle);
+            kGates.SetArg(7u, ((DirectOpenClGpuBuffer)gradHInit).Buffer.Handle);
+            kGates.SetArg(8u, ((DirectOpenClGpuBuffer)gradCInit).Buffer.Handle);
+            kGates.SetArg(9u, seqLen);
+            kGates.SetArg(10u, batch);
+            kGates.SetArg(11u, inputSize);
+            kGates.SetArg(12u, hiddenSize);
 
             int localA = CalculateOptimalWorkGroupSize1D(batch);
             int globalA = ((batch + localA - 1) / localA) * localA;
             kGates.Execute1D(globalA, localA);
 
             // --- Kernel B: weight/bias grads, global size = |dWih| + |dWhh| + |dBias| ---
-            // The in-order command queue guarantees kernel A completes before kernel B reads dGates.
+            // Both Execute1D calls enqueue on this backend's command queue, which is created
+            // in-order (CreateCommandQueue with CL_QUEUE_PROFILING_ENABLE only, never
+            // CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE), so kernel A is guaranteed to complete and its
+            // dGates writes are visible before kernel B begins reading them — no explicit barrier needed.
             kWeights.SetArg(0u, ((DirectOpenClGpuBuffer)dGates).Buffer.Handle);
             kWeights.SetArg(1u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
             kWeights.SetArg(2u, ((DirectOpenClGpuBuffer)allH).Buffer.Handle);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -13245,35 +13245,62 @@ KERNEL VARIANTS (A/B testing):
             if (hiddenSize <= 0)
                 throw new ArgumentException($"hiddenSize must be positive, got {hiddenSize}", nameof(hiddenSize));
 
-            if (!_kernelCache.TryGetValue("lstm_backward_sequence", out var kernel))
-                throw new InvalidOperationException("OpenCL kernel not found: lstm_backward_sequence");
+            // Correct race-free BPTT in two passes (see LstmKernels: lstm_backward_dgates /
+            // lstm_backward_dweights). Kernel A does the inherently-sequential reverse-time recurrence
+            // with ONE work-item per batch element (each independent -> no barriers/atomics) and emits
+            // the gate-preactivation grads dGates[S,B,4H], grad_input, and the initial-state grads
+            // (gradHInit/gradCInit double as the reverse-time carry). Kernel B sums dGates into the
+            // weight/bias grads with one work-item per output element. hInit/cInit are unused here -- the
+            // initial states are already in allH[0]/allC[0].
+            if (!_kernelCache.TryGetValue("lstm_backward_dgates", out var kGates))
+                throw new InvalidOperationException("OpenCL kernel not found: lstm_backward_dgates");
+            if (!_kernelCache.TryGetValue("lstm_backward_dweights", out var kWeights))
+                throw new InvalidOperationException("OpenCL kernel not found: lstm_backward_dweights");
 
-            int totalThreads = batch * hiddenSize;
-            int localSize = CalculateOptimalWorkGroupSize1D(totalThreads);
+            int gateCount = 4 * hiddenSize;
 
-            kernel.SetArg(0u, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
-            kernel.SetArg(1u, ((DirectOpenClGpuBuffer)allH).Buffer.Handle);
-            kernel.SetArg(2u, ((DirectOpenClGpuBuffer)allC).Buffer.Handle);
-            kernel.SetArg(3u, ((DirectOpenClGpuBuffer)cacheGates).Buffer.Handle);
-            kernel.SetArg(4u, ((DirectOpenClGpuBuffer)hInit).Buffer.Handle);
-            kernel.SetArg(5u, ((DirectOpenClGpuBuffer)cInit).Buffer.Handle);
-            kernel.SetArg(6u, ((DirectOpenClGpuBuffer)weightsIh).Buffer.Handle);
-            kernel.SetArg(7u, ((DirectOpenClGpuBuffer)weightsHh).Buffer.Handle);
-            kernel.SetArg(8u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            kernel.SetArg(9u, ((DirectOpenClGpuBuffer)gradInput).Buffer.Handle);
-            kernel.SetArg(10u, ((DirectOpenClGpuBuffer)gradHInit).Buffer.Handle);
-            kernel.SetArg(11u, ((DirectOpenClGpuBuffer)gradCInit).Buffer.Handle);
-            kernel.SetArg(12u, ((DirectOpenClGpuBuffer)gradWeightsIh).Buffer.Handle);
-            kernel.SetArg(13u, ((DirectOpenClGpuBuffer)gradWeightsHh).Buffer.Handle);
-            kernel.SetArg(14u, ((DirectOpenClGpuBuffer)gradBiasIh).Buffer.Handle);
-            kernel.SetArg(15u, ((DirectOpenClGpuBuffer)gradBiasHh).Buffer.Handle);
-            kernel.SetArg(16u, seqLen);
-            kernel.SetArg(17u, batch);
-            kernel.SetArg(18u, inputSize);
-            kernel.SetArg(19u, hiddenSize);
+            // Per-timestep gate-preactivation gradients [seqLen, batch, 4*hidden]. Written in full by
+            // kernel A (no zeroing needed) and consumed by kernel B. Pooled scratch; released on scope exit.
+            using var dGates = AllocateBuffer(seqLen * batch * gateCount);
 
-            int globalSize = ((totalThreads + localSize - 1) / localSize) * localSize;
-            kernel.Execute1D(globalSize, localSize);
+            // --- Kernel A: sequential BPTT recurrence, global size = batch ---
+            kGates.SetArg(0u, ((DirectOpenClGpuBuffer)gradOutput).Buffer.Handle);
+            kGates.SetArg(1u, ((DirectOpenClGpuBuffer)allC).Buffer.Handle);
+            kGates.SetArg(2u, ((DirectOpenClGpuBuffer)cacheGates).Buffer.Handle);
+            kGates.SetArg(3u, ((DirectOpenClGpuBuffer)weightsIh).Buffer.Handle);
+            kGates.SetArg(4u, ((DirectOpenClGpuBuffer)weightsHh).Buffer.Handle);
+            kGates.SetArg(5u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+            kGates.SetArg(6u, ((DirectOpenClGpuBuffer)dGates).Buffer.Handle);
+            kGates.SetArg(7u, ((DirectOpenClGpuBuffer)gradInput).Buffer.Handle);
+            kGates.SetArg(8u, ((DirectOpenClGpuBuffer)gradHInit).Buffer.Handle);
+            kGates.SetArg(9u, ((DirectOpenClGpuBuffer)gradCInit).Buffer.Handle);
+            kGates.SetArg(10u, seqLen);
+            kGates.SetArg(11u, batch);
+            kGates.SetArg(12u, inputSize);
+            kGates.SetArg(13u, hiddenSize);
+
+            int localA = CalculateOptimalWorkGroupSize1D(batch);
+            int globalA = ((batch + localA - 1) / localA) * localA;
+            kGates.Execute1D(globalA, localA);
+
+            // --- Kernel B: weight/bias grads, global size = |dWih| + |dWhh| + |dBias| ---
+            // The in-order command queue guarantees kernel A completes before kernel B reads dGates.
+            kWeights.SetArg(0u, ((DirectOpenClGpuBuffer)dGates).Buffer.Handle);
+            kWeights.SetArg(1u, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
+            kWeights.SetArg(2u, ((DirectOpenClGpuBuffer)allH).Buffer.Handle);
+            kWeights.SetArg(3u, ((DirectOpenClGpuBuffer)gradWeightsIh).Buffer.Handle);
+            kWeights.SetArg(4u, ((DirectOpenClGpuBuffer)gradWeightsHh).Buffer.Handle);
+            kWeights.SetArg(5u, ((DirectOpenClGpuBuffer)gradBiasIh).Buffer.Handle);
+            kWeights.SetArg(6u, ((DirectOpenClGpuBuffer)gradBiasHh).Buffer.Handle);
+            kWeights.SetArg(7u, seqLen);
+            kWeights.SetArg(8u, batch);
+            kWeights.SetArg(9u, inputSize);
+            kWeights.SetArg(10u, hiddenSize);
+
+            int weightThreads = gateCount * inputSize + gateCount * hiddenSize + gateCount;
+            int localB = CalculateOptimalWorkGroupSize1D(weightThreads);
+            int globalB = ((weightThreads + localB - 1) / localB) * localB;
+            kWeights.Execute1D(globalB, localB);
         }
 
         public void GruForwardSequence(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
@@ -655,10 +655,27 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         /// <summary>
+        /// Whether a CPU OpenCL device (e.g. POCL, the Intel/AMD CPU runtimes) may stand in
+        /// for a GPU when no GPU device is present. Controlled by
+        /// <c>AIDOTNET_OPENCL_ALLOW_CPU=1</c>; default <see langword="false"/>, so production
+        /// never binds the OpenCL backend to a CPU runtime (which would compile the whole
+        /// kernel cache against the CPU for no benefit). Enabled only in GPU-less CI so the
+        /// DirectGpu kernels actually EXECUTE on a CPU OpenCL device and CPU-vs-GPU parity can
+        /// gate releases — see the <c>gpu-parity-pocl</c> lane in <c>build.yml</c>. GPU is
+        /// still preferred everywhere; a CPU device is used only as a fallback when the GPU
+        /// scan finds nothing, so real-GPU machines are unaffected whether or not the flag is set.
+        /// </summary>
+        internal static bool AllowCpuOpenClDevice =>
+            string.Equals(Environment.GetEnvironmentVariable("AIDOTNET_OPENCL_ALLOW_CPU"), "1", StringComparison.Ordinal);
+
+        /// <summary>
         /// Checks if a real GPU device is exposed by any OpenCL platform on this system.
         /// Returns false on CPU-only machines that happen to have an OpenCL ICD installed
         /// (Intel CPU runtime, AMD APP CPU runtime, POCL), preventing the OpenCL backend
-        /// from compiling its ~591-kernel cache on hardware that has no use for it.
+        /// from compiling its ~591-kernel cache on hardware that has no use for it — UNLESS
+        /// <c>AIDOTNET_OPENCL_ALLOW_CPU=1</c> is set (see <see cref="AllowCpuOpenClDevice"/>),
+        /// in which case a CPU OpenCL device is accepted as a fallback so GPU kernels can be
+        /// parity-checked on a CPU OpenCL runtime in CI.
         /// Honors <c>AIDOTNET_DISABLE_OPENCL=1</c> as a manual opt-out for users who want
         /// to force the CPU path even on machines with a GPU.
         /// </summary>
@@ -691,6 +708,21 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         {
                             Trace.WriteLine($"[OpenCL Diagnostics] Found {numDevices} GPU device(s) on platform {p}.");
                             return true;
+                        }
+                    }
+                    // Opt-in CI/software fallback: no GPU was found, but AIDOTNET_OPENCL_ALLOW_CPU=1
+                    // lets a CPU OpenCL device (POCL) stand in so the GPU kernels can execute and be
+                    // parity-checked on GPU-less CI. Never reached in production (flag unset).
+                    if (AllowCpuOpenClDevice)
+                    {
+                        for (uint p = 0; p < numPlatforms; p++)
+                        {
+                            int cpuErr = GetDeviceIDs(platforms[p], CL_DEVICE_TYPE_CPU, 0, null, out uint numCpu);
+                            if (cpuErr == CL_SUCCESS && numCpu > 0)
+                            {
+                                Trace.WriteLine($"[OpenCL Diagnostics] AIDOTNET_OPENCL_ALLOW_CPU=1 — accepting {numCpu} CPU OpenCL device(s) on platform {p} (no GPU present).");
+                                return true;
+                            }
                         }
                     }
                     Trace.WriteLine("[OpenCL Diagnostics] No GPU devices found across any OpenCL platform.");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanResidentKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanResidentKernels.cs
@@ -208,9 +208,9 @@ layout(set=0,binding=8) writeonly buffer CacheGates { float cacheGates[]; };
 layout(push_constant) uniform Params { uint seqLen; uint batch; uint inputSize; uint hiddenSize; };
 float sigmoid(float x){return 1.0/(1.0+exp(-x));}
 void main(){uint b=gl_GlobalInvocationID.x;if(b>=batch)return;uint gateSize=4u*hiddenSize,cellSize=batch*hiddenSize;
-    for(uint t=0u;t<seqLen;++t){uint hOffset=t*cellSize,nextOffset=(t+1u)*cellSize,gateOffset=(t*batch+b)*gateSize,inputOffset=(t*batch+b)*inputSize;
+    for(uint t=0u;t<seqLen;++t){uint hOffset=t*cellSize,nextOffset=(t+1u)*cellSize,gateOffset=(t*batch+b)*gateSize,inputOffset=(b*seqLen+t)*inputSize;
         for(uint g=0u;g<gateSize;++g){float sum=biasIh[g]+biasHh[g];for(uint k=0u;k<inputSize;++k)sum+=inputData[inputOffset+k]*weightsIh[g*inputSize+k];for(uint k=0u;k<hiddenSize;++k)sum+=allH[hOffset+b*hiddenSize+k]*weightsHh[g*hiddenSize+k];cacheGates[gateOffset+g]=sum;}
-        for(uint i=0u;i<hiddenSize;++i){float ig=sigmoid(cacheGates[gateOffset+i]),fg=sigmoid(cacheGates[gateOffset+hiddenSize+i]),gg=tanh(cacheGates[gateOffset+2u*hiddenSize+i]),og=sigmoid(cacheGates[gateOffset+3u*hiddenSize+i]);uint state=b*hiddenSize+i;float ct=fg*allC[hOffset+state]+ig*gg,ht=og*tanh(ct);allC[nextOffset+state]=ct;allH[nextOffset+state]=ht;outputData[t*cellSize+state]=ht;}
+        for(uint i=0u;i<hiddenSize;++i){float ig=sigmoid(cacheGates[gateOffset+i]),fg=sigmoid(cacheGates[gateOffset+hiddenSize+i]),gg=tanh(cacheGates[gateOffset+2u*hiddenSize+i]),og=sigmoid(cacheGates[gateOffset+3u*hiddenSize+i]);uint state=b*hiddenSize+i;float ct=fg*allC[hOffset+state]+ig*gg,ht=og*tanh(ct);allC[nextOffset+state]=ct;allH[nextOffset+state]=ht;outputData[(b*seqLen+t)*hiddenSize+i]=ht;}
     }
 }";
 
@@ -234,8 +234,8 @@ float sigmoid(float x){return 1.0/(1.0+exp(-x));}
 void main(){if(gl_GlobalInvocationID.x!=0u)return;uint gateSize=4u*hiddenSize,cellSize=batch*hiddenSize;
     for(uint i=0u;i<seqLen*batch*inputSize;++i)gradInput[i]=0.0;for(uint i=0u;i<cellSize;++i){gradHInit[i]=0.0;gradCInit[i]=0.0;nextDh[i]=0.0;}for(uint i=0u;i<gateSize*inputSize;++i)gradWeightsIh[i]=0.0;for(uint i=0u;i<gateSize*hiddenSize;++i)gradWeightsHh[i]=0.0;for(uint i=0u;i<gateSize;++i)gradBias[i]=0.0;
     for(int ti=int(seqLen)-1;ti>=0;--ti){uint t=uint(ti),hOffset=t*cellSize,nextOffset=(t+1u)*cellSize;
-        for(uint b=0u;b<batch;++b){uint stateOffset=b*hiddenSize,gateOffset=(t*batch+b)*gateSize,inputOffset=(t*batch+b)*inputSize;
-            for(uint i=0u;i<hiddenSize;++i)gradHInit[stateOffset+i]+=gradOutput[t*cellSize+stateOffset+i];
+        for(uint b=0u;b<batch;++b){uint stateOffset=b*hiddenSize,gateOffset=(t*batch+b)*gateSize,inputOffset=(b*seqLen+t)*inputSize;
+            for(uint i=0u;i<hiddenSize;++i)gradHInit[stateOffset+i]+=gradOutput[(b*seqLen+t)*hiddenSize+i];
             for(uint i=0u;i<hiddenSize;++i){float ig=sigmoid(cacheGates[gateOffset+i]),fg=sigmoid(cacheGates[gateOffset+hiddenSize+i]),gg=tanh(cacheGates[gateOffset+2u*hiddenSize+i]),og=sigmoid(cacheGates[gateOffset+3u*hiddenSize+i]),ct=allC[nextOffset+stateOffset+i],tanhCt=tanh(ct),localDh=gradHInit[stateOffset+i];gradCInit[stateOffset+i]+=localDh*og*(1.0-tanhCt*tanhCt);float localDc=gradCInit[stateOffset+i],dIg=localDc*gg*ig*(1.0-ig),dFg=localDc*allC[hOffset+stateOffset+i]*fg*(1.0-fg),dGg=localDc*ig*(1.0-gg*gg),dOg=localDh*tanhCt*og*(1.0-og);
                 for(uint gi=0u;gi<4u;++gi){float dg=gi==0u?dIg:(gi==1u?dFg:(gi==2u?dGg:dOg));uint gate=gi*hiddenSize+i;gradBias[gate]+=dg;for(uint k=0u;k<inputSize;++k)gradWeightsIh[gate*inputSize+k]+=dg*inputData[inputOffset+k];for(uint k=0u;k<hiddenSize;++k)gradWeightsHh[gate*hiddenSize+k]+=dg*allH[hOffset+stateOffset+k];}
                 for(uint k=0u;k<inputSize;++k)for(uint gi=0u;gi<4u;++gi){float dg=gi==0u?dIg:(gi==1u?dFg:(gi==2u?dGg:dOg));gradInput[inputOffset+k]+=dg*weightsIh[(gi*hiddenSize+i)*inputSize+k];}gradCInit[stateOffset+i]*=fg;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5232,7 +5232,25 @@ public partial class DirectGpuTensorEngine
         backend.Synchronize();
 
         void Accum(Tensor<float> key, IGpuBuffer gradBuf, int[] shape)
-            => Autodiff.DifferentiableOps.AccumulateGrad(grads, key, new Tensor<float>(backend.DownloadBuffer(gradBuf), shape), engine);
+        {
+            int n = 1;
+            for (int d = 0; d < shape.Length; d++) n *= shape[d];
+            // The buffer pool may hand back a buffer larger than the logical size, and DownloadBuffer
+            // returns the full pool-rounded capacity. Truncate to exactly n so the tensor shape matches
+            // ("number of values does not match the specified shape" otherwise).
+            var full = backend.DownloadBuffer(gradBuf);
+            float[] host;
+            if (full.Length == n)
+            {
+                host = full;
+            }
+            else
+            {
+                host = new float[n];
+                System.Array.Copy(full, host, n);
+            }
+            Autodiff.DifferentiableOps.AccumulateGrad(grads, key, new Tensor<float>(host, shape), engine);
+        }
 
         Accum(input, bufGradInput, new[] { B, S, In });
         Accum(wIh, bufDWih, new[] { G, In });

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5130,7 +5130,7 @@ public partial class DirectGpuTensorEngine
             // override is float-gated above).
             if (typeof(T) == typeof(float) && Autodiff.DifferentiableOps.IsRecording<float>())
             {
-                var gatesHost = backend.DownloadBuffer(bufGates);   // [S, B, 4*Hd]  (slot order f,i,g,o)
+                var gatesHost = backend.DownloadBuffer(bufGates);   // [S, B, Hd, 4]  (slot order i,f,g,o)
                 var allHHost = backend.DownloadBuffer(bufAllH);     // [(S+1), B, Hd] (kernel wrote first S)
                 var allCHost = backend.DownloadBuffer(bufAllC);     // [(S+1), B, Hd]
                 var h0Host = backend.DownloadBuffer(bufH0.Buffer);  // [B, Hd]

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/CrossBackendKernelCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/CrossBackendKernelCoverageTests.cs
@@ -64,8 +64,10 @@ public sealed class CrossBackendKernelCoverageTests
         "conv_transpose2d_backward_weights",                   // -> conv_transpose2d_backward_kernel
         "gru_accumulate_bias_gradients", "gru_accumulate_weight_gradients_hh",
         "gru_accumulate_weight_gradients_ih",                  // -> gru_accumulate_weight_gradients (fused hh/ih/bias)
-        "lstm_accumulate_bias_gradients", "lstm_accumulate_weight_gradients_hh",
-        "lstm_accumulate_weight_gradients_ih",                 // -> lstm_accumulate_weight_gradients
+        "lstm_backward_dgates", "lstm_backward_dweights",      // OpenCL's race-free BPTT split (a per-batch
+                                                               // reverse-time gate pass + a weight-reduction
+                                                               // pass) -> CUDA lstm_cell_backward (+ its
+                                                               // deterministic split) / HIP lstm_backward_sequence
         "sparse_categorical_cross_entropy_gradient",
         "sparse_categorical_cross_entropy_loss",               // -> categorical_cross_entropy_* (int-label form)
         "weighted_cross_entropy_gradient", "weighted_cross_entropy_loss", // -> categorical_cross_entropy (class weights)

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityTests.cs
@@ -21,7 +21,7 @@ public sealed class OpParityTests
         OpParityRegistry.All().ToDictionary(o => o.Name);
 
     public static IEnumerable<object[]> ForwardCases =>
-        OpParityRegistry.All().Select(o => new object[] { o.Name });
+        OpParityRegistry.All().Where(o => ParityShard.Include(o.Name)).Select(o => new object[] { o.Name });
 
     [SkippableTheory]
     [MemberData(nameof(ForwardCases))]

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/ParityShard.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/ParityShard.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace AiDotNet.Tensors.Tests.Engines.OpParity
+{
+    /// <summary>
+    /// Optional test-time partitioning for the data-driven parity theories, so a single
+    /// <c>dotnet test</c> process only exercises a subset of ops. Set
+    /// <c>AIDOTNET_PARITY_SHARD="k/N"</c> (1-based k) to keep only ops whose stable name hash falls
+    /// in bucket k of N. Unset =&gt; the full set — so the normal build job, which never sets it, still
+    /// runs every op. Used by the POCL parity lane to keep each shard under POCL's per-process
+    /// kernel-compile ceiling (a single process that compiles too many distinct kernels loses the
+    /// OpenCL context part-way through).
+    /// </summary>
+    internal static class ParityShard
+    {
+        // Parsed once at type-init from the process environment (the workflow sets it per matrix job).
+        private static readonly (int Index, int Total)? Shard =
+            Parse(Environment.GetEnvironmentVariable("AIDOTNET_PARITY_SHARD"));
+
+        private static (int, int)? Parse(string spec)
+        {
+            if (string.IsNullOrWhiteSpace(spec)) return null;
+            var parts = spec.Split('/');
+            if (parts.Length == 2
+                && int.TryParse(parts[0], out int k) && int.TryParse(parts[1], out int n)
+                && n > 0 && k >= 1 && k <= n)
+            {
+                return (k - 1, n);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// True if <paramref name="opName"/> belongs to the current shard. Always true when
+        /// AIDOTNET_PARITY_SHARD is unset or malformed (full coverage).
+        /// </summary>
+        internal static bool Include(string opName)
+        {
+            if (Shard == null) return true;
+            var s = Shard.Value;
+            return (int)(StableHash(opName) % (uint)s.Total) == s.Index;
+        }
+
+        // FNV-1a 32-bit — deterministic across processes/runs, unlike string.GetHashCode() which is
+        // randomized per-process on modern .NET (that would put an op in a different shard each run).
+        private static uint StableHash(string s)
+        {
+            uint h = 2166136261u;
+            foreach (char c in s)
+            {
+                h ^= c;
+                h *= 16777619u;
+            }
+            return h;
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityTests.cs
@@ -21,7 +21,7 @@ public class TapeGradientParityTests
     public TapeGradientParityTests(OpParityFixture fx) => _fx = fx;
 
     public static IEnumerable<object[]> AllOps() =>
-        OpParityRegistry.All().Select(op => new object[] { op.Name });
+        OpParityRegistry.All().Where(op => ParityShard.Include(op.Name)).Select(op => new object[] { op.Name });
 
     [SkippableTheory]
     [MemberData(nameof(AllOps))]


### PR DESCRIPTION
## Summary

Fixes the GPU LSTM **forward and backward** kernels and closes the CI gap that let the forward bug ship: GPU-vs-CPU parity tests **skip** on GPU-less runners, so no kernel is ever executed in CI. Adds a **POCL (CPU-OpenCL) lane** that runs the DirectGpu kernels against the CPU oracle on a stock ubuntu runner.

Verified locally on an AMD RX 5500 XT: **`GpuMissingKernelsParityTests` 234/234 pass**, including LSTM forward 3/3 and LSTM backward 3/3.

## 1. LSTM forward layout fix (`0e77495d`)

`lstm_forward_sequence` indexed input/output **seq-major** `[seq,batch,*]` while the engine feeds/reads **batch-major** `[batch,seq,*]` (a prior change dropped the C#-side permute but left the kernel seq-major). Corrupted output whenever `batch != seq` (`max_abs_err ~0.3`). Index input/output batch-major; internal caches stay seq-major.

## 2. POCL CPU-OpenCL parity gate (`e23b85b2`)

The parity suites construct a real `DirectGpuTensorEngine` and compare to the CPU oracle, but on a GPU-less runner they `Skip`. POCL provides a CPU OpenCL device so the kernels execute on CPU.

- **Opt-in, default-unchanged backend:** `AIDOTNET_OPENCL_ALLOW_CPU=1` binds a CPU device **only as a fallback when the GPU scan finds nothing**. GPU is still preferred everywhere. Verified: forward parity still 3/3 on the local GPU with the flag unset (production path byte-for-byte unchanged).
- **`gpu-parity-pocl.yml`:** installs `ocl-icd-opencl-dev` + `pocl-opencl-icd`, sets `AIDOTNET_OPENCL_ALLOW_CPU=1` + `AIDOTNET_REQUIRE_GPU_TESTS=1` (missing device → hard fail, not silent skip), runs the GPU parity suites, uploads the divergence report.

## 3. LSTM backward BPTT rewrite (`918e2251`)

The backward was broken three ways: the C#/kernel arg order was mismatched (`CL_INVALID_ARG_SIZE` at launch); the weight-gradient kernels dropped the recurrent dH/dC term (mathematically wrong); and the recurrent hidden gradient was accumulated non-atomically across threads (a race the kernel's own comments admitted). Replaced the four broken kernels with a correct, **race-free two-kernel BPTT**:

- **`lstm_backward_dgates`** — one work-item per batch element does the inherently-sequential reverse-time recurrence (fully independent per row: no barriers, no shared writes), emitting the gate-preactivation grads `dGates[S,B,4H]`, `grad_input`, and the initial-state grads.
- **`lstm_backward_dweights`** — one work-item per weight/bias element sums `dGates` over `(t,b)`; no atomics, no races (the in-order queue orders the two kernels).

Also fixes a latent host bug the launch crash was masking: the grad readback built tensors from the raw `DownloadBuffer` array (pool-rounded capacity > logical size → "number of values does not match the specified shape"); now truncates to the exact shape product.

The POCL gate covers LSTM backward too — no ops are excluded.

## Making the lane a required check

The lane runs on this PR for the first time. To become a **required** status check without freezing other open PRs (e.g. the savedState release PR #906, which predates this workflow and would otherwise be blocked on a check that can't run on it), the workflow needs to land on `main` first and be confirmed green. Plan: merge this → confirm green on subsequent PRs → then add `gpu-parity-pocl` to `main` branch protection.

## Release

The `fix(gpu):` forward+backward fixes warrant a patch release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for CPU-backed OpenCL when no physical GPU is available.
  * Introduced automated GPU parity testing using POCL (CPU OpenCL), with per-shard divergence report artifacts.

* **Bug Fixes**
  * Corrected LSTM forward/input/output indexing to match batch-major layouts.
  * Reworked LSTM backward propagation to be race-free and improve gradient correctness.
  * Fixed GPU gradient accumulation so results don’t include extra trailing values.

* **Tests / CI**
  * Expanded parity test coverage via new OpenCL parity workflow shards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->