### PR TITLE
fix(autodiff): reject full-span views from backward tensor pool

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/TensorPool.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/TensorPool.cs
@@ -113,10 +113,13 @@ public static class TensorPool<T>
         // results (which call TensorPermute on rank-3+ inputs, producing
         // strided views). GetLiveBackingArrayOrNull returns null for
         // non-owned layouts (non-contiguous, _storageOffset != 0, or
-        // storage length != logical length), giving exactly the
-        // discriminator we need. CPU-only — GPU-resident tensors also
-        // fail this check so we don't pool device buffers.
-        if (tensor.GetLiveBackingArrayOrNull() is null) return;
+        // storage length != logical length). A contiguous full-span view
+        // is the exception: it has offset zero and matching lengths while
+        // still sharing its owner's storage, so reject every explicit view
+        // before applying the backing-layout discriminator. CPU-only —
+        // GPU-resident tensors also fail this check so we don't pool device
+        // buffers.
+        if (tensor.IsView || tensor.GetLiveBackingArrayOrNull() is null) return;
 
         if (_totalPooled >= MaxTotalPooled) return;
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/TensorPoolPinningTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/TensorPoolPinningTests.cs
@@ -199,18 +199,50 @@ public class TensorPoolPinningTests
     public void TensorPool_Return_RefusesReshapeView()
     {
         // A Reshape on contiguous storage returns a view sharing the
-        // backing array. Same pooling hazard as the permute view —
-        // the view-safety guard catches both via
-        // GetLiveBackingArrayOrNull, which requires _storageOffset == 0
-        // AND _storage.Length == Length (i.e. owned-not-aliased).
+        // backing array. Full-span views are particularly subtle: their
+        // offset, length, and contiguity are indistinguishable from owned
+        // storage unless the explicit IsView flag is checked.
         TensorPool<float>.Clear();
-        var source = new Tensor<float>(new[] { 24 });
+        var sourceValues = Enumerable.Range(1, 24).Select(i => (float)i).ToArray();
+        var source = new Tensor<float>(sourceValues, new[] { 24 });
+        var sourceSnapshot = source.ToArray();
         var reshapeView = source.Reshape(new[] { 2, 3, 4 });
+        Assert.True(reshapeView.IsView);
 
         TensorPool<float>.Return(reshapeView);
 
-        var rented = TensorPool<float>.Rent(new[] { 24 });
+        var rented = TensorPool<float>.RentZeroed(new[] { 2, 3, 4 });
+        Assert.Equal(sourceSnapshot, source.ToArray());
         Assert.NotSame(reshapeView, rented);
         Assert.NotSame(source, rented);
+    }
+
+    [Fact]
+    public void FullSpanSliceThenReshape_BackwardDoesNotMutateInput()
+    {
+        TensorPool<double>.Clear();
+        var engine = new CpuEngine();
+        var inputValues = new[] { 0.2, -0.4, 0.7, 0.1 };
+        var inputSnapshot = (double[])inputValues.Clone();
+        var input = new Tensor<double>(inputValues, new[] { 1, 1, 4 });
+        var weight = new Tensor<double>(new[] { 8, 4 });
+        var projection = new Tensor<double>(
+            new[] { 0.7, -0.3, 0.2, 0.9, -0.8, 0.4, -0.6, 0.1 },
+            new[] { 1, 8 });
+
+        for (int i = 0; i < weight.Length; i++)
+            weight[i] = -0.11 + i * 0.013;
+
+        using var tape = new GradientTape<double>();
+        var timestep = engine.Reshape(input.Slice(1, 0, 1), new[] { 1, 4 });
+        var output = engine.TensorMatMul(timestep, engine.TensorTranspose(weight));
+        var loss = engine.ReduceSum(
+            engine.TensorMultiply(output, projection),
+            new[] { 0, 1 },
+            keepDims: false);
+
+        tape.ComputeGradients(loss, new[] { weight });
+
+        Assert.Equal(inputSnapshot, input.ToArray());
     }
 }


### PR DESCRIPTION
## Summary

- reject every explicit tensor view from the backward scratch pool, including contiguous full-span views whose layout otherwise looks owned
- strengthen pool alias coverage and add a consumer-shaped `Slice -> Reshape -> MatMul -> backward` input-immutability regression

## Root cause

For a one-row recurrent timestep, the matmul backward transpose `[1,4] -> [4,1]` is a full-span view. It shares the forward input storage but remains contiguous with offset zero and matching storage/logical lengths. `TensorPool<T>.Return` therefore accepted it, and `NarrowBackward` could later receive that alias from `RentZeroed` and overwrite the original input with its gradient.

This is the primitive defect behind the GRU finite-difference mismatch tracked in [AiDotNet#1944](https://github.com/ooples/AiDotNet/issues/1944) for [AiDotNet PR #1789](https://github.com/ooples/AiDotNet/pull/1789). The GRU equations and tolerances are unchanged.

## Validation

- pre-fix strengthened pool regression: fails on net10.0 and net471 because the source becomes all zeros
- post-fix `TensorPool_Return_RefusesReshapeView`: passes on net10.0 and net471
- `FullSpanSliceThenReshape_BackwardDoesNotMutateInput`: passes on net10.0 and net471
- full `AiDotNet.Tensors.slnx` Release build: 0 errors across net471, net8.0, and net10.0
- original AiDotNet `GRULayerTests.TapeGradient_ShouldMatchNumericalGradient` against a locally packed candidate: 2 passed, 0 failed under net10.0 Release