### PR TITLE
fix(autodiff): harden gradient ownership and composite contracts

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -217,7 +217,7 @@ public sealed class CompiledBackwardGraph<T>
                 entry.ValidateInputVersions();
                 var inputsArray = entry.GetInputsArrayInto(inputsBuf1, inputsBuf2, inputsBuf3);
                 long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                DifferentiableOps.BeginBackwardStep(grads);
+                var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
                 try
                 {
                     entry.Backward(gradOutput, inputsArray, entry.Output,
@@ -225,7 +225,7 @@ public sealed class CompiledBackwardGraph<T>
                 }
                 finally
                 {
-                    DifferentiableOps.EndBackwardStep<T>();
+                    DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
                 if (BackwardTiming.Enabled)
                     BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -217,8 +217,16 @@ public sealed class CompiledBackwardGraph<T>
                 entry.ValidateInputVersions();
                 var inputsArray = entry.GetInputsArrayInto(inputsBuf1, inputsBuf2, inputsBuf3);
                 long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                entry.Backward(gradOutput, inputsArray, entry.Output,
-                    entry.SavedState ?? Array.Empty<object>(), _engine, grads);
+                DifferentiableOps.BeginBackwardStep(grads);
+                try
+                {
+                    entry.Backward(gradOutput, inputsArray, entry.Output,
+                        entry.SavedState ?? Array.Empty<object>(), _engine, grads);
+                }
+                finally
+                {
+                    DifferentiableOps.EndBackwardStep<T>();
+                }
                 if (BackwardTiming.Enabled)
                     BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
             }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardWalk.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardWalk.cs
@@ -1702,6 +1702,8 @@ internal static class CompiledBackwardWalk<T>
         // calls per entry. CLR allows byref locals for managed pointers to
         // struct types; the JIT keeps them in a register or stack slot.
         var entryRefLocal = il.DeclareLocal(typeof(TapeEntry<T>).MakeByRefType());
+        var previousAccumulatorOwnersLocal = il.DeclareLocal(
+            typeof(Dictionary<Tensor<T>, Tensor<T>>));
 
         // state = InitState(loss, reservedCount)
         il.Emit(OpCodes.Ldarg_1);
@@ -1806,9 +1808,8 @@ internal static class CompiledBackwardWalk<T>
             // operation. The specialised walker bypasses ProcessEntry, so it
             // must emit the same begin/finally/end contract as every delegate
             // execution path.
-            il.Emit(OpCodes.Ldloca, stateLocal);
-            il.Emit(OpCodes.Ldfld, gradsField);
             il.Emit(OpCodes.Call, beginBackwardStepMethod);
+            il.Emit(OpCodes.Stloc, previousAccumulatorOwnersLocal);
             il.BeginExceptionBlock();
 
             // Inliner registry check: if this backward method has a
@@ -1863,6 +1864,7 @@ internal static class CompiledBackwardWalk<T>
             }
 
             il.BeginFinallyBlock();
+            il.Emit(OpCodes.Ldloc, previousAccumulatorOwnersLocal);
             il.Emit(OpCodes.Call, endBackwardStepMethod);
             il.EndExceptionBlock();
 
@@ -1974,7 +1976,7 @@ internal static class CompiledBackwardWalkHelpers<T>
         if (!state.Grads.TryGetValue(entry.Output, out var gradOutput))
             return true;
 
-        DifferentiableOps.BeginBackwardStep(state.Grads);
+        var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
         try
         {
             entry.Backward(
@@ -1987,7 +1989,7 @@ internal static class CompiledBackwardWalkHelpers<T>
         }
         finally
         {
-            DifferentiableOps.EndBackwardStep<T>();
+            DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
         }
         return true;
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardWalk.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardWalk.cs
@@ -1765,6 +1765,14 @@ internal static class CompiledBackwardWalk<T>
             "AccumulateGrad",
             BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
             ?.MakeGenericMethod(typeof(T));
+        var beginBackwardStepMethod = diffOpsType.GetMethod(
+            "BeginBackwardStep",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(T));
+        var endBackwardStepMethod = diffOpsType.GetMethod(
+            "EndBackwardStep",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(T));
 
         for (int i = 0; i < reverseTopoIndices.Length; i++)
         {
@@ -1792,7 +1800,16 @@ internal static class CompiledBackwardWalk<T>
             il.Emit(OpCodes.Ldfld, outputField);       // entry.Output
             il.Emit(OpCodes.Ldloca, gradOutputLocal);
             il.Emit(OpCodes.Callvirt, tryGetValueMethod);
-            il.Emit(OpCodes.Brfalse_S, skipLabel);
+            il.Emit(OpCodes.Brfalse, skipLabel);
+
+            // Scope first-write accumulator ownership to exactly one backward
+            // operation. The specialised walker bypasses ProcessEntry, so it
+            // must emit the same begin/finally/end contract as every delegate
+            // execution path.
+            il.Emit(OpCodes.Ldloca, stateLocal);
+            il.Emit(OpCodes.Ldfld, gradsField);
+            il.Emit(OpCodes.Call, beginBackwardStepMethod);
+            il.BeginExceptionBlock();
 
             // Inliner registry check: if this backward method has a
             // per-op IL inliner, let it emit the gradient math directly
@@ -1845,7 +1862,9 @@ internal static class CompiledBackwardWalk<T>
                 il.Emit(OpCodes.Call, bwdMethod);
             }
 
-            il.Emit(OpCodes.Br_S, skipLabel);
+            il.BeginFinallyBlock();
+            il.Emit(OpCodes.Call, endBackwardStepMethod);
+            il.EndExceptionBlock();
 
             il.MarkLabel(skipLabel);
         }
@@ -1955,13 +1974,21 @@ internal static class CompiledBackwardWalkHelpers<T>
         if (!state.Grads.TryGetValue(entry.Output, out var gradOutput))
             return true;
 
-        entry.Backward(
-            gradOutput,
-            entry.GetInputsArrayInto(state.Buf1, state.Buf2, state.Buf3),
-            entry.Output,
-            entry.SavedState ?? Array.Empty<object>(),
-            engine,
-            state.Grads);
+        DifferentiableOps.BeginBackwardStep(state.Grads);
+        try
+        {
+            entry.Backward(
+                gradOutput,
+                entry.GetInputsArrayInto(state.Buf1, state.Buf2, state.Buf3),
+                entry.Output,
+                entry.SavedState ?? Array.Empty<object>(),
+                engine,
+                state.Grads);
+        }
+        finally
+        {
+            DifferentiableOps.EndBackwardStep<T>();
+        }
         return true;
     }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -223,8 +223,16 @@ internal sealed class CompiledDelegateChain<T>
                 continue;
 
             long start = timing ? Stopwatch.GetTimestamp() : 0;
-            step.Backward(gradOutput, step.Inputs, step.Output,
-                step.SavedState ?? Array.Empty<object>(), engine, grads);
+            DifferentiableOps.BeginBackwardStep(grads);
+            try
+            {
+                step.Backward(gradOutput, step.Inputs, step.Output,
+                    step.SavedState ?? Array.Empty<object>(), engine, grads);
+            }
+            finally
+            {
+                DifferentiableOps.EndBackwardStep<T>();
+            }
             if (timing)
             {
                 long ticks = Stopwatch.GetTimestamp() - start;

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -223,7 +223,7 @@ internal sealed class CompiledDelegateChain<T>
                 continue;
 
             long start = timing ? Stopwatch.GetTimestamp() : 0;
-            DifferentiableOps.BeginBackwardStep(grads);
+            var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
             try
             {
                 step.Backward(gradOutput, step.Inputs, step.Output,
@@ -231,7 +231,7 @@ internal sealed class CompiledDelegateChain<T>
             }
             finally
             {
-                DifferentiableOps.EndBackwardStep<T>();
+                DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
             }
             if (timing)
             {

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -210,12 +210,35 @@ internal static class DifferentiableOps
     internal static TensorViewRecordingSuppression SuppressTensorViewRecording()
     {
         s_tensorViewRecordingSuppressionDepth++;
-        return new TensorViewRecordingSuppression();
+        return new TensorViewRecordingSuppression(new TensorViewRecordingSuppressionState());
     }
 
     internal readonly struct TensorViewRecordingSuppression : IDisposable
     {
-        public void Dispose() => s_tensorViewRecordingSuppressionDepth--;
+        private readonly TensorViewRecordingSuppressionState? _state;
+
+        internal TensorViewRecordingSuppression(TensorViewRecordingSuppressionState state)
+        {
+            _state = state;
+        }
+
+        public void Dispose()
+        {
+            // A reference-backed lease makes disposal idempotent even when this
+            // readonly struct is copied: every copy observes the same release bit.
+            if (_state is null || _state.IsReleased)
+            {
+                return;
+            }
+
+            _state.IsReleased = true;
+            s_tensorViewRecordingSuppressionDepth--;
+        }
+    }
+
+    internal sealed class TensorViewRecordingSuppressionState
+    {
+        internal bool IsReleased;
     }
 
     /// <summary>
@@ -481,7 +504,7 @@ internal static class DifferentiableOps
         IEngine engine)
     {
         bool needsOutOfPlace = _isBackwardCreateGraph;
-        bool wasAlreadyOwned = !needsOutOfPlace && IsAccumulatorBufferOwned(grads, grad);
+        bool wasAlreadyOwned = !needsOutOfPlace && IsAccumulatorBufferOwned(grad);
         int idx = tensor._gradIndex;
         if (idx >= 0 && _indexedGrads != null && idx < _indexedGrads.Length
             && _indexedGrads[idx] != null)
@@ -594,7 +617,7 @@ internal static class DifferentiableOps
                     {
                         var previous = existing;
                         existing = existing.Contiguous();
-                        ReplaceAccumulatorBufferOwner(grads, tensor, previous, existing);
+                        ReplaceAccumulatorBufferOwner(tensor, previous, existing);
                     }
 
                     // A contribution can be the same tensor object as this
@@ -603,10 +626,10 @@ internal static class DifferentiableOps
                     // another input has had a chance to consume it. Detach this
                     // one slot out-of-place; ordinary unique accumulation stays
                     // on the zero-allocation in-place path.
-                    if (ReferenceEquals(existing, gradForInPlace))
+                    if (HasOverlappingStorage(existing, gradForInPlace))
                     {
                         accumulated = AddAliasedContributionOutOfPlace(existing, gradForInPlace, engine);
-                        ReplaceAccumulatorBufferOwner(grads, tensor, existing, accumulated);
+                        ReplaceAccumulatorBufferOwner(tensor, existing, accumulated);
                     }
                     else
                     {
@@ -625,7 +648,7 @@ internal static class DifferentiableOps
                 // isolates a contribution already owned by another slot.
                 var stored = needsOutOfPlace
                     ? grad
-                    : TakeAccumulatorBuffer(grads, tensor, gradForInPlace);
+                    : TakeAccumulatorBuffer(tensor, gradForInPlace);
                 _indexedGrads[idx] = stored;
                 tensor.Grad = stored;
             }
@@ -649,14 +672,14 @@ internal static class DifferentiableOps
                     var previous = existingDict;
                     existingDict = existingDict.Contiguous();
                     grads[tensor] = existingDict;
-                    ReplaceAccumulatorBufferOwner(grads, tensor, previous, existingDict);
+                    ReplaceAccumulatorBufferOwner(tensor, previous, existingDict);
                 }
-                if (ReferenceEquals(existingDict, gradForInPlace))
+                if (HasOverlappingStorage(existingDict, gradForInPlace))
                 {
                     var accumulated = AddAliasedContributionOutOfPlace(existingDict, gradForInPlace, engine);
                     grads[tensor] = accumulated;
                     tensor.Grad = accumulated;
-                    ReplaceAccumulatorBufferOwner(grads, tensor, existingDict, accumulated);
+                    ReplaceAccumulatorBufferOwner(tensor, existingDict, accumulated);
                 }
                 else
                 {
@@ -669,30 +692,33 @@ internal static class DifferentiableOps
         {
             var stored = needsOutOfPlace
                 ? grad
-                : TakeAccumulatorBuffer(grads, tensor, gradForInPlace);
+                : TakeAccumulatorBuffer(tensor, gradForInPlace);
             grads[tensor] = stored;
             tensor.Grad = stored;
         }
     }
 
     /// <summary>
-    /// Tracks ownership of donated first-write buffers for one backward dictionary.
+    /// Tracks ownership of donated first-write buffers for one backward step.
     /// </summary>
     /// <remarks>
     /// The reverse map makes the common unique-buffer path O(1) and zero-copy while
     /// identifying the exceptional case where one backward function offers the same
     /// contribution object to several inputs. It is thread-local because a tape's
-    /// backward walk is single-threaded, and it is cleared at both boundaries of
-    /// every backward operation so later operations cannot inherit stale ownership.
+    /// backward walk is single-threaded. Nested backward operations install their own
+    /// map and restore the outer map when they finish, so inner execution cannot erase
+    /// the outer operation's donation history.
     /// </remarks>
     private static class GradientAccumulatorOwnership<T>
     {
         [ThreadStatic]
         internal static Dictionary<Tensor<T>, Tensor<T>>? Owners;
+
+        [ThreadStatic]
+        internal static Stack<Dictionary<Tensor<T>, Tensor<T>>>? Available;
     }
 
-    private static Dictionary<Tensor<T>, Tensor<T>> GetAccumulatorOwners<T>(
-        Dictionary<Tensor<T>, Tensor<T>> grads)
+    private static Dictionary<Tensor<T>, Tensor<T>> GetAccumulatorOwners<T>()
     {
         GradientAccumulatorOwnership<T>.Owners ??=
             new Dictionary<Tensor<T>, Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
@@ -709,25 +735,43 @@ internal static class DifferentiableOps
     /// offered the identical object receives an isolated copy.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void BeginBackwardStep<T>(Dictionary<Tensor<T>, Tensor<T>> grads)
-        => GetAccumulatorOwners(grads).Clear();
+    internal static Dictionary<Tensor<T>, Tensor<T>>? BeginBackwardStep<T>()
+    {
+        var previous = GradientAccumulatorOwnership<T>.Owners;
+        var available = GradientAccumulatorOwnership<T>.Available;
+        var current = available is { Count: > 0 }
+            ? available.Pop()
+            : new Dictionary<Tensor<T>, Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+        current.Clear();
+        GradientAccumulatorOwnership<T>.Owners = current;
+        return previous;
+    }
 
-    /// <summary>Releases the final strong references held by one donation scope.</summary>
+    /// <summary>
+    /// Releases one donation scope and restores the enclosing scope, if any.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void EndBackwardStep<T>()
-        => GradientAccumulatorOwnership<T>.Owners?.Clear();
+    internal static void EndBackwardStep<T>(Dictionary<Tensor<T>, Tensor<T>>? previous)
+    {
+        var completed = GradientAccumulatorOwnership<T>.Owners;
+        GradientAccumulatorOwnership<T>.Owners = previous;
+        if (completed is null || ReferenceEquals(completed, previous))
+        {
+            return;
+        }
 
-    private static bool IsAccumulatorBufferOwned<T>(
-        Dictionary<Tensor<T>, Tensor<T>> grads,
-        Tensor<T> buffer)
-        => GetAccumulatorOwners(grads).ContainsKey(buffer);
+        completed.Clear();
+        (GradientAccumulatorOwnership<T>.Available ??= new()).Push(completed);
+    }
+
+    private static bool IsAccumulatorBufferOwned<T>(Tensor<T> buffer)
+        => GetAccumulatorOwners<T>().ContainsKey(buffer);
 
     private static Tensor<T> TakeAccumulatorBuffer<T>(
-        Dictionary<Tensor<T>, Tensor<T>> grads,
         Tensor<T> destination,
         Tensor<T> contribution)
     {
-        var owners = GetAccumulatorOwners(grads);
+        var owners = GetAccumulatorOwners<T>();
         if (!owners.ContainsKey(contribution))
         {
             owners[contribution] = destination;
@@ -744,14 +788,27 @@ internal static class DifferentiableOps
     }
 
     private static void ReplaceAccumulatorBufferOwner<T>(
-        Dictionary<Tensor<T>, Tensor<T>> grads,
         Tensor<T> destination,
         Tensor<T> previous,
         Tensor<T> replacement)
     {
-        var owners = GetAccumulatorOwners(grads);
+        var owners = GetAccumulatorOwners<T>();
         owners.Remove(previous);
         owners[replacement] = destination;
+    }
+
+    private static bool HasOverlappingStorage<T>(Tensor<T> left, Tensor<T> right)
+    {
+        if (!ReferenceEquals(left._storage, right._storage))
+        {
+            return false;
+        }
+
+        long leftStart = left._storageOffset;
+        long rightStart = right._storageOffset;
+        long leftEnd = leftStart + left.Length;
+        long rightEnd = rightStart + right.Length;
+        return leftStart < rightEnd && rightStart < leftEnd;
     }
 
     private static Tensor<T> AddAliasedContributionOutOfPlace<T>(

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -459,6 +459,7 @@ internal static class DifferentiableOps
         IEngine engine)
     {
         bool needsOutOfPlace = _isBackwardCreateGraph;
+        bool wasAlreadyOwned = !needsOutOfPlace && IsAccumulatorBufferOwned(grads, grad);
         int idx = tensor._gradIndex;
         if (idx >= 0 && _indexedGrads != null && idx < _indexedGrads.Length
             && _indexedGrads[idx] != null)
@@ -468,14 +469,17 @@ internal static class DifferentiableOps
             // In-place add consumes grad; out-of-place (createGraph) keeps
             // it linked into the recorded TensorAdd's input chain — DO NOT
             // pool in that case.
-            return !needsOutOfPlace;
+            return !needsOutOfPlace && !wasAlreadyOwned;
         }
         if (grads.ContainsKey(tensor))
         {
             AccumulateGrad(grads, tensor, grad, engine);
-            return !needsOutOfPlace;
+            return !needsOutOfPlace && !wasAlreadyOwned;
         }
-        // First-write: grad becomes the stored slot. Don't pool.
+        // First-write donates the buffer when it is unique, or copies it when it
+        // is already owned by another gradient slot. Either way, the caller must
+        // not return the contribution: the donated buffer is now the accumulator,
+        // while an aliased contribution still belongs to its earlier owner.
         AccumulateGrad(grads, tensor, grad, engine);
         return false;
     }
@@ -564,20 +568,42 @@ internal static class DifferentiableOps
                     // Defensive: if the existing slot is somehow
                     // non-contiguous (e.g. populated outside this
                     // method), materialize before in-place add.
-                    if (!existing.IsContiguous) existing = existing.Contiguous();
-                    engine.TensorAddInPlace(existing, gradForInPlace);
-                    accumulated = existing;
+                    if (!existing.IsContiguous)
+                    {
+                        var previous = existing;
+                        existing = existing.Contiguous();
+                        ReplaceAccumulatorBufferOwner(grads, tensor, previous, existing);
+                    }
+
+                    // A contribution can be the same tensor object as this
+                    // destination's first-write accumulator (for example x+x).
+                    // Mutating it would change the borrowed contribution before
+                    // another input has had a chance to consume it. Detach this
+                    // one slot out-of-place; ordinary unique accumulation stays
+                    // on the zero-allocation in-place path.
+                    if (ReferenceEquals(existing, gradForInPlace))
+                    {
+                        accumulated = AddAliasedContributionOutOfPlace(existing, gradForInPlace, engine);
+                        ReplaceAccumulatorBufferOwner(grads, tensor, existing, accumulated);
+                    }
+                    else
+                    {
+                        engine.TensorAddInPlace(existing, gradForInPlace);
+                        accumulated = existing;
+                    }
                 }
                 _indexedGrads[idx] = accumulated;
                 tensor.Grad = accumulated;
             }
             else
             {
-                // First-write slot. In createGraph mode keep the
-                // original `grad` so future TensorAdd entries can chain
-                // through it; in normal mode store the contiguous copy
-                // so the next AccumulateGrad can in-place-add into it.
-                var stored = needsOutOfPlace ? grad : gradForInPlace;
+                // First-write slot. In createGraph mode keep the original
+                // `grad` so future TensorAdd entries can chain through it.
+                // Normal backward donates unique scratch without a copy, but
+                // isolates a contribution already owned by another slot.
+                var stored = needsOutOfPlace
+                    ? grad
+                    : TakeAccumulatorBuffer(grads, tensor, gradForInPlace);
                 _indexedGrads[idx] = stored;
                 tensor.Grad = stored;
             }
@@ -598,18 +624,124 @@ internal static class DifferentiableOps
             {
                 if (!existingDict.IsContiguous)
                 {
+                    var previous = existingDict;
                     existingDict = existingDict.Contiguous();
                     grads[tensor] = existingDict;
+                    ReplaceAccumulatorBufferOwner(grads, tensor, previous, existingDict);
                 }
-                engine.TensorAddInPlace(existingDict, gradForInPlace);
-                tensor.Grad = existingDict;
+                if (ReferenceEquals(existingDict, gradForInPlace))
+                {
+                    var accumulated = AddAliasedContributionOutOfPlace(existingDict, gradForInPlace, engine);
+                    grads[tensor] = accumulated;
+                    tensor.Grad = accumulated;
+                    ReplaceAccumulatorBufferOwner(grads, tensor, existingDict, accumulated);
+                }
+                else
+                {
+                    engine.TensorAddInPlace(existingDict, gradForInPlace);
+                    tensor.Grad = existingDict;
+                }
             }
         }
         else
         {
-            var stored = needsOutOfPlace ? grad : gradForInPlace;
+            var stored = needsOutOfPlace
+                ? grad
+                : TakeAccumulatorBuffer(grads, tensor, gradForInPlace);
             grads[tensor] = stored;
             tensor.Grad = stored;
         }
