### PR TITLE
fix(tests): remove duplicate MeasuredResourceBudget theories in DirectPtxWmmaTests

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxWmmaTests.cs
@@ -771,34 +771,6 @@ public class DirectPtxWmmaTests
     }
 
     [Theory]
-    [InlineData(14, 16)]
-    [InlineData(22, 24)]
-    [InlineData(26, 32)]
-    [InlineData(34, 40)]
-    [InlineData(40, 40)]
-    public void MeasuredResourceBudget_StaysWithinCurrentRegisterAllocationBucket(
-        int measuredRegisters, int expectedMaximum)
-    {
-        DirectPtxResourceBudget budget = DirectPtxResourceBudget.FromDriverMeasurement(
-            measuredRegisters, maxStaticSharedBytes: 0,
-            maxLocalBytesPerThread: 0, minBlocksPerMultiprocessor: 1);
-
-        Assert.Equal(measuredRegisters, budget.MeasuredRegistersPerThread);
-        Assert.Equal(expectedMaximum, budget.MaxRegistersPerThread);
-    }
-
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-1)]
-    public void MeasuredResourceBudget_RejectsNonPositiveMeasurement(int measuredRegisters)
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
-            DirectPtxResourceBudget.FromDriverMeasurement(
-                measuredRegisters, maxStaticSharedBytes: 0,
-                maxLocalBytesPerThread: 0, minBlocksPerMultiprocessor: 1));
-    }
-
-    [Theory]
     [InlineData(8, 0, (int)DirectPtxArchitectureFamily.Ampere)]
     [InlineData(8, 6, (int)DirectPtxArchitectureFamily.Ampere)]
     [InlineData(8, 9, (int)DirectPtxArchitectureFamily.Ada)]


### PR DESCRIPTION
A merge (#885) landed two identical copies of the MeasuredResourceBudget_* theories in DirectPtxWmmaTests (CS0111), breaking the tests-project build on main. Removes the duplicate copy. Verified: tests project builds clean on net10.