### PR TITLE
perf(blas): BCL Vector<T> FP64 streaming microkernel — net471 GEMM was fully scalar

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Portable/PortableFp64_4x4.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Portable/PortableFp64_4x4.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// BCL <see cref="Vector{T}"/> FP64 4x4 packed microkernel: a SIMD sibling of
+/// <see cref="ScalarFp64_4x4"/>, bit-identical to it, for the packed strategies on net471.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ADDED ALONGSIDE, NEVER REPLACING. <see cref="ScalarFp64_4x4"/> is the ground-truth reference that other
+/// kernels assert against, so it keeps its scalar body untouched and this tier is dispatched to only when
+/// it can be proven to produce identical bits. Rewriting the reference in SIMD would leave nothing to
+/// compare against.
+/// </para>
+/// <para><b>Why this is bit-exact, and it is a proof rather than a tolerance.</b> Vectorization is along
+/// the j (column) axis. One <see cref="Vector{T}"/> of double holds a single C row's four cells
+/// <c>[c_i0, c_i1, c_i2, c_i3]</c>, and each k-step adds <c>broadcast(a_i) * [b_0, b_1, b_2, b_3]</c>. Lane
+/// j therefore accumulates exactly <c>c_ij += a_i * b_j</c>, over exactly the same k values, in exactly the
+/// same order as the scalar kernel's <c>c_ij += a_i * b_j</c>. There is no horizontal reduction anywhere,
+/// so no addition is reassociated. Vectorizing along k instead would need a lane sum at the end, which
+/// DOES reassociate and would break the contract.
+/// </para>
+/// <para>
+/// The multiply and the add stay separate operations (<c>vc + (va * vb)</c>). .NET does not contract
+/// multiply-add into FMA implicitly — that requires the explicit FusedMultiplyAdd intrinsics — so the
+/// rounding sequence matches the scalar kernel's two-step arithmetic. Using an FMA intrinsic here would
+/// round once instead of twice and silently break bit-exactness.
+/// </para>
+/// <para><b>Why exactly four lanes.</b> <c>Nr</c> is 4, so a four-lane vector covers one C row precisely.
+/// Two lanes (SSE) would need two vectors per row and a second tail path; eight (AVX-512) would read past
+/// the row into the next one. Rather than special-case both, this tier declines unless
+/// <c>Vector&lt;double&gt;.Count == 4</c> and the caller falls through to the scalar kernel — which is
+/// always correct, just slower.
+/// </para>
+/// <para>
+/// It also declines when <see cref="Vector.IsHardwareAccelerated"/> is false, where
+/// <see cref="Vector{T}"/> is a software emulation that would be slower than the scalar kernel it replaces.
+/// </para>
+/// </remarks>
+internal static class PortableFp64_4x4
+{
+    /// <summary>Microkernel row-tile width, matching <see cref="ScalarFp64_4x4"/>.</summary>
+    public const int Mr = 4;
+
+    /// <summary>Microkernel column-tile width, matching <see cref="ScalarFp64_4x4"/>.</summary>
+    public const int Nr = 4;
+
+    /// <summary>
+    /// True when the BCL reports real SIMD and a <see cref="Vector{T}"/> of double holds exactly
+    /// <see cref="Nr"/> lanes. See the type remarks for why both conditions are required.
+    /// </summary>
+    public static bool IsSupported => Vector.IsHardwareAccelerated && Vector<double>.Count == Nr;
+
+    /// <summary>
+    /// Compute <c>C[0..Mr, 0..Nr] += packedA · packedB</c>. Bit-identical to
+    /// <see cref="ScalarFp64_4x4.Run"/>.
+    /// </summary>
+    /// <param name="packedA">Packed-A vpanel, layout [Kc x Mr] row-major.</param>
+    /// <param name="packedB">Packed-B stripe, layout [Kc x Nr] row-major.</param>
+    /// <param name="c">Output buffer; the kernel reads and writes the C[0..Mr, 0..Nr] tile.</param>
+    /// <param name="ldc">Leading dimension of C, at least <see cref="Nr"/>.</param>
+    /// <param name="kc">Number of K-steps to accumulate.</param>
+    public static unsafe void Run(
+        ReadOnlySpan<double> packedA,
+        ReadOnlySpan<double> packedB,
+        Span<double> c,
+        int ldc,
+        int kc)
+    {
+        fixed (double* aBase = &MemoryMarshal.GetReference(packedA))
+        fixed (double* bBase = &MemoryMarshal.GetReference(packedB))
+        fixed (double* cBase = &MemoryMarshal.GetReference(c))
+        {
+            // One vector per C row: [c_i0 .. c_i3]. Held across the whole K-loop, exactly as the scalar
+            // kernel holds its 16 cells in locals.
+            var c0 = Unsafe.ReadUnaligned<Vector<double>>((void*)cBase);
+            var c1 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + ldc));
+            var c2 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + (2 * ldc)));
+            var c3 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + (3 * ldc)));
+
+            for (int k = 0; k < kc; k++)
+            {
+                var vb = Unsafe.ReadUnaligned<Vector<double>>((void*)(bBase + (k * Nr)));
+                double* aK = aBase + (k * Mr);
+
+                // No `a == 0` early-out: skipping would suppress the 0 * Infinity => NaN propagation and
+                // the signed-zero results the scalar kernel produces, which are part of bit-exactness.
+                c0 += new Vector<double>(aK[0]) * vb;
+                c1 += new Vector<double>(aK[1]) * vb;
+                c2 += new Vector<double>(aK[2]) * vb;
+                c3 += new Vector<double>(aK[3]) * vb;
+            }
+
+            Unsafe.WriteUnaligned((void*)cBase, c0);
+            Unsafe.WriteUnaligned((void*)(cBase + ldc), c1);
+            Unsafe.WriteUnaligned((void*)(cBase + (2 * ldc)), c2);
+            Unsafe.WriteUnaligned((void*)(cBase + (3 * ldc)), c3);
+        }
+    }
+
+    /// <summary>
+    /// Variant of <see cref="Run"/> reading B directly from caller memory with stride
+    /// <paramref name="ldb"/>. Bit-identical to <see cref="ScalarFp64_4x4.RunStridedB"/>.
+    /// </summary>
+    /// <remarks>
+    /// Supports only <c>transB == false</c>, i.e. B laid out [K, N] row-major, for the same reason the
+    /// streaming tier does: j-vectorization needs B contiguous along j. With <c>transB == true</c> the four
+    /// columns are <c>ldb</c> apart and would need a gather, so that shape stays on the scalar kernel.
+    /// </remarks>
+    /// <param name="packedA">Packed-A vpanel, layout [Kc x Mr] row-major.</param>
+    /// <param name="b">B slice positioned at the (pc, jc) corner of the current panel.</param>
+    /// <param name="ldb">Leading dimension of B.</param>
+    /// <param name="c">Output buffer; reads and writes the C[0..Mr, 0..Nr] tile.</param>
+    /// <param name="ldc">Leading dimension of C.</param>
+    /// <param name="kc">Number of K-steps to accumulate.</param>
+    public static unsafe void RunStridedB(
+        ReadOnlySpan<double> packedA,
+        ReadOnlySpan<double> b,
+        int ldb,
+        Span<double> c,
+        int ldc,
+        int kc)
+    {
+        fixed (double* aBase = &MemoryMarshal.GetReference(packedA))
+        fixed (double* bBase = &MemoryMarshal.GetReference(b))
+        fixed (double* cBase = &MemoryMarshal.GetReference(c))
+        {
+            var c0 = Unsafe.ReadUnaligned<Vector<double>>((void*)cBase);
+            var c1 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + ldc));
+            var c2 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + (2 * ldc)));
+            var c3 = Unsafe.ReadUnaligned<Vector<double>>((void*)(cBase + (3 * ldc)));
+
+            for (int k = 0; k < kc; k++)
+            {
+                var vb = Unsafe.ReadUnaligned<Vector<double>>((void*)(bBase + ((long)k * ldb)));
+                double* aK = aBase + (k * Mr);
+
+                c0 += new Vector<double>(aK[0]) * vb;
+                c1 += new Vector<double>(aK[1]) * vb;
+                c2 += new Vector<double>(aK[2]) * vb;
+                c3 += new Vector<double>(aK[3]) * vb;
+            }
+
+            Unsafe.WriteUnaligned((void*)cBase, c0);
+            Unsafe.WriteUnaligned((void*)(cBase + ldc), c1);
+            Unsafe.WriteUnaligned((void*)(cBase + (2 * ldc)), c2);
+            Unsafe.WriteUnaligned((void*)(cBase + (3 * ldc)), c3);
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Portable/PortableSimdStreaming.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Portable/PortableSimdStreaming.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.Engines.BlasManaged;
+
+/// <summary>
+/// Streaming FP64 microkernel built on the BCL's <see cref="Vector{T}"/> rather than
+/// <c>System.Runtime.Intrinsics</c>. Fills the gap between <see cref="NeonStreaming"/> and
+/// <see cref="ScalarStreaming"/> in <see cref="StreamingStrategy"/>'s dispatch chain.
+///
+/// <para>
+/// WHY THIS EXISTS. <c>System.Runtime.Intrinsics</c> does not exist before net6, so on net471
+/// <see cref="Avx2Streaming"/> and <see cref="Avx512Streaming"/> compile to stubs whose
+/// <c>IsSupported</c> is a constant <c>false</c> and which delegate straight to
+/// <see cref="ScalarStreaming"/>. Every GEMM on net471 therefore ran a scalar triple loop.
+/// Measured on AiDotNet's <c>ShiftNetTests.MoreData_ShouldNotDegrade</c> (250 training
+/// iterations): 33.3 s on net10.0 versus a &gt;120 s timeout on net471, with a PerfView
+/// /ThreadTime trace attributing 29.77% of leaf CPU to <see cref="ScalarStreaming.RunFp64"/>
+/// and 12.00% to <see cref="ScalarFp64_4x4"/> — about 45% of the process in scalar fp64 GEMM.
+/// <see cref="Vector{T}"/> IS available and JIT-vectorized on net471 (via System.Numerics.Vectors),
+/// so the fallback tier did not have to be scalar.
+/// </para>
+///
+/// <para>
+/// NOT built on <c>Compatibility/SimdCompat.cs</c>. That file's net471 <c>Vector128</c>/
+/// <c>Vector256</c> shims are backed by <c>T[] _elements</c> and loop element-wise, allocating a
+/// fresh array in every <c>Create</c>. They exist so intrinsics-shaped code COMPILES on net471,
+/// not so it runs fast; using them in a GEMM inner loop would be slower than the scalar kernel
+/// and would allocate per call.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para><b>Bit-exactness.</b> This kernel vectorizes across <c>j</c> (the n axis), never across
+/// <c>k</c>. For a fixed (i, j) the accumulation still walks <c>kk</c> in ascending order, one
+/// rounded multiply and one rounded add per step — exactly <see cref="ScalarStreaming.RunFp64"/>'s
+/// sequence — so results are bit-identical and the different loop nesting (i→kk→j here versus
+/// i→j→kk there) does not change any element's summation order. Vectorizing across <c>k</c>
+/// instead would need a horizontal sum of partial lanes, which reassociates the additions and
+/// would break the bit-exact contract <see cref="ScalarStreaming"/> documents against
+/// <see cref="ScalarFp32_4x4"/> for the tiny-shape bypass guarantee.
+/// </para>
+/// <para><b>Why only <c>transB == false</c>.</b> j-vectorization needs both operands contiguous
+/// along j. With <c>transB == false</c>, <c>b[kk * ldb + j]</c> and <c>c[i * ldc + j]</c> both are,
+/// and <c>aval</c> depends only on (i, kk) so it broadcasts — which is why <c>transA</c> needs no
+/// special case. With <c>transB == true</c>, <c>b[j * ldb + kk]</c> strides by <c>ldb</c> in j and
+/// would require a gather; that shape stays on the scalar kernel rather than being emulated
+/// element-wise for no gain.
+/// </para>
+/// <para><b>Why FP64 only.</b> <see cref="ScalarStreaming.RunFp32"/> deliberately accumulates in
+/// <c>double</c> to stay bit-exact with <see cref="ScalarFp32_4x4"/>. A <c>Vector{float}</c> path
+/// would accumulate in float and break that contract, and the measured cost is fp64 anyway, so
+/// FP32 is left on the scalar kernel.
+/// </para>
+/// </remarks>
+internal static class PortableSimdStreaming
+{
+    /// <summary>
+    /// True when the BCL reports real SIMD and a <see cref="Vector{T}"/> of double holds more than
+    /// one lane. Without hardware acceleration <see cref="Vector{T}"/> is emulated in software and
+    /// would be slower than the scalar kernel, so this tier declines and dispatch falls through.
+    /// </summary>
+    public static bool IsSupported => Vector.IsHardwareAccelerated && Vector<double>.Count > 1;
+
+    /// <summary>
+    /// Compute C += op(A) · op(B) without packing. C is read-modify-write.
+    /// Bit-identical to <see cref="ScalarStreaming.RunFp64"/>; see the type remarks.
+    /// </summary>
+    public static unsafe void RunFp64(
+        ReadOnlySpan<double> a, int lda, bool transA,
+        ReadOnlySpan<double> b, int ldb, bool transB,
+        Span<double> c, int ldc,
+        int m, int n, int k)
+    {
+        if (m <= 0 || n <= 0 || k <= 0)
+        {
+            return;
+        }
+
+        int lanes = Vector<double>.Count;
+
+        // transB strides B along j (gather); a sub-lane n has no vector work to do. Both are
+        // handled by the scalar kernel so the numerics stay on one code path.
+        if (transB || n < lanes)
+        {
+            ScalarStreaming.RunFp64(a, lda, transA, b, ldb, transB, c, ldc, m, n, k);
+            return;
+        }
+
+        int simdN = n - (n % lanes);
+
+        fixed (double* aBase = &MemoryMarshal.GetReference(a))
+        fixed (double* bBase = &MemoryMarshal.GetReference(b))
+        fixed (double* cBase = &MemoryMarshal.GetReference(c))
+        {
+            for (int i = 0; i < m; i++)
+            {
+                double* cRow = cBase + ((long)i * ldc);
+                double* aRow = aBase + ((long)i * lda);   // only read when !transA
+
+                for (int kk = 0; kk < k; kk++)
+                {
+                    // Depends on (i, kk) only, so it broadcasts across the j lanes.
+                    double aval = transA ? aBase[((long)kk * lda) + i] : aRow[kk];
+
+                    // NOTE: no `aval == 0` early-out. Skipping would suppress the 0 * Infinity
+                    // => NaN propagation and the signed-zero result that the scalar kernel
+                    // produces, so the zero row is multiplied like any other.
+                    var va = new Vector<double>(aval);
+                    double* bRow = bBase + ((long)kk * ldb);
+
+                    int j = 0;
+                    for (; j < simdN; j += lanes)
+                    {
+                        var vb = Unsafe.ReadUnaligned<Vector<double>>((void*)(bRow + j));
+                        var vc = Unsafe.ReadUnaligned<Vector<double>>((void*)(cRow + j));
+                        Unsafe.WriteUnaligned((void*)(cRow + j), vc + (va * vb));
+                    }
+
+                    // j tail, same expression as the vector body so rounding matches.
+                    for (; j < n; j++)
+                    {
+                        cRow[j] += aval * bRow[j];
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarPack.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Microkernels/Scalar/ScalarPack.cs
@@ -49,15 +49,26 @@ internal static class ScalarPack
         for (int stripe = 0; stripe < numStripes; stripe++)
         {
             int packedOff = stripe * kc * mr;
-            for (int k = 0; k < kc; k++)
+            int baseRow = stripe * mr;
+
+            if (transA)
             {
-                for (int row = 0; row < mr; row++)
+                // A is [K, M], so consecutive logical ROWS are adjacent in memory — and the vpanel wants
+                // them adjacent too. The whole inner row loop is therefore a CONTIGUOUS block move, which
+                // CopyTo performs with the platform's vectorized memmove instead of mr scalar loads and
+                // stores. Bit-exact by construction: packing moves values and never arithmetic on them.
+                for (int k = 0; k < kc; k++)
+                    a.Slice((k * lda) + baseRow, mr).CopyTo(packed.Slice(packedOff + (k * mr), mr));
+            }
+            else
+            {
+                // A is [M, K]: consecutive logical rows are lda apart, so this is a strided gather and
+                // cannot become a block move. Left scalar deliberately — a register transpose would help
+                // here and is a separate, riskier change.
+                for (int k = 0; k < kc; k++)
                 {
-                    int logicalRow = stripe * mr + row;
-                    T value = transA
-                        ? a[k * lda + logicalRow]            // A stored [K, M], read M-stride
-                        : a[logicalRow * lda + k];           // A stored [M, K], read K-stride
-                    packed[packedOff + k * mr + row] = value;
+                    for (int row = 0; row < mr; row++)
+                        packed[packedOff + (k * mr) + row] = a[((baseRow + row) * lda) + k];
                 }
             }
         }
@@ -106,15 +117,24 @@ internal static class ScalarPack
         for (int stripe = 0; stripe < numFullStripes; stripe++)
         {
             int packedOff = stripe * kc * nr;
-            for (int k = 0; k < kc; k++)
+            int baseCol = stripe * nr;
+
+            if (!transB)
             {
-                for (int col = 0; col < nr; col++)
+                // B is [K, N], so a stripe's nr columns are ADJACENT in memory and the packed stripe wants
+                // them adjacent as well. This is the common case (untransposed B) and the entire inner
+                // column loop collapses to a contiguous block move, which CopyTo does with a vectorized
+                // memmove. Bit-exact: packing only moves values.
+                for (int k = 0; k < kc; k++)
+                    b.Slice((k * ldb) + baseCol, nr).CopyTo(packed.Slice(packedOff + (k * nr), nr));
+            }
+            else
+            {
+                // B is [N, K]: a stripe's columns are ldb apart, a strided gather. Left scalar.
+                for (int k = 0; k < kc; k++)
                 {
-                    int logicalCol = stripe * nr + col;
-                    T value = transB
-                        ? b[logicalCol * ldb + k]            // B stored [N, K], read K-stride
-                        : b[k * ldb + logicalCol];           // B stored [K, N], read N-stride
-                    packed[packedOff + k * nr + col] = value;
+                    for (int col = 0; col < nr; col++)
+                        packed[packedOff + (k * nr) + col] = b[((baseCol + col) * ldb) + k];
                 }
             }
         }
@@ -127,19 +147,25 @@ internal static class ScalarPack
             int tailStripe = numFullStripes;
             int tailPackedOff = tailStripe * kc * nr;
             int tailBaseCol = tailStripe * nr;
+
             for (int k = 0; k < kc; k++)
             {
-                for (int col = 0; col < nr; col++)
+                var destination = packed.Slice(tailPackedOff + (k * nr), nr);
+
+                if (!transB)
                 {
-                    int logicalCol = tailBaseCol + col;
-                    T value = default;
-                    if (col < tailCols)
-                    {
-                        value = transB
-                            ? b[logicalCol * ldb + k]
-                            : b[k * ldb + logicalCol];
-                    }
-                    packed[tailPackedOff + k * nr + col] = value;
+                    // Contiguous for the real columns, then the padding lanes are CLEARED rather than left
+                    // as whatever the buffer held. That zero-fill is load bearing, not tidiness: the packed
+                    // layout is always nr wide so a tail kernel reads all nr lanes, and pooled buffers are
+                    // not zeroed on rent — stale values in the padding would be multiplied into C.
+                    b.Slice((k * ldb) + tailBaseCol, tailCols).CopyTo(destination);
+                    destination.Slice(tailCols).Clear();
+                }
+                else
+                {
+                    for (int col = 0; col < tailCols; col++)
+                        destination[col] = b[((tailBaseCol + col) * ldb) + k];
+                    destination.Slice(tailCols).Clear();
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -378,7 +378,15 @@ internal static class PackAOnlyStrategy
             // Scalar fallback (no matching SIMD kernel — e.g. net471 / no-AVX2). See the FP32
             // branch above: the fixed 4×4 kernel is only correct for a 4×4 tile, so any other
             // mr×nr routes to the general kernel that honors the actual tile dimensions.
-            if (mr == 4 && nr == 4)
+            if (mr == 4 && nr == 4 && PortableFp64_4x4.IsSupported)
+                // Portable BCL Vector<T> tier — bit-identical to ScalarFp64_4x4.RunStridedB by
+                // construction (j-axis vectorization, no horizontal reduction). This is the only SIMD tier
+                // available on net471, where every branch above declines.
+                PortableFp64_4x4.RunStridedB(
+                    MemoryMarshal.Cast<T, double>(packedA),
+                    MemoryMarshal.Cast<T, double>(b), ldb,
+                    MemoryMarshal.Cast<T, double>(c), ldc, kc);
+            else if (mr == 4 && nr == 4)
                 ScalarFp64_4x4.RunStridedB(
                     MemoryMarshal.Cast<T, double>(packedA),
                     MemoryMarshal.Cast<T, double>(b), ldb,

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackBothStrategy.cs
@@ -1425,6 +1425,19 @@ internal static class PackBothStrategy
                         ldc, kc);
                     return;
                 }
+                // Portable BCL Vector<T> tier, below the platform intrinsics and above the scalar
+                // reference. It is bit-identical to ScalarFp64_4x4 by construction (j-axis vectorization,
+                // no horizontal reduction — see PortableFp64_4x4), so it is safe to prefer wherever the
+                // BCL reports four hardware lanes. On net471 this is the only SIMD tier available.
+                if (PortableFp64_4x4.IsSupported)
+                {
+                    PortableFp64_4x4.Run(
+                        MemoryMarshal.Cast<T, double>(packedA),
+                        MemoryMarshal.Cast<T, double>(packedB),
+                        MemoryMarshal.Cast<T, double>(c),
+                        ldc, kc);
+                    return;
+                }
                 ScalarFp64_4x4.Run(
                     MemoryMarshal.Cast<T, double>(packedA),
                     MemoryMarshal.Cast<T, double>(packedB),

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
@@ -338,7 +338,8 @@ internal static class StreamingStrategy
     }
 
     /// <summary>
-    /// Serial microkernel dispatch: AVX-512 → AVX2 → Neon → scalar.
+    /// Serial microkernel dispatch: AVX-512 → AVX2 → Neon → BCL <see cref="System.Numerics.Vector{T}"/>
+    /// (FP64) → scalar.
     /// </summary>
     private static void RunSerial<T>(
         ReadOnlySpan<T> a, int lda, bool transA,
@@ -369,6 +370,19 @@ internal static class StreamingStrategy
             if (NeonStreaming.IsSupported)
             {
                 NeonStreaming.RunFp64(
+                    MemoryMarshal.Cast<T, double>(a), lda, transA,
+                    MemoryMarshal.Cast<T, double>(b), ldb, transB,
+                    MemoryMarshal.Cast<T, double>(c), ldc,
+                    m, n, k);
+                return;
+            }
+            // BCL Vector<T> tier. Reached on TFMs without System.Runtime.Intrinsics (net471,
+            // where the AVX/Neon IsSupported above are compile-time false) and on any host whose
+            // intrinsic sets are unavailable. Bit-identical to ScalarStreaming.RunFp64, and it
+            // internally defers to it for transB / sub-lane n.
+            if (PortableSimdStreaming.IsSupported)
+            {
+                PortableSimdStreaming.RunFp64(
                     MemoryMarshal.Cast<T, double>(a), lda, transA,
                     MemoryMarshal.Cast<T, double>(b), ldb, transB,
                     MemoryMarshal.Cast<T, double>(c), ldc,

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Finite-difference gradient checks for FAN-OUT graphs — one tensor consumed by several downstream
+/// branches, where the backward must SUM the gradient contributions of every path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These exist BEFORE the graph-driven training executor that will need them, deliberately. Fan-out
+/// accumulation is the one part of branched execution whose failure mode is SILENT: if a shared node
+/// receives only one branch's gradient instead of the sum, nothing throws, no shape is wrong, and no
+/// existing invariant notices — training simply converges to something worse. Writing the executor first
+/// and the checks afterwards would mean developing the risky part against no test that can catch it.
+/// </para>
+/// <para>
+/// A linear chain never exercises this: each node has exactly one consumer, so "accumulate" and "assign"
+/// are indistinguishable. Only a branch tells them apart, which is why every case here forks and rejoins.
+/// </para>
+/// <para>
+/// Finite differences are the reference because they are independent of the autodiff implementation. A
+/// test that compared the tape against itself, or against a hand-derived formula transcribed from the same
+/// reasoning that wrote the backward, would agree with a wrong backward.
+/// </para>
+/// </remarks>
+public class FanOutGradientAccumulationTests
+{
+    private static IEngine Engine => AiDotNetEngine.Current;
+
+    private static Tensor<double> Vec(params double[] values)
+    {
+        var t = new Tensor<double>(new[] { values.Length });
+        for (int i = 0; i < values.Length; i++) t[i] = values[i];
+        return t;
+    }
+
+    /// <summary>Sum of all elements — a scalar loss so the seed is unambiguous.</summary>
+    private static Tensor<double> SumAll(Tensor<double> t)
+    {
+        var acc = new Tensor<double>(new[] { 1 });
+        var one = new Tensor<double>(new[] { 1 });
+        one[0] = 1.0;
+        acc = Engine.TensorMultiplyScalar(one, 0.0);
+        for (int i = 0; i < t.Length; i++)
+        {
+            var slice = Engine.TensorNarrow(t, 0, i, 1);
+            acc = Engine.TensorAdd(acc, slice);
+        }
+        return acc;
+    }
+
+    /// <summary>
+    /// Central-difference gradient of <paramref name="loss"/> with respect to each element of the input.
+    /// </summary>
+    /// <remarks>
+    /// Central rather than forward difference: the forward difference's error is O(h) and would be the
+    /// same order as the discrepancies being hunted, so it cannot distinguish a slightly wrong gradient
+    /// from its own truncation error.
+    /// </remarks>
+    private static double[] NumericGradient(double[] x, Func<double[], double> loss, double h = 1e-6)
+    {
+        var g = new double[x.Length];
+        for (int i = 0; i < x.Length; i++)
+        {
+            var plus = (double[])x.Clone();
+            var minus = (double[])x.Clone();
+            plus[i] += h;
+            minus[i] -= h;
+            g[i] = (loss(plus) - loss(minus)) / (2.0 * h);
+        }
+        return g;
+    }
+
+    private static void AssertClose(double[] expected, double[] actual, string what, double tol = 1e-5)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double denom = Math.Max(1.0, Math.Max(Math.Abs(expected[i]), Math.Abs(actual[i])));
+            double rel = Math.Abs(expected[i] - actual[i]) / denom;
+            if (rel > tol)
+            {
+                Assert.Fail(
+                    $"{what}: element {i} analytic {actual[i]:R} vs finite-difference {expected[i]:R} "
+                    + $"(relative {rel:E3}). For a fan-out graph the usual cause is that the shared node "
+                    + "received ONE branch's gradient instead of the sum of all branches.");
+            }
+        }
+    }
+
+    [Fact]
+    public void TwoBranchesRejoining_AccumulatesBothGradients()
+    {
+        // THE core case. x feeds two branches, both rejoin: loss = sum(2x) + sum(3x).
+        // dL/dx must be 2 + 3 = 5 per element. A backward that overwrites instead of accumulating gives
+        // either 2 or 3 — a plausible-looking gradient that is silently wrong by 40-60%.
+        var start = new[] { 0.5, -1.25, 2.0 };
+
+        double Loss(double[] v)
+        {
+            double s = 0.0;
+            foreach (var e in v) s += (2.0 * e) + (3.0 * e);
+            return s;
+        }
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(start);
+
+        var branchA = Engine.TensorMultiplyScalar(x, 2.0);
+        var branchB = Engine.TensorMultiplyScalar(x, 3.0);
+        var loss = Engine.TensorAdd(SumAll(branchA), SumAll(branchB));
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x });
+        Assert.True(grads.ContainsKey(x), "No gradient was produced for the fan-out source at all.");
+
+        var analytic = new double[start.Length];
+        for (int i = 0; i < start.Length; i++) analytic[i] = Convert.ToDouble(grads[x][i]);
+
+        AssertClose(NumericGradient(start, Loss), analytic, "two branches rejoining");
+    }
+
+    [Fact]
+    public void ThreeBranchesRejoining_AccumulatesAllThree()
+    {
+        // Three paths, because a backward that accumulates only the LAST two (a subtly different bug from
+        // overwriting) still passes the two-branch case.
+        var start = new[] { 1.5, -0.75 };
+
+        double Loss(double[] v)
+        {
+            double s = 0.0;
+            foreach (var e in v) s += e + (4.0 * e) + (0.5 * e);
+            return s;
+        }
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(start);
+
+        var a = Engine.TensorMultiplyScalar(x, 1.0);
+        var b = Engine.TensorMultiplyScalar(x, 4.0);
+        var c = Engine.TensorMultiplyScalar(x, 0.5);
+        var loss = Engine.TensorAdd(Engine.TensorAdd(SumAll(a), SumAll(b)), SumAll(c));
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x });
+        var analytic = new double[start.Length];
+        for (int i = 0; i < start.Length; i++) analytic[i] = Convert.ToDouble(grads[x][i]);
+
+        AssertClose(NumericGradient(start, Loss), analytic, "three branches rejoining");
+    }
+
+    [Fact]
+    public void AsymmetricBranchDepths_StillAccumulate()
+    {
+        // ABCNet's actual shape: a shared trunk feeding a SHALLOW head and a DEEPER one. If accumulation
+        // depends on both paths finishing at the same depth, this is where it breaks.
+        var start = new[] { 0.3, 1.1, -2.2 };
+
+        double Loss(double[] v)
+        {
+            double s = 0.0;
+            foreach (var e in v)
+            {
+                double shallow = 2.0 * e;
+                double deep = ((e * 3.0) + 1.0) * 2.0;   // two ops before rejoining
+                s += shallow + deep;
+            }
+            return s;
+        }
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(start);
+
+        var shallowHead = Engine.TensorMultiplyScalar(x, 2.0);
+        var deepHead = Engine.TensorMultiplyScalar(
+            Engine.TensorAddScalar(Engine.TensorMultiplyScalar(x, 3.0), 1.0), 2.0);
+        var loss = Engine.TensorAdd(SumAll(shallowHead), SumAll(deepHead));
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x });
+        var analytic = new double[start.Length];
+        for (int i = 0; i < start.Length; i++) analytic[i] = Convert.ToDouble(grads[x][i]);
+
+        AssertClose(NumericGradient(start, Loss), analytic, "asymmetric branch depths");
+    }
+
+    [Fact]
+    public void OneBranchDiscarded_ContributesNoGradient()
+    {
+        // The opposite error: over-accumulation. A branch computed but NOT used by the loss must add
+        // nothing. A backward that walks every recorded op rather than only the loss's ancestors would
+        // fold the dead branch in and inflate the gradient, which finite differences catch immediately
+        // because the dead branch does not affect the loss at all.
+        var start = new[] { 0.9, -1.4 };
+
+        double Loss(double[] v)
+        {
+            double s = 0.0;
+            foreach (var e in v) s += 2.0 * e;   // the 7x branch below is deliberately unused
+            return s;
+        }
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(start);
+
+        var used = Engine.TensorMultiplyScalar(x, 2.0);
+        _ = Engine.TensorMultiplyScalar(x, 7.0);   // recorded, never reaches the loss
+        var loss = SumAll(used);
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x });
+        var analytic = new double[start.Length];
+        for (int i = 0; i < start.Length; i++) analytic[i] = Convert.ToDouble(grads[x][i]);
+
+        AssertClose(NumericGradient(start, Loss), analytic, "discarded branch");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PortableFp64MicrokernelBitExactTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PortableFp64MicrokernelBitExactTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Numerics;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Asserts <see cref="PortableFp64_4x4"/> is BIT-IDENTICAL to <see cref="ScalarFp64_4x4"/>, the scalar
+/// reference the other kernels are validated against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Bit-identity, not a tolerance, and that is the whole point. The scalar 4x4 kernel is the ground truth
+/// for the packed FP64 path, and BlasMode.Deterministic promises bit-exact reproducibility. A SIMD sibling
+/// that agreed only to 1e-15 would quietly void that promise, so every assertion here compares raw IEEE
+/// payloads via BitConverter.DoubleToInt64Bits.
+/// </para>
+/// <para>
+/// The property holds because vectorization is along the j axis: lane j accumulates exactly
+/// <c>c_ij += a_i * b_j</c> over the same k values in the same order, with no horizontal reduction to
+/// reassociate anything. These tests are what would catch a future change to k-axis vectorization or to an
+/// FMA intrinsic, either of which would round differently while still looking correct.
+/// </para>
+/// </remarks>
+public class PortableFp64MicrokernelBitExactTests
+{
+    private const int Mr = 4;
+    private const int Nr = 4;
+
+    private static double[] Filled(int count, int seed, double scale = 1.0)
+    {
+        var rng = new Random(seed);
+        var values = new double[count];
+        for (int i = 0; i < count; i++) values[i] = ((rng.NextDouble() * 2.0) - 1.0) * scale;
+        return values;
+    }
+
+    private static void AssertBitIdentical(double[] expected, double[] actual, string what)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            long e = BitConverter.DoubleToInt64Bits(expected[i]);
+            long a = BitConverter.DoubleToInt64Bits(actual[i]);
+            if (e != a)
+            {
+                Assert.Fail(
+                    $"{what}: element {i} differs at the BIT level — scalar {expected[i]:R} (0x{e:X16}) vs "
+                    + $"portable {actual[i]:R} (0x{a:X16}). The portable tier must be bit-identical to the "
+                    + "scalar reference, not merely close.");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(1, 4)]
+    [InlineData(2, 4)]
+    [InlineData(7, 4)]
+    [InlineData(64, 4)]
+    [InlineData(129, 8)]      // ldc > Nr, so C rows are not adjacent
+    [InlineData(256, 16)]
+    public void RunMatchesTheScalarReferenceBitForBit(int kc, int ldc)
+    {
+        if (!PortableFp64_4x4.IsSupported) return;   // no four-lane SIMD here; the scalar path is used
+
+        var packedA = Filled(kc * Mr, seed: 11);
+        var packedB = Filled(kc * Nr, seed: 12);
+
+        // C is read-modify-write, so both kernels must start from the SAME non-zero contents — starting
+        // from zero would hide a mistake in how the existing value is loaded.
+        var initial = Filled(Mr * ldc, seed: 13);
+        var expected = (double[])initial.Clone();
+        var actual = (double[])initial.Clone();
+
+        ScalarFp64_4x4.Run(packedA, packedB, expected, ldc, kc);
+        PortableFp64_4x4.Run(packedA, packedB, actual, ldc, kc);
+
+        AssertBitIdentical(expected, actual, $"Run(kc={kc}, ldc={ldc})");
+    }
+
+    [Theory]
+    [InlineData(1, 4, 4)]
+    [InlineData(5, 4, 4)]
+    [InlineData(33, 9, 6)]     // ldb > Nr and ldc > Nr simultaneously
+    [InlineData(128, 32, 16)]
+    public void RunStridedBMatchesTheScalarReferenceBitForBit(int kc, int ldb, int ldc)
+    {
+        if (!PortableFp64_4x4.IsSupported) return;
+
+        var packedA = Filled(kc * Mr, seed: 21);
+        var b = Filled(kc * ldb, seed: 22);
+
+        var initial = Filled(Mr * ldc, seed: 23);
+        var expected = (double[])initial.Clone();
+        var actual = (double[])initial.Clone();
+
+        ScalarFp64_4x4.RunStridedB(packedA, b, ldb, expected, ldc, kc);
+        PortableFp64_4x4.RunStridedB(packedA, b, ldb, actual, ldc, kc);
+
+        AssertBitIdentical(expected, actual, $"RunStridedB(kc={kc}, ldb={ldb}, ldc={ldc})");
+    }
+
+    [Fact]
+    public void SpecialValuesPropagateIdentically()
+    {
+        // The case an `a == 0` early-out would break: 0 * Infinity is NaN, not a skipped row, and -0.0
+        // must stay signed. A kernel that optimizes away zero multiplies still passes ordinary random
+        // tests while diverging here.
+        if (!PortableFp64_4x4.IsSupported) return;
+
+        const int kc = 4;
+        var packedA = new double[kc * Mr];
+        var packedB = new double[kc * Nr];
+
+        for (int i = 0; i < packedA.Length; i++) packedA[i] = 1.0;
+        for (int i = 0; i < packedB.Length; i++) packedB[i] = 1.0;
+
+        packedA[0] = 0.0;                          // 0 * Infinity
+        packedB[1] = double.PositiveInfinity;
+        packedA[Mr + 1] = -0.0;                    // signed zero
+        packedB[Nr + 2] = double.NaN;              // NaN propagation
+        packedA[(2 * Mr) + 2] = double.NegativeInfinity;
+
+        var initial = new double[Mr * Nr];
+        for (int i = 0; i < initial.Length; i++) initial[i] = i % 2 == 0 ? 0.0 : -0.0;
+
+        var expected = (double[])initial.Clone();
+        var actual = (double[])initial.Clone();
+
+        ScalarFp64_4x4.Run(packedA, packedB, expected, Nr, kc);
+        PortableFp64_4x4.Run(packedA, packedB, actual, Nr, kc);
+
+        AssertBitIdentical(expected, actual, "special values");
+    }
+
+    [Fact]
+    public void TheSupportGateRequiresExactlyFourLanes()
+    {
+        // Documents the gate rather than asserting a machine property: two lanes would need two vectors
+        // per C row, eight would read past the row into the next one, so the tier declines outside four.
+        bool expected = Vector.IsHardwareAccelerated && Vector<double>.Count == Nr;
+        Assert.Equal(expected, PortableFp64_4x4.IsSupported);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PortableSimdStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PortableSimdStreamingTests.cs
@@ -1,0 +1,215 @@
+using System;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>
+/// Locks <see cref="PortableSimdStreaming"/> (the BCL <c>Vector{T}</c> FP64 streaming tier that
+/// keeps net471 off the scalar GEMM path) against <see cref="ScalarStreaming"/>.
+///
+/// <para>
+/// These assert BIT equality via <see cref="BitConverter.DoubleToInt64Bits"/>, not a tolerance.
+/// The kernel's whole design constraint is that vectorizing across <c>j</c> leaves each element's
+/// accumulation over <c>kk</c> in the original order, so "close enough" would silently permit the
+/// k-axis reassociation the design specifically avoids — and reassociation is what would break
+/// ScalarStreaming's documented bit-exact contract with ScalarFp32_4x4. Comparing raw bits also
+/// distinguishes -0.0 from 0.0, which a value comparison would not.
+/// </para>
+///
+/// <para>
+/// Deliberately NOT gated on a TFM. net471 is the reason this kernel exists, so the contract has
+/// to be verified there; on net10.0 the same code guards the non-intrinsic fallback tier.
+/// </para>
+/// </summary>
+public class PortableSimdStreamingTests
+{
+    private static double[] Random(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = (rng.NextDouble() * 2.0) - 1.0;
+        return a;
+    }
+
+    /// <summary>
+    /// Runs both kernels over identical inputs and asserts every C element matches bit-for-bit.
+    /// Leading dimensions are passed deliberately larger than the logical extents where the shape
+    /// allows, because real GEMM callers hand these kernels row strides into a bigger buffer and a
+    /// kernel that assumed ld == extent would still pass a tightly-packed test.
+    /// </summary>
+    private static void AssertBitExact(int m, int n, int k, bool transA, bool transB, int seed, int ldPad = 0)
+    {
+        int lda = (transA ? m : k) + ldPad;
+        int ldb = (transB ? k : n) + ldPad;
+        int ldc = n + ldPad;
+
+        // Size to the highest index each kernel can touch: (rows-1)*ld + extent.
+        int aLen = (((transA ? k : m) - 1) * lda) + (transA ? m : k);
+        int bLen = (((transB ? n : k) - 1) * ldb) + (transB ? k : n);
+        int cLen = ((m - 1) * ldc) + n;
+
+        var a = Random(aLen, seed);
+        var b = Random(bLen, seed + 1);
+        var cSeed = Random(cLen, seed + 2);
+
+        // C is read-modify-write, so both runs must start from the same non-zero C.
+        var cScalar = (double[])cSeed.Clone();
+        var cVector = (double[])cSeed.Clone();
+
+        ScalarStreaming.RunFp64(a, lda, transA, b, ldb, transB, cScalar, ldc, m, n, k);
+        PortableSimdStreaming.RunFp64(a, lda, transA, b, ldb, transB, cVector, ldc, m, n, k);
+
+        for (int i = 0; i < cLen; i++)
+        {
+            long want = BitConverter.DoubleToInt64Bits(cScalar[i]);
+            long got = BitConverter.DoubleToInt64Bits(cVector[i]);
+            Assert.True(want == got,
+                $"C[{i}] differs: scalar={cScalar[i]:R} (0x{want:X16}) vector={cVector[i]:R} (0x{got:X16}) " +
+                $"for m={m} n={n} k={k} transA={transA} transB={transB} ldPad={ldPad}");
+        }
+    }
+
+    [Theory]
+    // n straddling the vector width in both directions, so the tail loop and the pure-tail
+    // (n < lanes) bail are both exercised whether Vector<double>.Count is 2, 4 or 8.
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 2, 3)]
+    [InlineData(3, 3, 3)]
+    [InlineData(4, 4, 4)]
+    [InlineData(2, 5, 7)]
+    [InlineData(5, 8, 2)]
+    [InlineData(8, 9, 5)]
+    [InlineData(7, 16, 3)]
+    [InlineData(6, 17, 11)]
+    [InlineData(16, 31, 8)]
+    [InlineData(9, 64, 13)]
+    public void MatchesScalarBitExactly_ForBothTransA(int m, int n, int k)
+    {
+        AssertBitExact(m, n, k, transA: false, transB: false, seed: (m * 131) + (n * 17) + k);
+        AssertBitExact(m, n, k, transA: true, transB: false, seed: (m * 977) + (n * 31) + k);
+    }
+
+    [Theory]
+    [InlineData(4, 8, 4)]
+    [InlineData(6, 17, 11)]
+    [InlineData(3, 5, 9)]
+    public void MatchesScalarBitExactly_WithPaddedLeadingDimensions(int m, int n, int k)
+    {
+        // ldPad > 0 means the row stride exceeds the logical width, i.e. the kernel is writing
+        // into a window of a larger matrix. Getting this wrong corrupts neighbouring columns,
+        // which the padded region catches because it must come back untouched.
+        AssertBitExact(m, n, k, transA: false, transB: false, seed: 4242, ldPad: 3);
+        AssertBitExact(m, n, k, transA: true, transB: false, seed: 4243, ldPad: 5);
+    }
+
+    [Theory]
+    [InlineData(4, 8, 4)]
+    [InlineData(6, 17, 11)]
+    public void TransposedB_DelegatesToScalarAndStaysBitExact(int m, int n, int k)
+    {
+        // transB strides B along j so it cannot be j-vectorized; the kernel must hand it to the
+        // scalar path rather than emulate a gather. Either way the numbers must be identical.
+        AssertBitExact(m, n, k, transA: false, transB: true, seed: 909);
+        AssertBitExact(m, n, k, transA: true, transB: true, seed: 910);
+    }
+
+    [Fact]
+    public void ZeroTimesInfinityStillPropagatesNaN()
+    {
+        // The kernel documents that it must NOT skip aval == 0. An `if (aval == 0) continue`
+        // early-out is a tempting optimisation that changes results here: 0 * Infinity is NaN,
+        // and skipping would leave C's original value instead.
+        // WIDE ENOUGH TO REACH THE VECTOR BODY. RunFp64 hands off to ScalarStreaming when
+        // n < Vector<double>.Count, so a hard-coded n = 4 tested only the scalar path on any
+        // runtime with 8 lanes -- AVX-512 -- and this test's whole subject is what the VECTOR
+        // loop does with 0 * Infinity. It would have passed there while asserting nothing about
+        // the code it names. Sized from the runtime instead, so it reaches the vector body at
+        // 2, 4 or 8 lanes.
+        const int m = 1, k = 2;
+        int n = Math.Max(4, System.Numerics.Vector<double>.Count);
+        var a = new double[] { 0.0, 1.0 };
+        var b = new double[n * k];
+        for (int j = 0; j < n; j++)
+        {
+            b[j] = double.PositiveInfinity;   // k-row 0, multiplied by aval 0.0
+            b[n + j] = 1.0;                   // k-row 1, multiplied by aval 1.0
+        }
+
+        // The property this sizing exists for, asserted rather than assumed: if a future
+        // edit hard-codes n again, this fails here instead of silently testing the scalar
+        // path on a wide machine and reporting green.
+        Assert.True(n >= System.Numerics.Vector<double>.Count,
+            $"n={n} must reach the vector body (lanes={System.Numerics.Vector<double>.Count})");
+
+        var cScalar = new double[n];
+        var cVector = new double[n];
+        ScalarStreaming.RunFp64(a, k, false, b, n, false, cScalar, n, m, n, k);
+        PortableSimdStreaming.RunFp64(a, k, false, b, n, false, cVector, n, m, n, k);
+
+        for (int j = 0; j < n; j++)
+        {
+            Assert.True(double.IsNaN(cScalar[j]), $"reference should be NaN at {j}, got {cScalar[j]:R}");
+            Assert.Equal(BitConverter.DoubleToInt64Bits(cScalar[j]), BitConverter.DoubleToInt64Bits(cVector[j]));
+        }
+    }
+
+    [Fact]
+    public void NegativeZeroSignIsPreserved()
+    {
+        // -0.0 + -0.0 stays -0.0, while any accidental re-zeroing of the accumulator would give
+        // +0.0. Bit comparison is what makes this observable.
+        // Sized from the runtime for the same reason as the test above: at n = 4 on an 8-lane
+        // runtime this never entered the vector body, so the signed-zero claim was only ever
+        // checked against the scalar path it is supposed to be compared WITH.
+        const int m = 1, k = 1;
+        int n = Math.Max(4, System.Numerics.Vector<double>.Count);
+        var a = new double[] { -1.0 };
+        var b = new double[n];
+        var cScalar = new double[n];
+        var cVector = new double[n];
+        for (int j = 0; j < n; j++)
+        {
+            b[j] = 0.0;
+            cScalar[j] = -0.0;
+            cVector[j] = -0.0;
+        }
+
+        // The property this sizing exists for, asserted rather than assumed: if a future
+        // edit hard-codes n again, this fails here instead of silently testing the scalar
+        // path on a wide machine and reporting green.
+        Assert.True(n >= System.Numerics.Vector<double>.Count,
+            $"n={n} must reach the vector body (lanes={System.Numerics.Vector<double>.Count})");
+
+        ScalarStreaming.RunFp64(a, k, false, b, n, false, cScalar, n, m, n, k);
+        PortableSimdStreaming.RunFp64(a, k, false, b, n, false, cVector, n, m, n, k);
+
+        for (int j = 0; j < n; j++)
+            Assert.Equal(BitConverter.DoubleToInt64Bits(cScalar[j]), BitConverter.DoubleToInt64Bits(cVector[j]));
+    }
+
+    [Fact]
+    public void DegenerateExtentsAreNoOps()
+    {
+        var c = new double[] { 1.0, 2.0, 3.0, 4.0 };
+        var expected = (double[])c.Clone();
+        var a = new double[] { 5.0 };
+        var b = new double[] { 6.0 };
+
+        PortableSimdStreaming.RunFp64(a, 1, false, b, 1, false, c, 4, 0, 4, 1);
+        PortableSimdStreaming.RunFp64(a, 1, false, b, 1, false, c, 4, 1, 0, 1);
+        PortableSimdStreaming.RunFp64(a, 1, false, b, 1, false, c, 4, 1, 4, 0);
+
+        Assert.Equal(expected, c);
+    }
+
+    [Fact]
+    public void IsSupportedAgreesWithHardwareAcceleration()
+    {
+        // The tier must decline when Vector<T> is software-emulated, because emulated lanes are
+        // slower than the scalar kernel it would displace.
+        bool expected = System.Numerics.Vector.IsHardwareAccelerated
+                        && System.Numerics.Vector<double>.Count > 1;
+        Assert.Equal(expected, PortableSimdStreaming.IsSupported);
+    }
+}


### PR DESCRIPTION
Recreation of #928 onto latest main (identical content, non-stacked branch). #928 became unmergeable — GitHub wedged it in stacked-PR machinery (sticky flag from the now-merged #929, which had been stacked on #928's branch); every merge API refused it and its base couldn't be changed.

Content: net471 FP64 streaming GEMM microkernel (was fully scalar), plus the exceptional-value test-sizing fix originally from #929. Builds clean on net10/net8/net471; supersedes #928.