+    }
+
+    /// <summary>
+    /// Tracks ownership of donated first-write buffers for one backward dictionary.
+    /// </summary>
+    /// <remarks>
+    /// The reverse map makes the common unique-buffer path O(1) and zero-copy while
+    /// identifying the exceptional case where one backward function offers the same
+    /// contribution object to several inputs. It is thread-local because a tape's
+    /// backward walk is single-threaded, and it is cleared at both boundaries of
+    /// every backward operation so later operations cannot inherit stale ownership.
+    /// </remarks>
+    private static class GradientAccumulatorOwnership<T>
+    {
+        [ThreadStatic]
+        internal static Dictionary<Tensor<T>, Tensor<T>>? Owners;
+    }
+
+    private static Dictionary<Tensor<T>, Tensor<T>> GetAccumulatorOwners<T>(
+        Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        GradientAccumulatorOwnership<T>.Owners ??=
+            new Dictionary<Tensor<T>, Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+        return GradientAccumulatorOwnership<T>.Owners!;
+    }
+
+    /// <summary>
+    /// Starts one backward operation's donation scope.
+    /// </summary>
+    /// <remarks>
+    /// A node's incoming gradient is fully accumulated before its backward runs,
+    /// so that node may donate the buffer to its first input. Ownership must then
+    /// remain visible for the rest of the same backward call so a second input
+    /// offered the identical object receives an isolated copy.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void BeginBackwardStep<T>(Dictionary<Tensor<T>, Tensor<T>> grads)
+        => GetAccumulatorOwners(grads).Clear();
+
+    /// <summary>Releases the final strong references held by one donation scope.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void EndBackwardStep<T>()
+        => GradientAccumulatorOwnership<T>.Owners?.Clear();
+
+    private static bool IsAccumulatorBufferOwned<T>(
+        Dictionary<Tensor<T>, Tensor<T>> grads,
+        Tensor<T> buffer)
+        => GetAccumulatorOwners(grads).ContainsKey(buffer);
+
+    private static Tensor<T> TakeAccumulatorBuffer<T>(
+        Dictionary<Tensor<T>, Tensor<T>> grads,
+        Tensor<T> destination,
+        Tensor<T> contribution)
+    {
+        var owners = GetAccumulatorOwners(grads);
+        if (!owners.ContainsKey(contribution))
+        {
+            owners[contribution] = destination;
+            return contribution;
+        }
+
+        // This contribution is borrowed by another destination. Use dedicated,
+        // non-arena storage for the exceptional copy so its lifetime is not tied
+        // to recyclable backward scratch.
+        var owned = new Tensor<T>(contribution._shape);
+        contribution.CopyTo(owned.AsWritableSpan());
+        owners[owned] = destination;
+        return owned;
+    }
+
+    private static void ReplaceAccumulatorBufferOwner<T>(
+        Dictionary<Tensor<T>, Tensor<T>> grads,
+        Tensor<T> destination,
+        Tensor<T> previous,
+        Tensor<T> replacement)
+    {
+        var owners = GetAccumulatorOwners(grads);
+        owners.Remove(previous);
+        owners[replacement] = destination;
+    }
+
+    private static Tensor<T> AddAliasedContributionOutOfPlace<T>(
+        Tensor<T> existing,
+        Tensor<T> contribution,
+        IEngine engine)
+    {
+        // Use the explicit destination API instead of TensorAdd. Besides making
+        // ownership unambiguous, this cannot be collapsed by an algebraic/CSE
+        // identity when both operands are the same tensor object.
+        var accumulated = new Tensor<T>(existing._shape);
+        engine.TensorAddInto(accumulated, existing, contribution);
+        return accumulated;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -196,6 +196,28 @@ internal static class DifferentiableOps
         return GradientTape<T>.Current is not null && !NoGradScope<T>.IsSuppressed;
     }
 
+    // Engine view methods delegate their storage work to Tensor.Reshape/Transpose and then
+    // register an operation-specific backward edge themselves. Suppress the Tensor-level
+    // fallback only for that narrow call so a view is recorded exactly once. Direct Tensor
+    // view APIs remain fully differentiable and replayable.
+    [ThreadStatic]
+    private static int s_tensorViewRecordingSuppressionDepth;
+
+    internal static bool IsTensorViewRecordingSuppressed
+        => s_tensorViewRecordingSuppressionDepth > 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TensorViewRecordingSuppression SuppressTensorViewRecording()
+    {
+        s_tensorViewRecordingSuppressionDepth++;
+        return new TensorViewRecordingSuppression();
+    }
+
+    internal readonly struct TensorViewRecordingSuppression : IDisposable
+    {
+        public void Dispose() => s_tensorViewRecordingSuppressionDepth--;
+    }
+
     /// <summary>
     /// Records a variadic operation (4+ inputs) to the current gradient tape if one is active.
     /// The caller must provide the pre-allocated inputs array.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -662,8 +662,16 @@ public sealed class GradientTape<T> : IDisposable
                         }
                     }
 
-                    step.Backward(gradOutput, step.Inputs, step.Output,
-                        step.SavedState ?? Array.Empty<object>(), engine, grads);
+                    DifferentiableOps.BeginBackwardStep(grads);
+                    try
+                    {
+                        step.Backward(gradOutput, step.Inputs, step.Output,
+                            step.SavedState ?? Array.Empty<object>(), engine, grads);
+                    }
+                    finally
+                    {
+                        DifferentiableOps.EndBackwardStep<T>();
+                    }
 
                     // Release this node-output's gradient now that its backward has
                     // consumed it. In the reverse topo walk every consumer of this
@@ -1125,7 +1133,15 @@ public sealed class GradientTape<T> : IDisposable
                 // Invoke the backward function. Phase A (#338) timing
                 // wrapper records per-op ticks when AIDOTNET_BWD_TIMING=1.
                 long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                entry.Backward(gradOutput, inputsArray, entry.Output, entry.SavedState ?? Array.Empty<object>(), engine, grads);
+                DifferentiableOps.BeginBackwardStep(grads);
+                try
+                {
+                    entry.Backward(gradOutput, inputsArray, entry.Output, entry.SavedState ?? Array.Empty<object>(), engine, grads);
+                }
+                finally
+                {
+                    DifferentiableOps.EndBackwardStep<T>();
+                }
                 if (BackwardTiming.Enabled)
                     BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -1663,10 +1663,15 @@ public sealed class GradientTape<T> : IDisposable
                         if (nodeToEntryIndex.TryGetValue(node, out int entryIdx))
                             reverseTopoIndices[writeIdx++] = entryIdx;
                     }
-                    if (writeIdx < reverseTopoIndices.Length)
-                        Array.Resize(ref reverseTopoIndices, writeIdx);
-
-                    RebindablePlanCache<T>.Store(patternHash, _entries.Count, reverseTopoIndices, _entries);
+                    // A rebindable plan is correct only when EVERY graph node has a matching
+                    // current-tape entry. Graph-only nodes cannot be represented by an entry-index
+                    // replay. Never cache a partial walk: falling back to DFS costs time; replaying
+                    // a partial walk silently loses gradients.
+                    if (writeIdx == reverseTopoIndices.Length)
+                    {
+                        RebindablePlanCache<T>.Store(
+                            patternHash, _entries.Count, reverseTopoIndices, _entries);
+                    }
                 }
             }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -662,7 +662,7 @@ public sealed class GradientTape<T> : IDisposable
                         }
                     }
 
