### PR TITLE
feat(engine): add fused complex diagonal SSM scan

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -172,6 +172,7 @@ internal static class OpRegistry
         // backward, replacing the per-timestep tape micro-ops. All differentiable.
         "Rwkv4WkvForward",
         "MambaSelectiveScanForward",
+        "ComplexDiagonalSsmScanForward",
         "RgLruScanForward",
         "GlaScanForward",
         "GatedDeltaNetScanForward",

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
@@ -59,14 +59,14 @@ public partial class CpuEngine
         out int width,
         out int state)
     {
-        ArgumentNullException.ThrowIfNull(input);
-        ArgumentNullException.ThrowIfNull(transitionReal);
-        ArgumentNullException.ThrowIfNull(transitionImag);
-        ArgumentNullException.ThrowIfNull(inputMapReal);
-        ArgumentNullException.ThrowIfNull(inputMapImag);
-        ArgumentNullException.ThrowIfNull(outputMapReal);
-        ArgumentNullException.ThrowIfNull(outputMapImag);
-        ArgumentNullException.ThrowIfNull(skip);
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (transitionReal is null) throw new ArgumentNullException(nameof(transitionReal));
+        if (transitionImag is null) throw new ArgumentNullException(nameof(transitionImag));
+        if (inputMapReal is null) throw new ArgumentNullException(nameof(inputMapReal));
+        if (inputMapImag is null) throw new ArgumentNullException(nameof(inputMapImag));
+        if (outputMapReal is null) throw new ArgumentNullException(nameof(outputMapReal));
+        if (outputMapImag is null) throw new ArgumentNullException(nameof(outputMapImag));
+        if (skip is null) throw new ArgumentNullException(nameof(skip));
 
         if (input.Rank != 4)
             throw new ArgumentException(
@@ -95,12 +95,12 @@ public partial class CpuEngine
     {
         if (tensor.Rank != expected.Length)
             throw new ArgumentException(
-                $"{paramName} must have shape [{string.Join(',', expected)}]; got rank {tensor.Rank}.", paramName);
+                $"{paramName} must have shape [{string.Join(",", expected)}]; got rank {tensor.Rank}.", paramName);
         for (int i = 0; i < expected.Length; i++)
         {
             if (tensor.Shape[i] != expected[i])
                 throw new ArgumentException(
-                    $"{paramName} must have shape [{string.Join(',', expected)}]; " +
+                    $"{paramName} must have shape [{string.Join(",", expected)}]; " +
                     $"dimension {i} was {tensor.Shape[i]}.", paramName);
         }
     }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <inheritdoc />
+    public virtual Tensor<T> ComplexDiagonalSsmScanForward<T>(
+        Tensor<T> input,
+        Tensor<T> transitionReal,
+        Tensor<T> transitionImag,
+        Tensor<T> inputMapReal,
+        Tensor<T> inputMapImag,
+        Tensor<T> outputMapReal,
+        Tensor<T> outputMapImag,
+        Tensor<T> skip)
+    {
+        ValidateComplexDiagonalSsmScan(
+            input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+            outputMapReal, outputMapImag, skip,
+            out int batch, out int time, out int groups, out int width, out int state);
+
+        var output = new Tensor<T>(new[] { batch, time, groups, width });
+        ComplexDiagonalSsmScanForwardCore(
+            input.GetDataArray()!, transitionReal.GetDataArray()!, transitionImag.GetDataArray()!,
+            inputMapReal.GetDataArray()!, inputMapImag.GetDataArray()!,
+            outputMapReal.GetDataArray()!, outputMapImag.GetDataArray()!, skip.GetDataArray()!,
+            output.GetDataArray()!, batch, time, groups, width, state);
+
+        DifferentiableOps.RecordIfActive<T>(
+            "ComplexDiagonalSsmScan", output,
+            new[]
+            {
+                input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip
+            },
+            ComplexDiagonalSsmScanBackward<T>,
+            savedState: null);
+
+        return output;
+    }
+
+    private static void ValidateComplexDiagonalSsmScan<T>(
+        Tensor<T> input,
+        Tensor<T> transitionReal,
+        Tensor<T> transitionImag,
+        Tensor<T> inputMapReal,
+        Tensor<T> inputMapImag,
+        Tensor<T> outputMapReal,
+        Tensor<T> outputMapImag,
+        Tensor<T> skip,
+        out int batch,
+        out int time,
+        out int groups,
+        out int width,
+        out int state)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(transitionReal);
+        ArgumentNullException.ThrowIfNull(transitionImag);
+        ArgumentNullException.ThrowIfNull(inputMapReal);
+        ArgumentNullException.ThrowIfNull(inputMapImag);
+        ArgumentNullException.ThrowIfNull(outputMapReal);
+        ArgumentNullException.ThrowIfNull(outputMapImag);
+        ArgumentNullException.ThrowIfNull(skip);
+
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                $"input must be rank-4 [batch,time,group,width]; got rank {input.Rank}.", nameof(input));
+
+        batch = input.Shape[0];
+        time = input.Shape[1];
+        groups = input.Shape[2];
+        width = input.Shape[3];
+        if (batch < 1 || time < 1 || groups < 1 || width < 1)
+            throw new ArgumentException("All input dimensions must be positive.", nameof(input));
+
+        if (transitionReal.Rank != 2 || transitionReal.Shape[0] != groups || transitionReal.Shape[1] < 1)
+            throw new ArgumentException(
+                $"transitionReal must be [group={groups},state>0].", nameof(transitionReal));
+        state = transitionReal.Shape[1];
+        EnsureShape(transitionImag, new[] { groups, state }, nameof(transitionImag));
+        EnsureShape(inputMapReal, new[] { groups, state, width }, nameof(inputMapReal));
+        EnsureShape(inputMapImag, new[] { groups, state, width }, nameof(inputMapImag));
+        EnsureShape(outputMapReal, new[] { groups, width, state }, nameof(outputMapReal));
+        EnsureShape(outputMapImag, new[] { groups, width, state }, nameof(outputMapImag));
+        EnsureShape(skip, new[] { groups, width }, nameof(skip));
+    }
+
+    private static void EnsureShape<T>(Tensor<T> tensor, int[] expected, string paramName)
+    {
+        if (tensor.Rank != expected.Length)
+            throw new ArgumentException(
+                $"{paramName} must have shape [{string.Join(',', expected)}]; got rank {tensor.Rank}.", paramName);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            if (tensor.Shape[i] != expected[i])
+                throw new ArgumentException(
+                    $"{paramName} must have shape [{string.Join(',', expected)}]; " +
+                    $"dimension {i} was {tensor.Shape[i]}.", paramName);
+        }
+    }
+
+    private static void ComplexDiagonalSsmScanForwardCore<T>(
+        T[] x, T[] ar, T[] ai, T[] br, T[] bi, T[] cr, T[] ci, T[] d, T[] y,
+        int batch, int time, int groups, int width, int state)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var hr = new T[state];
+        var hi = new T[state];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int g = 0; g < groups; g++)
+            {
+                Array.Clear(hr, 0, state);
+                Array.Clear(hi, 0, state);
+                int aBase = g * state;
+                int mapBase = g * state * width;
+                int outMapBase = g * width * state;
+                int dBase = g * width;
+
+                for (int t = 0; t < time; t++)
+                {
+                    int xBase = ((b * time + t) * groups + g) * width;
+                    for (int n = 0; n < state; n++)
+                    {
+                        T oldR = hr[n];
+                        T oldI = hi[n];
+                        T nextR = ops.Subtract(
+                            ops.Multiply(ar[aBase + n], oldR),
+                            ops.Multiply(ai[aBase + n], oldI));
+                        T nextI = ops.Add(
+                            ops.Multiply(ar[aBase + n], oldI),
+                            ops.Multiply(ai[aBase + n], oldR));
+                        int bn = mapBase + n * width;
+                        for (int w = 0; w < width; w++)
+                        {
+                            T xv = x[xBase + w];
+                            nextR = ops.Add(nextR, ops.Multiply(br[bn + w], xv));
+                            nextI = ops.Add(nextI, ops.Multiply(bi[bn + w], xv));
+                        }
+                        hr[n] = nextR;
+                        hi[n] = nextI;
+                    }
+
+                    for (int w = 0; w < width; w++)
+                    {
+                        T value = ops.Multiply(d[dBase + w], x[xBase + w]);
+                        int cn = outMapBase + w * state;
+                        for (int n = 0; n < state; n++)
+                        {
+                            value = ops.Add(value, ops.Subtract(
+                                ops.Multiply(cr[cn + n], hr[n]),
+                                ops.Multiply(ci[cn + n], hi[n])));
+                        }
+                        y[xBase + w] = value;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ComplexDiagonalSsmScanBackward<T>(
+        Tensor<T> gradOutput,
+        Tensor<T>[] inputs,
+        Tensor<T> output,
+        object[] savedState,
+        IEngine engine,
+        Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var xTensor = inputs[0];
+        int batch = xTensor.Shape[0];
+        int time = xTensor.Shape[1];
+        int groups = xTensor.Shape[2];
+        int width = xTensor.Shape[3];
+        int state = inputs[1].Shape[1];
+
+        var gradients = new Tensor<T>[8];
+        for (int i = 0; i < gradients.Length; i++)
+            gradients[i] = new Tensor<T>(inputs[i].Shape.ToArray());
+
+        ComplexDiagonalSsmScanBackwardCore(
+            gradOutput.GetDataArray()!,
+            inputs[0].GetDataArray()!, inputs[1].GetDataArray()!, inputs[2].GetDataArray()!,
+            inputs[3].GetDataArray()!, inputs[4].GetDataArray()!, inputs[5].GetDataArray()!,
+            inputs[6].GetDataArray()!, inputs[7].GetDataArray()!,
+            gradients[0].GetDataArray()!, gradients[1].GetDataArray()!, gradients[2].GetDataArray()!,
+            gradients[3].GetDataArray()!, gradients[4].GetDataArray()!, gradients[5].GetDataArray()!,
+            gradients[6].GetDataArray()!, gradients[7].GetDataArray()!,
+            batch, time, groups, width, state);
+
+        for (int i = 0; i < gradients.Length; i++)
+            DifferentiableOps.AccumulateGrad(grads, inputs[i], gradients[i], engine);
+    }
+
+    private static void ComplexDiagonalSsmScanBackwardCore<T>(
+        T[] dy, T[] x, T[] ar, T[] ai, T[] br, T[] bi, T[] cr, T[] ci, T[] d,
+        T[] dx, T[] dar, T[] dai, T[] dbr, T[] dbi, T[] dcr, T[] dci, T[] dd,
+        int batch, int time, int groups, int width, int state)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        var statesR = new T[(time + 1) * state];
+        var statesI = new T[(time + 1) * state];
+        var adjR = new T[state];
+        var adjI = new T[state];
+
+        for (int b = 0; b < batch; b++)
+        {
+            for (int g = 0; g < groups; g++)
+            {
+                Array.Clear(statesR, 0, statesR.Length);
+                Array.Clear(statesI, 0, statesI.Length);
+                Array.Clear(adjR, 0, state);
+                Array.Clear(adjI, 0, state);
+                int aBase = g * state;
+                int mapBase = g * state * width;
+                int outMapBase = g * width * state;
+                int dBase = g * width;
+
+                // Recompute states once; keeping only this group bounds memory at O(time*state).
+                for (int t = 0; t < time; t++)
+                {
+                    int xBase = ((b * time + t) * groups + g) * width;
+                    int prev = t * state;
+                    int next = prev + state;
+                    for (int n = 0; n < state; n++)
+                    {
+                        T nextR = ops.Subtract(
+                            ops.Multiply(ar[aBase + n], statesR[prev + n]),
+                            ops.Multiply(ai[aBase + n], statesI[prev + n]));
+                        T nextI = ops.Add(
+                            ops.Multiply(ar[aBase + n], statesI[prev + n]),
+                            ops.Multiply(ai[aBase + n], statesR[prev + n]));
+                        int bn = mapBase + n * width;
+                        for (int w = 0; w < width; w++)
+                        {
+                            nextR = ops.Add(nextR, ops.Multiply(br[bn + w], x[xBase + w]));
+                            nextI = ops.Add(nextI, ops.Multiply(bi[bn + w], x[xBase + w]));
+                        }
+                        statesR[next + n] = nextR;
+                        statesI[next + n] = nextI;
+                    }
+                }
+
+                for (int t = time - 1; t >= 0; t--)
+                {
+                    int xBase = ((b * time + t) * groups + g) * width;
+                    int prev = t * state;
+                    int current = prev + state;
+
+                    for (int w = 0; w < width; w++)
+                    {
+                        T grad = dy[xBase + w];
+                        dd[dBase + w] = ops.Add(dd[dBase + w], ops.Multiply(grad, x[xBase + w]));
+                        dx[xBase + w] = ops.Add(dx[xBase + w], ops.Multiply(grad, d[dBase + w]));
+                        int cn = outMapBase + w * state;
+                        for (int n = 0; n < state; n++)
+                        {
+                            adjR[n] = ops.Add(adjR[n], ops.Multiply(cr[cn + n], grad));
+                            adjI[n] = ops.Subtract(adjI[n], ops.Multiply(ci[cn + n], grad));
+                            dcr[cn + n] = ops.Add(dcr[cn + n], ops.Multiply(grad, statesR[current + n]));
+                            dci[cn + n] = ops.Subtract(dci[cn + n], ops.Multiply(grad, statesI[current + n]));
+                        }
+                    }
+
+                    for (int n = 0; n < state; n++)
+                    {
+                        T gr = adjR[n];
+                        T gi = adjI[n];
+                        T oldR = statesR[prev + n];
+                        T oldI = statesI[prev + n];
+                        int an = aBase + n;
+                        dar[an] = ops.Add(dar[an], ops.Add(ops.Multiply(gr, oldR), ops.Multiply(gi, oldI)));
+                        dai[an] = ops.Add(dai[an], ops.Subtract(ops.Multiply(gi, oldR), ops.Multiply(gr, oldI)));
+
+                        int bn = mapBase + n * width;
+                        for (int w = 0; w < width; w++)
+                        {
+                            T xv = x[xBase + w];
+                            dbr[bn + w] = ops.Add(dbr[bn + w], ops.Multiply(gr, xv));
+                            dbi[bn + w] = ops.Add(dbi[bn + w], ops.Multiply(gi, xv));
+                            dx[xBase + w] = ops.Add(dx[xBase + w], ops.Add(
+                                ops.Multiply(br[bn + w], gr), ops.Multiply(bi[bn + w], gi)));
+                        }
+
+                        adjR[n] = ops.Add(ops.Multiply(ar[an], gr), ops.Multiply(ai[an], gi));
+                        adjI[n] = ops.Subtract(ops.Multiply(ar[an], gi), ops.Multiply(ai[an], gr));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -15824,6 +15824,25 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 
+    public unsafe void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+    {
+        if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0 || width > 256 || state > 256)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM dimensions must be in [1,256] for width/state.");
+        if (!_kernelCache.TryGetValue("complex_diagonal_ssm_scan_forward", out var kernel))
+            throw new InvalidOperationException("CUDA kernel not found: complex_diagonal_ssm_scan_forward");
+        using var _ = PushContext();
+        IntPtr px=input.Handle, par=transitionReal.Handle, pai=transitionImag.Handle, pbr=inputMapReal.Handle,
+            pbi=inputMapImag.Handle, pcr=outputMapReal.Handle, pci=outputMapImag.Handle, pd=skip.Handle, po=output.Handle;
+        void** args = stackalloc void*[14];
+        args[0]=&px; args[1]=&par; args[2]=&pai; args[3]=&pbr; args[4]=&pbi; args[5]=&pcr; args[6]=&pci; args[7]=&pd; args[8]=&po;
+        args[9]=&batch; args[10]=&time; args[11]=&groups; args[12]=&width; args[13]=&state;
+        LaunchKernel(kernel, (uint)(batch * groups), 256, args);
+    }
+
     // ── Fused Mamba-2 SSD scan forward (#1464) ─────────────────────────────────────────────
     public unsafe void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMambaKernels.cs
@@ -47,8 +47,44 @@ extern ""C"" __global__ void mamba_selective_scan_forward(
         output[baseID + di] = y + D[di] * xv;
     }
 }
+
+extern ""C"" __global__ void complex_diagonal_ssm_scan_forward(
+    const float* X, const float* Ar, const float* Ai, const float* Br, const float* Bi,
+    const float* Cr, const float* Ci, const float* D, float* output,
+    int batch, int time, int groups, int width, int state)
+{
+    int bg = blockIdx.x;
+    int lane = threadIdx.x;
+    if (bg >= batch * groups) return;
+    int b = bg / groups;
+    int g = bg % groups;
+    __shared__ float hr[256];
+    __shared__ float hi[256];
+    if (lane < state) { hr[lane] = 0.0f; hi[lane] = 0.0f; }
+    __syncthreads();
+    for (int t = 0; t < time; t++) {
+        int xBase = ((b * time + t) * groups + g) * width;
+        if (lane < state) {
+            int a = g * state + lane;
+            int bm = (g * state + lane) * width;
+            float oldR = hr[lane], oldI = hi[lane];
+            float nextR = Ar[a] * oldR - Ai[a] * oldI;
+            float nextI = Ar[a] * oldI + Ai[a] * oldR;
+            for (int w = 0; w < width; w++) { float xv = X[xBase+w]; nextR += Br[bm+w]*xv; nextI += Bi[bm+w]*xv; }
+            hr[lane] = nextR; hi[lane] = nextI;
+        }
+        __syncthreads();
+        if (lane < width) {
+            int cm = (g * width + lane) * state;
+            float y = D[g * width + lane] * X[xBase + lane];
+            for (int n = 0; n < state; n++) y += Cr[cm+n] * hr[n] - Ci[cm+n] * hi[n];
+            output[xBase + lane] = y;
+        }
+        __syncthreads();
+    }
+}
 ";
     }
 
-    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward", "complex_diagonal_ssm_scan_forward" };
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.FusedKernels.cs
@@ -699,6 +699,24 @@ public sealed partial class HipBackend
         LaunchKernel(kernel, (total + (uint)DefaultBlockSize - 1) / (uint)DefaultBlockSize, (uint)DefaultBlockSize, args);
     }
 
+    public unsafe void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+    {
+        if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0 || width > 256 || state > 256)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM dimensions must be in [1,256] for width/state.");
+        if (!_kernelCache.TryGetValue("complex_diagonal_ssm_scan_forward", out var kernel))
+            throw new InvalidOperationException("HIP kernel not found: complex_diagonal_ssm_scan_forward");
+        IntPtr px=input.Handle, par=transitionReal.Handle, pai=transitionImag.Handle, pbr=inputMapReal.Handle,
+            pbi=inputMapImag.Handle, pcr=outputMapReal.Handle, pci=outputMapImag.Handle, pd=skip.Handle, po=output.Handle;
+        void** args = stackalloc void*[14];
+        args[0]=&px; args[1]=&par; args[2]=&pai; args[3]=&pbr; args[4]=&pbi; args[5]=&pcr; args[6]=&pci; args[7]=&pd; args[8]=&po;
+        args[9]=&batch; args[10]=&time; args[11]=&groups; args[12]=&width; args[13]=&state;
+        LaunchKernel(kernel, (uint)(batch * groups), 256, args);
+    }
+
     // ── Fused Mamba-2 SSD scan forward (#1464) ─────────────────────────────────────────────
     public unsafe void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMambaKernels.cs
@@ -51,8 +51,40 @@ extern ""C"" __global__ __launch_bounds__(1024) void mamba_selective_scan_forwar
         output[baseID + di] = y + D[di] * xv;
     }
 }
