### PR TITLE
test(autodiff): ratchet the gradcheck sweep at zero harness skips

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -796,12 +796,37 @@ public class DifferentiableOpsGradCheckSweep
         _out.WriteLine("");
         foreach (var s in skipped.OrderBy(x => x)) _out.WriteLine("skip  " + s);
 
-        if (mismatches.Count > 0 || noGradient.Count > 0)
+        // A SKIP is an op the harness could not drive at all, so its gradient is simply UNVERIFIED.
+        // That is materially different from a pass, and it is invisible in a green build unless it
+        // is asserted on: this suite went from 114 skips to 0 by adding per-op argument tables, and
+        // without a ratchet the next op whose parameters the synthesizer cannot handle would slip
+        // back in silently and CI would stay green while coverage rotted.
+        //
+        // Measured 0 skips on BOTH target frameworks (net10.0 and net471, 251 ops verified on each),
+        // so 0 is the honest floor rather than a number chosen to make the assertion pass.
+        //
+        // An op that genuinely cannot be gradient-checked has a supported escape hatch — add it to
+        // the Exempt table above with the reason, which keeps it visible as a deliberate exclusion
+        // instead of an accident. So the ratchet does not block legitimate work; it forces a new op
+        // to be either COVERED or DOCUMENTED, never silently unchecked.
+        if (mismatches.Count > 0 || noGradient.Count > 0 || skipped.Count > 0)
         {
+            var problems = new List<string>();
+            if (mismatches.Count > 0)
+                problems.Add($"{mismatches.Count} op(s) disagree with finite differences");
+            if (noGradient.Count > 0)
+                problems.Add($"{noGradient.Count} record no gradient despite being classified differentiable");
+            if (skipped.Count > 0)
+                problems.Add($"{skipped.Count} could not be driven by the harness at all, leaving their " +
+                             "gradients unverified (add a per-op entry to the argument table so the op can be " +
+                             "invoked, or add it to the Exempt table with a documented reason)");
+
             Assert.Fail(
-                $"{mismatches.Count} op(s) disagree with finite differences and {noGradient.Count} record no " +
-                "gradient despite being classified differentiable.\n" +
-                string.Join("\n", mismatches.Concat(noGradient).Take(40)));
+                string.Join("; ", problems) + ".\n" +
+                string.Join("\n", mismatches
+                    .Concat(noGradient)
+                    .Concat(skipped.OrderBy(x => x).Select(s => "SKIPPED " + s))
+                    .Take(40)));
         }
     }
 


### PR DESCRIPTION
## Problem

`DifferentiableOpsGradCheckSweep` asserted on mismatches and on ops that record no gradient, but **not on skips**. A skip means the harness could not drive the op at all, so its gradient is simply **unverified** — indistinguishable from a pass in a green build.

That mattered because the skip count is hard-won: this suite went from **114 skips to 0** by adding per-op argument tables. Without a ratchet, the next op whose parameters the synthesizer cannot handle silently rejoins the unchecked set and nothing reports it.

## Fix

Fail the sweep when `skipped.Count > 0`, with a message naming every offending op and the two ways to resolve it.

Zero is the honest floor, not a number chosen to make the assertion pass — measured **0 skips with 251 ops verified on BOTH target frameworks** (net10.0 and net471), which is why this is a hard 0 rather than a per-TFM budget.

An op that genuinely cannot be gradient-checked keeps its supported escape hatch: the `Exempt` table, which records the reason and keeps the exclusion visible. So a new op must end up either **covered** or **documented**, never silently unchecked.

## Verification

The ratchet was checked to actually **fire**, not merely to stay green. Temporarily disabling the `TensorMatMul` argument-table entry produced:

```
1 could not be driven by the harness at all, leaving their gradients unverified
(add a per-op entry to the argument table so the op can be invoked, or add it to
the Exempt table with a documented reason).
SKIPPED TensorMatMul|T,T: 2D threw ArgumentException: Matrix dimensions incompatible: [2,3] x [2,3]
```

The entry was then restored. Green on **net10.0 and net471** (6/6 including `RfftAndLogVarianceGradTests`).

Current sweep state on both TFMs:

```
gradient-checked OK : 251
MISMATCH            : 0
NO GRADIENT         : 0
exempt (documented) : 7
skipped (harness)   : 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)