-                    DifferentiableOps.BeginBackwardStep(grads);
+                    var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
                     try
                     {
                         step.Backward(gradOutput, step.Inputs, step.Output,
@@ -670,7 +670,7 @@ public sealed class GradientTape<T> : IDisposable
                     }
                     finally
                     {
-                        DifferentiableOps.EndBackwardStep<T>();
+                        DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                     }
 
                     // Release this node-output's gradient now that its backward has
@@ -1133,14 +1133,14 @@ public sealed class GradientTape<T> : IDisposable
                 // Invoke the backward function. Phase A (#338) timing
                 // wrapper records per-op ticks when AIDOTNET_BWD_TIMING=1.
                 long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                DifferentiableOps.BeginBackwardStep(grads);
+                var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
                 try
                 {
                     entry.Backward(gradOutput, inputsArray, entry.Output, entry.SavedState ?? Array.Empty<object>(), engine, grads);
                 }
                 finally
                 {
-                    DifferentiableOps.EndBackwardStep<T>();
+                    DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
                 if (BackwardTiming.Enabled)
                     BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -142,30 +142,38 @@ internal sealed class OptimizedBackwardPlan<T>
 
                 entry.ValidateInputVersions();
 
-                // Try optimized path for MatMul operations
-                if (TryOptimizedMatMulBackward(ref entry, gradOutput, cse, grads))
+                DifferentiableOps.BeginBackwardStep(grads);
+                try
                 {
+                    // Try optimized path for MatMul operations
+                    if (TryOptimizedMatMulBackward(ref entry, gradOutput, cse, grads))
+                    {
+                        FreeDeadActivation(entry.Output);
+                        continue;
+                    }
+
+                    // Default path: use the original backward function.
+                    // Phase A (#338) timing wrapper records per-op ticks when
+                    // AIDOTNET_BWD_TIMING=1.
+                    //
+                    // Issue #433 phase-2: GetInputsArrayInto with thread-local
+                    // scratch buffers eliminates the per-entry array allocation
+                    // GetInputsArray() previously paid. Buffers acquired once
+                    // before the loop, reused across all entries; same buffers
+                    // CompiledBackwardGraph.Execute uses.
+                    var inputsArray = entry.GetInputsArrayInto(_inputsBuf1!, _inputsBuf2!, _inputsBuf3!);
+                    long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+                    entry.Backward(gradOutput, inputsArray, entry.Output,
+                        entry.SavedState ?? Array.Empty<object>(), _engine, grads);
+                    if (BackwardTiming.Enabled)
+                        BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
+
                     FreeDeadActivation(entry.Output);
-                    continue;
                 }
-
-                // Default path: use the original backward function.
-                // Phase A (#338) timing wrapper records per-op ticks when
-                // AIDOTNET_BWD_TIMING=1.
-                //
-                // Issue #433 phase-2: GetInputsArrayInto with thread-local
-                // scratch buffers eliminates the per-entry array allocation
-                // GetInputsArray() previously paid. Buffers acquired once
-                // before the loop, reused across all entries; same buffers
-                // CompiledBackwardGraph.Execute uses.
-                var inputsArray = entry.GetInputsArrayInto(_inputsBuf1!, _inputsBuf2!, _inputsBuf3!);
-                long _bwdStart = BackwardTiming.Enabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
-                entry.Backward(gradOutput, inputsArray, entry.Output,
-                    entry.SavedState ?? Array.Empty<object>(), _engine, grads);
-                if (BackwardTiming.Enabled)
-                    BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
-
-                FreeDeadActivation(entry.Output);
+                finally
+                {
+                    DifferentiableOps.EndBackwardStep<T>();
+                }
             }
         }
         finally

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -142,7 +142,7 @@ internal sealed class OptimizedBackwardPlan<T>
 
                 entry.ValidateInputVersions();
 
-                DifferentiableOps.BeginBackwardStep(grads);
+                var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
                 try
                 {
                     // Try optimized path for MatMul operations
@@ -172,7 +172,7 @@ internal sealed class OptimizedBackwardPlan<T>
                 }
                 finally
                 {
-                    DifferentiableOps.EndBackwardStep<T>();
+                    DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
             }
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
@@ -207,7 +207,7 @@ internal static class RebindablePlanCache<T>
                     continue;
 
                 long start = timing ? Stopwatch.GetTimestamp() : 0;
-                DifferentiableOps.BeginBackwardStep(grads);
+                var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
                 try
                 {
                     entry.Backward(
@@ -220,7 +220,7 @@ internal static class RebindablePlanCache<T>
                 }
                 finally
                 {
-                    DifferentiableOps.EndBackwardStep<T>();
+                    DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
                 if (timing)
                 {

--- a/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
@@ -207,13 +207,21 @@ internal static class RebindablePlanCache<T>
                     continue;
 
                 long start = timing ? Stopwatch.GetTimestamp() : 0;
-                entry.Backward(
-                    gradOutput,
-                    entry.GetInputsArrayInto(inputsBuffer1, inputsBuffer2, inputsBuffer3),
-                    entry.Output,
-                    entry.SavedState ?? Array.Empty<object>(),
-                    engine,
-                    grads);
+                DifferentiableOps.BeginBackwardStep(grads);
+                try
+                {
+                    entry.Backward(
+                        gradOutput,
+                        entry.GetInputsArrayInto(inputsBuffer1, inputsBuffer2, inputsBuffer3),
+                        entry.Output,
+                        entry.SavedState ?? Array.Empty<object>(),
+                        engine,
+                        grads);
+                }
+                finally
+                {
+                    DifferentiableOps.EndBackwardStep<T>();
+                }
                 if (timing)
                 {
                     long ticks = Stopwatch.GetTimestamp() - start;

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTrainingCompiler.cs
@@ -281,12 +281,17 @@ internal static class AutoTrainingCompiler
         hash ^= typeof(T).GetHashCode();
         hash *= unchecked((long)0x100000001b3L);
 
-        HashSet<Tensor<T>>? produced = null;
+        // Track the ordinal of each produced tensor for every hash, not only the
+        // value-sensitive compiler hash. Operation names and shapes do not describe a DAG:
+        // a dead recorded branch and a loss-connected branch can have the same flat op sequence.
+        // Reusing one branch's reverse-topology plan for the other silently omits gradients.
+        var producerOrdinals = StructureHashScratch<T>.ProducerOrdinals ??=
+            new Dictionary<Tensor<T>, int>(TensorIdentityComparer<T>.Instance);
+        producerOrdinals.Clear();
         HashSet<Tensor<T>>? parameters = null;
         Dictionary<Tensor<T>, long>? leafValueHashes = null;
         if (sources is not null)
         {
-            produced = new HashSet<Tensor<T>>(TensorIdentityComparer<T>.Instance);
             parameters = new HashSet<Tensor<T>>(TensorIdentityComparer<T>.Instance);
             leafValueHashes = new Dictionary<Tensor<T>, long>(TensorIdentityComparer<T>.Instance);
             foreach (var source in sources)
@@ -295,52 +300,81 @@ internal static class AutoTrainingCompiler
             }
         }
 
-        for (int i = 0; i < entryCount; i++)
+        try
         {
-            ref var entry = ref entries[i];
-            hash ^= entry.OperationName.GetHashCode();
-            hash *= unchecked((long)0x100000001b3L);
-            if (entry.Output is not null)
+            for (int i = 0; i < entryCount; i++)
             {
-                // Shape only - NOT identity. Two steps with the same model
-                // shape produce the same structure hash.
-                foreach (int dim in entry.Output._shape)
+                ref var entry = ref entries[i];
+                hash ^= entry.OperationName.GetHashCode();
+                hash *= unchecked((long)0x100000001b3L);
+                if (entry.Output is not null)
                 {
-                    hash ^= dim;
+                    // Shape only - NOT identity. Two steps with the same model
+                    // shape produce the same structure hash.
+                    hash ^= entry.Output._shape.Length;
                     hash *= unchecked((long)0x100000001b3L);
-                }
-            }
-
-            if (produced is not null && parameters is not null && leafValueHashes is not null)
-            {
-                if (!TryHashLeafValue(entry.Input0, produced, parameters, leafValueHashes, ref hash)
-                    || !TryHashLeafValue(entry.Input1, produced, parameters, leafValueHashes, ref hash)
-                    || !TryHashLeafValue(entry.Input2, produced, parameters, leafValueHashes, ref hash))
-                {
-                    return false;
-                }
-
-                // Variadic ops (Concat, Stack, TensorAddMany) keep inputs 4+ ONLY here, and
-                // TapeEntry treats this array as the authoritative input list when it is set.
-                // Reading Input0-2 alone would let a data-derived constant in an extra slot
-                // escape the hash entirely - precisely the staleness this method exists to catch.
-                var overflow = entry.InputsOverflow;
-                if (overflow is not null)
-                {
-                    for (int j = 0; j < overflow.Length; j++)
+                    foreach (int dim in entry.Output._shape)
                     {
-                        if (!TryHashLeafValue(overflow[j], produced, parameters, leafValueHashes, ref hash))
+                        hash ^= dim;
+                        hash *= unchecked((long)0x100000001b3L);
+                    }
+                }
+
+                // Encode input arity, order, and connectivity. Leaves share a stable sentinel;
+                // produced inputs use their forward entry ordinal, which is stable across fresh
+                // executions without retaining tensor identity in the cache key.
+                hash ^= entry.InputCount;
+                hash *= unchecked((long)0x100000001b3L);
+                if (entry.InputsOverflow is not null)
+                {
+                    for (int j = 0; j < entry.InputsOverflow.Length; j++)
+                        HashInputTopology(entry.InputsOverflow[j], producerOrdinals, ref hash);
+                }
+                else
+                {
+                    HashInputTopology(entry.Input0, producerOrdinals, ref hash);
+                    if (entry.InputCount >= 2) HashInputTopology(entry.Input1, producerOrdinals, ref hash);
+                    if (entry.InputCount >= 3) HashInputTopology(entry.Input2, producerOrdinals, ref hash);
+                }
+
+                if (parameters is not null && leafValueHashes is not null)
+                {
+                    if (!TryHashLeafValue(entry.Input0, producerOrdinals, parameters, leafValueHashes, ref hash)
+                        || !TryHashLeafValue(entry.Input1, producerOrdinals, parameters, leafValueHashes, ref hash)
+                        || !TryHashLeafValue(entry.Input2, producerOrdinals, parameters, leafValueHashes, ref hash))
+                    {
+                        return false;
+                    }
+
+                    // Variadic ops (Concat, Stack, TensorAddMany) keep inputs 4+ ONLY here, and
+                    // TapeEntry treats this array as the authoritative input list when it is set.
+                    // Reading Input0-2 alone would let a data-derived constant in an extra slot
+                    // escape the hash entirely - precisely the staleness this method exists to catch.
+                    var overflow = entry.InputsOverflow;
+                    if (overflow is not null)
+                    {
+                        for (int j = 0; j < overflow.Length; j++)
                         {
-                            return false;
+                            if (!TryHashLeafValue(overflow[j], producerOrdinals, parameters, leafValueHashes, ref hash))
+                            {
+                                return false;
+                            }
                         }
                     }
                 }
 
-                if (entry.Output is not null) produced.Add(entry.Output);
+                if (entry.Output is not null) producerOrdinals[entry.Output] = i;
             }
-        }
 
-        return true;
+            return true;
+        }
+        finally
+        {
+            // Thread-static reuse keeps the structure-only hot path allocation-free after warmup,
+            // while clearing references prevents one training graph from being retained by its
+            // worker thread. Hash computation is synchronous and never re-enters itself.
+            producerOrdinals.Clear();
+        }
     }
 
     /// <summary>
@@ -357,11 +391,31 @@ internal static class AutoTrainingCompiler
         public int GetHashCode(Tensor<TElement> obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
     }
 
+    private static class StructureHashScratch<TElement>
+    {
+        [ThreadStatic]
+        internal static Dictionary<Tensor<TElement>, int>? ProducerOrdinals;
+    }
+
     /// <summary>
     /// Largest non-parameter leaf whose values are folded into the hash. Beyond this, hashing on
     /// every step would outweigh the benefit of compiling, so the tape is declared uncompilable.
     /// </summary>
     private const int MaxHashedConstantElements = 4096;
+
+    private static void HashInputTopology<T>(
+        Tensor<T>? input,
+        Dictionary<Tensor<T>, int> producerOrdinals,
+        ref long hash)
+    {
+        // Distinguish null from a leaf even though normal recorded operations do not use null
+        // inputs. This keeps malformed/manual entries from aliasing valid structures.
+        int token = input is null
+            ? int.MinValue
+            : producerOrdinals.TryGetValue(input, out int producer) ? producer : -1;
+        hash ^= token;
+        hash *= unchecked((long)0x100000001b3L);
+    }
 
     /// <summary>
     /// Folds a leaf constant's values into the hash. Returns false when the leaf is too large to
@@ -375,14 +429,14 @@ internal static class AutoTrainingCompiler
     /// </param>
     private static bool TryHashLeafValue<T>(
         Tensor<T>? candidate,
-        HashSet<Tensor<T>> produced,
+        Dictionary<Tensor<T>, int> producerOrdinals,
         HashSet<Tensor<T>> parameters,
         Dictionary<Tensor<T>, long> leafValueHashes,
         ref long hash)
     {
         // Only LEAVES matter: anything an earlier entry produced is recomputed on replay.
         if (candidate is null) return true;
-        if (produced.Contains(candidate)) return true;
+        if (producerOrdinals.ContainsKey(candidate)) return true;
         // Parameters legitimately change every step; the plan binds them by identity.
         if (parameters.Contains(candidate)) return true;
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2032,7 +2032,9 @@ public partial class CpuEngine : ITensorLevelEngine
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Reshape", tensor._shape); if (ac is not null) return ac.Execute(); }
 
         var originalShape = tensor.Shape.ToArray();
-        var result = tensor.Reshape(newShape);
+        Tensor<T> result;
+        using (DifferentiableOps.SuppressTensorViewRecording())
+            result = tensor.Reshape(newShape);
         DifferentiableOps.RecordUnary("Reshape", result, tensor, BackwardFunctions<T>.ReshapeBackward, new object[] { originalShape });
         AutoTracer.RecordOp("Reshape", result, eng => eng.Reshape(tensor, newShape));
         return result;
@@ -7144,8 +7146,15 @@ public partial class CpuEngine : ITensorLevelEngine
             for (int i = 0; i < src.Length; i++)
                 dest[i] = numOps.FromDouble(Math.Round(numOps.ToDouble(src[i])));
         }
+        // Match the mathematical contract used by PyTorch/JAX and by this method's graph-mode
+        // path: round is piecewise constant, so its derivative is zero almost everywhere. A
+        // straight-through estimator is an optimization policy for quantization-aware training,
+        // not the derivative of a basic arithmetic primitive; silently applying it here made the
+        // same expression differentiate differently in eager and captured execution. Callers that
+        // intentionally need an STE must opt into a dedicated estimator rather than changing the
+        // meaning of TensorRound for every loss (notably angular anti-wrapping).
         DifferentiableOps.RecordUnary("Round", result, tensorOrig,
-            BackwardFunctions<T>.StraightThroughBackward);
+            BackwardFunctions<T>.SignBackward);
         { var c = tensor; AutoTracer.RecordOp("Round", result, eng => eng.TensorRound(c)); }
         return result;
     }