+
+extern ""C"" __global__ __launch_bounds__(256) void complex_diagonal_ssm_scan_forward(
+    const float* X, const float* Ar, const float* Ai, const float* Br, const float* Bi,
+    const float* Cr, const float* Ci, const float* D, float* output,
+    int batch, int time, int groups, int width, int state)
+{
+    int bg = blockIdx.x;
+    int lane = threadIdx.x;
+    if (bg >= batch * groups) return;
+    int b = bg / groups, g = bg % groups;
+    __shared__ float hr[256], hi[256];
+    if (lane < state) { hr[lane] = 0.0f; hi[lane] = 0.0f; }
+    __syncthreads();
+    for (int t = 0; t < time; t++) {
+        int xBase = ((b * time + t) * groups + g) * width;
+        if (lane < state) {
+            int a = g * state + lane, bm = (g * state + lane) * width;
+            float oldR = hr[lane], oldI = hi[lane];
+            float nextR = Ar[a] * oldR - Ai[a] * oldI;
+            float nextI = Ar[a] * oldI + Ai[a] * oldR;
+            for (int w = 0; w < width; w++) { float xv=X[xBase+w]; nextR+=Br[bm+w]*xv; nextI+=Bi[bm+w]*xv; }
+            hr[lane]=nextR; hi[lane]=nextI;
+        }
+        __syncthreads();
+        if (lane < width) {
+            int cm=(g*width+lane)*state; float y=D[g*width+lane]*X[xBase+lane];
+            for (int n=0;n<state;n++) y += Cr[cm+n]*hr[n]-Ci[cm+n]*hi[n];
+            output[xBase+lane]=y;
+        }
+        __syncthreads();
+    }
+}
 ";
     }
 
-    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward", "complex_diagonal_ssm_scan_forward" };
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IDirectGpuBackend.cs
@@ -3060,6 +3060,13 @@ public interface IDirectGpuBackend : IDisposable
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int stateDim);
 
+    /// <summary>Grouped complex diagonal state-space scan with device-resident inputs and output.</summary>
+    void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state);
+
     /// <summary>
     /// Fused Mamba-2 SSD scan forward (#1464). x: [batch, seqLen, innerDim];
     /// delta: [batch, seqLen, numHeads]; aLog/dParam: [numHeads]; bParam/cParam: [batch, seqLen, stateDim];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Rnn.cs
@@ -104,6 +104,20 @@ public partial class MetalBackend
             new[] { M(x), M(delta), M(aLog), M(bParam), M(cParam), M(dParam), M(output) },
             new[] { batch, seqLen, innerDim, stateDim });
 
+    public void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+    {
+        if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0 || width > 256 || state > 256)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM width/state must be in [1,256].");
+        DispatchRecurrence("complex_diagonal_ssm_scan_forward", batch * groups,
+            new[] { M(input), M(transitionReal), M(transitionImag), M(inputMapReal), M(inputMapImag),
+                M(outputMapReal), M(outputMapImag), M(skip), M(output) },
+            new[] { batch, time, groups, width, state });
+    }
+
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalRecurrenceKernels.cs
@@ -219,6 +219,36 @@ kernel void mamba_selective_scan_forward(
     }
 }
 