@@ -12306,8 +12315,12 @@ public partial class CpuEngine : ITensorLevelEngine
 
         // Return a contiguous transposed copy for API compatibility.
         // The lazy graph path uses a more efficient execute delegate.
-        var view = tensor.Transpose();
-        var result = view.Contiguous();
+        Tensor<T> result;
+        using (DifferentiableOps.SuppressTensorViewRecording())
+        {
+            var view = tensor.Transpose();
+            result = view.Contiguous();
+        }
         DifferentiableOps.RecordUnary("TensorTranspose", result, tensor, BackwardFunctions<T>.TransposeBackward);
         { var c = tensor; AutoTracer.RecordOp("TensorTranspose", result, eng => eng.TensorTranspose(c)); }
         return result;
@@ -14856,15 +14869,28 @@ public partial class CpuEngine : ITensorLevelEngine
                                     flippedF[fBase + kh * kernelWidth + kw] =
                                         kernelFlip[kBase + (kernelHeight - 1 - kh) * kernelWidth + (kernelWidth - 1 - kw)];
                         }
-                    var fusedResult = Conv2D<float>(gradOutFloat, flippedKernel, 1, padHt, 1);
-                    var fusedF = (float[])(object)fusedResult.GetFlattenedData();
                     var destFused = (float[])(object)dest._storage.GetDataArray();
                     int destOffFused = dest._storageOffset;
                     int totalFused = batch * inChannels * height * width;
-                    if (accumulate)
-                        for (int i = 0; i < totalFused; i++) destFused[destOffFused + i] += fusedF[i];
+                    if (!accumulate)
+                    {
+                        // Write through to the caller-owned destination. This
+                        // preserves the overwrite contract while avoiding the
+                        // allocating scalar overload and a full result copy.
+                        Conv2DInto(
+                            (Tensor<float>)(object)dest,
+                            gradOutFloat,
+                            flippedKernel,
+                            new[] { 1, 1 },
+                            new[] { padHt, padWt },
+                            new[] { 1, 1 });
+                    }
                     else
-                        Array.Copy(fusedF, 0, destFused, destOffFused, totalFused);
+                    {
+                        var fusedResult = Conv2D<float>(gradOutFloat, flippedKernel, 1, padHt, 1);
+                        var fusedF = (float[])(object)fusedResult.GetFlattenedData();
+                        for (int i = 0; i < totalFused; i++) destFused[destOffFused + i] += fusedF[i];
+                    }
                     return;
                 }
             }
@@ -34023,8 +34049,27 @@ public partial class CpuEngine : ITensorLevelEngine
             resultData[flatIdx] = tensorData[inputFlat];
         });
 
-        DifferentiableOps.RecordUnary("TensorSlice", result, tensor, BackwardFunctions<T>.SliceBackward, new object[] { start });
-        AutoTracer.RecordOp("TensorSlice", result, eng => eng.TensorSlice(tensor, start, length));
+        // A tape is an immutable record of the FORWARD call. `start` and `length` are mutable
+        // caller-owned arrays, and high-throughput callers commonly reuse one buffer across a
+        // loop. Capturing either array by reference lets a later mutation rewrite an earlier
+        // node's backward/replay semantics (RAFT's two flow-channel slices both became channel 1,
+        // dropping channel 0's gradient). Snapshot metadata only when a consumer will retain it;
+        // ordinary eager inference keeps the allocation-free path.
+        if (DifferentiableOps.IsRecording<T>())
+        {
+            var recordedStart = (int[])start.Clone();
+            DifferentiableOps.RecordUnary(
+                "TensorSlice", result, tensor, BackwardFunctions<T>.SliceBackward,
+                new object[] { recordedStart });
+        }
+        if (AutoTracer.ShouldRecord)
+        {
+            var tracedStart = (int[])start.Clone();
+            var tracedLength = (int[])length.Clone();
+            AutoTracer.RecordOp(
+                "TensorSlice", result,
+                eng => eng.TensorSlice(tensor, tracedStart, tracedLength));
+        }
         return result;
     }
 
@@ -34507,8 +34552,11 @@ public partial class CpuEngine : ITensorLevelEngine
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorPermute", tensor._shape); if (ac is not null) return ac.Execute(); }
 
-        // Use tensor's built-in Transpose method
-        var result = tensor.Transpose(axes);
+        // Use tensor's built-in Transpose method. The engine registers the operation-specific
+        // edge below, so suppress the Tensor API's direct-call fallback for this one delegation.
+        Tensor<T> result;
+        using (DifferentiableOps.SuppressTensorViewRecording())
+            result = tensor.Transpose(axes);
         DifferentiableOps.RecordUnary("TensorPermute", result, tensor, BackwardFunctions<T>.PermuteBackward, new object[] { axes });
         AutoTracer.RecordOp("TensorPermute", result, eng => eng.TensorPermute(tensor, axes));
         return result;
@@ -34553,7 +34601,9 @@ public partial class CpuEngine : ITensorLevelEngine
         for (int i = axis; i < rank; i++)
             newShape[i + 1] = tensor._shape[i];
 
-        var result = tensor.Reshape(newShape);
+        Tensor<T> result;
+        using (DifferentiableOps.SuppressTensorViewRecording())
+            result = tensor.Reshape(newShape);
         DifferentiableOps.RecordUnary("TensorExpandDims", result, tensor, BackwardFunctions<T>.ExpandDimsBackward, new object[] { axis });
         AutoTracer.RecordOp("TensorExpandDims", result, eng => eng.TensorExpandDims(tensor, axis));
         return result;
@@ -34603,7 +34653,9 @@ public partial class CpuEngine : ITensorLevelEngine
             if (shape.Count == 0) shape.Add(1);
         }
 
-        var squeezeResult = tensor.Reshape(shape.ToArray());
+        Tensor<T> squeezeResult;
+        using (DifferentiableOps.SuppressTensorViewRecording())
+            squeezeResult = tensor.Reshape(shape.ToArray());
         DifferentiableOps.RecordUnary("TensorSqueeze", squeezeResult, tensor, BackwardFunctions<T>.SqueezeBackward, new object[] { axis });
         AutoTracer.RecordOp("TensorSqueeze", squeezeResult, eng => squeezeResult);
         return squeezeResult;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -14872,6 +14872,8 @@ public partial class CpuEngine : ITensorLevelEngine
                     var destFused = (float[])(object)dest._storage.GetDataArray();
                     int destOffFused = dest._storageOffset;
                     int totalFused = batch * inChannels * height * width;
+                    const int UnitStride = 1;
+                    const int UnitDilation = 1;
                     if (!accumulate)
                     {
                         // Write through to the caller-owned destination. This
@@ -14881,13 +14883,18 @@ public partial class CpuEngine : ITensorLevelEngine
                             (Tensor<float>)(object)dest,
                             gradOutFloat,
                             flippedKernel,
-                            new[] { 1, 1 },
+                            new[] { UnitStride, UnitStride },
                             new[] { padHt, padWt },
-                            new[] { 1, 1 });
+                            new[] { UnitDilation, UnitDilation });
                     }
                     else
                     {
-                        var fusedResult = Conv2D<float>(gradOutFloat, flippedKernel, 1, padHt, 1);
+                        var fusedResult = Conv2D<float>(
+                            gradOutFloat,
+                            flippedKernel,
+                            UnitStride,
+                            padHt,
+                            UnitDilation);
                         var fusedF = (float[])(object)fusedResult.GetFlattenedData();
                         for (int i = 0; i < totalFused; i++) destFused[destOffFused + i] += fusedF[i];
                     }

--- a/src/AiDotNet.Tensors/Helpers/SimdConvHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/SimdConvHelper.cs
@@ -653,6 +653,17 @@ internal static class SimdConvHelper
         }
     }
 
+    [MethodImpl(HotInline)]
+    private static void GetInteriorRowRange(int outputHeight, int padding, out int start, out int end)
+    {
+        int boundaryRows = Math.Max(0, padding);
+        start = Math.Min(boundaryRows, outputHeight);
+        // Clamp the bottom boundary after the top boundary. Without this,
+        // inputs whose padded output is shorter than both boundary regions
+        // process the same row in both loops (for example, 1x1 + 3x3/pad1).
+        end = Math.Max(start, outputHeight - boundaryRows);
+    }
+
     /// <summary>
     /// Per-(ic, oc) Vector256&lt;double&gt; 3×3 conv. Loads 9 broadcasted kernel
     /// values, then sweeps the output rows with 4-double FMA accumulators.