+kernel void complex_diagonal_ssm_scan_forward(
+    device const float* X [[buffer(0)]], device const float* Ar [[buffer(1)]],
+    device const float* Ai [[buffer(2)]], device const float* Br [[buffer(3)]],
+    device const float* Bi [[buffer(4)]], device const float* Cr [[buffer(5)]],
+    device const float* Ci [[buffer(6)]], device const float* D [[buffer(7)]],
+    device float* output [[buffer(8)]], constant int& batch [[buffer(9)]],
+    constant int& time [[buffer(10)]], constant int& groups [[buffer(11)]],
+    constant int& width [[buffer(12)]], constant int& state [[buffer(13)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if ((int)gid >= batch*groups) return;
+    int b=(int)gid/groups, g=(int)gid%groups;
+    thread float hr[256], hi[256];
+    for (int n=0;n<state;n++) { hr[n]=0.0f; hi[n]=0.0f; }
+    for (int t=0;t<time;t++) {
+        int xBase=((b*time+t)*groups+g)*width;
+        for (int n=0;n<state;n++) {
+            int a=g*state+n, bm=(g*state+n)*width; float oldR=hr[n], oldI=hi[n];
+            float nextR=Ar[a]*oldR-Ai[a]*oldI, nextI=Ar[a]*oldI+Ai[a]*oldR;
+            for (int w=0;w<width;w++) { float xv=X[xBase+w]; nextR+=Br[bm+w]*xv; nextI+=Bi[bm+w]*xv; }
+            hr[n]=nextR; hi[n]=nextI;
+        }
+        for (int w=0;w<width;w++) {
+            int cm=(g*width+w)*state; float y=D[g*width+w]*X[xBase+w];
+            for (int n=0;n<state;n++) y+=Cr[cm+n]*hr[n]-Ci[cm+n]*hi[n];
+            output[xBase+w]=y;
+        }
+    }
+}
+
 // ── Mamba-2 SSD scan forward ───────────────────────────────────────────────────────────────
 kernel void mamba2_ssd_scan_forward(
     device const float* X [[buffer(0)]], device const float* delta [[buffer(1)]],

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MambaKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MambaKernels.cs
@@ -49,8 +49,37 @@ __kernel void mamba_selective_scan_forward(
         output[baseID + di] = y + D[di] * xv;
     }
 }
+
+__kernel void complex_diagonal_ssm_scan_forward(
+    __global const float* X, __global const float* Ar, __global const float* Ai,
+    __global const float* Br, __global const float* Bi,
+    __global const float* Cr, __global const float* Ci, __global const float* D,
+    __global float* output, __global float* stateR, __global float* stateI,
+    int batch, int time, int groups, int width, int state)
+{
+    int bg = get_global_id(0);
+    if (bg >= batch * groups) return;
+    int b = bg / groups, g = bg % groups;
+    int hbase = bg * state;
+    for (int n=0;n<state;n++) { stateR[hbase+n]=0.0f; stateI[hbase+n]=0.0f; }
+    for (int t=0;t<time;t++) {
+        int xBase=((b*time+t)*groups+g)*width;
+        for (int n=0;n<state;n++) {
+            int a=g*state+n, bm=(g*state+n)*width;
+            float oldR=stateR[hbase+n], oldI=stateI[hbase+n];
+            float nextR=Ar[a]*oldR-Ai[a]*oldI, nextI=Ar[a]*oldI+Ai[a]*oldR;
+            for (int w=0;w<width;w++) { float xv=X[xBase+w]; nextR+=Br[bm+w]*xv; nextI+=Bi[bm+w]*xv; }
+            stateR[hbase+n]=nextR; stateI[hbase+n]=nextI;
+        }
+        for (int w=0;w<width;w++) {
+            int cm=(g*width+w)*state; float y=D[g*width+w]*X[xBase+w];
+            for (int n=0;n<state;n++) y+=Cr[cm+n]*stateR[hbase+n]-Ci[cm+n]*stateI[hbase+n];
+            output[xBase+w]=y;
+        }
+    }
+}
 ";
     }
 
-    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward" };
+    public static string[] GetKernelNames() => new[] { "mamba_selective_scan_forward", "complex_diagonal_ssm_scan_forward" };
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -13126,6 +13126,29 @@ KERNEL VARIANTS (A/B testing):
             _context?.Finish();
         }
 
+        public void ComplexDiagonalSsmScanForward(
+            IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+            IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+            IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+            IGpuBuffer output, int batch, int time, int groups, int width, int state)
+        {
+            if (_context == null) throw new InvalidOperationException("OpenCL context is not initialized.");
+            if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0)
+                throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM dimensions must be positive.");
+            if (!_kernelCache.TryGetValue("complex_diagonal_ssm_scan_forward", out var kernel))
+                throw new InvalidOperationException("OpenCL kernel not found: complex_diagonal_ssm_scan_forward");
+            int total = batch * groups;
+            using var stateR = AllocateBuffer(total * state);
+            using var stateI = AllocateBuffer(total * state);
+            IGpuBuffer[] buffers = { input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip, output, stateR, stateI };
+            for (uint i=0;i<buffers.Length;i++) kernel.SetArg(i, ((DirectOpenClGpuBuffer)buffers[i]).Buffer.Handle);
+            kernel.SetArg(11u,batch); kernel.SetArg(12u,time); kernel.SetArg(13u,groups); kernel.SetArg(14u,width); kernel.SetArg(15u,state);
+            int local = CalculateOptimalWorkGroupSize1D(total);
+            kernel.Execute1D(((total+local-1)/local)*local, local);
+            _context.Finish();
+        }
+
         // ── Fused Mamba-2 SSD scan forward (#1464) ──────────────────────────────────────────
         public void Mamba2SsdScanForward(
             IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.GpuBackend4.cs
@@ -841,6 +841,20 @@ public sealed unsafe partial class VulkanBackend
         => GlslNaryOp(VulkanRecurrenceKernels.MambaScan, new[] { x, delta, aLog, bParam, cParam, dParam, output },
             batch * innerDim, new[] { (uint)batch, (uint)seqLen, (uint)innerDim, (uint)stateDim });
 
+    public void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+    {
+        if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0 || width > 256 || state > 256)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM width/state must be in [1,256].");
+        GlslNaryOp(VulkanRecurrenceKernels.ComplexDiagonalSsmScan,
+            new[] { input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip, output }, batch * groups,
+            new[] { (uint)batch, (uint)time, (uint)groups, (uint)width, (uint)state });
+    }
+
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanRecurrenceKernels.cs
@@ -170,6 +170,28 @@ void main() {
     }
 }";
 
+    public static string ComplexDiagonalSsmScan => Header + @"
+layout(set=0,binding=0) readonly buffer Xb { float X[]; };
+layout(set=0,binding=1) readonly buffer Arb { float Ar[]; };
+layout(set=0,binding=2) readonly buffer Aib { float Ai[]; };
+layout(set=0,binding=3) readonly buffer Brb { float Br[]; };
+layout(set=0,binding=4) readonly buffer Bib { float Bi[]; };
+layout(set=0,binding=5) readonly buffer Crb { float Cr[]; };
+layout(set=0,binding=6) readonly buffer Cib { float Ci[]; };
+layout(set=0,binding=7) readonly buffer Db { float D[]; };
+layout(set=0,binding=8) writeonly buffer Ob { float outp[]; };
+layout(push_constant) uniform PC { uint batch; uint time; uint groups; uint width; uint state; };
+void main() {
+    int gid=int(gl_GlobalInvocationID.x), G=int(groups), T=int(time), W=int(width), S=int(state);
+    if (gid>=int(batch)*G) return; int b=gid/G, g=gid%G; float hr[256]; float hi[256];
+    for(int n=0;n<S;n++){hr[n]=0.0;hi[n]=0.0;}
+    for(int t=0;t<T;t++) { int xb=((b*T+t)*G+g)*W;
+        for(int n=0;n<S;n++){int a=g*S+n,bm=(g*S+n)*W;float orr=hr[n],oi=hi[n];float nr=Ar[a]*orr-Ai[a]*oi,ni=Ar[a]*oi+Ai[a]*orr;
+            for(int w=0;w<W;w++){float xv=X[xb+w];nr+=Br[bm+w]*xv;ni+=Bi[bm+w]*xv;}hr[n]=nr;hi[n]=ni;}
+        for(int w=0;w<W;w++){int cm=(g*W+w)*S;float y=D[g*W+w]*X[xb+w];for(int n=0;n<S;n++)y+=Cr[cm+n]*hr[n]-Ci[cm+n]*hi[n];outp[xb+w]=y;}
+    }
+}";
+
     public static string Mamba2Ssd => Header + @"
 layout(set=0,binding=0) readonly buffer Xb { float X[]; };
 layout(set=0,binding=1) readonly buffer Dtb { float delta[]; };

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.GpuBackend4.cs
@@ -929,6 +929,19 @@ public sealed partial class WebGpuBackend
         => DispatchRecurrence("mamba", WebGpuRecurrenceKernels.MambaScan, batch * innerDim,
             new[] { x, delta, aLog, bParam, cParam, dParam, output }, new[] { batch, seqLen, innerDim, stateDim });
 
+    public void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+    {
+        if (batch <= 0 || time <= 0 || groups <= 0 || width <= 0 || state <= 0 || width > 256 || state > 256)
+            throw new ArgumentOutOfRangeException(nameof(batch), "Complex diagonal SSM width/state must be in [1,256].");
+        DispatchRecurrence("complex_diagonal_ssm", WebGpuRecurrenceKernels.ComplexDiagonalSsmScan,
+            batch * groups, new[] { input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip, output }, new[] { batch, time, groups, width, state });
+    }
+
     public void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuRecurrenceKernels.cs
@@ -174,6 +174,29 @@ struct P { batch: i32, seqLen: i32, innerDim: i32, stateDim: i32 };
     }
 }";
 
+    public const string ComplexDiagonalSsmScan = @"
+@group(0) @binding(0) var<storage, read> X: array<f32>;
+@group(0) @binding(1) var<storage, read> Ar: array<f32>;
+@group(0) @binding(2) var<storage, read> Ai: array<f32>;
+@group(0) @binding(3) var<storage, read> Br: array<f32>;
+@group(0) @binding(4) var<storage, read> Bi: array<f32>;
+@group(0) @binding(5) var<storage, read> Cr: array<f32>;
+@group(0) @binding(6) var<storage, read> Ci: array<f32>;
+@group(0) @binding(7) var<storage, read> D: array<f32>;
+@group(0) @binding(8) var<storage, read_write> outp: array<f32>;
+struct P { batch:i32, time:i32, groups:i32, width:i32, state:i32 };
+@group(0) @binding(9) var<uniform> p:P;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id:vec3<u32>) {
+    let gid=i32(id.x); let G=p.groups; let T=p.time; let W=p.width; let S=p.state;
+    if(gid>=p.batch*G){return;} let b=gid/G; let g=gid%G; var hr:array<f32,256>;var hi:array<f32,256>;
+    for(var n:i32=0;n<S;n=n+1){hr[n]=0.0;hi[n]=0.0;}
+    for(var t:i32=0;t<T;t=t+1){let xb=((b*T+t)*G+g)*W;
+        for(var n:i32=0;n<S;n=n+1){let a=g*S+n;let bm=(g*S+n)*W;let orr=hr[n];let oi=hi[n];var nr=Ar[a]*orr-Ai[a]*oi;var ni=Ar[a]*oi+Ai[a]*orr;
+            for(var w:i32=0;w<W;w=w+1){let xv=X[xb+w];nr=nr+Br[bm+w]*xv;ni=ni+Bi[bm+w]*xv;}hr[n]=nr;hi[n]=ni;}
+        for(var w:i32=0;w<W;w=w+1){let cm=(g*W+w)*S;var y=D[g*W+w]*X[xb+w];for(var n:i32=0;n<S;n=n+1){y=y+Cr[cm+n]*hr[n]-Ci[cm+n]*hi[n];}outp[xb+w]=y;}
+    }
+}";
+
     public const string Mamba2Ssd = @"
 @group(0) @binding(0) var<storage, read> X: array<f32>;
 @group(0) @binding(1) var<storage, read> delta: array<f32>;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10057,6 +10057,56 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    // Grouped complex diagonal SSM scan. GPU inference uses a resident fused kernel; when the tape