@@ -677,9 +688,7 @@ internal static class SimdConvHelper
 
         if (dilationH == 1 && dilationW == 1)
         {
-            int ohStart = padH > 0 ? padH : 0;
-            int ohEnd = outHeight - (padH > 0 ? padH : 0);
-            if (ohEnd > outHeight) ohEnd = outHeight;
+            GetInteriorRowRange(outHeight, padH, out int ohStart, out int ohEnd);
 
             // Top boundary rows
             for (int topOh = 0; topOh < ohStart && topOh < outHeight; topOh++)
@@ -1651,9 +1660,7 @@ internal static class SimdConvHelper
         if (dilationH == 1 && dilationW == 1)
         {
             // Process interior rows (no top/bottom boundary)
-            int ohStart = padH > 0 ? padH : 0;
-            int ohEnd = outHeight - (padH > 0 ? padH : 0);
-            if (ohEnd > outHeight) ohEnd = outHeight;
+            GetInteriorRowRange(outHeight, padH, out int ohStart, out int ohEnd);
 
             // Handle boundary rows at top
             for (int topOh = 0; topOh < ohStart && topOh < outHeight; topOh++)
@@ -1979,9 +1986,7 @@ internal static class SimdConvHelper
         if (dilationH == 1 && dilationW == 1)
         {
             // Process interior rows (no top/bottom boundary)
-            int ohStart = padH > 0 ? padH : 0;
-            int ohEnd = outHeight - (padH > 0 ? padH : 0);
-            if (ohEnd > outHeight) ohEnd = outHeight;
+            GetInteriorRowRange(outHeight, padH, out int ohStart, out int ohEnd);
 
             // Handle boundary rows at top
             for (int oh = 0; oh < ohStart && oh < outHeight; oh++)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -269,16 +269,15 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         var savedState = new object[] { (int[])_shape.Clone() };
         Engines.Autodiff.BackwardFunction<T> backward =
             Engines.Autodiff.BackwardFunctions<T>.ReshapeBackward;
-        if (Engines.Autodiff.GradientTape<T>.Current is { } tape)
+        if (Engines.Autodiff.GradientTape<T>.Current is not null
+            && !Engines.Autodiff.DifferentiableOps.IsTensorViewRecordingSuppressed)
         {
-            var node = Engines.Autodiff.GradNodePool<T>.Rent();
-            node.OwningTape = tape;
-            node.Backward = backward;
-            node.Output = result;
-            node.Input0 = this;
-            node.InputCount = 1;
-            node.SavedState = savedState;
-            result.GradFn = node;
+            // Views and materialized copies must use the same recording funnel as engine ops.
+            // Creating only a GradNode makes the eager DFS backward appear correct, but leaves
+            // no TapeEntry for compiled/rebindable replay. A repeated fresh tape would then
+            // silently omit this edge and stop the gradient at the view.
+            Engines.Autodiff.DifferentiableOps.RecordUnary(
+                "Contiguous", result, this, backward, savedState);
         }
 
         var graphScope = Engines.Compilation.GraphMode.Current;
@@ -313,16 +312,14 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         Engines.Autodiff.BackwardFunction<T> backward,
         object[] savedState)
     {
-        if (Engines.Autodiff.GradientTape<T>.Current is { } tape)
+        if (Engines.Autodiff.GradientTape<T>.Current is not null
+            && !Engines.Autodiff.DifferentiableOps.IsTensorViewRecordingSuppressed)
         {
-            var node = Engines.Autodiff.GradNodePool<T>.Rent();
-            node.OwningTape = tape;
-            node.Backward = backward;
-            node.Output = view;
-            node.Input0 = this;
-            node.InputCount = 1;
-            node.SavedState = savedState;
-            view.GradFn = node;
+            // Record both representations atomically: the GradNode used by eager DFS and the
+            // TapeEntry used by compiled/rebindable walks. Keeping a graph-only edge here made
+            // correctness depend on which backward executor happened to run.
+            Engines.Autodiff.DifferentiableOps.RecordUnary(
+                opName, view, this, backward, savedState);
         }
 
         var graphScope = Engines.Compilation.GraphMode.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/CompiledBackwardWalkTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/CompiledBackwardWalkTests.cs
@@ -777,6 +777,50 @@ public class CompiledBackwardWalkTests
     }
 
     [Fact]
+    public async Task CompiledWalker_IdentityFanOut_AccumulatesEachPathOnce()
+    {
+        await Task.Yield();
+
+        var prior = AiDotNetEngine.Current;
+        var engine = new CpuEngine();
+        AiDotNetEngine.Current = engine;
+
+        var walkerType = WalkerOfFloat();
+        var overrideField = walkerType.GetField("_testEnabledOverride",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var resetMethod = walkerType.GetMethod("ResetForTests",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        try
+        {
+            for (int pass = 0; pass < 3; pass++)
+            {
+                overrideField.SetValue(null, pass == 0 ? (object?)false : true);
+                if (pass == 1)
+                {
+                    resetMethod.Invoke(null, null);
+                }
+
+                using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
+                var x = new Tensor<float>(new[] { 0.5f, -1.25f, 2.0f }, new[] { 3 });
+                var left = engine.TensorAdd(x, x);
+                var right = engine.TensorAdd(x, x);
+                var loss = engine.ReduceSum(engine.TensorAdd(left, right));
+
+                var grads = tape.ComputeGradients(loss, new List<Tensor<float>> { x });
+
+                Assert.Equal(new[] { 4.0f, 4.0f, 4.0f }, grads[x].ToArray());
+            }
+        }
+        finally
+        {
+            overrideField.SetValue(null, null);
+            resetMethod.Invoke(null, null);
+            AiDotNetEngine.Current = prior;
+        }
+    }
+
+    [Fact]
     public void CompiledWalker_LongTape_ManyOps_ProducesIdenticalGradients()
     {
         // Stress test for the IL emitter — verifies the unrolled

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Guards convolution VJPs when padding makes a kernel larger than the input's
+/// spatial extent. This geometry occurs in encoder/decoder models whose final
+/// feature map is 1x1 but whose decoder still uses padded 3x3 convolutions.
+/// </summary>
+[Collection("EngineCurrentGlobalState")]
+public sealed class Conv2DDegenerateSpatialGradientTests : IDisposable
+{
+    private const float Epsilon = 1e-3f;
+    private const float RelativeTolerance = 2e-2f;
+
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly IEngine _engine;
+
+    public Conv2DDegenerateSpatialGradientTests()
+    {
+        AiDotNetEngine.Current = new CpuEngine();
+        _engine = AiDotNetEngine.Current;
+    }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task Conv2D_PaddedThreeByThreeOverOneByOne_MatchesFiniteDifferences()
+    {
+        await Task.Yield();
+
+        var input = CreateTensor([1, 2, 1, 1], 0.35f, -0.20f);
+        var kernel = CreateSequence([2, 2, 3, 3], -0.18f, 0.011f);
+
+        AssertGradientsMatch(
+            () => _engine.Conv2D(input, kernel, [1, 1], [1, 1], [1, 1]),
+            input,
+            kernel);
+    }
+
+    [Fact]
+    public async Task FusedConv2D_PaddedThreeByThreeOverOneByOne_MatchesFiniteDifferences()
+    {
+        await Task.Yield();
+
+        var input = CreateTensor([1, 2, 1, 1], 0.35f, -0.20f);
+        var kernel = CreateSequence([2, 2, 3, 3], -0.18f, 0.011f);
+        // Keep both outputs away from ReLU's non-differentiable boundary.
+        var bias = CreateTensor([2], 0.40f, 0.55f);
+
+        AssertGradientsMatch(
+            () => _engine.FusedConv2D(
+                input,
+                kernel,
+                bias,
+                strideH: 1,
+                strideW: 1,
+                padH: 1,
+                padW: 1,
+                dilationH: 1,
+                dilationW: 1,
+                FusedActivationType.ReLU),
+            input,
+            kernel,
+            bias);
+    }
+
+    [Fact]
+    public async Task Conv2DBackwardInput_PaddedThreeByThreeOverOneByOne_MatchesReference()
+    {
+        await Task.Yield();
+
+        var cpu = Assert.IsType<CpuEngine>(_engine);
+        var gradOutput = CreateTensor([1, 2, 1, 1], 1f, 1f);
+        var kernel = CreateSequence([2, 2, 3, 3], -0.18f, 0.011f);
+        var into = new Tensor<float>([1, 2, 1, 1]);
+        var flippedKernel = FlipAndTranspose(kernel, inputChannels: 2, outputChannels: 2);
+        var forwardIdentity = cpu.Conv2D(gradOutput, flippedKernel, [1, 1], [1, 1], [1, 1]);
+        var scalarForwardIdentity = cpu.Conv2D(gradOutput, flippedKernel, stride: 1, padding: 1, dilation: 1);
+
+        cpu.Conv2DBackwardInputInto(
+            into,
+            gradOutput,
+            kernel,
+            [1, 2, 1, 1],
+            [1, 1],
+            [1, 1],
+            [1, 1],
+            accumulate: false);
+        var allocating = cpu.Conv2DBackwardInput(
+            gradOutput,
+            kernel,
+            [1, 2, 1, 1],
+            [1, 1],
+            [1, 1],
+            [1, 1]);
+
+        for (int inputChannel = 0; inputChannel < 2; inputChannel++)
+        {
+            float expected = 0f;
+            for (int outputChannel = 0; outputChannel < 2; outputChannel++)
+            {
+                int centerIndex = (((outputChannel * 2) + inputChannel) * 3 * 3) + 4;
+                expected += kernel[centerIndex];
+            }
+
+            AssertClose(allocating[inputChannel], expected, $"allocating input channel {inputChannel}");
+            AssertClose(forwardIdentity[inputChannel], expected, $"forward identity input channel {inputChannel}");
+            AssertClose(scalarForwardIdentity[inputChannel], expected, $"scalar forward identity input channel {inputChannel}");
+            AssertClose(into[inputChannel], expected, $"into input channel {inputChannel}");
+        }
+    }
+
+    private void AssertGradientsMatch(Func<Tensor<float>> forward, params Tensor<float>[] sources)
+    {
+        Dictionary<Tensor<float>, Tensor<float>> gradients;
+        using (var tape = new GradientTape<float>())
+        {
+            var loss = _engine.ReduceSum(forward(), axes: null);
+            gradients = tape.ComputeGradients(loss, sources);
+        }
+
+        foreach (var source in sources)
+        {
+            Assert.True(gradients.TryGetValue(source, out var analytical), "Autodiff did not produce a source gradient.");
+            Assert.NotNull(analytical);
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                float original = source[i];
+                source[i] = original + Epsilon;
+                float plus = Sum(forward());
+                source[i] = original - Epsilon;
+                float minus = Sum(forward());
+                source[i] = original;
+
+                float numerical = (plus - minus) / (2f * Epsilon);
+                AssertClose(analytical![i], numerical, $"source shape [{string.Join(",", source._shape)}], index {i}");
+            }
+        }
+    }
+
+    private static void AssertClose(float analytical, float numerical, string coordinate)
+    {
+        float difference = Math.Abs(analytical - numerical);
+        float scale = Math.Max(Math.Abs(analytical), Math.Abs(numerical));
+        float tolerance = Math.Max(1e-4f, scale * RelativeTolerance);
+        Assert.True(
+            difference <= tolerance,
+            $"{coordinate}: analytical={analytical:G9}, numerical={numerical:G9}, difference={difference:G9}, tolerance={tolerance:G9}");
+    }
+
+    private static float Sum(Tensor<float> tensor)
+    {
+        float sum = 0f;
+        for (int i = 0; i < tensor.Length; i++)
+        {
+            sum += tensor[i];
+        }
+
+        return sum;
+    }
+
+    private static Tensor<float> CreateSequence(int[] shape, float start, float step)
+    {
+        var tensor = new Tensor<float>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+        {
+            tensor[i] = start + (i * step);
+        }
+
+        return tensor;
+    }
+
+    private static Tensor<float> FlipAndTranspose(Tensor<float> kernel, int inputChannels, int outputChannels)
+    {
+        var flipped = new Tensor<float>([inputChannels, outputChannels, 3, 3]);
+        for (int outputChannel = 0; outputChannel < outputChannels; outputChannel++)
+        {
+            for (int inputChannel = 0; inputChannel < inputChannels; inputChannel++)
+            {
+                for (int kernelRow = 0; kernelRow < 3; kernelRow++)
+                {
+                    for (int kernelColumn = 0; kernelColumn < 3; kernelColumn++)
+                    {
+                        int source = (((outputChannel * inputChannels) + inputChannel) * 3 * 3)
+                            + ((2 - kernelRow) * 3)
+                            + (2 - kernelColumn);
+                        int destination = (((inputChannel * outputChannels) + outputChannel) * 3 * 3)
+                            + (kernelRow * 3)
+                            + kernelColumn;
+                        flipped[destination] = kernel[source];
+                    }
+                }
+            }
+        }
+
+        return flipped;
+    }
+
+    private static Tensor<float> CreateTensor(int[] shape, params float[] values)
+        => new(values, shape);
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
@@ -142,7 +142,7 @@ public sealed class Conv2DDegenerateSpatialGradientTests : IDisposable
                 source[i] = original;
 
                 float numerical = (plus - minus) / (2f * Epsilon);
-                AssertClose(analytical![i], numerical, $"source shape [{string.Join(",", source._shape)}], index {i}");
+                AssertClose(analytical![i], numerical, $"source shape [{string.Join(",", source.Shape.ToArray())}], index {i}");
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsOwnershipScopeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsOwnershipScopeTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class DifferentiableOpsOwnershipScopeTests
+{
+    [Fact]
+    public async Task TensorViewRecordingSuppression_CopiedLeaseReleasesDepthOnlyOnce()
+    {
+        await Task.Yield();
+
+        Assert.False(DifferentiableOps.IsTensorViewRecordingSuppressed);
+        var outer = DifferentiableOps.SuppressTensorViewRecording();
+        var inner = DifferentiableOps.SuppressTensorViewRecording();
+        var innerCopy = inner;
+
+        try
+        {
+            Assert.True(DifferentiableOps.IsTensorViewRecordingSuppressed);
+            inner.Dispose();
+            Assert.True(DifferentiableOps.IsTensorViewRecordingSuppressed);
+
+            innerCopy.Dispose();
+            Assert.True(DifferentiableOps.IsTensorViewRecordingSuppressed);
+
+            outer.Dispose();
+            Assert.False(DifferentiableOps.IsTensorViewRecordingSuppressed);
+
+            outer.Dispose();
+            Assert.False(DifferentiableOps.IsTensorViewRecordingSuppressed);
+        }
+        finally
+        {
+            innerCopy.Dispose();
+            inner.Dispose();
+            outer.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task NestedBackwardStep_RestoresOuterDonationOwnership()
+    {
+        await Task.Yield();
+
+        var engine = new CpuEngine();
+        var outerGradients = new Dictionary<Tensor<double>, Tensor<double>>();
+        var firstDestination = new Tensor<double>([2]);
+        var secondDestination = new Tensor<double>([2]);
+        var sharedContribution = new Tensor<double>(new[] { 2.0, -3.0 }, [2]);
+        var previousOuterOwners = DifferentiableOps.BeginBackwardStep<double>();
+
+        try
+        {
+            DifferentiableOps.AccumulateGrad(
+                outerGradients,
+                firstDestination,
+                sharedContribution,
+                engine);
+
+            var previousInnerOwners = DifferentiableOps.BeginBackwardStep<double>();
+            try
+            {
+                var innerGradients = new Dictionary<Tensor<double>, Tensor<double>>();
+                DifferentiableOps.AccumulateGrad(
+                    innerGradients,
+                    new Tensor<double>([2]),
+                    new Tensor<double>(new[] { 5.0, 7.0 }, [2]),
+                    engine);
+            }
+            finally
+            {
+                DifferentiableOps.EndBackwardStep(previousInnerOwners);
+            }
+
+            DifferentiableOps.AccumulateGrad(
+                outerGradients,
+                secondDestination,
+                sharedContribution,
+                engine);
+
+            Assert.Same(sharedContribution, outerGradients[firstDestination]);
+            Assert.NotSame(outerGradients[firstDestination], outerGradients[secondDestination]);
+            outerGradients[firstDestination][0] = 41.0;
+            Assert.Equal(2.0, outerGradients[secondDestination][0]);
+        }
+        finally
+        {
+            DifferentiableOps.EndBackwardStep(previousOuterOwners);
+        }
+    }
+
+    [Fact]
+    public async Task AccumulateGrad_OverlappingStorageUsesIndependentResult()
+    {
+        await Task.Yield();
+
+        var engine = new CpuEngine();
+        var backing = new Tensor<double>(new[] { 1.0, 2.0, 3.0, 4.0 }, [4]);
+        var existing = backing.Reshape(2, 2);
+        var overlappingContribution = backing.Reshape(2, 2);
+        var destination = new Tensor<double>([2, 2]);
+        var gradients = new Dictionary<Tensor<double>, Tensor<double>>
+        {
+            [destination] = existing,
+        };
+        destination.Grad = existing;
+        var previousOwners = DifferentiableOps.BeginBackwardStep<double>();
+
+        try
+        {
+            DifferentiableOps.AccumulateGrad(
+                gradients,
+                destination,
+                overlappingContribution,
+                engine);
+
+            Assert.NotSame(existing, gradients[destination]);
+            Assert.Equal(new[] { 2.0, 4.0, 6.0, 8.0 }, gradients[destination].ToArray());
+            Assert.Equal(new[] { 1.0, 2.0, 3.0, 4.0 }, backing.ToArray());
+        }
+        finally
+        {
+            DifferentiableOps.EndBackwardStep(previousOwners);
+        }
+    }
+
+    [Fact]
+    public async Task AccumulateGrad_DisjointSharedStorageKeepsInPlaceFastPath()
+    {
+        await Task.Yield();
+
+        var engine = new CpuEngine();
+        var backing = new Tensor<double>(new[] { 1.0, 2.0, 3.0, 4.0 }, [4]);
+        var existing = backing.Slice(axis: 0, start: 0, end: 2);
+        var disjointContribution = backing.Slice(axis: 0, start: 2, end: 4);
+        var destination = new Tensor<double>([2]);
+        var gradients = new Dictionary<Tensor<double>, Tensor<double>>
+        {
+            [destination] = existing,
+        };
+        destination.Grad = existing;
+        var previousOwners = DifferentiableOps.BeginBackwardStep<double>();
+
+        try
+        {
+            DifferentiableOps.AccumulateGrad(
+                gradients,
+                destination,
+                disjointContribution,
+                engine);
+
+            Assert.Same(existing, gradients[destination]);
+            Assert.Equal(new[] { 4.0, 6.0 }, gradients[destination].ToArray());
+            Assert.Equal(new[] { 3.0, 4.0 }, disjointContribution.ToArray());
+        }
+        finally
+        {
+            DifferentiableOps.EndBackwardStep(previousOwners);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DivideDenominatorGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DivideDenominatorGradientTests.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class DivideDenominatorGradientTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly CpuEngine _engine = new();
+
+    public DivideDenominatorGradientTests() => AiDotNetEngine.Current = _engine;
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task NumeratorAndDenominatorGradients_MatchFiniteDifferences()
+    {
+        await Task.Yield();
+
+        var numerator = new Tensor<double>(new[] { 4 });
+        var denominator = new Tensor<double>(new[] { 4 });
+        var projection = new Tensor<double>(new[] { 4 });
+        for (int i = 0; i < 4; i++)
+        {
+            numerator[i] = -0.4 + (0.3 * i);
+            denominator[i] = 0.55 + (0.2 * i);
+            projection[i] = 0.2 - (0.07 * i);
+        }
+
+        Tensor<double> numeratorGradient;
+        Tensor<double> denominatorGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var ratio = _engine.TensorDivide(numerator, denominator);
+            var objective = _engine.ReduceSum(_engine.TensorMultiply(ratio, projection));
+            var gradients = tape.ComputeGradients(objective, new[] { numerator, denominator });
+            numeratorGradient = gradients[numerator];
+            denominatorGradient = gradients[denominator];
+        }
+
+        AssertGradient(numerator, numeratorGradient, numerator, denominator, projection);
+        AssertGradient(denominator, denominatorGradient, numerator, denominator, projection);
+    }
+
+    [Fact]
+    public async Task RangeReducedAtanComposite_GradientMatchesFiniteDifferences()
+    {
+        await Task.Yield();
+
+        var input = new Tensor<double>(new[] { 4 });
+        var projection = new Tensor<double>(new[] { 4 });
+        input[0] = -0.73;
+        input[1] = -0.42;
+        input[2] = 0.38;
+        input[3] = 1.27;
+        for (int i = 0; i < projection.Length; i++) projection[i] = 0.2 - (0.07 * i);
+
+        Tensor<double> analytical;
+        using (var tape = new GradientTape<double>())
+        {
+            var objective = _engine.ReduceSum(_engine.TensorMultiply(RangeReducedAtan(input), projection));
+            analytical = tape.ComputeGradients(objective, new[] { input })[input];
+        }
+
+        const double step = 1e-6;
+        for (int i = 0; i < input.Length; i++)
+        {
+            double original = input[i];
+            input[i] = original + step;
+            double plus = Project(RangeReducedAtan(input), projection);
+            input[i] = original - step;
+            double minus = Project(RangeReducedAtan(input), projection);
+            input[i] = original;
+
+            double numerical = (plus - minus) / (2.0 * step);
+            Assert.True(
+                Math.Abs(analytical[i] - numerical) < 1e-8,
+                $"index {i}: analytical={analytical[i]:G17}, numerical={numerical:G17}");
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task AngularDifferenceFanOut_RealAndImaginaryGradientsMatchFiniteDifferences(
+        bool includeFrequencyDifference,
+        bool includeTimeDifference)
+    {
+        await Task.Yield();
+
+        var real = CreateGrid(0.55, 0.025);
+        var imaginary = CreateGrid(-0.35, 0.02);
+        var targetReal = CreateGrid(0.44, 0.021);
+        var targetImaginary = CreateGrid(-0.46, 0.017);
+
+        Tensor<double> realGradient;
+        Tensor<double> imaginaryGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var objective = AngularDifferenceLoss(
+                real, imaginary, targetReal, targetImaginary,
+                includeFrequencyDifference, includeTimeDifference);
+            var gradients = tape.ComputeGradients(objective, new[] { real, imaginary });
+            realGradient = gradients[real];
+            imaginaryGradient = gradients[imaginary];
+        }
+
+        AssertAngularGradient(
+            real, realGradient, real, imaginary, targetReal, targetImaginary,
+            includeFrequencyDifference, includeTimeDifference);
+        AssertAngularGradient(
+            imaginary, imaginaryGradient, real, imaginary, targetReal, targetImaginary,
+            includeFrequencyDifference, includeTimeDifference);
+    }
+
+    private void AssertAngularGradient(
+        Tensor<double> source,
+        Tensor<double> analytical,
+        Tensor<double> real,
+        Tensor<double> imaginary,
+        Tensor<double> targetReal,
+        Tensor<double> targetImaginary,
+        bool includeFrequencyDifference,
+        bool includeTimeDifference)
+    {
+        const double step = 1e-6;
+        for (int i = 0; i < source.Length; i++)
+        {
+            double original = source[i];
+            source[i] = original + step;
+            double plus = AngularDifferenceLoss(
+                real, imaginary, targetReal, targetImaginary,
+                includeFrequencyDifference, includeTimeDifference)[0];
+            source[i] = original - step;
+            double minus = AngularDifferenceLoss(
+                real, imaginary, targetReal, targetImaginary,
+                includeFrequencyDifference, includeTimeDifference)[0];
+            source[i] = original;
+
+            double numerical = (plus - minus) / (2.0 * step);
+            Assert.True(
+                Math.Abs(analytical[i] - numerical) < 1e-7,
+                $"index {i}: analytical={analytical[i]:G17}, numerical={numerical:G17}");
+        }
+    }
+
+    private Tensor<double> AngularDifferenceLoss(
+        Tensor<double> real,
+        Tensor<double> imaginary,
+        Tensor<double> targetReal,
+        Tensor<double> targetImaginary,
+        bool includeFrequencyDifference,
+        bool includeTimeDifference)
+    {
+        var phase = Phase(real, imaginary);
+        var target = Phase(targetReal, targetImaginary);
+        var loss = MeanAbs(AntiWrap(_engine.TensorSubtract(phase, target)));
+        if (includeFrequencyDifference)
+        {
+            loss = _engine.TensorAdd(loss, MeanAbs(AntiWrap(_engine.TensorSubtract(
+                Difference(phase, axis: 1), Difference(target, axis: 1)))));
+        }
+        if (includeTimeDifference)
+        {
+            loss = _engine.TensorAdd(loss, MeanAbs(AntiWrap(_engine.TensorSubtract(
+                Difference(phase, axis: 0), Difference(target, axis: 0)))));
+        }
+        return loss;
+    }
+
+    private Tensor<double> Phase(Tensor<double> real, Tensor<double> imaginary)
+    {
+        var signReal = SignStar(real);
+        var signImaginary = SignStar(imaginary);
+        var safeReal = _engine.TensorAdd(real, _engine.TensorMultiply(signReal, ConstantLike(real, 1e-7)));
+        var principal = RangeReducedAtan(_engine.TensorDivide(imaginary, safeReal));
+        var correction = _engine.TensorMultiply(
+            _engine.TensorMultiply(
+                signImaginary,
+                _engine.TensorSubtract(signReal, ConstantLike(real, 1.0))),
+            ConstantLike(real, Math.PI / 2.0));
+        return _engine.TensorSubtract(principal, correction);
+    }
+
+    private Tensor<double> SignStar(Tensor<double> input)
+    {
+        var sign = _engine.TensorSign(input);
+        return _engine.TensorAdd(
+            sign,
+            _engine.TensorSubtract(ConstantLike(input, 1.0), _engine.TensorAbs(sign)));
+    }
+
+    private Tensor<double> AntiWrap(Tensor<double> input)
+    {
+        var turns = _engine.TensorRound(_engine.TensorMultiply(
+            input, ConstantLike(input, 1.0 / (2.0 * Math.PI))));
+        return _engine.TensorSubtract(
+            input,
+            _engine.TensorMultiply(turns, ConstantLike(input, 2.0 * Math.PI)));
+    }
+
+    private Tensor<double> Difference(Tensor<double> input, int axis)
+    {
+        int length = input.Shape[axis];
+        return _engine.TensorSubtract(
+            _engine.TensorNarrow(input, axis, 1, length - 1),
+            _engine.TensorNarrow(input, axis, 0, length - 1));
+    }
+
+    private Tensor<double> MeanAbs(Tensor<double> input)
+        => _engine.ReduceMean(
+            _engine.TensorAbs(input),
+            System.Linq.Enumerable.Range(0, input.Shape.Length).ToArray(),
+            keepDims: false);
+
+    private static Tensor<double> CreateGrid(double offset, double step)
+    {
+        var result = new Tensor<double>(new[] { 2, 5 });
+        for (int i = 0; i < result.Length; i++) result[i] = offset + (step * i);
+        return result;
+    }
+
+    private Tensor<double> RangeReducedAtan(Tensor<double> input)
+    {
+        var sign = _engine.TensorSign(input);
+        var magnitude = _engine.TensorAbs(input);
+        var one = ConstantLike(input, 1.0);
+        var isLarge = _engine.TensorGreaterThan(magnitude, one);
+        var reciprocal = _engine.TensorReciprocal(_engine.TensorClampMin(magnitude, 1.0));
+        var reduced = _engine.TensorWhere(isLarge, reciprocal, magnitude);
+        var squared = _engine.TensorMultiply(reduced, reduced);
+
+        var polynomial = ConstantLike(input, 0.0208351);
+        polynomial = _engine.TensorAdd(_engine.TensorMultiply(polynomial, squared), ConstantLike(input, -0.0851330));
+        polynomial = _engine.TensorAdd(_engine.TensorMultiply(polynomial, squared), ConstantLike(input, 0.1801410));
+        polynomial = _engine.TensorAdd(_engine.TensorMultiply(polynomial, squared), ConstantLike(input, -0.3302995));
+        polynomial = _engine.TensorAdd(_engine.TensorMultiply(polynomial, squared), ConstantLike(input, 0.9998660));
+        polynomial = _engine.TensorMultiply(reduced, polynomial);
+
+        var large = _engine.TensorSubtract(ConstantLike(input, Math.PI / 2.0), polynomial);
+        var magnitudeAtan = _engine.TensorWhere(isLarge, large, polynomial);
+        return _engine.TensorMultiply(sign, magnitudeAtan);
+    }
+
+    private static Tensor<double> ConstantLike(Tensor<double> like, double value)
+    {
+        var result = new Tensor<double>(like.Shape.ToArray());
+        for (int i = 0; i < result.Length; i++) result[i] = value;
+        return result;
+    }
+
+    private void AssertGradient(
+        Tensor<double> source,
+        Tensor<double> analytical,
+        Tensor<double> numerator,
+        Tensor<double> denominator,
+        Tensor<double> projection)
+    {
+        const double step = 1e-6;
+        for (int i = 0; i < source.Length; i++)
+        {
+            double original = source[i];
+            source[i] = original + step;
+            double plus = Project(numerator, denominator, projection);
+            source[i] = original - step;
+            double minus = Project(numerator, denominator, projection);
+            source[i] = original;
+
+            double numerical = (plus - minus) / (2.0 * step);
+            Assert.True(
+                Math.Abs(analytical[i] - numerical) < 1e-9,
+                $"index {i}: analytical={analytical[i]:G17}, numerical={numerical:G17}");
+        }
+    }
+
+    private double Project(
+        Tensor<double> numerator,
+        Tensor<double> denominator,
+        Tensor<double> projection)
+    {
+        var ratio = _engine.TensorDivide(numerator, denominator);
+        double sum = 0.0;
+        for (int i = 0; i < ratio.Length; i++) sum += ratio[i] * projection[i];
+        return sum;
+    }
+
+    private static double Project(Tensor<double> value, Tensor<double> projection)
+    {
+        double sum = 0.0;
+        for (int i = 0; i < value.Length; i++) sum += value[i] * projection[i];
+        return sum;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
@@ -95,6 +95,40 @@ public class FanOutGradientAccumulationTests
     }
 
     [Fact]
+    public async Task FirstWriteGradientSlots_OwnIndependentStorage()
+    {
+        await Task.Yield();
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(0.5, -1.25, 2.0);
+        var y = Vec(-0.75, 1.5, 0.25);
+        var loss = SumAll(Engine.TensorAdd(x, y));
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x, y });
+
+        Assert.NotSame(grads[x], grads[y]);
+        double originalY = grads[y][0];
+        grads[x][0] = 17.0;
+        Assert.Equal(originalY, grads[y][0]);
+    }
+
+    [Fact]
+    public async Task NestedIdentityFanOut_AccumulatesEveryPathExactlyOnce()
+    {
+        await Task.Yield();
+
+        using var tape = new GradientTape<double>();
+        var x = Vec(0.5, -1.25, 2.0);
+        var left = Engine.TensorAdd(x, x);
+        var right = Engine.TensorAdd(x, x);
+        var loss = SumAll(Engine.TensorAdd(left, right));
+
+        var grads = tape.ComputeGradients(loss, new List<Tensor<double>> { x });
+
+        AssertClose(new[] { 4.0, 4.0, 4.0 }, grads[x].ToArray(), "nested identity fan-out", 1e-12);
+    }
+
+    [Fact]
     public void TwoBranchesRejoining_AccumulatesBothGradients()
     {
         // THE core case. x feeds two branches, both rejoin: loss = sum(2x) + sum(3x).

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FanOutGradientAccumulationTests.cs
@@ -29,6 +29,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// reasoning that wrote the backward, would agree with a wrong backward.
 /// </para>
 /// </remarks>
+[Collection("EngineCurrentGlobalState")]
 public class FanOutGradientAccumulationTests
 {
     private static IEngine Engine => AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearLargeInputGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearLargeInputGradientTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class FusedLinearLargeInputGradientTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly CpuEngine _engine = new();
+
+    public FusedLinearLargeInputGradientTests() => AiDotNetEngine.Current = _engine;
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task FusedLinear_LargeParallelBackward_InputGradientMatchesReference()
+    {
+        await Task.Yield();
+
+        const int rows = 64;
+        const int inputFeatures = 32;
+        const int outputFeatures = 128;
+        var input = CreatePattern([rows, inputFeatures], 0.013f);
+        var weights = CreatePattern([inputFeatures, outputFeatures], -0.017f);
+        var bias = CreatePattern([outputFeatures], 0.007f);
+        var projection = CreatePattern([rows, outputFeatures], 0.011f);
+
+        Tensor<float> inputGradient;
+        using (var tape = new GradientTape<float>())
+        {
+            var output = _engine.FusedLinear(
+                input, weights, bias, FusedActivationType.None);
+            var projected = _engine.TensorMultiply(output, projection);
+            var objective = _engine.ReduceSum(projected, [0, 1], keepDims: false);
+            inputGradient = tape.ComputeGradients(objective, [input])[input];
+        }
+
+        for (int row = 0; row < rows; row++)
+        {
+            for (int feature = 0; feature < inputFeatures; feature++)
+            {
+                double expected = 0.0;
+                for (int output = 0; output < outputFeatures; output++)
+                    expected += projection[row, output] * weights[feature, output];
+
+                double actual = inputGradient[row, feature];
+                Assert.True(Math.Abs(expected - actual) <= 2e-5,
+                    $"Input gradient [{row},{feature}] mismatch: expected={expected:R}, actual={actual:R}.");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SwishAfterLinear_LargeBackward_InputGradientMatchesReference()
+    {
+        await Task.Yield();
+
+        const int rows = 64;
+        const int inputFeatures = 32;
+        const int outputFeatures = 128;
+        var input = CreatePatternDouble([rows, inputFeatures], 0.013);
+        var weights = CreatePatternDouble([inputFeatures, outputFeatures], -0.017);
+        var bias = CreatePatternDouble([outputFeatures], 0.007);
+        var projection = CreatePatternDouble([rows, outputFeatures], 0.011);
+
+        Tensor<double> inputGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var linear = _engine.FusedLinear(
+                input, weights, bias, FusedActivationType.None);
+            var output = _engine.Swish(linear);
+            var projected = _engine.TensorMultiply(output, projection);
+            var objective = _engine.ReduceSum(projected, [0, 1], keepDims: false);
+            inputGradient = tape.ComputeGradients(objective, [input])[input];
+        }
+
+        for (int row = 0; row < rows; row++)
+        {
+            for (int feature = 0; feature < inputFeatures; feature++)
+            {
+                double expected = 0.0;
+                for (int output = 0; output < outputFeatures; output++)
+                {
+                    double preActivation = bias[output];
+                    for (int inner = 0; inner < inputFeatures; inner++)
+                        preActivation += input[row, inner] * weights[inner, output];
+                    double sigmoid = 1.0 / (1.0 + Math.Exp(-preActivation));
+                    double derivative = sigmoid + preActivation * sigmoid * (1.0 - sigmoid);
+                    expected += projection[row, output] * derivative * weights[feature, output];
+                }
+
+                double actual = inputGradient[row, feature];
+                Assert.True(Math.Abs(expected - actual) <= 1e-9,
+                    $"Swish input gradient [{row},{feature}] mismatch: expected={expected:R}, actual={actual:R}.");
+            }
+        }
+    }
+
+    private static Tensor<float> CreatePattern(int[] shape, float scale)
+    {
+        var tensor = new Tensor<float>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = scale * (((i * 17) % 29) - 14);
+        return tensor;
+    }
+
+    private static Tensor<double> CreatePatternDouble(int[] shape, double scale)
+    {
+        var tensor = new Tensor<double>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = scale * (((i * 17) % 29) - 14);
+        return tensor;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearLargeInputGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearLargeInputGradientTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 
+[Collection("EngineCurrentGlobalState")]
 public sealed class FusedLinearLargeInputGradientTests : IDisposable
 {
     private readonly IEngine _priorEngine = AiDotNetEngine.Current;
@@ -48,8 +49,10 @@ public sealed class FusedLinearLargeInputGradientTests : IDisposable
                     expected += projection[row, output] * weights[feature, output];
 
                 double actual = inputGradient[row, feature];
-                Assert.True(Math.Abs(expected - actual) <= 2e-5,
-                    $"Input gradient [{row},{feature}] mismatch: expected={expected:R}, actual={actual:R}.");
+                double scale = Math.Max(Math.Abs(expected), Math.Abs(actual));
+                double tolerance = Math.Max(2e-5, scale * 1e-4);
+                Assert.True(Math.Abs(expected - actual) <= tolerance,
+                    $"Input gradient [{row},{feature}] mismatch: expected={expected:R}, actual={actual:R}, tolerance={tolerance:R}.");
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LayerNormGradientCheckTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/LayerNormGradientCheckTests.cs
@@ -25,6 +25,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// Runs on whatever <see cref="AiDotNetEngine.Current"/> is configured (CPU in CI,
 /// GPU when present) — the finite-difference check is backend-agnostic.
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class LayerNormGradientCheckTests
 {
     private readonly IEngine _engine = AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RebindablePlanCacheCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RebindablePlanCacheCorrectnessTests.cs
@@ -1,0 +1,107 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class RebindablePlanCacheCorrectnessTests
+{
+    private readonly CpuEngine _engine = new();
+
+    [Fact]
+    public async Task FreshTapeReplay_PreservesGradientAcrossMetadataView()
+    {
+        await Task.Yield();
+        RebindablePlanCache<double>.ResetForTests();
+
+        try
+        {
+            for (int run = 0; run < 2; run++)
+            {
+                var x = new Tensor<double>(new[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }, new[] { 2, 3 });
+                var scale = new Tensor<double>(new[] { 2.0 }, new[] { 1 });
+
+                using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = false });
+                // Exercise the direct Tensor API. Engine.Reshape already owns an engine-level
+                // tape entry; direct metadata views historically created only a GradNode and were
+                // therefore invisible to entry-index replay.
+                var view = x.Reshape(new[] { 3, 2 });
+                var scaled = _engine.TensorMultiply(view, scale);
+                var loss = _engine.ReduceSum(scaled, null);
+                var gradients = tape.ComputeGradients(loss, new[] { x, scale });
+
+                Assert.True(gradients.TryGetValue(x, out var xGradient));
+                Assert.True(gradients.TryGetValue(scale, out var scaleGradient));
+                Assert.Equal(new[] { 2.0, 2.0, 2.0, 2.0, 2.0, 2.0 }, xGradient.ToArray());
+                Assert.Equal(21.0, scaleGradient[0], 12);
+            }
+        }
+        finally
+        {
+            RebindablePlanCache<double>.ResetForTests();
+        }
+    }
+
+    [Fact]
+    public async Task StructureHash_DistinguishesDeadBranchFromConnectedBranch()
+    {
+        await Task.Yield();
+
+        long deadBranchHash = RecordHash(connectProductToLoss: false);
+        long connectedBranchHash = RecordHash(connectProductToLoss: true);
+
+        Assert.NotEqual(deadBranchHash, connectedBranchHash);
+    }
+
+    [Fact]
+    public async Task FreshTapeReplay_DoesNotReusePlanWithDifferentDagConnectivity()
+    {
+        await Task.Yield();
+        RebindablePlanCache<double>.ResetForTests();
+
+        try
+        {
+            // Store a plan whose multiply branch is recorded but dead.
+            _ = ComputeGradient(connectProductToLoss: false);
+
+            // Same operation names, shapes, and entry count, but the multiply now feeds the loss.
+            // A flat structure hash aliases these graphs and replays the incomplete dead-branch plan.
+            var gradient = ComputeGradient(connectProductToLoss: true);
+            Assert.Equal(new[] { 5.0, 6.0, 7.0 }, gradient.ToArray());
+        }
+        finally
+        {
+            RebindablePlanCache<double>.ResetForTests();
+        }
+    }
+
+    private long RecordHash(bool connectProductToLoss)
+    {
+        var a = new Tensor<double>(new[] { 1.0, 2.0, 3.0 }, new[] { 3 });
+        var b = new Tensor<double>(new[] { 4.0, 5.0, 6.0 }, new[] { 3 });
+        using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = false });
+        var product = _engine.TensorMultiply(a, b);
+        var sum = connectProductToLoss
+            ? _engine.TensorAdd(product, a)
+            : _engine.TensorAdd(a, b);
+        var loss = _engine.ReduceSum(sum, null);
+        long hash = AutoTrainingCompiler.ComputeStructureHash(tape.Entries, tape.EntryCount);
+        GC.KeepAlive(loss);
+        return hash;
+    }
+
+    private Tensor<double> ComputeGradient(bool connectProductToLoss)
+    {
+        var a = new Tensor<double>(new[] { 1.0, 2.0, 3.0 }, new[] { 3 });
+        var b = new Tensor<double>(new[] { 4.0, 5.0, 6.0 }, new[] { 3 });
+        using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = false });
+        var product = _engine.TensorMultiply(a, b);
+        var sum = connectProductToLoss
+            ? _engine.TensorAdd(product, a)
+            : _engine.TensorAdd(a, b);
+        var loss = _engine.ReduceSum(sum, null);
+        return tape.ComputeGradients(loss, new[] { a })[a];
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RmsNormCompositeGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RmsNormCompositeGradientTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Verifies the composed RMSNorm graph used by higher-level layers. The input
+/// fans out through both x-squared and x-times-inverse-RMS paths, making this a
+/// high-value gradient-ownership contract rather than an isolated op check.
+/// </summary>
+[Collection("EngineCurrentGlobalState")]
+public sealed class RmsNormCompositeGradientTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly CpuEngine _engine;
+
+    public RmsNormCompositeGradientTests()
+    {
+        AiDotNetEngine.Current = new CpuEngine();
+        _engine = (CpuEngine)AiDotNetEngine.Current;
+    }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task InputAndScaleGradients_MatchFiniteDifferences()
+    {
+        await Task.Yield();
+
+        const int featureSize = 32;
+        var input = CreateTensor([8, featureSize], 0.02f);
+        var scale = CreateTensor([featureSize], 0.04f, offset: 1f);
+        var projection = CreateTensor([8, featureSize], 0.03f);
+
+        Tensor<float> Forward()
+        {
+            var squared = _engine.TensorSquare(input);
+            var sumSquared = _engine.ReduceSum(squared, [1], keepDims: true);
+            var meanSquared = _engine.TensorDivideScalar(sumSquared, featureSize);
+            var stabilized = _engine.TensorAddScalar(meanSquared, 1e-6f);
+            var inverseRms = _engine.TensorReciprocal(_engine.TensorSqrt(stabilized));
+            var normalized = _engine.TensorBroadcastMultiply(input, inverseRms);
+            return _engine.TensorBroadcastMultiply(normalized, scale);
+        }
+
+        Tensor<float> inputGradient;
+        Tensor<float> scaleGradient;
+        using (var tape = new GradientTape<float>())
+        {
+            var objective = _engine.ReduceSum(
+                _engine.TensorMultiply(Forward(), projection),
+                axes: null);
+            var gradients = tape.ComputeGradients(objective, [input, scale]);
+            inputGradient = gradients[input];
+            scaleGradient = gradients[scale];
+        }
+
+        AssertSampledGradient(input, inputGradient, Forward, projection, sampleCount: 16);
+        AssertSampledGradient(scale, scaleGradient, Forward, projection, sampleCount: 16);
+    }
+
+    private static void AssertSampledGradient(
+        Tensor<float> source,
+        Tensor<float> analytical,
+        Func<Tensor<float>> forward,
+        Tensor<float> projection,
+        int sampleCount)
+    {
+        const float step = 1e-3f;
+        for (int sample = 0; sample < sampleCount; sample++)
+        {
+            int index = sample * (source.Length - 1) / Math.Max(1, sampleCount - 1);
+            float original = source[index];
+            source[index] = original + step;
+            float plus = Project(forward(), projection);
+            source[index] = original - step;
+            float minus = Project(forward(), projection);
+            source[index] = original;
+
+            float numerical = (plus - minus) / (2f * step);
+            float difference = Math.Abs(analytical[index] - numerical);
+            float scale = Math.Max(Math.Abs(analytical[index]), Math.Abs(numerical));
+            float tolerance = Math.Max(2e-3f, scale * 3e-2f);
+            Assert.True(
+                difference <= tolerance,
+                $"index {index}: analytical={analytical[index]:G9}, numerical={numerical:G9}, " +
+                $"difference={difference:G9}, tolerance={tolerance:G9}");
+        }
+    }
+
+    private static float Project(Tensor<float> output, Tensor<float> projection)
+    {
+        float sum = 0f;
+        for (int i = 0; i < output.Length; i++) sum += output[i] * projection[i];
+        return sum;
+    }
+
+    private static Tensor<float> CreateTensor(int[] shape, float scale, float offset = 0f)
+    {
+        var tensor = new Tensor<float>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = offset + (scale * (((i * 17) % 31) - 15) / 15f);
+        return tensor;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RoundGradientContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RoundGradientContractTests.cs
@@ -1,0 +1,41 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class RoundGradientContractTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly CpuEngine _engine = new();
+
+    public RoundGradientContractTests() => AiDotNetEngine.Current = _engine;
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task EagerTape_UsesMathematicalZeroDerivativeAwayFromDiscontinuities()
+    {
+        await Task.Yield();
+
+        var input = new Tensor<double>(
+            new[] { -1.27, -0.73, -0.18, 0.22, 0.81, 1.34 },
+            new[] { 6 });
+        var projection = new Tensor<double>(
+            new[] { 0.7, -0.5, 0.3, -0.2, 0.4, -0.6 },
+            new[] { 6 });
+
+        Tensor<double> gradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var rounded = _engine.TensorRound(input);
+            var objective = _engine.ReduceSum(_engine.TensorMultiply(rounded, projection), null);
+            gradient = tape.ComputeGradients(objective, new[] { input })[input];
+        }
+
+        for (int i = 0; i < gradient.Length; i++)
+            Assert.Equal(0.0, gradient[i]);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ScaledDotProductAttentionGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/ScaledDotProductAttentionGradientTests.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class ScaledDotProductAttentionGradientTests : IDisposable
+{
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+    private readonly CpuEngine _engine = new();
+
+    public ScaledDotProductAttentionGradientTests() => AiDotNetEngine.Current = _engine;
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    [Fact]
+    public async Task Double_QkvGradients_MatchFiniteDifferencesAtTransformerShape()
+    {
+        await Task.Yield();
+
+        const int headDimension = 8;
+        double scale = 1.0 / Math.Sqrt(headDimension);
+        var query = CreatePattern([4, 4, 16, headDimension], 0.013);
+        var key = CreatePattern([4, 4, 16, headDimension], -0.017);
+        var value = CreatePattern([4, 4, 16, headDimension], 0.019);
+        var projection = CreatePattern([4, 4, 16, headDimension], 0.011);
+
+        Tensor<double> queryGradient;
+        Tensor<double> keyGradient;
+        Tensor<double> valueGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var output = _engine.ScaledDotProductAttention(
+                query, key, value, mask: null, scale, out _);
+            var projected = _engine.TensorMultiply(output, projection);
+            var objective = _engine.ReduceSum(projected, [0, 1, 2, 3], keepDims: false);
+            var gradients = tape.ComputeGradients(objective, [query, key, value]);
+            queryGradient = gradients[query];
+            keyGradient = gradients[key];
+            valueGradient = gradients[value];
+        }
+
+        AssertFiniteDifference(query, queryGradient, key, value, projection, scale, "query");
+        AssertFiniteDifference(key, keyGradient, query, value, projection, scale, "key", sourceIsKey: true);
+        AssertFiniteDifference(value, valueGradient, query, key, projection, scale, "value", sourceIsValue: true);
+    }
+
+    [Fact]
+    public async Task Double_PermutedQkvGradients_MatchFiniteDifferencesAtTransformerShape()
+    {
+        await Task.Yield();
+
+        const int batch = 4;
+        const int sequence = 16;
+        const int heads = 4;
+        const int headDimension = 8;
+        double scale = 1.0 / Math.Sqrt(headDimension);
+        var queryBase = CreatePattern([batch, sequence, heads, headDimension], 0.013);
+        var keyBase = CreatePattern([batch, sequence, heads, headDimension], -0.017);
+        var valueBase = CreatePattern([batch, sequence, heads, headDimension], 0.019);
+        var projection = CreatePattern([batch, heads, sequence, headDimension], 0.011);
+
+        Tensor<double> queryGradient;
+        Tensor<double> keyGradient;
+        Tensor<double> valueGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var query = _engine.TensorPermute(queryBase, [0, 2, 1, 3]);
+            var key = _engine.TensorPermute(keyBase, [0, 2, 1, 3]);
+            var value = _engine.TensorPermute(valueBase, [0, 2, 1, 3]);
+            var output = _engine.ScaledDotProductAttention(
+                query, key, value, mask: null, scale, out _);
+            var projected = _engine.TensorMultiply(output, projection);
+            var objective = _engine.ReduceSum(projected, [0, 1, 2, 3], keepDims: false);
+            var gradients = tape.ComputeGradients(objective, [queryBase, keyBase, valueBase]);
+            queryGradient = gradients[queryBase];
+            keyGradient = gradients[keyBase];
+            valueGradient = gradients[valueBase];
+        }
+
+        AssertPermutedFiniteDifference(
+            queryBase, queryGradient,
+            () => ProjectPermuted(queryBase, keyBase, valueBase, projection, scale),
+            "query");
+        AssertPermutedFiniteDifference(
+            keyBase, keyGradient,
+            () => ProjectPermuted(queryBase, keyBase, valueBase, projection, scale),
+            "key");
+        AssertPermutedFiniteDifference(
+            valueBase, valueGradient,
+            () => ProjectPermuted(queryBase, keyBase, valueBase, projection, scale),
+            "value");
+    }
+
+    [Fact]
+    public async Task Double_SelfAttentionInputGradient_MatchesFiniteDifferencesThroughOutputProjection()
+    {
+        await Task.Yield();
+
+        const int batch = 4;
+        const int sequence = 16;
+        const int heads = 4;
+        const int headDimension = 8;
+        const int embedding = heads * headDimension;
+        var input = CreatePattern([batch * sequence, embedding], 0.007);
+        var queryWeights = CreatePattern([embedding, embedding], 0.003);
+        var keyWeights = CreatePattern([embedding, embedding], -0.004);
+        var valueWeights = CreatePattern([embedding, embedding], 0.005);
+        var outputWeights = CreatePattern([embedding, embedding], -0.006);
+        var outputBias = CreatePattern([embedding], 0.002);
+        var projection = CreatePattern([batch * sequence, embedding], 0.009);
+
+        Tensor<double> inputGradient;
+        using (var tape = new GradientTape<double>())
+        {
+            var output = ProjectSelfAttention(
+                input, queryWeights, keyWeights, valueWeights, outputWeights, outputBias,
+                batch, sequence, heads, headDimension);
+            var projected = _engine.TensorMultiply(output, projection);
+            var objective = _engine.ReduceSum(projected, [0, 1], keepDims: false);
+            inputGradient = tape.ComputeGradients(objective, [input])[input];
+        }
+
+        AssertPermutedFiniteDifference(
+            input, inputGradient,
+            () => EvaluateSelfAttention(
+                input, queryWeights, keyWeights, valueWeights, outputWeights, outputBias,
+                projection, batch, sequence, heads, headDimension),
+            "self-attention input");
+    }
+
+    private void AssertFiniteDifference(
+        Tensor<double> source,
+        Tensor<double> analytical,
+        Tensor<double> firstOther,
+        Tensor<double> secondOther,
+        Tensor<double> projection,
+        double scale,
+        string name,
+        bool sourceIsKey = false,
+        bool sourceIsValue = false)
+    {
+        const double step = 1e-6;
+        int[] samples = [0, source.Length / 3, source.Length - 1];
+        foreach (int index in samples)
+        {
+            double original = source[index];
+            source[index] = original + step;
+            double plus = sourceIsValue
+                ? Project(firstOther, secondOther, source, projection, scale)
+                : sourceIsKey
+                    ? Project(firstOther, source, secondOther, projection, scale)
+                    : Project(source, firstOther, secondOther, projection, scale);
+            source[index] = original - step;
+            double minus = sourceIsValue
+                ? Project(firstOther, secondOther, source, projection, scale)
+                : sourceIsKey
+                    ? Project(firstOther, source, secondOther, projection, scale)
+                    : Project(source, firstOther, secondOther, projection, scale);
+            source[index] = original;
+
+            double numerical = (plus - minus) / (2.0 * step);
+            double actual = analytical[index];
+            double tolerance = Math.Max(1e-9, Math.Abs(numerical) * 1e-6);
+            Assert.True(Math.Abs(numerical - actual) <= tolerance,
+                $"{name}[{index}] mismatch: numerical={numerical:R}, analytical={actual:R}, " +
+                $"difference={Math.Abs(numerical - actual):R}, tolerance={tolerance:R}.");
+        }
+    }
+
+    private double Project(
+        Tensor<double> query,
+        Tensor<double> key,
+        Tensor<double> value,
+        Tensor<double> projection,
+        double scale)
+    {
+        using var noGrad = new NoGradScope<double>();
+        var output = _engine.ScaledDotProductAttention(
+            query, key, value, mask: null, scale, out _);
+        double sum = 0.0;
+        for (int i = 0; i < output.Length; i++) sum += output[i] * projection[i];
+        return sum;
+    }
+
+    private void AssertPermutedFiniteDifference(
+        Tensor<double> source,
+        Tensor<double> analytical,
+        Func<double> evaluate,
+        string name)
+    {
+        const double step = 1e-6;
+        int[] samples = [0, source.Length / 3, source.Length - 1];
+        foreach (int index in samples)
+        {
+            double original = source[index];
+            source[index] = original + step;
+            double plus = evaluate();
+            source[index] = original - step;
+            double minus = evaluate();
+            source[index] = original;
+
+            double numerical = (plus - minus) / (2.0 * step);
+            double actual = analytical[index];
+            double tolerance = Math.Max(1e-9, Math.Abs(numerical) * 1e-6);
+            Assert.True(Math.Abs(numerical - actual) <= tolerance,
+                $"{name}[{index}] mismatch after QKV permutation: numerical={numerical:R}, " +
+                $"analytical={actual:R}, difference={Math.Abs(numerical - actual):R}, " +
+                $"tolerance={tolerance:R}.");
+        }
+    }
+
+    private double ProjectPermuted(
+        Tensor<double> queryBase,
+        Tensor<double> keyBase,
+        Tensor<double> valueBase,
+        Tensor<double> projection,
+        double scale)
+    {
+        using var noGrad = new NoGradScope<double>();
+        var query = _engine.TensorPermute(queryBase, [0, 2, 1, 3]);
+        var key = _engine.TensorPermute(keyBase, [0, 2, 1, 3]);
+        var value = _engine.TensorPermute(valueBase, [0, 2, 1, 3]);
+        var output = _engine.ScaledDotProductAttention(
+            query, key, value, mask: null, scale, out _);
+        double sum = 0.0;
+        for (int i = 0; i < output.Length; i++) sum += output[i] * projection[i];
+        return sum;
+    }
+
+    private Tensor<double> ProjectSelfAttention(
+        Tensor<double> input,
+        Tensor<double> queryWeights,
+        Tensor<double> keyWeights,
+        Tensor<double> valueWeights,
+        Tensor<double> outputWeights,
+        Tensor<double> outputBias,
+        int batch,
+        int sequence,
+        int heads,
+        int headDimension)
+    {
+        int embedding = heads * headDimension;
+        var queryFlat = _engine.TensorMatMul(input, queryWeights);
+        var keyFlat = _engine.TensorMatMul(input, keyWeights);
+        var valueFlat = _engine.TensorMatMul(input, valueWeights);
+        var query = _engine.TensorPermute(
+            _engine.Reshape(queryFlat, [batch, sequence, heads, headDimension]),
+            [0, 2, 1, 3]);
+        var key = _engine.TensorPermute(
+            _engine.Reshape(keyFlat, [batch, sequence, heads, headDimension]),
+            [0, 2, 1, 3]);
+        var value = _engine.TensorPermute(
+            _engine.Reshape(valueFlat, [batch, sequence, heads, headDimension]),
+            [0, 2, 1, 3]);
+        var context = _engine.ScaledDotProductAttention(
+            query, key, value, mask: null, 1.0 / Math.Sqrt(headDimension), out _);
+        var contextTransposed = _engine.TensorPermute(context, [0, 2, 1, 3]);
+        var contextFlat = _engine.Reshape(contextTransposed, [batch * sequence, embedding]);
+        return _engine.FusedLinear(
+            contextFlat, outputWeights, outputBias, FusedActivationType.None);
+    }
+
+    private double EvaluateSelfAttention(
+        Tensor<double> input,
+        Tensor<double> queryWeights,
+        Tensor<double> keyWeights,
+        Tensor<double> valueWeights,
+        Tensor<double> outputWeights,
+        Tensor<double> outputBias,
+        Tensor<double> projection,
+        int batch,
+        int sequence,
+        int heads,
+        int headDimension)
+    {
+        using var noGrad = new NoGradScope<double>();
+        var output = ProjectSelfAttention(
+            input, queryWeights, keyWeights, valueWeights, outputWeights, outputBias,
+            batch, sequence, heads, headDimension);
+        double sum = 0.0;
+        for (int i = 0; i < output.Length; i++) sum += output[i] * projection[i];
+        return sum;
+    }
+
+    private static Tensor<double> CreatePattern(int[] shape, double scale)
+    {
+        var tensor = new Tensor<double>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = scale * (((i * 17) % 29) - 14);
+        return tensor;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SliceMetadataSnapshotGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SliceMetadataSnapshotGradientTests.cs
@@ -1,0 +1,36 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public class SliceMetadataSnapshotGradientTests
+{
+    [Fact]
+    public async Task TensorSlice_BackwardUsesMetadataFromEachForwardCall()
+    {
+        await Task.Yield();
+
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, [2, 2]);
+        var start = new[] { 0, 0 };
+        var length = new[] { 1, 2 };
+
+        Tensor<float> gradient;
+        using (var tape = new GradientTape<float>())
+        {
+            var firstRow = engine.TensorSlice(input, start, length);
+            start[0] = 1;
+            var secondRow = engine.TensorSlice(input, start, length);
+            var objective = engine.TensorAdd(
+                engine.ReduceSum(firstRow, [0, 1], keepDims: false),
+                engine.TensorMultiplyScalar(
+                    engine.ReduceSum(secondRow, [0, 1], keepDims: false),
+                    2f));
+            gradient = tape.ComputeGradients(objective, [input])[input];
+        }
+
+        Assert.Equal(new[] { 1f, 1f, 2f, 2f }, gradient.ToArray());
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SliceMetadataSnapshotGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SliceMetadataSnapshotGradientTests.cs
@@ -33,4 +33,31 @@ public class SliceMetadataSnapshotGradientTests
 
         Assert.Equal(new[] { 1f, 1f, 2f, 2f }, gradient.ToArray());
     }
+
+    [Fact]
+    public async Task TensorSlice_BackwardSnapshotsLengthFromEachForwardCall()
+    {
+        await Task.Yield();
+
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, [2, 2]);
+        var start = new[] { 0, 0 };
+        var length = new[] { 2, 1 };
+
+        Tensor<float> gradient;
+        using (var tape = new GradientTape<float>())
+        {
+            var firstColumn = engine.TensorSlice(input, start, length);
+            length[1] = 2;
+            var entireInput = engine.TensorSlice(input, start, length);
+            var objective = engine.TensorAdd(
+                engine.ReduceSum(firstColumn, [0, 1], keepDims: false),
+                engine.TensorMultiplyScalar(
+                    engine.ReduceSum(entireInput, [0, 1], keepDims: false),
+                    2f));
+            gradient = tape.ComputeGradients(objective, [input])[input];
+        }
+
+        Assert.Equal(new[] { 3f, 2f, 3f, 2f }, gradient.ToArray());
+    }
 }


### PR DESCRIPTION
## Summary

- isolate first-write gradient ownership when a backward operation reuses one contribution tensor
- snapshot mutable slice metadata when recording eager and traced operations, so later caller mutations cannot rewrite tape history
- make direct tensor views, round, degenerate Conv2D input gradients, divide denominators, fused linear paths, RMSNorm, and scaled-dot-product attention obey their mathematical gradient contracts
- make rebindable compiled-plan caching fail closed when graph structure or replay safety is uncertain
- add focused async finite-difference and ownership regressions for each repaired contract

## Root cause

Several fast paths relied on aliasing or mutable caller-owned state that is safe during a single forward operation but not over the lifetime of a backward graph. In RAFT, both convex-upsample channel slices recorded the same mutable `start` array; after the loop mutated it, channel 0's backward node replayed channel 1 and silently dropped its gradient. The ownership fix applies the same principle to gradient buffers: optimization may donate storage only when ownership is unique and explicit.

The repair establishes an immutable-forward-record contract while preserving zero-copy/in-place behavior where uniqueness is proven.

## Validation

- full .NET 10 autodiff slice: 1,250 passed, 30 skipped, 0 failed
- focused immutable-slice metadata regression: 1 passed, 0 failed
- AiDotNet generated full-RAFT finite-difference gate against the packaged branch build: 1 passed, 0 failed
- AiDotNet shared-convolution output-lifetime regression: 1 passed, 0 failed
- AiDotNet Release net10.0 isolated build: 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autodiff gradient accumulation across branched and nested computations.
  * Ensured backward-pass cleanup completes even when an operation fails.
  * Corrected cached plan reuse for structurally different computation graphs.
  * Fixed convolution gradients for small, padded inputs and large parallel workloads.
  * Corrected rounding derivatives to return zero and preserved slice metadata across operations.
  * Prevented duplicate view tracking and improved handling of aliased gradient buffers.

* **Tests**
  * Added broad gradient coverage for attention, normalization, division, convolution, fused layers, fan-out, and plan caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->