+    // is active, CpuEngine records the single analytic BPTT node.
+    public override Tensor<T> ComplexDiagonalSsmScanForward<T>(
+        Tensor<T> input, Tensor<T> transitionReal, Tensor<T> transitionImag,
+        Tensor<T> inputMapReal, Tensor<T> inputMapImag,
+        Tensor<T> outputMapReal, Tensor<T> outputMapImag, Tensor<T> skip)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
+            input.Rank != 4 || transitionReal.Rank != 2)
+            return base.ComplexDiagonalSsmScanForward(
+                input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip);
+
+        int batch = input.Shape._dims[0];
+        int time = input.Shape._dims[1];
+        int groups = input.Shape._dims[2];
+        int width = input.Shape._dims[3];
+        int state = transitionReal.Shape._dims[1];
+        if (state > 256 || width > 256)
+            throw new NotSupportedException(
+                $"The GPU complex diagonal SSM scan supports width/state up to 256; got width={width}, state={state}.");
+        if (transitionReal.Shape._dims[0] != groups || transitionImag.Rank != 2 ||
+            transitionImag.Shape._dims[0] != groups || transitionImag.Shape._dims[1] != state ||
+            inputMapReal.Rank != 3 || inputMapReal.Shape._dims[0] != groups || inputMapReal.Shape._dims[1] != state || inputMapReal.Shape._dims[2] != width ||
+            inputMapImag.Rank != 3 || inputMapImag.Shape._dims[0] != groups || inputMapImag.Shape._dims[1] != state || inputMapImag.Shape._dims[2] != width ||
+            outputMapReal.Rank != 3 || outputMapReal.Shape._dims[0] != groups || outputMapReal.Shape._dims[1] != width || outputMapReal.Shape._dims[2] != state ||
+            outputMapImag.Rank != 3 || outputMapImag.Shape._dims[0] != groups || outputMapImag.Shape._dims[1] != width || outputMapImag.Shape._dims[2] != state ||
+            skip.Rank != 2 || skip.Shape._dims[0] != groups || skip.Shape._dims[1] != width)
+            return base.ComplexDiagonalSsmScanForward(
+                input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                outputMapReal, outputMapImag, skip);
+
+        using var x = GetOrAllocateBuffer(backend, input);
+        using var ar = GetOrAllocateBuffer(backend, transitionReal);
+        using var ai = GetOrAllocateBuffer(backend, transitionImag);
+        using var br = GetOrAllocateBuffer(backend, inputMapReal);
+        using var bi = GetOrAllocateBuffer(backend, inputMapImag);
+        using var cr = GetOrAllocateBuffer(backend, outputMapReal);
+        using var ci = GetOrAllocateBuffer(backend, outputMapImag);
+        using var d = GetOrAllocateBuffer(backend, skip);
+        using var y = AllocateOutputBuffer(backend, batch * time * groups * width);
+        backend.ComplexDiagonalSsmScanForward(
+            x.Buffer, ar.Buffer, ai.Buffer, br.Buffer, bi.Buffer, cr.Buffer, ci.Buffer, d.Buffer, y.Buffer,
+            batch, time, groups, width, state);
+        var result = DeferTensorResult<T>(backend, y.Buffer, batch * time * groups * width,
+            new[] { batch, time, groups, width });
+        y.RelinquishOwnership();
+        return result;
+    }
+
     // Fused Mamba-2 SSD scan (#1464). GPU inference fast path; defer to CpuEngine otherwise.
     public override Tensor<T> Mamba2SsdScanForward<T>(
         Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam, int numHeads)

--- a/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DelegatingGpuBackend.cs
@@ -1858,6 +1858,16 @@ public class DelegatingGpuBackend : IDirectGpuBackend
         => Inner.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam, output, batch, seqLen, innerDim, stateDim);
 
     /// <inheritdoc/>
+    public virtual void ComplexDiagonalSsmScanForward(
+        IGpuBuffer input, IGpuBuffer transitionReal, IGpuBuffer transitionImag,
+        IGpuBuffer inputMapReal, IGpuBuffer inputMapImag,
+        IGpuBuffer outputMapReal, IGpuBuffer outputMapImag, IGpuBuffer skip,
+        IGpuBuffer output, int batch, int time, int groups, int width, int state)
+        => Inner.ComplexDiagonalSsmScanForward(
+            input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+            outputMapReal, outputMapImag, skip, output, batch, time, groups, width, state);
+
+    /// <inheritdoc/>
     public virtual void Mamba2SsdScanForward(
         IGpuBuffer x, IGpuBuffer delta, IGpuBuffer aLog, IGpuBuffer bParam, IGpuBuffer cParam, IGpuBuffer dParam,
         IGpuBuffer output, int batch, int seqLen, int innerDim, int numHeads, int headDim, int stateDim)

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4321,6 +4321,28 @@ public interface IEngine
         Tensor<T> dParam);
 
     /// <summary>
+    /// Fused grouped complex diagonal state-space scan with an analytic BPTT backward pass.
+    /// The recurrence is evaluated over <c>input [batch,time,group,width]</c>, using complex
+    /// transition <c>A [group,state]</c>, input map <c>B [group,state,width]</c>, output map
+    /// <c>C [group,width,state]</c>, and real diagonal skip <c>D [group,width]</c>. The returned
+    /// tensor has the same shape as <paramref name="input"/>.
+    /// </summary>
+    /// <remarks>
+    /// Real and imaginary parts are supplied separately. Callers are responsible for any continuous-
+    /// to-discrete parameterization, which keeps that parameterization visible to autodiff while the
+    /// time-dependent recurrence is represented by one tape node.
+    /// </remarks>
+    Tensor<T> ComplexDiagonalSsmScanForward<T>(
+        Tensor<T> input,
+        Tensor<T> transitionReal,
+        Tensor<T> transitionImag,
+        Tensor<T> inputMapReal,
+        Tensor<T> inputMapImag,
+        Tensor<T> outputMapReal,
+        Tensor<T> outputMapImag,
+        Tensor<T> skip);
+
+    /// <summary>
     /// Fused RG-LRU (Griffin/Hawk/RecurrentGemma) gated linear recurrence over a whole sequence as one
     /// differentiable op (forward + analytic BPTT backward); see <c>CpuEngine.RgLruScan.cs</c> (#1464).
     /// </summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -332,6 +332,9 @@ public class DifferentiableOpsGradCheckSweep
         // d [innerDim].
         ["MambaSelectiveScanForward"] = r => [SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([4, 2], r),
                                               SafeTensor([1, 3, 2], r), SafeTensor([1, 3, 2], r), SafeTensor([4], r)],
+        ["ComplexDiagonalSsmScanForward"] = r => [SafeTensor([1, 3, 2, 2], r), SafeTensor([2, 3], r), SafeTensor([2, 3], r),
+                                                   SafeTensor([2, 3, 2], r), SafeTensor([2, 3, 2], r),
+                                                   SafeTensor([2, 2, 3], r), SafeTensor([2, 2, 3], r), SafeTensor([2, 2], r)],
         // Mamba-2 SSD is per-HEAD where Mamba S6 is per-channel: delta is [B, L, numHeads], and aLog
         // and dParam are per-head SCALAR vectors of length numHeads rather than S6's
         // [innerDim, stateDim] matrix and [innerDim] vector. That is the "scalar-decay"

--- a/tests/AiDotNet.Tensors.Tests/Engines/ComplexDiagonalSsmScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/ComplexDiagonalSsmScanTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public sealed class ComplexDiagonalSsmScanTests
+{
+    private static double[] Values(int length, int seed, double scale = 0.35)
+    {
+        var values = new double[length];
+        for (int i = 0; i < length; i++)
+            values[i] = Math.Sin((i + 1) * 0.71 + seed * 0.37) * scale;
+        return values;
+    }
+
+    private static Tensor<double> Tensor(int[] shape, int seed, double scale = 0.35)
+    {
+        int length = 1;
+        foreach (int dimension in shape) length *= dimension;
+        return new Tensor<double>(Values(length, seed, scale), shape);
+    }
+
+    private static Tensor<double>[] Inputs(int batch, int time, int groups, int width, int state)
+        => new[]
+        {
+            Tensor(new[] { batch, time, groups, width }, 1),
+            Tensor(new[] { groups, state }, 2, 0.25),
+            Tensor(new[] { groups, state }, 3, 0.18),
+            Tensor(new[] { groups, state, width }, 4),
+            Tensor(new[] { groups, state, width }, 5),
+            Tensor(new[] { groups, width, state }, 6),
+            Tensor(new[] { groups, width, state }, 7),
+            Tensor(new[] { groups, width }, 8)
+        };
+
+    [Fact]
+    public void Forward_MatchesIndependentGroupedReference()
+    {
+        const int batch = 2, time = 4, groups = 3, width = 2, state = 3;
+        Tensor<double>[] p = Inputs(batch, time, groups, width, state);
+        var engine = new CpuEngine();
+
+        Tensor<double> actual = Scan(engine, p);
+        double[] expected = Reference(p, batch, time, groups, width, state);
+
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], actual.GetFlat(i), precision: 11);
+    }
+
+    [Fact]
+    public void Backward_AllEightInputsMatchCentralFiniteDifferences()
+    {
+        const int batch = 1, time = 3, groups = 2, width = 2, state = 2;
+        Tensor<double>[] p = Inputs(batch, time, groups, width, state);
+        var engine = new CpuEngine();
+        Dictionary<Tensor<double>, Tensor<double>> gradients;
+
+        using (var tape = new GradientTape<double>())
+            gradients = tape.ComputeGradients(Scan(engine, p), p);
+
+        const double epsilon = 1e-6;
+        foreach (Tensor<double> parameter in p)
+        {
+            double[] data = parameter.GetDataArray()!;
+            Tensor<double> analytic = gradients[parameter];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double original = data[i];
+                data[i] = original + epsilon;
+                double plus = Sum(Scan(engine, p));
+                data[i] = original - epsilon;
+                double minus = Sum(Scan(engine, p));
+                data[i] = original;
+
+                double numeric = (plus - minus) / (2 * epsilon);
+                double calculated = analytic.GetFlat(i);
+                double tolerance = 2e-6 + 2e-5 * Math.Abs(numeric);
+                Assert.True(Math.Abs(numeric - calculated) <= tolerance,
+                    $"gradient mismatch for input {Array.IndexOf(p, parameter)}, element {i}: " +
+                    $"analytic={calculated:R}, numeric={numeric:R}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Contract_RejectsMismatchedGroupedMaps()
+    {
+        Tensor<double>[] p = Inputs(batch: 1, time: 2, groups: 2, width: 3, state: 4);
+        p[5] = Tensor(new[] { 2, 2, 4 }, 9);
+
+        var error = Assert.Throws<ArgumentException>(() => Scan(new CpuEngine(), p));
+        Assert.Contains("outputMapReal must have shape [2,3,4]", error.Message);
+    }
+
+    private static Tensor<double> Scan(CpuEngine engine, Tensor<double>[] p)
+        => engine.ComplexDiagonalSsmScanForward(p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
+
+    private static double Sum(Tensor<double> tensor)
+    {
+        double sum = 0;
+        foreach (double value in tensor.GetDataArray()!) sum += value;
+        return sum;
+    }
+
+    private static double[] Reference(
+        Tensor<double>[] p, int batch, int time, int groups, int width, int state)
+    {
+        var result = new double[batch * time * groups * width];
+        for (int b = 0; b < batch; b++)
+        {
+            for (int g = 0; g < groups; g++)
+            {
+                var real = new double[state];
+                var imag = new double[state];
+                for (int t = 0; t < time; t++)
+                {
+                    for (int n = 0; n < state; n++)
+                    {
+                        double oldReal = real[n];
+                        double oldImag = imag[n];
+                        double nextReal = p[1][g, n] * oldReal - p[2][g, n] * oldImag;
+                        double nextImag = p[1][g, n] * oldImag + p[2][g, n] * oldReal;
+                        for (int w = 0; w < width; w++)
+                        {
+                            nextReal += p[3][g, n, w] * p[0][b, t, g, w];
+                            nextImag += p[4][g, n, w] * p[0][b, t, g, w];
+                        }
+                        real[n] = nextReal;
+                        imag[n] = nextImag;
+                    }
+
+                    for (int w = 0; w < width; w++)
+                    {
+                        double y = p[7][g, w] * p[0][b, t, g, w];
+                        for (int n = 0; n < state; n++)
+                            y += p[5][g, w, n] * real[n] - p[6][g, w, n] * imag[n];
+                        result[((b * time + t) * groups + g) * width + w] = y;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ComplexDiagonalSsmGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ComplexDiagonalSsmGpuParityTests.cs
@@ -1,0 +1,72 @@
+#if NET6_0_OR_GREATER
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+using AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class ComplexDiagonalSsmGpuParityTests
+{
+    public enum BackendKind { OpenCL, Vulkan }
+    public static TheoryData<BackendKind> Backends => new() { BackendKind.OpenCL, BackendKind.Vulkan };
+
+    [SkippableTheory]
+    [MemberData(nameof(Backends))]
+    public void NativeForward_MatchesCpuEngine(BackendKind kind)
+    {
+        (IDirectGpuBackend? backend, Action dispose) = TryCreate(kind);
+        Skip.If(backend is null, $"{kind} backend is unavailable on this host.");
+        try
+        {
+            const int batch=2, time=4, groups=2, width=3, state=4;
+            float[] x=Values(batch*time*groups*width,1), ar=Values(groups*state,2,0.2f), ai=Values(groups*state,3,0.15f);
+            float[] br=Values(groups*state*width,4), bi=Values(groups*state*width,5);
+            float[] cr=Values(groups*width*state,6), ci=Values(groups*width*state,7), d=Values(groups*width,8);
+            var engine=new CpuEngine();
+            float[] expected=engine.ComplexDiagonalSsmScanForward(
+                new Tensor<float>(x,[batch,time,groups,width]), new Tensor<float>(ar,[groups,state]),
+                new Tensor<float>(ai,[groups,state]), new Tensor<float>(br,[groups,state,width]),
+                new Tensor<float>(bi,[groups,state,width]), new Tensor<float>(cr,[groups,width,state]),
+                new Tensor<float>(ci,[groups,width,state]), new Tensor<float>(d,[groups,width])).GetDataArray()!;
+
+            using var xb=backend!.AllocateBuffer(x); using var arb=backend.AllocateBuffer(ar); using var aib=backend.AllocateBuffer(ai);
+            using var brb=backend.AllocateBuffer(br); using var bib=backend.AllocateBuffer(bi); using var crb=backend.AllocateBuffer(cr);
+            using var cib=backend.AllocateBuffer(ci); using var db=backend.AllocateBuffer(d); using var yb=backend.AllocateBuffer(expected.Length);
+            backend.ComplexDiagonalSsmScanForward(xb,arb,aib,brb,bib,crb,cib,db,yb,batch,time,groups,width,state);
+            float[] actual=backend.DownloadBuffer(yb);
+            for(int i=0;i<expected.Length;i++)
+                Assert.True(MathF.Abs(expected[i]-actual[i]) <= 2e-5f + 2e-5f*MathF.Abs(expected[i]),
+                    $"{kind} output[{i}]={actual[i]:R}, CPU={expected[i]:R}");
+        }
+        finally { dispose(); }
+    }
+
+    private static (IDirectGpuBackend?,Action) TryCreate(BackendKind kind)
+    {
+        try
+        {
+            if(kind==BackendKind.OpenCL)
+            {
+                var backend=new OpenClBackend();
+                if(backend.IsAvailable) return (backend,backend.Dispose);
+                backend.Dispose(); return (null,()=>{});
+            }
+            var vulkan=VulkanBackend.Instance;
+            return vulkan.Initialize() && vulkan.IsGlslCompilerAvailable ? (vulkan,()=>{}) : (null,()=>{});
+        }
+        catch { return (null,()=>{}); }
+    }
+
+    private static float[] Values(int length,int seed,float scale=0.3f)
+    {
+        var values=new float[length];
+        for(int i=0;i<length;i++) values[i]=(float)Math.Sin((i+1)*0.63+seed*0.41)*scale;
+        return values;
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -502,6 +502,7 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         "RgLruScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
         "Rwkv4WkvForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
         "MambaSelectiveScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
+        "ComplexDiagonalSsmScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",
         "Mamba2SsdScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
         "FusedLinearCrossEntropyWithLogits(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<Int32>)",
         "FusedLinearCrossEntropyWithLogits(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
@@ -1525,6 +1525,20 @@ public static class OpParityRegistry
             e => e.MambaSelectiveScanForward(mx.F(), mdelta.F(), maLog.F(), mb.F(), mc.F(), md.F()),
             e => e.MambaSelectiveScanForward(mx.D(), mdelta.D(), maLog.D(), mb.D(), mc.D(), md.D()),
             ParityTol.Accum(1e-3), opMethod: "MambaSelectiveScanForward");
+        // Grouped complex diagonal SSM: input [B,S,G,W], A [G,ST], B [G,ST,W], C [G,W,ST], D [G,W].
+        const int G = 2, W = 3;
+        var cx = OpInput.Rand(3670, new[] { B, S, G, W });
+        var car = OpInput.Rand(3671, new[] { G, ST });
+        var cai = OpInput.Rand(3672, new[] { G, ST });
+        var cbr = OpInput.Rand(3673, new[] { G, ST, W });
+        var cbi = OpInput.Rand(3674, new[] { G, ST, W });
+        var ccr = OpInput.Rand(3675, new[] { G, W, ST });
+        var cci = OpInput.Rand(3676, new[] { G, W, ST });
+        var cd = OpInput.Rand(3677, new[] { G, W });
+        yield return new OpCase("ComplexDiagonalSsmScanForward[2,4,2,3]", "scan",
+            e => e.ComplexDiagonalSsmScanForward(cx.F(), car.F(), cai.F(), cbr.F(), cbi.F(), ccr.F(), cci.F(), cd.F()),
+            e => e.ComplexDiagonalSsmScanForward(cx.D(), car.D(), cai.D(), cbr.D(), cbi.D(), ccr.D(), cci.D(), cd.D()),
+            ParityTol.Accum(1e-3), opMethod: "ComplexDiagonalSsmScanForward");
         // Mamba2 SSD: delta [B,S,H], aLog/D per-head [H], shared B/C [B,S,ST].
         var m2delta = OpInput.RandPositive(3606, new[] { B, S, H }, 0.1, 1.0);
         var m2aLog = OpInput.Rand(3607, new[] { H });


### PR DESCRIPTION
## What changed

- adds `IEngine.ComplexDiagonalSsmScanForward` for grouped complex diagonal state-space recurrences
- records one analytic BPTT tape node instead of one graph fragment per timestep
- implements native resident forward kernels for CUDA, HIP, OpenCL, Metal, Vulkan, and WebGPU
- refuses unsupported GPU width/state dimensions instead of silently round-tripping through CPU
- adds contract, independent forward-oracle, all-input finite-difference gradient, registry, and native GPU parity coverage

## Why

AiDotNet's LRU, S4D, and S5 layers currently express their time recurrence as nested model-level loops. That creates very large tapes, performs poorly, and makes the missing engine abstraction look like model-specific fixes. This operation keeps model-specific discretization in ordinary differentiable engine operations while fusing only the shared sequential scan.

## Validation

- `dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -f net10.0 --no-restore` — 0 warnings, 0 errors
- focused scan/contract/autodiff/GPU tests — 8 passed, 1 skipped (Vulkan unavailable locally)
- native AMD OpenCL output matched the independent CPU implementation
- analytic gradients for all 8 tensor inputs matched central finite differences
- autodiff completeness and differentiable-op gradcheck registry gates passed
- `git diff --check`

## Backend contract

Input is `[batch,time,group,width]`; transition is `[group,state]`; B is `[group,state,width]`; C is `[group,width,state]`; D is `[group,width]`. LRU/S5 use one group, while S4D uses one group per channel with width one.
