### PR TITLE
fix(streaming): make paged tensor access mutation-safe

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/TapeStepContext.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/TapeStepContext.cs
@@ -349,7 +349,7 @@ public sealed class TapeStepContext<T>
                 throw new InvalidOperationException(
                     $"SetFlatParameters requires contiguous parameter tensors. " +
                     $"Call Contiguous() on non-contiguous parameters before using flat access.");
-            var dst = p.DataVector.AsWritableSpan().Slice(p._storageOffset, p.Length);
+            var dst = p.AsWritableSpan();
             src.Slice(offset, p.Length).CopyTo(dst);
             offset += p.Length;
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/TensorPool.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/TensorPool.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Autodiff;
@@ -101,7 +101,7 @@ public static class TensorPool<T>
         // even without _gpuBuffer set (Half-resident store). Pooling it would FORCE that download to recycle the
         // array. Skip — the few recycled bytes aren't worth breaking residency; the temp is GC'd. Complements the
         // _gpuBuffer check above.
-        var unsafeBacking = tensor.DataVector.GetBackingArrayUnsafe();
+        var unsafeBacking = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (unsafeBacking is not null && Helpers.DeferredArrayMaterializer.IsPending(unsafeBacking)) return;
 
         // Issue #338 view-safety: refuse view-tensors whose backing

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/PackAOnlyStrategy.cs
@@ -215,6 +215,15 @@ internal static class PackAOnlyStrategy
         in BlasOptions<T> options) where T : unmanaged
     {
         int elemSize = Unsafe.SizeOf<T>();
+        // Every packed-A stripe contains exactly mr rows. Autotuning is allowed to choose an mc
+        // that is not a multiple of the active microkernel tile (for example mc=190, mr=6).
+        // Iterating those raw mc-sized panels leaves a partial stripe at the end of every interior
+        // panel; DispatchStridedMicrokernel then slices effectiveKc*mr elements from a shorter
+        // buffer and throws during otherwise-valid GEMM/backward workloads. Round the live block
+        // down once and advance by that aligned extent. The outer Run method already gives us an
+        // mr-aligned interior, so the final block remains full-stripe too.
+        int alignedMc = mc - mc % mr;
+        if (alignedMc <= 0) alignedMc = mr;
         int packABytes = mc * kc * elemSize;
 
         var carver = new WorkspaceCarver(options.Workspace);
@@ -231,6 +240,7 @@ internal static class PackAOnlyStrategy
         // consumer running a different active mr would read them at the wrong
         // stride (see WeightPackHandle.PackMr). Mismatch -> live pack below.
         bool multiPanelA = options.PackedA != null
+            && alignedMc == mc
             && WeightPackCache.IsCacheCurrent(options.PackedA)
             && options.PackedA.PackMr == mr
             && options.PackedA.TilingMatches(mc, kc)
@@ -242,10 +252,10 @@ internal static class PackAOnlyStrategy
             int effectiveKc = Math.Min(kc, k - pc);
             int pcIdx = pc / kc;
 
-            for (int ic = 0; ic < m; ic += mc)
+            for (int ic = 0; ic < m; ic += alignedMc)
             {
-                int effectiveMc = Math.Min(mc, m - ic);
-                int icIdx = ic / mc;
+                int effectiveMc = Math.Min(alignedMc, m - ic);
+                int icIdx = ic / alignedMc;
 
                 int effectivePackABytes = effectiveMc * effectiveKc * elemSize;
                 bool packAFromPrePack = false;
@@ -260,7 +270,9 @@ internal static class PackAOnlyStrategy
                         packAFromPrePack = true;
                     }
                 }
-                else if (options.PackedA != null && WeightPackCache.IsCacheCurrent(options.PackedA)
+                else if (options.PackedA != null
+                    && options.PackedA.MultiPanelStride <= 0
+                    && WeightPackCache.IsCacheCurrent(options.PackedA)
                     && options.PackedA.PackMr == mr
                     && options.PackedA.PackedBuffer.Length >= effectivePackABytes)
                 {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1650,7 +1650,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private void MaterializeStepLoss()
     {
-        var lossKey = _lossOutput.DataVector.GetBackingArrayUnsafe();
+        var lossKey = _lossOutput.GetBackingArrayForCacheLookupUnsafe();
         if (lossKey is not null)
             Helpers.DeferredArrayMaterializer.TryMaterialize(lossKey);
         Helpers.DeferredArrayMaterializer.TryMaterialize(_lossOutput.DataVector);
@@ -1669,7 +1669,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private static void AddActivationCacheKeys(HashSet<object> keys, Tensor<T>? tensor)
     {
         if (tensor is null) return;
-        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        var backing = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backing is not null)
             keys.Add(backing);
         keys.Add(tensor.DataVector);

--- a/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
@@ -281,13 +281,13 @@ public sealed class MixedPrecisionCompiledPlan
                         protect!.Clear();
                         foreach (var g in fp32.Values)
                         {
-                            var a = g.DataVector.GetBackingArrayUnsafe();
+                            var a = g.GetBackingArrayForCacheLookupUnsafe();
                             if (a is not null) protect.Add(a);
                             protect.Add(g.DataVector);
                         }
                         foreach (var g in fp16.Values)
                         {
-                            var a = g.DataVector.GetBackingArrayUnsafe();
+                            var a = g.GetBackingArrayForCacheLookupUnsafe();
                             if (a is not null) protect.Add(a);
                             protect.Add(g.DataVector);
                         }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -328,18 +328,25 @@ public partial class CpuEngine
 
         try
         {
+            // LSTM is also used after channel/sequence permutations (for example,
+            // Demucs feeds a [B, seq, channels] view).  Keep the zero-copy hot path
+            // for ordinary tensors while materializing only operands whose logical
+            // row-major order is not represented by one contiguous span.
+            var inputData = input.GetFlattenedData();
+            var wIhData = wIh.GetFlattenedData();
+
             // Wx = input @ wIh^T using SimdGemm with transB=true.
             // input rows = totalRows, K = inFeatures, wIh rows = gateRows, ldb = inFeatures.
             SimdGemm.Sgemm(
-                input.AsSpan(), inFeatures, false,
-                wIh.AsSpan(), inFeatures, true,
+                inputData.AsSpan(), inFeatures, false,
+                wIhData.AsSpan(), inFeatures, true,
                 wxBuf.AsSpan(0, totalRows * gateRows),
                 totalRows, inFeatures, gateRows);
 
             // Fold bIh into Wx (broadcast add) — SIMD-friendly contiguous loop.
             if (bIh is not null)
             {
-                var bIhArr = bIh.AsSpan();
+                var bIhArr = bIh.GetFlattenedData().AsSpan();
                 for (int r = 0; r < totalRows; r++)
                 {
                     int off = r * gateRows;
@@ -348,10 +355,10 @@ public partial class CpuEngine
                 }
             }
 
-            var wHhSpan = wHh.AsSpan();
-            float[]? bHhArr = bHh?.ToArray();
-            float[]? h0Arr = h0?.ToArray();
-            float[]? c0Arr = c0?.ToArray();
+            var wHhSpan = wHh.GetFlattenedData().AsSpan();
+            float[]? bHhArr = bHh?.GetFlattenedData();
+            float[]? h0Arr = h0?.GetFlattenedData();
+            float[]? c0Arr = c0?.GetFlattenedData();
 
             // #477: the recurrent GEMM h_prev @ wHh^T runs once per timestep. The old
             // transB=true Sgemm re-transposed wHh on EVERY step. Pre-transpose wHh
@@ -638,7 +645,7 @@ public partial class CpuEngine
         var wIhT = lstmPool.Rent(inFeatures * gateRows);
         var wxBuf = lstmPool.Rent(wxRows * gateRows);
         {
-            var wIhSrc = wIh.AsSpan();
+            var wIhSrc = wIh.GetFlattenedData().AsSpan();
             for (int g = 0; g < gateRows; g++)
                 for (int fcol = 0; fcol < inFeatures; fcol++)
                     wIhT[fcol * gateRows + g] = wIhSrc[g * inFeatures + fcol];
@@ -654,7 +661,7 @@ public partial class CpuEngine
         if (bIh is not null)
         {
             var ops = MathHelper.GetNumericOperations<T>();
-            var bIhSpan = bIh.AsSpan();
+            var bIhSpan = bIh.GetFlattenedData().AsSpan();
             for (int r = 0; r < wxRows; r++)
             {
                 int off = r * gateRows;
@@ -683,6 +690,7 @@ public partial class CpuEngine
 
         var opsT = MathHelper.GetNumericOperations<T>();
         var wxSpanRO = new ReadOnlySpan<T>(wxBuf, 0, wxRows * gateRows);
+        var bHhData = bHh?.GetFlattenedData();
 
         // #478: pool the per-timestep hidden GEMM. The old TensorMatMulTransposed(hPrev, wHh) allocated
         // a fresh [batch, 4*hidden] output (plus the GEMM's packing scratch) EVERY step. Pre-transpose
@@ -692,7 +700,7 @@ public partial class CpuEngine
         var wHhT = lstmPool.Rent(hidden * gateRows);
         var hhBuf = lstmPool.Rent(batch * gateRows);
         {
-            var wHhSrc = wHh.AsSpan();
+            var wHhSrc = wHh.GetFlattenedData().AsSpan();
             for (int g = 0; g < gateRows; g++)
                 for (int hcol = 0; hcol < hidden; hcol++)
                     wHhT[hcol * gateRows + g] = wHhSrc[g * hidden + hcol];
@@ -717,8 +725,8 @@ public partial class CpuEngine
             var hCurrSpan = hCurr.AsWritableSpan();
             var cCurrSpan = cCurr.AsWritableSpan();
             var cPrevSpan = cbufs[cur].AsSpan();
-            bool hasBhh = bHh is not null;
-            ReadOnlySpan<T> bHhSpan = hasBhh ? bHh!.AsSpan() : default;
+            bool hasBhh = bHhData is not null;
+            ReadOnlySpan<T> bHhSpan = hasBhh ? bHhData.AsSpan() : default;
 
             for (int b = 0; b < batch; b++)
             {
@@ -819,7 +827,7 @@ public partial class CpuEngine
         if (source is null)
             dst.Slice(0, n).Clear();
         else
-            source.AsSpan().Slice(0, n).CopyTo(dst.Slice(0, n));
+            source.GetFlattenedData().AsSpan(0, n).CopyTo(dst.Slice(0, n));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -127,13 +127,16 @@ public partial class CpuEngine
         int G = gateRows;                 // 4 * hidden
         int totalRows = batch * seqLen;
 
-        var inSpan = input.AsSpan();      // [batch, seqLen, inFeatures], row = b*seqLen + t
-        var wIhSpan = wIh.AsSpan();       // [G, inFeatures]
-        var wHhSpan = wHh.AsSpan();       // [G, hidden]
-        float[]? bIhArr = bIh?.ToArray();
-        float[]? bHhArr = bHh?.ToArray();
-        float[]? h0Arr = h0?.ToArray();
-        float[]? c0Arr = c0?.ToArray();
+        // A fused op may receive stride-only views from a preceding permute.
+        // GetFlattenedData is zero-copy for packed tensors and materializes only
+        // a view, while the tape continues to record the original tensor identity.
+        var inSpan = input.GetFlattenedData().AsSpan(); // [batch, seqLen, inFeatures]
+        var wIhSpan = wIh.GetFlattenedData().AsSpan();  // [G, inFeatures]
+        var wHhSpan = wHh.GetFlattenedData().AsSpan();  // [G, hidden]
+        float[]? bIhArr = bIh?.GetFlattenedData();
+        float[]? bHhArr = bHh?.GetFlattenedData();
+        float[]? h0Arr = h0?.GetFlattenedData();
+        float[]? c0Arr = c0?.GetFlattenedData();
 
         // Saved state (captured by the backward closure → persists past this call).
         //   gates:   [b, t] post-activation i|f|g|o, row (b*seqLen+t)*G
@@ -374,8 +377,10 @@ public partial class CpuEngine
         var input = inp[0];
         var wIh = inp[1];
         var wHh = inp[2];
-        var wHhSpan = wHh.AsSpan();          // [G, hidden]
-        var gradOutSpan = gradOutput.AsSpan();
+        var wHhSpan = wHh.GetFlattenedData().AsSpan(); // [G, hidden]
+        var wIhSpan = wIh.GetFlattenedData().AsSpan(); // [G, inFeatures]
+        var inputSpan = input.GetFlattenedData().AsSpan();
+        var gradOutSpan = gradOutput.GetFlattenedData().AsSpan();
 
         // Pool the backward scratch (it otherwise allocates several MB/step — dgatesAll and
         // hPrevAll dominate — churning Gen0 GC during training). Returned at method end.
@@ -452,14 +457,14 @@ public partial class CpuEngine
         // gradInput = dgatesAll @ wIh  → [totalRows, inFeatures]
         var gradInput = new Tensor<float>(new[] { batch, seqLen, inFeatures });
         GemmBig(dgatesAll.AsSpan(0, totalRows * G), G, false,
-                wIh.AsSpan().Slice(0, G * inFeatures), inFeatures, false,
+                wIhSpan.Slice(0, G * inFeatures), inFeatures, false,
                 gradInput.AsWritableSpan(), totalRows, G, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
 
         // gradWIh = dgatesAll^T @ input2d  → [G, inFeatures]
         var gradWIh = new Tensor<float>(new[] { G, inFeatures });
         GemmBig(dgatesAll.AsSpan(0, totalRows * G), G, true,
-                input.AsSpan(), inFeatures, false,
+                inputSpan, inFeatures, false,
                 gradWIh.AsWritableSpan(), G, totalRows, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, wIh, gradWIh, engine);
 
@@ -566,13 +571,13 @@ public partial class CpuEngine
         int G = gateRows;
         int totalRows = batch * seqLen;
 
-        var inSpan = input.AsSpan();
-        var wIhSpan = wIh.AsSpan();
-        var wHhSpan = wHh.AsSpan();
-        double[]? bIhArr = bIh?.ToArray();
-        double[]? bHhArr = bHh?.ToArray();
-        double[]? h0Arr = h0?.ToArray();
-        double[]? c0Arr = c0?.ToArray();
+        var inSpan = input.GetFlattenedData().AsSpan();
+        var wIhSpan = wIh.GetFlattenedData().AsSpan();
+        var wHhSpan = wHh.GetFlattenedData().AsSpan();
+        double[]? bIhArr = bIh?.GetFlattenedData();
+        double[]? bHhArr = bHh?.GetFlattenedData();
+        double[]? h0Arr = h0?.GetFlattenedData();
+        double[]? c0Arr = c0?.GetFlattenedData();
 
         // Saved state (captured by the backward closure). Layout matches the float path.
         var gates = new double[totalRows * G];
@@ -768,7 +773,10 @@ public partial class CpuEngine
         var input = inp[0];
         var wIh = inp[1];
         var wHh = inp[2];
-        var gradOutSpan = gradOutput.AsSpan();
+        var wHhSpan = wHh.GetFlattenedData().AsSpan();
+        var wIhSpan = wIh.GetFlattenedData().AsSpan();
+        var inputSpan = input.GetFlattenedData().AsSpan();
+        var gradOutSpan = gradOutput.GetFlattenedData().AsSpan();
 
         var pool = System.Buffers.ArrayPool<double>.Shared;
         var dgatesAll = pool.Rent(totalRows * G);
@@ -827,7 +835,7 @@ public partial class CpuEngine
             // dh_prev = dgates_t @ wHh → [batch, hidden]; carried to t-1. BlasManaged double
             // microkernel (NOT the generic MultiplyBlocked — ~128x slower at this per-step shape).
             GemmBigD(dgatesT.AsSpan(0, batch * G), G, false,
-                     wHh.AsSpan().Slice(0, G * hidden), hidden, false,
+                     wHhSpan.Slice(0, G * hidden), hidden, false,
                      dhPrev.AsSpan(0, batch * hidden), batch, G, hidden);
             Array.Copy(dhPrev, dhNext, batch * hidden);
         }
@@ -835,14 +843,14 @@ public partial class CpuEngine
         // gradInput = dgatesAll @ wIh → [totalRows, inFeatures]
         var gradInput = new Tensor<double>(new[] { batch, seqLen, inFeatures });
         GemmBigD(dgatesAll.AsSpan(0, totalRows * G), G, false,
-                 wIh.AsSpan().Slice(0, G * inFeatures), inFeatures, false,
+                 wIhSpan.Slice(0, G * inFeatures), inFeatures, false,
                  gradInput.AsWritableSpan(), totalRows, G, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, input, gradInput, engine);
 
         // gradWIh = dgatesAll^T @ input2d → [G, inFeatures]
         var gradWIh = new Tensor<double>(new[] { G, inFeatures });
         GemmBigD(dgatesAll.AsSpan(0, totalRows * G), G, true,
-                 input.AsSpan(), inFeatures, false,
+                 inputSpan, inFeatures, false,
                  gradWIh.AsWritableSpan(), G, totalRows, inFeatures);
         DifferentiableOps.AccumulateGrad(grads, wIh, gradWIh, engine);
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -143,8 +143,9 @@ public partial class CpuEngine
     }
 
     /// <summary>
-    /// Float32 fast path. Calls <see cref="SimdGemm.Sgemm"/> directly for the
-    /// four projections, writes Q/K/V into <c>[B, heads, seq, dHead]</c>
+    /// Float32 fast path. Calls <see cref="SimdGemm.Sgemm"/> directly for normal
+    /// weights and the no-upcast int8/int4 kernels for streamed weights, writes
+    /// Q/K/V into <c>[B, heads, seq, dHead]</c>
     /// layout inline via a small post-GEMM scatter (one O(B*seq*dModel)
     /// memory pass instead of three through <see cref="Tensor{T}.Transpose"/>),
     /// reuses pooled scratch buffers across the whole call, and only
@@ -160,6 +161,27 @@ public partial class CpuEngine
         int totalRows = batch * seqLen;
         var pool = ArrayPool<float>.Shared;
 
+#if NET5_0_OR_GREATER
+        // Resolve the kernel-ready forms before touching any weight span. AsSpan is the
+        // intentional generic fallback that dequantizes a streamed weight to fp32; doing
+        // that for four paper-scale attention matrices defeated streaming and was visible
+        // as TensorBase.DequantizeStreamingInt8 in exact-model traces.
+        var qQ8 = qWeight.GetMaterializedStreamingInt8();
+        var kQ8 = kWeight.GetMaterializedStreamingInt8();
+        var vQ8 = vWeight.GetMaterializedStreamingInt8();
+        var oQ8 = outWeight.GetMaterializedStreamingInt8();
+        var qQ4 = qQ8 is null ? qWeight.GetMaterializedStreamingInt4() : null;
+        var kQ4 = kQ8 is null ? kWeight.GetMaterializedStreamingInt4() : null;
+        var vQ4 = vQ8 is null ? vWeight.GetMaterializedStreamingInt4() : null;
+        var oQ4 = oQ8 is null ? outWeight.GetMaterializedStreamingInt4() : null;
+        bool hasQuantizedProjection = qQ8 is not null || kQ8 is not null || vQ8 is not null || oQ8 is not null
+            || qQ4 is not null || kQ4 is not null || vQ4 is not null || oQ4 is not null;
+#else
+        StreamingInt8Weight? qQ8 = null, kQ8 = null, vQ8 = null, oQ8 = null;
+        StreamingInt4Weight? qQ4 = null, kQ4 = null, vQ4 = null, oQ4 = null;
+        bool hasQuantizedProjection = false;
+#endif
+
         // Fused QKV projection: one [B*seq, dModel] @ [dModel, 3*dModel] GEMM
         // instead of three @ [dModel, dModel]. Reads `input` once (vs 3×), one
         // dispatch (vs 3), and a wider N=3*dModel that the SIMD microkernel
@@ -167,7 +189,10 @@ public partial class CpuEngine
         // projection GEMM quality). Output rows are [q(dModel)|k(dModel)|v(dModel)].
         int dModel3 = 3 * dModel;
         var qkvFlatBuf = pool.Rent(totalRows * dModel3);
-        var fusedWBuf = pool.Rent(dModel * dModel3);    // [dModel, 3*dModel] = [qW | kW | vW]
+        // Quantized kernels produce one contiguous projection at a time; normal fp32
+        // retains the faster single fused-QKV GEMM. Rent only the scratch each route uses.
+        var fusedWBuf = hasQuantizedProjection ? null : pool.Rent(dModel * dModel3);
+        var projectionBuf = hasQuantizedProjection ? pool.Rent(totalRows * dModel) : null;
         var concatBuf = pool.Rent(totalRows * dModel); // [B*seq, dModel] attention output, pre out-proj
 
         var output = AutoTensorCache.RentOrAllocate<float>(new[] { batch, seqLen, dModel });
@@ -179,13 +204,24 @@ public partial class CpuEngine
             // weight once (cheap: dModel*3*dModel = ~48 KB at the AIsEval shape),
             // then ONE GEMM input[B*seq, dModel] @ fusedW[dModel, 3*dModel] ->
             // qkvFlat[B*seq, 3*dModel]. Each output row is [q|k|v].
-            var inputSpan = input.AsSpan();
+            var inputArray = input.GetReadOnlyDataArray();
+            var inputSpan = inputArray.AsSpan(0, totalRows * dModel);
             int batchSeqRows = totalRows;
+            if (hasQuantizedProjection)
+            {
+                ProjectMhaFloat(inputArray, qWeight, qQ8, qQ4, projectionBuf!, batchSeqRows, dModel);
+                CopyMhaProjection(projectionBuf!, qkvFlatBuf, batchSeqRows, dModel, dModel3, 0);
+                ProjectMhaFloat(inputArray, kWeight, kQ8, kQ4, projectionBuf!, batchSeqRows, dModel);
+                CopyMhaProjection(projectionBuf!, qkvFlatBuf, batchSeqRows, dModel, dModel3, dModel);
+                ProjectMhaFloat(inputArray, vWeight, vQ8, vQ4, projectionBuf!, batchSeqRows, dModel);
+                CopyMhaProjection(projectionBuf!, qkvFlatBuf, batchSeqRows, dModel, dModel3, 2 * dModel);
+            }
+            else
             {
                 var qWS = qWeight.AsSpan();
                 var kWS = kWeight.AsSpan();
                 var vWS = vWeight.AsSpan();
-                var fW = fusedWBuf.AsSpan();
+                var fW = fusedWBuf!.AsSpan();
                 for (int kk = 0; kk < dModel; kk++)
                 {
                     int dstRow = kk * dModel3;
@@ -193,13 +229,13 @@ public partial class CpuEngine
                     kWS.Slice(kk * dModel, dModel).CopyTo(fW.Slice(dstRow + dModel, dModel));
                     vWS.Slice(kk * dModel, dModel).CopyTo(fW.Slice(dstRow + 2 * dModel, dModel));
                 }
+                using (Profiling.Profiler.OpScope("MHA.QKVproj"))
+                SimdGemm.Sgemm(
+                    inputSpan, dModel, false,
+                    fusedWBuf.AsSpan(0, dModel * dModel3), dModel3, false,
+                    qkvFlatBuf.AsSpan(0, totalRows * dModel3),
+                    batchSeqRows, dModel, dModel3);
             }
-            using (Profiling.Profiler.OpScope("MHA.QKVproj"))
-            SimdGemm.Sgemm(
-                inputSpan, dModel, false,
-                fusedWBuf.AsSpan(0, dModel * dModel3), dModel3, false,
-                qkvFlatBuf.AsSpan(0, totalRows * dModel3),
-                batchSeqRows, dModel, dModel3);
 
             // ---- Transpose-fused SDPA (#476 root-cause-2). ----
             // Instead of three full [B,seq,dModel]→[B,H,seq,dHead] transpose
@@ -221,19 +257,73 @@ public partial class CpuEngine
 
             // ---- Output projection: [B*seq, dModel] @ outWeight [dModel, dModel] -> output. ----
             using (Profiling.Profiler.OpScope("MHA.OutProj"))
-            SimdGemm.Sgemm(
-                concatBuf.AsSpan(0, totalRows * dModel), dModel, false,
-                outWeight.AsSpan(), dModel, false,
-                output.AsWritableSpan(),
-                batchSeqRows, dModel, dModel);
+            if (hasQuantizedProjection)
+            {
+                ProjectMhaFloat(
+                    concatBuf, outWeight, oQ8, oQ4,
+                    (float[])(object)output.GetDataArray(), batchSeqRows, dModel);
+            }
+            else
+            {
+                SimdGemm.Sgemm(
+                    concatBuf.AsSpan(0, totalRows * dModel), dModel, false,
+                    outWeight.AsSpan(), dModel, false,
+                    output.AsWritableSpan(),
+                    batchSeqRows, dModel, dModel);
+            }
 
             return output;
         }
         finally
         {
             pool.Return(qkvFlatBuf);
-            pool.Return(fusedWBuf);
+            if (fusedWBuf is not null) pool.Return(fusedWBuf);
+            if (projectionBuf is not null) pool.Return(projectionBuf);
             pool.Return(concatBuf);
+        }
+    }
+
+    /// <summary>Projects one MHA matrix without dequantizing a streamed weight.</summary>
+    private static void ProjectMhaFloat(
+        float[] input,
+        Tensor<float> weight,
+        StreamingInt8Weight? q8,
+        StreamingInt4Weight? q4,
+        float[] output,
+        int rows,
+        int dModel)
+    {
+#if NET5_0_OR_GREATER
+        if (q8 is not null && q8.Rows == dModel && q8.K == dModel)
+        {
+            SimdGemm.SgemmWithInt8RowScaledCachedB(
+                input, q8.Data, q8.Scales, output, rows, dModel, dModel);
+            return;
+        }
+
+        if (q4 is not null && q4.Rows == dModel && q4.K == dModel)
+        {
+            SimdGemm.SgemmWithInt4GroupScaledDispatch(
+                input, q4.Data, q4.GroupScales, q4.GroupSize,
+                output, rows, dModel, dModel);
+            return;
+        }
+#endif
+
+        SimdGemm.Sgemm(
+            input.AsSpan(0, rows * dModel), dModel, false,
+            weight.AsSpan(), dModel, false,
+            output.AsSpan(0, rows * dModel), rows, dModel, dModel);
+    }
+
+    private static void CopyMhaProjection(
+        float[] source, float[] destination,
+        int rows, int dModel, int destinationStride, int destinationColumn)
+    {
+        for (int row = 0; row < rows; row++)
+        {
+            source.AsSpan(row * dModel, dModel).CopyTo(
+                destination.AsSpan(row * destinationStride + destinationColumn, dModel));
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -33549,11 +33549,15 @@ public partial class CpuEngine : ITensorLevelEngine
                         // held-out). Refresh the shared idxSnap from the live indices tensor so BOTH this
                         // forward gather AND the matching backward (which holds the same idxSnap array) use the
                         // current step's tokens. Covered by EmbeddingIndicesMustRefreshAcrossStep_NotFrozenAtCompileTime.
-                        var liveRaw = capturedIndices.GetDataArray();
+                        var liveRaw = capturedIndices.GetReadOnlyDataArray();
                         for (int i = 0; i < n; i++) idxSnap[i] = Convert.ToInt64(liveRaw[i]);
                         // Replay forward: re-execute the row-gather into
                         // the pre-allocated output buffer.
-                        var embDataLocal = capturedEmb.GetDataArray();
+                        // Embedding tables are input operands. Inference may keep them in a
+                        // quantized streaming store, whose writable accessors intentionally
+                        // reject mutation; asking for write intent here made a pure gather fail
+                        // after its first eviction. Keep only the destination writable.
+                        var embDataLocal = capturedEmb.GetReadOnlyDataArray();
                         var outDataLocal = output.GetDataArray();
                         for (int i = 0; i < n; i++)
                         {
@@ -33574,9 +33578,9 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         var result = new Tensor<TValue>(outputShape);
-        var embData = embeddings.GetDataArray();
+        var embData = embeddings.GetReadOnlyDataArray();
         var resultData = result.GetDataArray();
-        var idxData = indices.GetDataArray();
+        var idxData = indices.GetReadOnlyDataArray();
 
         // For each index, copy the entire embedding row. Promote to long
         // for the bounds check so a TIndex=long input with an index that
@@ -33666,8 +33670,8 @@ public partial class CpuEngine : ITensorLevelEngine
                         // via banker's rounding (matches Convert.ToInt32(double)
                         // semantics used by the eager path so any code that flips
                         // between fused and eager produces identical lookups).
-                        var idxData = capturedFloatIdx.GetDataArray();
-                        var embData = capturedEmb.GetDataArray();
+                        var idxData = capturedFloatIdx.GetReadOnlyDataArray();
+                        var embData = capturedEmb.GetReadOnlyDataArray();
                         var outData = output.GetDataArray();
                         for (int i = 0; i < n; i++)
                         {
@@ -33690,7 +33694,7 @@ public partial class CpuEngine : ITensorLevelEngine
         // so eager-path callers transparently get all the work done by the
         // tape-registration + GPU paths in TensorEmbeddingLookup.
         var intIndices = new Tensor<int>(floatIndices._shape);
-        var floatData = floatIndices.GetDataArray();
+        var floatData = floatIndices.GetReadOnlyDataArray();
         var intData = intIndices.GetDataArray();
         var nopsEager = MathHelper.GetNumericOperations<T>();
         for (int i = 0; i < numIndices; i++)
@@ -33713,7 +33717,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         int n = indices.Length;
         var snap = new long[n];
-        var raw = indices.GetDataArray();
+        var raw = indices.GetReadOnlyDataArray();
         for (int i = 0; i < n; i++) snap[i] = Convert.ToInt64(raw[i]);
         return snap;
     }
@@ -33733,8 +33737,8 @@ public partial class CpuEngine : ITensorLevelEngine
         var gradEmbeddings = new Tensor<TValue>(new[] { vocabSize, embeddingDim });
         var gradEmbData = gradEmbeddings.GetDataArray();
 
-        var gradData = gradOutput.GetDataArray();
-        var idxData = indices.GetDataArray();
+        var gradData = gradOutput.GetReadOnlyDataArray();
+        var idxData = indices.GetReadOnlyDataArray();
         int numIndices = indices.Length;
 
         // Scatter-add: for each index, accumulate gradients to the embedding row.

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -39864,13 +39864,13 @@ public partial class CpuEngine : ITensorLevelEngine
 
     /// <inheritdoc/>
     /// <remarks>
-    /// On CPU, this is a no-op. Persistent tensor management only provides benefits
-    /// on GPU where data transfer between host and device is expensive.
+    /// On CPU, registration protects arena-rented model state from scratch reuse. GPU engines
+    /// inherit that lifetime guarantee before adding their device-residency bookkeeping.
     /// </remarks>
     public virtual void RegisterPersistentTensor<T>(Tensor<T> tensor, PersistentTensorRole role)
     {
-        // No-op on CPU: persistence only benefits GPU by avoiding repeated transfers
-        // The tensor is already in CPU memory, so there's nothing to cache
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        TensorArena.Current?.PinExistingTensor(tensor);
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -46,6 +46,11 @@ namespace AiDotNet.Tensors.Engines;
 /// </remarks>
 public partial class CpuEngine : ITensorLevelEngine
 {
+    // Conv3D's im2col expansion can be tens of times larger than the input. Keep the combined
+    // columns + GEMM-output scratch below a fixed process-friendly ceiling and stream larger
+    // volumes through row tiles instead of risking multi-gigabyte allocations.
+    private const long Conv3DIm2ColWorkspaceBytes = 256L * 1024 * 1024;
+
     private static int _randomNormalSeedCounter = Environment.TickCount;
     private const int TensorMatMulGemvParallelThreshold = 128 * 1024;
     private const double CapsuleSquashEpsilon = 1e-8;
@@ -19997,63 +20002,96 @@ public partial class CpuEngine : ITensorLevelEngine
             return false;
         }
 
+        int elementSize;
+        if (typeof(T) == typeof(float)) elementSize = sizeof(float);
+        else if (typeof(T) == typeof(double)) elementSize = sizeof(double);
+        else return false;
+
         int rows = (int)rowsLong;
         int columnsPerRow = (int)columnsLong;
-        var columns = new T[(int)columnElementsLong];
-        var flatOutput = new T[(int)flatOutputElementsLong];
+        long elementsPerTileRow = columnsLong + outChannels;
+        long bytesPerTileRow = checked(elementsPerTileRow * elementSize);
+        if (bytesPerTileRow > Conv3DIm2ColWorkspaceBytes)
+            return false;
+
+        int tileCapacity = (int)Math.Min(rowsLong,
+            Math.Max(1L, Conv3DIm2ColWorkspaceBytes / bytesPerTileRow));
+        int columnCapacity = checked(tileCapacity * columnsPerRow);
+        int flatCapacity = checked(tileCapacity * outChannels);
+        var columns = System.Buffers.ArrayPool<T>.Shared.Rent(columnCapacity);
+        var flatOutput = System.Buffers.ArrayPool<T>.Shared.Rent(flatCapacity);
         var inputData = input.GetReadOnlyDataArray();
         var kernelData = kernel.GetReadOnlyDataArray();
-
-        Helpers.CpuIm2Col3DHelper.BuildColumns(
-            inputData, columns,
-            batch, inChannels, depth, height, width,
-            kernelDepth, kernelHeight, kernelWidth,
-            outputDepth, outputHeight, outputWidth,
-            strideDepth, strideHeight, strideWidth,
-            padDepth, padHeight, padWidth,
-            dilationDepth, dilationHeight, dilationWidth);
-
-        bool multiplied;
-        if (typeof(T) == typeof(float))
-        {
-            multiplied = Helpers.BlasProvider.TryGemmEx(
-                rows, outChannels, columnsPerRow,
-                (float[])(object)columns, 0, columnsPerRow, false,
-                (float[])(object)kernelData, 0, columnsPerRow, true,
-                (float[])(object)flatOutput, 0, outChannels);
-        }
-        else if (typeof(T) == typeof(double))
-        {
-            multiplied = Helpers.BlasProvider.TryGemmEx(
-                rows, outChannels, columnsPerRow,
-                (double[])(object)columns, 0, columnsPerRow, false,
-                (double[])(object)kernelData, 0, columnsPerRow, true,
-                (double[])(object)flatOutput, 0, outChannels);
-        }
-        else
-        {
-            return false;
-        }
-
-        if (!multiplied) return false;
-
         result = TensorAllocator.Rent<T>([batch, outChannels, outputDepth, outputHeight, outputWidth]);
         var outputData = result.GetDataArray();
         int spatial = outputDepth * outputHeight * outputWidth;
-
-        // GEMM emits [B*OD*OH*OW, OC] (NDHWC flattening). Conv3D's public
-        // contract is NCDHW, so transpose the channel axis into its final layout.
-        CpuParallelSettings.ParallelForOrSerial(0, batch * outChannels, flatOutput.Length, batchChannel =>
+        try
         {
-            int b = batchChannel / outChannels;
-            int oc = batchChannel % outChannels;
-            int outputBase = (b * outChannels + oc) * spatial;
-            int flatBase = b * spatial * outChannels + oc;
-            for (int position = 0; position < spatial; position++)
-                outputData[outputBase + position] = flatOutput[flatBase + position * outChannels];
-        });
+            for (int rowStart = 0; rowStart < rows; rowStart += tileCapacity)
+            {
+                int tileRows = Math.Min(tileCapacity, rows - rowStart);
+                Helpers.CpuIm2Col3DHelper.BuildColumnsRange(
+                    inputData, columns, rowStart, tileRows,
+                    batch, inChannels, depth, height, width,
+                    kernelDepth, kernelHeight, kernelWidth,
+                    outputDepth, outputHeight, outputWidth,
+                    strideDepth, strideHeight, strideWidth,
+                    padDepth, padHeight, padWidth,
+                    dilationDepth, dilationHeight, dilationWidth);
 
-        return true;
+                bool multiplied;
+                if (typeof(T) == typeof(float))
+                {
+                    multiplied = Helpers.BlasProvider.TryGemmEx(
+                        tileRows, outChannels, columnsPerRow,
+                        (float[])(object)columns, 0, columnsPerRow, false,
+                        (float[])(object)kernelData, 0, columnsPerRow, true,
+                        (float[])(object)flatOutput, 0, outChannels);
+                }
+                else
+                {
+                    multiplied = Helpers.BlasProvider.TryGemmEx(
+                        tileRows, outChannels, columnsPerRow,
+                        (double[])(object)columns, 0, columnsPerRow, false,
+                        (double[])(object)kernelData, 0, columnsPerRow, true,
+                        (double[])(object)flatOutput, 0, outChannels);
+                }
+
+                if (!multiplied)
+                {
+                    result.Dispose();
+                    result = null!;
+                    return false;
+                }
+
+                // GEMM emits [tileRows, OC] in NDHWC row order. Scatter the tile directly into
+                // Conv3D's NCDHW result so no full-size flat output temporary is needed.
+                int currentRowStart = rowStart;
+                CpuParallelSettings.ParallelForOrSerial(0, tileRows,
+                    (long)tileRows * outChannels, localRow =>
+                {
+                    int globalRow = currentRowStart + localRow;
+                    int b = globalRow / spatial;
+                    int position = globalRow - b * spatial;
+                    int flatBase = localRow * outChannels;
+                    for (int oc = 0; oc < outChannels; oc++)
+                        outputData[(b * outChannels + oc) * spatial + position] = flatOutput[flatBase + oc];
+                });
+            }
+
+            return true;
+        }
+        catch
+        {
+            result.Dispose();
+            result = null!;
+            throw;
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<T>.Shared.Return(columns);
+            System.Buffers.ArrayPool<T>.Shared.Return(flatOutput);
+        }
     }
 
     /// <inheritdoc/>
@@ -35293,7 +35331,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (shape == null) throw new ArgumentNullException(nameof(shape));
         var tensor = new Tensor<T>(shape);
         var rng = new Helpers.SimdRandom();
-        rng.FillUniform(tensor.DataVector.AsWritableSpan());
+        rng.FillUniform(tensor.AsWritableSpan());
         return tensor;
     }
 
@@ -46556,7 +46594,7 @@ public partial class CpuEngine : ITensorLevelEngine
             // Zero allocations, zero copy passes — SIMD kernel reads/writes the tensor memory directly.
             int n = rows * cols;
             var srcData = input.DataVector.AsSpan();
-            var dstData = result.DataVector.AsWritableSpan();
+            var dstData = result.AsWritableSpan();
             ref T srcHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(srcData);
             ref T dstHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dstData);
             var srcD = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
@@ -46570,7 +46608,7 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             int n = rows * cols;
             var srcData = input.DataVector.AsSpan();
-            var dstData = result.DataVector.AsWritableSpan();
+            var dstData = result.AsWritableSpan();
             ref T srcHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(srcData);
             ref T dstHead = ref System.Runtime.InteropServices.MemoryMarshal.GetReference(dstData);
             var srcF = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(
@@ -46586,7 +46624,7 @@ public partial class CpuEngine : ITensorLevelEngine
             // net471 fallback: no MemoryMarshal.CreateSpan. Use temp buffer path.
             int n = rows * cols;
             var srcData = input.DataVector.AsSpan();
-            var dstData = result.DataVector.AsWritableSpan();
+            var dstData = result.AsWritableSpan();
             var srcD = new double[n];
             var dstD = new double[n];
             for (int i = 0; i < n; i++)
@@ -46603,7 +46641,7 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             int n = rows * cols;
             var srcData = input.DataVector.AsSpan();
-            var dstData = result.DataVector.AsWritableSpan();
+            var dstData = result.AsWritableSpan();
             var srcF = new float[n];
             var dstF = new float[n];
             for (int i = 0; i < n; i++)
@@ -46783,7 +46821,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 srcD[i] = System.Runtime.CompilerServices.Unsafe.As<T, double>(ref s);
             }
             Engines.Simd.SimdKernels.Tanh(srcD, dstD);
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
                 dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
             return result;
@@ -46799,7 +46837,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 srcF[i] = System.Runtime.CompilerServices.Unsafe.As<T, float>(ref s);
             }
             Engines.Simd.SimdKernels.Tanh(srcF, dstF);
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
                 dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
             return result;
@@ -46833,7 +46871,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 fixed (float* ip = srcF) fixed (float* op = dstF)
                     Engines.Simd.SimdKernels.ExpUnsafe(ip, op, n);
             }
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
                 dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref dstF[i]);
             return result;
@@ -46853,7 +46891,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 fixed (double* ip = srcD) fixed (double* op = dstD)
                     Engines.Simd.SimdKernels.ExpUnsafe(ip, op, n);
             }
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
                 dstSpan[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref dstD[i]);
             return result;
@@ -46888,7 +46926,7 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             var iSpan = imag.DataVector.AsSpan();
             var rSpan = real.DataVector.AsSpan();
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
             {
                 ref T iRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in iSpan[i]);
@@ -46904,7 +46942,7 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             var iSpan = imag.DataVector.AsSpan();
             var rSpan = real.DataVector.AsSpan();
-            var dstSpan = result.DataVector.AsWritableSpan();
+            var dstSpan = result.AsWritableSpan();
             for (int i = 0; i < n; i++)
             {
                 ref T iRef = ref System.Runtime.CompilerServices.Unsafe.AsRef(in iSpan[i]);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -12892,6 +12892,17 @@ public partial class CpuEngine : ITensorLevelEngine
         // RentUninitialized: BLAS GEMM with beta=0 overwrites every element
         var result = AutoTensorCache.RentOrAllocate<T>(new[] { m, p });
 
+#if NET5_0_OR_GREATER
+        // A streamed inference weight is stored in the quantized kernel layout [P,N]
+        // even though its logical tensor shape remains [N,P]. Consume that representation
+        // directly before any Data/AsSpan access can lazily create a full fp32 copy. This
+        // makes the no-upcast contract apply to ordinary TensorMatMul, not only FusedLinear.
+        if (TryTensorMatMulStreamingWeight(a, b, result, m, n, p))
+        {
+            return result;
+        }
+#endif
+
         if (p == 1 && TryTensorMatMulGemv(a, b, result, m, n))
         {
             return result;
@@ -13036,6 +13047,45 @@ public partial class CpuEngine : ITensorLevelEngine
 
         return result;
     }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Executes <c>A[rows,K] * B[K,N]</c> directly from B's no-upcast int8/int4
+    /// streaming representation. Returns false for normal, non-float, or training
+    /// weights without touching their data.
+    /// </summary>
+    private static bool TryTensorMatMulStreamingWeight<T>(
+        Tensor<T> a, Tensor<T> b, Tensor<T> result, int rows, int k, int outputColumns)
+    {
+        if (typeof(T) != typeof(float) || !a.IsContiguous || !b.IsContiguous)
+        {
+            return false;
+        }
+
+        var q8 = b.GetMaterializedStreamingInt8();
+        if (q8 is not null && q8.Rows == outputColumns && q8.K == k)
+        {
+            var input = (float[])(object)a.GetReadOnlyDataArray();
+            var output = (float[])(object)result.GetDataArray();
+            Simd.SimdGemm.SgemmWithInt8RowScaledCachedB(
+                input, q8.Data, q8.Scales, output, rows, k, outputColumns);
+            return true;
+        }
+
+        var q4 = b.GetMaterializedStreamingInt4();
+        if (q4 is not null && q4.Rows == outputColumns && q4.K == k)
+        {
+            var input = (float[])(object)a.GetReadOnlyDataArray();
+            var output = (float[])(object)result.GetDataArray();
+            Simd.SimdGemm.SgemmWithInt4GroupScaledDispatch(
+                input, q4.Data, q4.GroupScales, q4.GroupSize,
+                output, rows, k, outputColumns);
+            return true;
+        }
+
+        return false;
+    }
+#endif
 
     /// <summary>
     /// Sub-E (#373): inference fast path that consumes a pre-packed weight handle
@@ -13259,6 +13309,16 @@ public partial class CpuEngine : ITensorLevelEngine
 
         int matrixSizeA = m * n;
         int matrixSizeResult = m * p;
+
+#if NET5_0_OR_GREATER
+        // All batch slices are contiguous in A, so the broadcast ND x 2D operation is
+        // one [batchSize*M,K] projection. Route streamed weights before bData/Data is
+        // requested; those accessors intentionally dequantize as a generic fallback.
+        if (TryTensorMatMulStreamingWeight(a, b, result, batchSize * m, n, p))
+        {
+            return result;
+        }
+#endif
 
         var aData = a.GetReadOnlyDataArray();
         var bData = b.GetReadOnlyDataArray();
@@ -38751,7 +38811,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     var inA = (float[])(object)input.GetReadOnlyDataArray();
                     var outA = (float[])(object)int8Result.GetDataArray();
                     Simd.SimdGemm.SgemmWithInt8RowScaledCachedB(
-                        inA.AsSpan(0, M * K), q8.Data, q8.Scales, outA.AsSpan(0, M * N), M, K, N);
+                        inA, q8.Data, q8.Scales, outA, M, K, N);
                     if (bias != null || activation != FusedActivationType.None)
                     {
                         var bA = bias != null ? (float[])(object)bias.GetReadOnlyDataArray() : null;
@@ -39051,7 +39111,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     var inA = (float[])(object)input.GetReadOnlyDataArray();
                     var outA = (float[])(object)destination.GetDataArray();
                     Simd.SimdGemm.SgemmWithInt8RowScaledCachedB(
-                        inA.AsSpan(0, M * K), q8.Data, q8.Scales, outA.AsSpan(0, M * N), M, K, N);
+                        inA, q8.Data, q8.Scales, outA, M, K, N);
                     if (bias != null || activation != FusedActivationType.None)
                     {
                         var bA = bias != null ? (float[])(object)bias.GetReadOnlyDataArray() : null;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -19818,9 +19818,32 @@ public partial class CpuEngine : ITensorLevelEngine
                 $"Check kernel size, stride, padding, and dilation parameters for input size {depth}x{height}x{width}.");
         }
 
+        // Float/double Conv3D is a matrix multiplication after im2col. The former direct
+        // implementation below performs seven scalar loops for every output element; on a
+        // paper-scale 3D U-Net that made each 32^3 inference take ~34 seconds. Build the
+        // receptive-field rows once and contract them with all output kernels in one BLAS GEMM.
+        // This remains the CpuEngine implementation of the existing cross-backend IEngine op;
+        // GPU backends keep their resident Conv3D kernels and model/layer code stays unchanged.
+        if ((typeof(T) == typeof(float) || typeof(T) == typeof(double))
+            && TryConv3DIm2ColGemm(
+                input, kernel,
+                batch, inChannels, depth, height, width,
+                outChannels, kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideD, strideH, strideW,
+                padD, padH, padW,
+                dilationD, dilationH, dilationW,
+                out var gemmResult))
+        {
+            DifferentiableOps.RecordBinary("Conv3D", gemmResult, input, kernel, BackwardFunctions<T>.Conv3DBackward,
+                new object[] { stride, padding, dilation });
+            AutoTracer.RecordOp("Conv3D", gemmResult, eng => eng.Conv3D(input, kernel, stride, padding, dilation));
+            return gemmResult;
+        }
+
         var result = TensorAllocator.Rent<T>([batch, outChannels, outputDepth, outputHeight, outputWidth]);
-        var inputData = input.GetDataArray();
-        var kernelData = kernel.GetDataArray();
+        var inputData = input.GetReadOnlyDataArray();
+        var kernelData = kernel.GetReadOnlyDataArray();
         var outputData = result.GetDataArray();
 
         // Parallel over batch * outChannels for maximum parallelism
@@ -19873,6 +19896,104 @@ public partial class CpuEngine : ITensorLevelEngine
             new object[] { stride, padding, dilation });
         AutoTracer.RecordOp("Conv3D", result, eng => eng.Conv3D(input, kernel, stride, padding, dilation));
         return result;
+    }
+
+    private static bool TryConv3DIm2ColGemm<T>(
+        Tensor<T> input,
+        Tensor<T> kernel,
+        int batch,
+        int inChannels,
+        int depth,
+        int height,
+        int width,
+        int outChannels,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth,
+        out Tensor<T> result)
+    {
+        result = null!;
+
+        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
+        long columnsLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
+        long columnElementsLong = rowsLong * columnsLong;
+        long flatOutputElementsLong = rowsLong * outChannels;
+        if (rowsLong <= 0 || columnsLong <= 0
+            || rowsLong > int.MaxValue || columnsLong > int.MaxValue
+            || columnElementsLong > int.MaxValue || flatOutputElementsLong > int.MaxValue)
+        {
+            return false;
+        }
+
+        int rows = (int)rowsLong;
+        int columnsPerRow = (int)columnsLong;
+        var columns = new T[(int)columnElementsLong];
+        var flatOutput = new T[(int)flatOutputElementsLong];
+        var inputData = input.GetReadOnlyDataArray();
+        var kernelData = kernel.GetReadOnlyDataArray();
+
+        Helpers.CpuIm2Col3DHelper.BuildColumns(
+            inputData, columns,
+            batch, inChannels, depth, height, width,
+            kernelDepth, kernelHeight, kernelWidth,
+            outputDepth, outputHeight, outputWidth,
+            strideDepth, strideHeight, strideWidth,
+            padDepth, padHeight, padWidth,
+            dilationDepth, dilationHeight, dilationWidth);
+
+        bool multiplied;
+        if (typeof(T) == typeof(float))
+        {
+            multiplied = Helpers.BlasProvider.TryGemmEx(
+                rows, outChannels, columnsPerRow,
+                (float[])(object)columns, 0, columnsPerRow, false,
+                (float[])(object)kernelData, 0, columnsPerRow, true,
+                (float[])(object)flatOutput, 0, outChannels);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            multiplied = Helpers.BlasProvider.TryGemmEx(
+                rows, outChannels, columnsPerRow,
+                (double[])(object)columns, 0, columnsPerRow, false,
+                (double[])(object)kernelData, 0, columnsPerRow, true,
+                (double[])(object)flatOutput, 0, outChannels);
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!multiplied) return false;
+
+        result = TensorAllocator.Rent<T>([batch, outChannels, outputDepth, outputHeight, outputWidth]);
+        var outputData = result.GetDataArray();
+        int spatial = outputDepth * outputHeight * outputWidth;
+
+        // GEMM emits [B*OD*OH*OW, OC] (NDHWC flattening). Conv3D's public
+        // contract is NCDHW, so transpose the channel axis into its final layout.
+        CpuParallelSettings.ParallelForOrSerial(0, batch * outChannels, flatOutput.Length, batchChannel =>
+        {
+            int b = batchChannel / outChannels;
+            int oc = batchChannel % outChannels;
+            int outputBase = (b * outChannels + oc) * spatial;
+            int flatBase = b * spatial * outChannels + oc;
+            for (int position = 0; position < spatial; position++)
+                outputData[outputBase + position] = flatOutput[flatBase + position * outChannels];
+        });
+
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20018,15 +20018,23 @@ public partial class CpuEngine : ITensorLevelEngine
             Math.Max(1L, Conv3DIm2ColWorkspaceBytes / bytesPerTileRow));
         int columnCapacity = checked(tileCapacity * columnsPerRow);
         int flatCapacity = checked(tileCapacity * outChannels);
-        var columns = System.Buffers.ArrayPool<T>.Shared.Rent(columnCapacity);
-        var flatOutput = System.Buffers.ArrayPool<T>.Shared.Rent(flatCapacity);
-        var inputData = input.GetReadOnlyDataArray();
-        var kernelData = kernel.GetReadOnlyDataArray();
-        result = TensorAllocator.Rent<T>([batch, outChannels, outputDepth, outputHeight, outputWidth]);
-        var outputData = result.GetDataArray();
+        T[]? columns = null;
+        T[]? flatOutput = null;
+        Tensor<T>? allocatedResult = null;
         int spatial = outputDepth * outputHeight * outputWidth;
         try
         {
+            // Protect the complete acquisition sequence. A later rent, input materialization,
+            // result allocation, or writable-array acquisition may throw independently.
+            columns = System.Buffers.ArrayPool<T>.Shared.Rent(columnCapacity);
+            flatOutput = System.Buffers.ArrayPool<T>.Shared.Rent(flatCapacity);
+            var inputData = input.GetReadOnlyDataArray();
+            var kernelData = kernel.GetReadOnlyDataArray();
+            allocatedResult = TensorAllocator.Rent<T>(
+                [batch, outChannels, outputDepth, outputHeight, outputWidth]);
+            var outputData = allocatedResult.GetDataArray();
+            result = allocatedResult;
+
             for (int rowStart = 0; rowStart < rows; rowStart += tileCapacity)
             {
                 int tileRows = Math.Min(tileCapacity, rows - rowStart);
@@ -20059,7 +20067,8 @@ public partial class CpuEngine : ITensorLevelEngine
 
                 if (!multiplied)
                 {
-                    result.Dispose();
+                    allocatedResult.Dispose();
+                    allocatedResult = null;
                     result = null!;
                     return false;
                 }
@@ -20083,14 +20092,16 @@ public partial class CpuEngine : ITensorLevelEngine
         }
         catch
         {
-            result.Dispose();
+            allocatedResult?.Dispose();
             result = null!;
             throw;
         }
         finally
         {
-            System.Buffers.ArrayPool<T>.Shared.Return(columns);
-            System.Buffers.ArrayPool<T>.Shared.Return(flatOutput);
+            if (columns is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(columns);
+            if (flatOutput is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(flatOutput);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -3442,7 +3442,7 @@ public partial class DirectGpuTensorEngine
     private static bool TryCountHostMask(Tensor<Bit> mask, out int count)
     {
         count = 0;
-        var backingArray = mask.DataVector.GetBackingArrayUnsafe();
+        var backingArray = mask.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is null
             || Helpers.DeferredArrayMaterializer.IsPending(backingArray)
             || Helpers.DeferredArrayMaterializer.IsPending(mask.DataVector))
@@ -3470,7 +3470,7 @@ public partial class DirectGpuTensorEngine
     private static bool HasResidentIndexStorage(Tensor<int> indices)
     {
         if (indices.IsGpuResident) return true;
-        var backingArray = indices.DataVector.GetBackingArrayUnsafe();
+        var backingArray = indices.GetBackingArrayForCacheLookupUnsafe();
         return backingArray is not null &&
             Helpers.DeferredArrayMaterializer.IsPending(backingArray);
     }
@@ -6660,7 +6660,7 @@ public partial class DirectGpuTensorEngine
     private static bool HasResidentTensorStorage<T>(Tensor<T> tensor)
     {
         if (tensor.IsGpuResident) return true;
-        var backingArray = tensor.DataVector.GetBackingArrayUnsafe();
+        var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         return backingArray is not null &&
             Helpers.DeferredArrayMaterializer.IsPending(backingArray);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -670,7 +670,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal void BindResidentBufferFp16<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend, int elementCount)
     {
         t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return;
         _fp16ResidentArrays[arr] = elementCount;
         var capBuf = buf; var capBackend = backend; var capCount = elementCount;
@@ -688,7 +688,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal bool IsFp16Resident<T>(Tensor<T> t)
     {
         if (!Fp16ActEnabled) return false;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         return arr is not null && _fp16ResidentArrays.ContainsKey(arr);
     }
 
@@ -698,7 +698,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         count = 0;
         if (!Fp16ActEnabled) return null;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null || !_fp16ResidentArrays.TryGetValue(arr, out count)) return null;
         if (t._gpuBuffer is null || t._gpuBuffer.Handle == System.IntPtr.Zero) return null;
         return t._gpuBuffer;
@@ -741,7 +741,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var be) || be is not Engines.DirectGpu.CUDA.CudaBackend cb || !cb.SupportsFp16NativeOps) return false;
         var aHalf = TryFp16ResidentInput(a, out _);
         if (aHalf is null) return false; // only when the in-place target is FP16
-        var aArr = a.DataVector.GetBackingArrayUnsafe();
+        var aArr = a.GetBackingArrayForCacheLookupUnsafe();
         if (aArr is null) return false;
         int len = a.Length;
         try
@@ -769,7 +769,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var be) || be is not Engines.DirectGpu.CUDA.CudaBackend cb || !cb.Fp16BroadcastAddChannelAvailable) return false;
         var aHalf = TryFp16ResidentInput(a, out _);
         if (aHalf is null) return false;
-        var aArr = a.DataVector.GetBackingArrayUnsafe();
+        var aArr = a.GetBackingArrayForCacheLookupUnsafe();
         if (aArr is null) return false;
         int c = a.Shape._dims[1], hw = a.Shape._dims[2] * a.Shape._dims[3];
         try
@@ -1392,7 +1392,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var tHalfG = TryFp16ResidentInput(tensor, out var tCountG);
         if (tHalfG is not null)
         {
-            var kG = tensor.DataVector.GetBackingArrayUnsafe();
+            var kG = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (kG is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfG, tCountG, kG), ownsBuffer: false);
         }
         // A non-contiguous tensor (or one with a nonzero storage offset) is a STRIDED VIEW: it shares
@@ -1432,7 +1432,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // ran on this branch and the vector-keyed entry stayed orphaned,
             // consuming cache budget. Invalidate BOTH keys: each is a
             // TryRemove, so the one that wasn't used is a no-op.
-            var staleArray = tensor.DataVector.GetBackingArrayUnsafe();
+            var staleArray = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (staleArray is not null)
                 InvalidateActivationCacheEntry(staleArray);
             InvalidateActivationCacheEntry(tensor.DataVector);
@@ -1444,7 +1444,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Get the backing array reference WITHOUT triggering materialization.
         // This is critical: GetDataArray() would download from GPU, which is wasteful
         // when we're about to find the GPU buffer in the activation cache.
-        var backingArray = tensor.DataVector.GetBackingArrayUnsafe();
+        var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is not null)
         {
             // Check caches using the raw array reference (no download triggered)
@@ -1495,7 +1495,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private bool IsCachedGpuBufferLive<T>(Tensor<T> tensor, IDirectGpuBackend backend)
     {
         if (tensor.IsGpuResident) return true;
-        var key = (object?)tensor.DataVector.GetBackingArrayUnsafe() ?? tensor.DataVector;
+        var key = (object?)tensor.GetBackingArrayForCacheLookupUnsafe() ?? tensor.DataVector;
         // _activationCache is a ConcurrentDictionary — this read is lock-free.
         return _activationCache.TryGetValue(key, out var entry)
             && ReferenceEquals(entry.Buffer, tensor._gpuBuffer)
@@ -1532,7 +1532,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // (its #226 "user might read after Dispose" behaviour) would overwrite the fresh weights on
         // the fused-optimizer path (#739 review). Removing the registration keeps the just-written
         // host weights authoritative — the next forward re-uploads them.
-        var pendingBacking = tensor.DataVector.GetBackingArrayUnsafe();
+        var pendingBacking = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (pendingBacking is not null)
             Helpers.DeferredArrayMaterializer.Remove(pendingBacking);
 
@@ -1548,7 +1548,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // serves the STALE pre-update device weights (the GPU model trains against frozen weights: host
         // GetParameters is correct + Version bumped, but the forward prediction never reflects the update).
         // Clearing it here forces GetOrCacheWeightBuffer to re-upload the current host weights next forward.
-        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        var backing = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backing is not null)
         {
             lock (_persistentBufferLock)
@@ -1565,7 +1565,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Both the array-keyed and vector-keyed activation cache
         // entries may have been added (different cache paths use
         // different keys). Invalidate both to be safe.
-        var backingArray = tensor.DataVector.GetBackingArrayUnsafe();
+        var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is not null)
         {
             if (Helpers.DeferredArrayMaterializer.IsPending(backingArray))
@@ -1726,7 +1726,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend)))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);   // compiled step: buffers pinned, don't orphan aliases
 
-            var staleArray = tensor.DataVector.GetBackingArrayUnsafe();
+            var staleArray = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (staleArray is not null)
                 InvalidateActivationCacheEntry(staleArray);
             tensor._gpuBuffer = null;
@@ -1735,7 +1735,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
 
         // Check caches without triggering CPU materialization
-        var backingArray = tensor.DataVector.GetBackingArrayUnsafe();
+        var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is not null)
         {
             var cached = TryGetCachedBuffer(backingArray);
@@ -1788,7 +1788,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             tensor._gpuBuffer = owned.Buffer;
             tensor._gpuBackend = backend;
             tensor._gpuBufferVersion = tensor.Version;
-            var backingArray = tensor.DataVector.GetBackingArrayUnsafe();
+            var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (backingArray is not null)
             {
                 CacheActivation(backingArray, owned.Buffer, tensor.Shape.ToArray(), backend);
@@ -2097,7 +2097,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         int n = t.Length;
         bool any = TryCompressActivationFp16ByKey(t.DataVector, n);
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (!any && arr is not null) any = TryCompressActivationFp16ByKey(arr, n);
         if (any) { t._gpuBuffer = null; t._gpuBufferVersion = -1; }
     }
@@ -2106,7 +2106,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal void UpcastActivationFp32(Tensor<float> t)
     {
         TryUpcastActivationFp32ByKey(t.DataVector);
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null) TryUpcastActivationFp32ByKey(arr);
     }
 
@@ -2120,7 +2120,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal void FreeFloatActivation(Tensor<float> t)
     {
         bool any = TryFreeActivationByKey(t.DataVector);
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null) any |= TryFreeActivationByKey(arr);
         if (any) { t._gpuBuffer = null; t._gpuBufferVersion = -1; }
     }
@@ -2796,7 +2796,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (r is null || o is null || o.Length == 0 || r.Length != o.Length) return false;
         if (!TryGetBackend(out var backend) || backend is not Engines.DirectGpu.CUDA.CudaBackend cb) return false;
         if (!TryGetResidentFp16Buffer(r, backend, out var rBuf) || rBuf is null) return false;
-        var oKey = o.DataVector.GetBackingArrayUnsafe();
+        var oKey = o.GetBackingArrayForCacheLookupUnsafe();
         if (oKey is null) return false;
         int n = o.Length;
         long bytes = (long)n * 2;
@@ -2832,7 +2832,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal void RegisterResidentParamBuffer<T>(Tensor<T> param)
     {
         if (param is null || typeof(T) != typeof(float) || !TryGetBackend(out var backend)) return;
-        var arr = param.DataVector.GetBackingArrayUnsafe();
+        var arr = param.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not float[] farr) return;
         lock (_persistentBufferLock)
         {
@@ -2860,7 +2860,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         try
         {
             IGpuBuffer? xbuf = null;
-            var xarr = x.DataVector.GetBackingArrayUnsafe();
+            var xarr = x.GetBackingArrayForCacheLookupUnsafe();
             // Take the on-device resident cast ONLY when x's device buffer is VERSION-FRESH relative to the host
             // array. A device-only write (the fused optimizer updating the param buffer in place) does NOT bump the
             // host Version, so a version-match means the buffer holds the latest weights — read it with no transfer.
@@ -2881,7 +2881,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // n floats hold n packed halves) rather than AllocateByteBuffer. ConvertToFp16/Hgemm cast the buffer
             // to the standard device-buffer type, so a byte-typed buffer throws InvalidCastException on those
             // backends (e.g. OpenCL) — the float-typed buffer is the type those kernels accept.
-            var oArr = o.DataVector.GetBackingArrayUnsafe();
+            var oArr = o.GetBackingArrayForCacheLookupUnsafe();
             if (oArr is null) return false;
             // REUSE an already-cached Half buffer for this output IN PLACE instead of dispose+realloc. The Half
             // buffers come from a POOLED allocator: disposing one (InvalidateActivationCacheEntry frees the GPU
@@ -2937,7 +2937,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // producing gradients that diverge from the FP32 reference). Resolve the cache entry FIRST (by backing
         // array, then DataVector); only fall back to g._gpuBuffer when it is the live cached buffer for g.
         IGpuBuffer? srcBuf = null;
-        object? k2 = g.DataVector?.GetBackingArrayUnsafe();
+        object? k2 = g.GetBackingArrayForCacheLookupUnsafe();
         object? k1 = g.DataVector;
         lock (_activationCacheLock)
         {
@@ -2979,7 +2979,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Find the source's resident GPU buffer (and whether it is a true Half byte buffer or FP32).
         IGpuBuffer? srcBuf = null; bool srcIsFp16 = false;
         object? k1 = src.DataVector;
-        object? k2 = src.DataVector?.GetBackingArrayUnsafe();
+        object? k2 = src.GetBackingArrayForCacheLookupUnsafe();
         lock (_activationCacheLock)
         {
             if (k2 is not null && _activationCache.TryGetValue(k2, out var e2) && ReferenceEquals(e2.Backend, backend))
@@ -3017,7 +3017,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         halfBuf = null;
         object? k1 = t.DataVector;
-        object? k2 = t.DataVector?.GetBackingArrayUnsafe();
+        object? k2 = t.GetBackingArrayForCacheLookupUnsafe();
         lock (_activationCacheLock)
         {
             if (k1 is not null && _activationCache.TryGetValue(k1, out var e1) && ReferenceEquals(e1.Backend, backend) && e1.IsFp16)
@@ -3096,7 +3096,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal static void TagProducer<T>(Tensor<T> output, string? op)
     {
         if (op is null || s_currentForwardOp is null) return;
-        var arr = output.DataVector.GetBackingArrayUnsafe();
+        var arr = output.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[arr] = op;
     }
     private static void AliasDiag(string reason)
@@ -3141,7 +3141,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (s_currentForwardOp is not null)
         {
-            var dArr = dest.DataVector.GetBackingArrayUnsafe();
+            var dArr = dest.GetBackingArrayForCacheLookupUnsafe();
             if (dArr is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[dArr] = s_currentForwardOp;
         }
         if (eng is DirectGpuTensorEngine gpu && gpu.TryAliasResidentOutput(src, dest))
@@ -3171,7 +3171,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         else
         {
-            var srcArr = src.DataVector.GetBackingArrayUnsafe();
+            var srcArr = src.GetBackingArrayForCacheLookupUnsafe();
             // Persistent weight cache first — a reshape/view of a PARAMETER (e.g. positional embedding) has the
             // param resident in _persistentBufferCache (uploaded once by the optimizer / an earlier op) but NOT in
             // the activation cache; without this the alias declines and host-copies, dropping the param's reshape
@@ -3194,7 +3194,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // never fire a materializer (a DtoH that 900s) for a real activation that merely hasn't been bound yet.
         if (srcBuf is null)
         {
-            var cArr = src.DataVector.GetBackingArrayUnsafe();
+            var cArr = src.GetBackingArrayForCacheLookupUnsafe();
             if (cArr is not null && src.IsContiguous && !Helpers.DeferredArrayMaterializer.IsPending(cArr))
             {
                 try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights, src.Version).Buffer; }
@@ -3206,14 +3206,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
             bool hasBuf = src._gpuBuffer is not null;
             bool verMatch = hasBuf && src._gpuBufferVersion == src.Version;
-            var srcArr2 = src.DataVector.GetBackingArrayUnsafe();
+            var srcArr2 = src.GetBackingArrayForCacheLookupUnsafe();
             string realProducer = (srcArr2 is not null && s_producerOf.TryGetValue(srcArr2, out var rp)) ? rp : "<untagged/host>";
             AliasDiag($"skip: src not resident PRODUCER={realProducer} consumer={s_currentForwardOp} shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} capturing={capturing}");
             return false;
         }
 
         // dest needs a backing array as the deferred-materializer key (for any host read of dest).
-        var destArr = dest.DataVector.GetBackingArrayUnsafe();
+        var destArr = dest.GetBackingArrayForCacheLookupUnsafe();
         if (destArr is null) { AliasDiag("skip: dest has no backing array"); return false; }
 
         // Borrow src's buffer: consumers resolve dest via the _gpuBuffer fast path. We do NOT add a second
@@ -4057,7 +4057,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // FIRST: firing it here is wasteful (its bytes are about to be replaced) and crashes if the source buffer
         // was already recycled ("buffer released before materialization"). Reading the unsafe reference does not
         // fire the materializer; Remove clears it so a later host read can't resurrect obsolete GPU bytes either.
-        var rawArr = destination.DataVector.GetBackingArrayUnsafe();
+        var rawArr = destination.GetBackingArrayForCacheLookupUnsafe();
         if (rawArr is not null) Helpers.DeferredArrayMaterializer.Remove(rawArr);
 
         destinationArray = destination.GetLiveBackingArrayOrNull()!;
@@ -4082,7 +4082,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var tHalfC = TryFp16ResidentInput(tensor, out var tCountC);
         if (tHalfC is not null)
         {
-            var kC = tensor.DataVector.GetBackingArrayUnsafe();
+            var kC = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (kC is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfC, tCountC, kC), ownsBuffer: false);
         }
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
@@ -4171,7 +4171,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (t._gpuBuffer is not null && ReferenceEquals(t._gpuBackend, backend) && IsCachedGpuBufferLive(t, backend)
             && t._gpuBuffer.Handle != System.IntPtr.Zero && t._gpuBuffer.Size >= length)
             return t._gpuBuffer;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null)
         {
             lock (_activationCacheLock)
@@ -4200,7 +4200,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal void BindResidentBuffer<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend)
     {
         t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return;
         // #3 FP16-act: this array now holds FP32 — drop any stale FP16 tag (a pooled array reused FP16→FP32).
         if (Fp16ActEnabled) _fp16ResidentArrays.TryRemove(arr, out _);
@@ -4293,7 +4293,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var resident = t.TryGetGpuBuffer();
         if (resident is not null && resident.Handle != System.IntPtr.Zero && resident.Size >= need)
             return resident;
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null)
         {
             var cached = TryGetCachedBuffer(arr);
@@ -4369,7 +4369,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         mean = null; variance = null;
         if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
         if (!TryGetBackend(out var backend) || input.Rank < 2) return false;
-        var arr = output.DataVector.GetBackingArrayUnsafe();
+        var arr = output.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return false;
         try
         {
@@ -4420,7 +4420,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return false;
         if (!TryGetBackend(out var backend) || input.Rank < 2) return false;
-        var arr = output.DataVector.GetBackingArrayUnsafe();
+        var arr = output.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return false;
         try
         {
@@ -4613,7 +4613,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
             ResidentSyncCheck("Embedding");
             output._gpuBuffer = outBuf; output._gpuBackend = backend; output._gpuBufferVersion = output.Version;
-            var oArr = output.DataVector.GetBackingArrayUnsafe();
+            var oArr = output.GetBackingArrayForCacheLookupUnsafe();
             if (oArr is not null && s_currentForwardOp is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[oArr] = s_currentForwardOp;
             return true;
         }
@@ -4734,7 +4734,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var tHalfR = TryFp16ResidentInput(t, out var tCountR);
         if (tHalfR is not null)
         {
-            var kR = t.DataVector.GetBackingArrayUnsafe();
+            var kR = t.GetBackingArrayForCacheLookupUnsafe();
             if (kR is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfR, tCountR, kR), ownsBuffer: false);
         }
         // PR #638 (CUDA-700 fix): a REUSED input buffer must hold at least the tensor's logical length, else the
@@ -4759,7 +4759,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var resident = t.TryGetGpuBuffer();
         if (resident is not null && resident.Handle != System.IntPtr.Zero && resident.Size >= need)
             return new OwnedBuffer(resident, ownsBuffer: false);
-        var arr = t.DataVector.GetBackingArrayUnsafe();
+        var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null)
         {
             var cached = TryGetCachedBuffer(arr);
@@ -5532,7 +5532,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // output), so making it resident is what lets the residual add downstream stay on-device.
         if (ResidentStepActive && !Gpu.AutocastScope.IsEnabled && typeof(T) == typeof(float)
             && input.Rank == 4 && kernel.Rank == 4
-            && output.DataVector.GetBackingArrayUnsafe() is not null
+            && output.GetBackingArrayForCacheLookupUnsafe() is not null
             && TryGetBackend(out var rbk) && rbk is Engines.DirectGpu.CUDA.CudaBackend)
         {
             try
@@ -5554,7 +5554,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // weights[outC,K], GemmFp16In32fOut/HalfOut → out[outC,N]. #3 FP16-ACT: read FP16 input directly
                 // (UnfoldKNFp16FromFp16, no convert) + write FP16 output (GemmFp16HalfOut) so the next op stays FP16.
                 int gemmK = ic * kh * kw, gemmN = b * oh * ow, gemmM = oc;
-                var outArr = output.DataVector.GetBackingArrayUnsafe(); // stable scratch key (gate above ensured non-null)
+                var outArr = output.GetBackingArrayForCacheLookupUnsafe(); // stable scratch key (gate above ensured non-null)
                 // The matrix-unit GEMM only PAYS OFF on a big-enough GEMM. Deep convs at small spatial (8x8→N=64,
                 // 4x4→N=16) are tiny GEMMs where the im2col + launch overhead exceeds the win. Gate on N/K/M so
                 // only the large convs take the FP16 path; the small ones stay on the FP32 conv kernel.
@@ -6117,7 +6117,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (s_residentInPlace && InGradAccumulation && ResidentStepActive && System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1" && typeof(T) == typeof(float))
         {
             var aB = a.TryGetGpuBuffer(); var bB2 = b.TryGetGpuBuffer();
-            var aArr = a.DataVector.GetBackingArrayUnsafe();
+            var aArr = a.GetBackingArrayForCacheLookupUnsafe();
             var aCached = aArr is not null ? TryGetCachedBuffer(aArr) : null;
             AliasDiag($"gradacc-inplace probe: aField={(aB is null ? "null" : "H=" + ((long)aB.Handle).ToString("X") + "/sz" + aB.Size)} aCache={(aCached is null ? "null" : "H=" + ((long)aCached.Handle).ToString("X") + "/sz" + aCached.Size)} bField={(bB2 is null ? "null" : "H=" + ((long)bB2.Handle).ToString("X") + "/sz" + bB2.Size)} need={a.Length} aContig={a.IsContiguous}");
         }
@@ -6282,7 +6282,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Read the optional backing WITHOUT materializing. Zero-allocation deferred tensors have no
         // host array yet and are cached by DataVector; rejecting them here would force an in-place
         // activation to read a not-yet-executed result during graph recording.
-        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        var backing = tensor.GetBackingArrayForCacheLookupUnsafe();
         object cacheKey = backing ?? tensor.DataVector;
 
         OwnedBuffer owned;
@@ -19293,7 +19293,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // per-call cuMemAlloc (which would itself abort the capture). Host reads of output download lazily
                 // via the registered materializer.
                 using var bufIn = GetOrAllocateBuffer(backend, tensor);   // Tensor overload: resident fast-path, no forced download
-                var arr = output.DataVector.GetBackingArrayUnsafe();
+                var arr = output.GetBackingArrayForCacheLookupUnsafe();
                 IGpuBuffer? outBuf = null;
                 // ResidentStepActive ⇒ eviction is suspended for the whole step, so output._gpuBuffer (set by the
                 // pre-residency pass below at output._gpuBuffer = outBuf) is GUARANTEED live — accept it on
@@ -21505,7 +21505,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // registers it there and defers the download; it is NOT exposed through Tensor.TryGetGpuBuffer(),
         // which stays null for these. Probe the cache directly, or this always falls back and the
         // comparison -> where chain never stays on the device.
-        var condArr = condition.DataVector.GetBackingArrayUnsafe();
+        var condArr = condition.GetBackingArrayForCacheLookupUnsafe();
         // The mask IS resident and its DEVICE BUFFER IS CORRECT — measured by downloading it:
         // deviceFloats = 0,0,0,0,1,0,0,0 for TensorIsNan, exactly the float 0/1 where_select reads.
         //

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
@@ -38,6 +38,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using AiDotNet.Tensors.Helpers;
 
 namespace AiDotNet.Tensors.Engines.Simd;
 
@@ -98,6 +99,12 @@ internal static partial class SimdGemm
     /// <param name="m">Output rows (batch).</param>
     /// <param name="k">Inner dim.</param>
     /// <param name="n">Output cols (features).</param>
+    /// <remarks>
+    /// This span-compatible adapter is retained for direct kernel callers. The engine-owned hot
+    /// path uses the array overload below so bounded native routes can pin stable buffers without
+    /// copying. Arbitrary spans cannot safely recover their backing-array offset, so this adapter
+    /// owns bounded input/output copies and preserves the original span surface.
+    /// </remarks>
     public static void SgemmWithInt8RowScaledCachedB(
         ReadOnlySpan<float> a,
         sbyte[] bInt8,
@@ -105,7 +112,26 @@ internal static partial class SimdGemm
         Span<float> c,
         int m, int k, int n)
     {
+        float[] input = a.ToArray();
+        var output = new float[c.Length];
+        SgemmWithInt8RowScaledCachedB(input, bInt8, rowScales, output, m, k, n);
+        output.AsSpan().CopyTo(c);
+    }
+
+    /// <summary>
+    /// Array-backed engine hot path. Stable arrays let the bounded medium-width route use the
+    /// shared BLAS provider directly while wide matrices stay in the no-upcast managed kernel.
+    /// </summary>
+    public static void SgemmWithInt8RowScaledCachedB(
+        float[] a,
+        sbyte[] bInt8,
+        ReadOnlySpan<float> rowScales,
+        float[] c,
+        int m, int k, int n)
+    {
+        if (a is null) throw new ArgumentNullException(nameof(a));
         if (bInt8 is null) throw new ArgumentNullException(nameof(bInt8));
+        if (c is null) throw new ArgumentNullException(nameof(c));
         if (rowScales.Length < n)
             throw new ArgumentException(
                 $"rowScales.Length ({rowScales.Length}) must be >= n ({n}).",
@@ -114,35 +140,50 @@ internal static partial class SimdGemm
             throw new ArgumentException(
                 $"bInt8.Length ({bInt8.Length}) must be >= n*k ({(long)n * k}) for the [n, k] layout.",
                 nameof(bInt8));
-        if (m <= 0 || n <= 0 || k <= 0) { c.Clear(); return; }
+        if (m <= 0 || n <= 0 || k <= 0) { Array.Clear(c, 0, c.Length); return; }
+        if ((long)a.Length < (long)m * k)
+            throw new ArgumentException(
+                $"a.Length ({a.Length}) must be >= m*k ({(long)m * k}).", nameof(a));
+        if ((long)c.Length < (long)m * n)
+            throw new ArgumentException(
+                $"c.Length ({c.Length}) must be >= m*n ({(long)m * n}).", nameof(c));
 
-        c.Clear();
+        c.AsSpan(0, checked(m * n)).Clear();
 
-        // Path A: large-n / AVX-512 — fall back to a one-time on-the-fly
-        // dequant + standard SGEMM. The packed tiled path is sized for the
-        // Nc=4096 sub-block budget; once n exceeds that, the per-tile dequant
-        // overhead in the cached path equals or exceeds a single-pass FP32
-        // dequant + the existing SgemmAddInternal large-n fast path.
-        if (n > Nc || Avx512Sgemm.CanUse)
+        // Path A: for a medium-width AVX-512 shape, one-time dequant + the highly tuned SGEMM can
+        // still beat the AVX2 int8-widening tiles. Wide N must NOT take this route: a paper-scale
+        // [4096,16384] FFN would expand 268 MiB per projection on one thread. The tiled path below
+        // now partitions every output column across cached sub-blocks, so it remains genuinely
+        // no-upcast above Nc=4096.
+        if (n <= Nc && Avx512Sgemm.CanUse)
         {
             // Allocate a single FP32 buffer for the full dequantized B and
-            // run the standard Sgemm. This path is rare (n > 4096 is unusual
-            // for transformer FFN; or AVX-512 hosts where Sgemm dispatches
-            // straight to the 512-bit kernel and per-tile dequant isn't a
-            // win). We don't cache this path — it's the cold/edge case.
+            // run the standard Sgemm. This path is bounded to N <= Nc; wide transformer FFNs stay
+            // in the no-upcast tiled path. We don't cache this medium-width edge case.
             var dequantFull = System.Buffers.ArrayPool<float>.Shared.Rent(n * k);
             try
             {
                 DequantizeInt8WithRowScalesToFloat32_Reference(
                     bInt8, dequantFull.AsSpan(0, n * k), rowScales, n, k);
                 // bInt8 is [n, k] row-major; Sgemm wants B in [k, n].
-                // Use transB:true to read the dequantized [n, k] buffer
-                // through Sgemm's transposed-B path.
-                SgemmAddInternal(
-                    a, k, false,
-                    dequantFull.AsSpan(0, n * k), k, true,
-                    c, m, k, n,
-                    allowParallel: true, clearedOutput: true);
+                // Use transB:true to read the dequantized [n, k] buffer through the shared BLAS
+                // dispatcher. The former SgemmAddInternal call bypassed native BLAS entirely, so
+                // paper-scale FFNs (N=16,384) ran the managed fallback even in production mode and
+                // timed out. TryGemmEx retains the deterministic/managed/autotuned routing contract
+                // and uses native multi-threaded BLAS when selected. Keep the original kernel as a
+                // defensive fallback if a provider reports failure.
+                if (!BlasProvider.TryGemmEx(
+                        m, n, k,
+                        a, 0, k, false,
+                        dequantFull, 0, k, true,
+                        c, 0, n))
+                {
+                    SgemmAddInternal(
+                        a.AsSpan(0, m * k), k, false,
+                        dequantFull.AsSpan(0, n * k), k, true,
+                        c.AsSpan(0, m * n), m, k, n,
+                        allowParallel: true, clearedOutput: true);
+                }
             }
             finally
             {
@@ -224,7 +265,11 @@ internal static partial class SimdGemm
         int maxThreads = Math.Max(1, Math.Min(Environment.ProcessorCount, Int8RowScaledMaxGridThreads));
         int numPcIters = (k + Kc - 1) / Kc;
 
-        int nc0 = Math.Min(Nc, n);
+        // Partition the ENTIRE output width. The previous Math.Min(Nc, n) packed only the first
+        // 4096 columns and forced every wider projection into full fp32 dequantization. Sub-blocks
+        // already carry independent packed buffers and global column offsets, so they naturally
+        // scale across N without another operation or model-specific loop.
+        int nc0 = n;
         int desiredColSubs = Math.Max(1, maxThreads / numRowBlocks);
         int maxColSubs = Math.Max(1, nc0 / (Nr * 4));
         int numColSubBlocks = Math.Min(desiredColSubs, maxColSubs);
@@ -238,22 +283,28 @@ internal static partial class SimdGemm
         int colSubRounded = ((colSubSize + Nr - 1) / Nr) * Nr;
         int lastColSubWidth = nc0 - (numColSubBlocks - 1) * colSubSize;
         int lastColSubRounded = ((lastColSubWidth + Nr - 1) / Nr) * Nr;
-        int packedBSizePerSub = Kc * Math.Max(colSubRounded, lastColSubRounded);
+        int maxPackedColumns = Math.Max(colSubRounded, lastColSubRounded);
 
         var packedSubs = new sbyte[numPcIters * numColSubBlocks][];
-        for (int pcIter = 0; pcIter < numPcIters; pcIter++)
+        int totalPackTasks = packedSubs.Length;
+        void PackTask(int task)
         {
+            int pcIter = task / numColSubBlocks;
+            int cs = task % numColSubBlocks;
             int pc = pcIter * Kc;
             int kc = Math.Min(Kc, k - pc);
-            for (int cs = 0; cs < numColSubBlocks; cs++)
-            {
-                int jStart = cs * colSubSize;
-                int subNc = (cs == numColSubBlocks - 1) ? (nc0 - jStart) : colSubSize;
-                var int8Buf = new sbyte[packedBSizePerSub];
-                PackBInt8FromNK(bInt8, int8Buf, k, n, pc, kc, jStart, subNc);
-                packedSubs[pcIter * numColSubBlocks + cs] = int8Buf;
-            }
+            int jStart = cs * colSubSize;
+            int subNc = (cs == numColSubBlocks - 1) ? (nc0 - jStart) : colSubSize;
+            var int8Buf = new sbyte[checked(kc * maxPackedColumns)];
+            PackBInt8FromNK(bInt8, int8Buf, k, n, pc, kc, jStart, subNc);
+            packedSubs[task] = int8Buf;
         }
+
+        // First-use packing is part of cold inference latency. Paper-scale weights previously packed
+        // all Kc×N panels serially even though every destination buffer is independent. Fan the same
+        // stable panel decomposition across the persistent executor; the total-work overload keeps
+        // tiny matrices inline and avoids parallel-startup noise.
+        Helpers.CpuParallelSettings.LightweightParallel(totalPackTasks, (long)n * k, PackTask);
 
         // Defensive copy so the cache key (the sbyte[] reference) is
         // honoured at lookup time — if the caller mutates rowScales
@@ -363,7 +414,7 @@ internal static partial class SimdGemm
         try
         {
             int jc = 0;
-            int nc = Math.Min(Nc, n);
+            int nc = n;
             float[] rowScalesArr = cached.RowScales;
 
             for (int pcIter = 0; pcIter < cached.NumPcIters; pcIter++)
@@ -470,7 +521,7 @@ internal static partial class SimdGemm
     }
 
     /// <summary>
-    /// Reference dequantizer for the large-n / AVX-512 fallback path. Walks
+    /// Reference dequantizer for the bounded AVX-512 fallback path. Walks
     /// the source <c>[n, k]</c> sbyte layout directly (no pack) and writes
     /// the same <c>[n, k]</c> layout in FP32 — the caller passes this to
     /// SgemmAddInternal with <c>transB:true</c>.

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.Int8RowScaled.cs
@@ -132,6 +132,9 @@ internal static partial class SimdGemm
         if (a is null) throw new ArgumentNullException(nameof(a));
         if (bInt8 is null) throw new ArgumentNullException(nameof(bInt8));
         if (c is null) throw new ArgumentNullException(nameof(c));
+        if (m < 0) throw new ArgumentOutOfRangeException(nameof(m), m, "m must be non-negative.");
+        if (k < 0) throw new ArgumentOutOfRangeException(nameof(k), k, "k must be non-negative.");
+        if (n < 0) throw new ArgumentOutOfRangeException(nameof(n), n, "n must be non-negative.");
         if (rowScales.Length < n)
             throw new ArgumentException(
                 $"rowScales.Length ({rowScales.Length}) must be >= n ({n}).",
@@ -140,7 +143,7 @@ internal static partial class SimdGemm
             throw new ArgumentException(
                 $"bInt8.Length ({bInt8.Length}) must be >= n*k ({(long)n * k}) for the [n, k] layout.",
                 nameof(bInt8));
-        if (m <= 0 || n <= 0 || k <= 0) { Array.Clear(c, 0, c.Length); return; }
+        if (m == 0 || n == 0 || k == 0) { Array.Clear(c, 0, c.Length); return; }
         if ((long)a.Length < (long)m * k)
             throw new ArgumentException(
                 $"a.Length ({a.Length}) must be >= m*k ({(long)m * k}).", nameof(a));

--- a/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
+++ b/src/AiDotNet.Tensors/Helpers/BlasProvider.cs
@@ -105,6 +105,28 @@ internal static class BlasProvider
     private static int _openblasThreadCount = -1; // -1 = unset
 
     /// <summary>
+    /// Resolves the explicit OpenBLAS thread count used when leaving deterministic mode. Passing
+    /// zero to <c>openblas_set_num_threads</c> does not restore the library default on all builds;
+    /// several builds simply retain the prior single-thread setting. Respect the standard provider
+    /// environment knobs first, then use AiDotNet's process-level CPU parallelism policy.
+    /// </summary>
+    private static int ResolveParallelOpenBlasThreadCount()
+    {
+        foreach (string variable in new[] { "OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS" })
+        {
+            string? raw = Environment.GetEnvironmentVariable(variable);
+            if (int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture, out int configured)
+                && configured > 0)
+            {
+                return configured;
+            }
+        }
+
+        return Math.Max(1, CpuParallelSettings.MaxDegreeOfParallelism);
+    }
+
+    /// <summary>
     /// Sets the OpenBLAS internal thread count. Pass 1 to force deterministic
     /// single-threaded GEMM. Caller must verify <see cref="HasNativeDgemm"/>
     /// is true before calling, otherwise the P/Invoke will throw.
@@ -231,7 +253,7 @@ internal static class BlasProvider
                 if (_openblasScopeDepth == 0)
                 {
                     int restore = _openblasScopeRestoreTarget;
-                    TrySetOpenBlasThreads(restore < 0 ? 0 : restore);
+                    TrySetOpenBlasThreads(restore < 0 ? ResolveParallelOpenBlasThreadCount() : restore);
                 }
             }
         }
@@ -1054,7 +1076,7 @@ internal static class BlasProvider
         // on top of the managed-side determinism the SimdGemm fallback
         // already guarantees. Restoring multi-threading on disable lets
         // perf go back up for callers that re-enter non-deterministic mode.
-        TrySetOpenBlasThreads(deterministic ? 1 : 0);
+        TrySetOpenBlasThreads(deterministic ? 1 : ResolveParallelOpenBlasThreadCount());
         // Unify the switch (plan item 1.4): deterministic mode must ALSO make the
         // order-dependent reduction/accumulation kernels bit-reproducible — their
         // multi-threaded partial-sum combine is non-associative. Previously callers

--- a/src/AiDotNet.Tensors/Helpers/Im2Col3DHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2Col3DHelper.cs
@@ -1,0 +1,127 @@
+using System;
+
+namespace AiDotNet.Tensors.Helpers;
+
+/// <summary>
+/// Builds the row-major receptive-field matrix used by the CPU Conv3D GEMM path.
+/// Kept in the tensor engine so every Conv3D consumer shares the same optimized
+/// implementation instead of rebuilding seven nested loops in individual layers.
+/// </summary>
+internal static class CpuIm2Col3DHelper
+{
+    /// <summary>
+    /// Converts NCDHW input into [B*OD*OH*OW, C*KD*KH*KW] rows. The destination
+    /// is cleared first so padded positions remain numeric zero.
+    /// </summary>
+    internal static void BuildColumns<T>(
+        T[] input,
+        T[] columns,
+        int batch,
+        int channels,
+        int depth,
+        int height,
+        int width,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (columns is null) throw new ArgumentNullException(nameof(columns));
+
+        int columnsPerRow = checked(channels * kernelDepth * kernelHeight * kernelWidth);
+        int rowsPerDepth = checked(outputHeight * outputWidth);
+        int rowsPerBatch = checked(outputDepth * rowsPerDepth);
+        int expectedColumns = checked(batch * rowsPerBatch * columnsPerRow);
+        if (columns.Length < expectedColumns)
+            throw new ArgumentException(
+                $"Im2Col3D destination is too short: expected at least {expectedColumns}, got {columns.Length}.",
+                nameof(columns));
+
+        Array.Clear(columns, 0, expectedColumns);
+
+        // Split by batch/output-depth. Each worker owns complete destination rows, so
+        // writes are disjoint and require no synchronization. Keeping OH/OW inside the
+        // worker amortizes dispatch overhead on small volumes.
+        long work = (long)expectedColumns;
+        CpuParallelSettings.ParallelForOrSerial(0, batch * outputDepth, work, batchDepth =>
+        {
+            int b = batchDepth / outputDepth;
+            int od = batchDepth % outputDepth;
+            int sourceDepthOrigin = od * strideDepth - padDepth;
+            int batchInputBase = b * channels * depth * height * width;
+            int batchRowBase = b * rowsPerBatch + od * rowsPerDepth;
+
+            for (int oh = 0; oh < outputHeight; oh++)
+            {
+                int sourceHeightOrigin = oh * strideHeight - padHeight;
+                for (int ow = 0; ow < outputWidth; ow++)
+                {
+                    int sourceWidthOrigin = ow * strideWidth - padWidth;
+                    int row = batchRowBase + oh * outputWidth + ow;
+                    int destinationRowBase = row * columnsPerRow;
+
+                    for (int channel = 0; channel < channels; channel++)
+                    {
+                        int channelInputBase = batchInputBase + channel * depth * height * width;
+                        int channelColumnBase = destinationRowBase
+                            + channel * kernelDepth * kernelHeight * kernelWidth;
+
+                        for (int kd = 0; kd < kernelDepth; kd++)
+                        {
+                            int sourceDepth = sourceDepthOrigin + kd * dilationDepth;
+                            if ((uint)sourceDepth >= (uint)depth) continue;
+                            int depthInputBase = channelInputBase + sourceDepth * height * width;
+                            int depthColumnBase = channelColumnBase + kd * kernelHeight * kernelWidth;
+
+                            for (int kh = 0; kh < kernelHeight; kh++)
+                            {
+                                int sourceHeight = sourceHeightOrigin + kh * dilationHeight;
+                                if ((uint)sourceHeight >= (uint)height) continue;
+                                int sourceRowBase = depthInputBase + sourceHeight * width;
+                                int destinationKernelRow = depthColumnBase + kh * kernelWidth;
+
+                                // The overwhelmingly common dilation-W=1 case is a contiguous
+                                // row slice. Copy it in bulk, clipping only the padded edges.
+                                if (dilationWidth == 1)
+                                {
+                                    int firstKernelWidth = Math.Max(0, -sourceWidthOrigin);
+                                    int endKernelWidth = Math.Min(kernelWidth, width - sourceWidthOrigin);
+                                    int copyLength = endKernelWidth - firstKernelWidth;
+                                    if (copyLength > 0)
+                                    {
+                                        Array.Copy(
+                                            input,
+                                            sourceRowBase + sourceWidthOrigin + firstKernelWidth,
+                                            columns,
+                                            destinationKernelRow + firstKernelWidth,
+                                            copyLength);
+                                    }
+                                    continue;
+                                }
+
+                                for (int kw = 0; kw < kernelWidth; kw++)
+                                {
+                                    int sourceWidth = sourceWidthOrigin + kw * dilationWidth;
+                                    if ((uint)sourceWidth < (uint)width)
+                                        columns[destinationKernelRow + kw] = input[sourceRowBase + sourceWidth];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/AiDotNet.Tensors/Helpers/Im2Col3DHelper.cs
+++ b/src/AiDotNet.Tensors/Helpers/Im2Col3DHelper.cs
@@ -49,75 +49,127 @@ internal static class CpuIm2Col3DHelper
                 $"Im2Col3D destination is too short: expected at least {expectedColumns}, got {columns.Length}.",
                 nameof(columns));
 
+        BuildColumnsRange(
+            input, columns, 0, batch * rowsPerBatch,
+            batch, channels, depth, height, width,
+            kernelDepth, kernelHeight, kernelWidth,
+            outputDepth, outputHeight, outputWidth,
+            strideDepth, strideHeight, strideWidth,
+            padDepth, padHeight, padWidth,
+            dilationDepth, dilationHeight, dilationWidth);
+    }
+
+    /// <summary>
+    /// Builds a contiguous row range of the im2col matrix. This is the bounded-workspace primitive
+    /// used by Conv3D: paper-scale volumes can be tiled through GEMM without allocating the full
+    /// [B*OD*OH*OW, C*KD*KH*KW] matrix at once.
+    /// </summary>
+    internal static void BuildColumnsRange<T>(
+        T[] input,
+        T[] columns,
+        int rowStart,
+        int rowCount,
+        int batch,
+        int channels,
+        int depth,
+        int height,
+        int width,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (columns is null) throw new ArgumentNullException(nameof(columns));
+
+        int columnsPerRow = checked(channels * kernelDepth * kernelHeight * kernelWidth);
+        int rowsPerDepth = checked(outputHeight * outputWidth);
+        int rowsPerBatch = checked(outputDepth * rowsPerDepth);
+        int totalRows = checked(batch * rowsPerBatch);
+        if (rowStart < 0 || rowCount < 0 || rowStart > totalRows - rowCount)
+            throw new ArgumentOutOfRangeException(nameof(rowStart),
+                $"Im2Col3D row range [{rowStart}, {rowStart + (long)rowCount}) exceeds {totalRows} rows.");
+
+        int expectedColumns = checked(rowCount * columnsPerRow);
+        if (columns.Length < expectedColumns)
+            throw new ArgumentException(
+                $"Im2Col3D destination is too short: expected at least {expectedColumns}, got {columns.Length}.",
+                nameof(columns));
+
         Array.Clear(columns, 0, expectedColumns);
 
-        // Split by batch/output-depth. Each worker owns complete destination rows, so
-        // writes are disjoint and require no synchronization. Keeping OH/OW inside the
-        // worker amortizes dispatch overhead on small volumes.
-        long work = (long)expectedColumns;
-        CpuParallelSettings.ParallelForOrSerial(0, batch * outputDepth, work, batchDepth =>
+        // Each worker owns a complete destination row, so writes are disjoint. Global row decoding
+        // preserves the exact NCDHW traversal order used by the full-matrix implementation.
+        CpuParallelSettings.ParallelForOrSerial(0, rowCount, expectedColumns, localRow =>
         {
-            int b = batchDepth / outputDepth;
-            int od = batchDepth % outputDepth;
+            int globalRow = rowStart + localRow;
+            int b = globalRow / rowsPerBatch;
+            int rowWithinBatch = globalRow - b * rowsPerBatch;
+            int od = rowWithinBatch / rowsPerDepth;
+            int rowWithinDepth = rowWithinBatch - od * rowsPerDepth;
+            int oh = rowWithinDepth / outputWidth;
+            int ow = rowWithinDepth - oh * outputWidth;
             int sourceDepthOrigin = od * strideDepth - padDepth;
+            int sourceHeightOrigin = oh * strideHeight - padHeight;
+            int sourceWidthOrigin = ow * strideWidth - padWidth;
             int batchInputBase = b * channels * depth * height * width;
-            int batchRowBase = b * rowsPerBatch + od * rowsPerDepth;
+            int destinationRowBase = localRow * columnsPerRow;
 
-            for (int oh = 0; oh < outputHeight; oh++)
+            for (int channel = 0; channel < channels; channel++)
             {
-                int sourceHeightOrigin = oh * strideHeight - padHeight;
-                for (int ow = 0; ow < outputWidth; ow++)
+                int channelInputBase = batchInputBase + channel * depth * height * width;
+                int channelColumnBase = destinationRowBase
+                    + channel * kernelDepth * kernelHeight * kernelWidth;
+
+                for (int kd = 0; kd < kernelDepth; kd++)
                 {
-                    int sourceWidthOrigin = ow * strideWidth - padWidth;
-                    int row = batchRowBase + oh * outputWidth + ow;
-                    int destinationRowBase = row * columnsPerRow;
+                    int sourceDepth = sourceDepthOrigin + kd * dilationDepth;
+                    if ((uint)sourceDepth >= (uint)depth) continue;
+                    int depthInputBase = channelInputBase + sourceDepth * height * width;
+                    int depthColumnBase = channelColumnBase + kd * kernelHeight * kernelWidth;
 
-                    for (int channel = 0; channel < channels; channel++)
+                    for (int kh = 0; kh < kernelHeight; kh++)
                     {
-                        int channelInputBase = batchInputBase + channel * depth * height * width;
-                        int channelColumnBase = destinationRowBase
-                            + channel * kernelDepth * kernelHeight * kernelWidth;
+                        int sourceHeight = sourceHeightOrigin + kh * dilationHeight;
+                        if ((uint)sourceHeight >= (uint)height) continue;
+                        int sourceRowBase = depthInputBase + sourceHeight * width;
+                        int destinationKernelRow = depthColumnBase + kh * kernelWidth;
 
-                        for (int kd = 0; kd < kernelDepth; kd++)
+                        // The overwhelmingly common dilation-W=1 case is a contiguous row slice.
+                        // Copy it in bulk, clipping only the padded edges.
+                        if (dilationWidth == 1)
                         {
-                            int sourceDepth = sourceDepthOrigin + kd * dilationDepth;
-                            if ((uint)sourceDepth >= (uint)depth) continue;
-                            int depthInputBase = channelInputBase + sourceDepth * height * width;
-                            int depthColumnBase = channelColumnBase + kd * kernelHeight * kernelWidth;
-
-                            for (int kh = 0; kh < kernelHeight; kh++)
+                            int firstKernelWidth = Math.Max(0, -sourceWidthOrigin);
+                            int endKernelWidth = Math.Min(kernelWidth, width - sourceWidthOrigin);
+                            int copyLength = endKernelWidth - firstKernelWidth;
+                            if (copyLength > 0)
                             {
-                                int sourceHeight = sourceHeightOrigin + kh * dilationHeight;
-                                if ((uint)sourceHeight >= (uint)height) continue;
-                                int sourceRowBase = depthInputBase + sourceHeight * width;
-                                int destinationKernelRow = depthColumnBase + kh * kernelWidth;
-
-                                // The overwhelmingly common dilation-W=1 case is a contiguous
-                                // row slice. Copy it in bulk, clipping only the padded edges.
-                                if (dilationWidth == 1)
-                                {
-                                    int firstKernelWidth = Math.Max(0, -sourceWidthOrigin);
-                                    int endKernelWidth = Math.Min(kernelWidth, width - sourceWidthOrigin);
-                                    int copyLength = endKernelWidth - firstKernelWidth;
-                                    if (copyLength > 0)
-                                    {
-                                        Array.Copy(
-                                            input,
-                                            sourceRowBase + sourceWidthOrigin + firstKernelWidth,
-                                            columns,
-                                            destinationKernelRow + firstKernelWidth,
-                                            copyLength);
-                                    }
-                                    continue;
-                                }
-
-                                for (int kw = 0; kw < kernelWidth; kw++)
-                                {
-                                    int sourceWidth = sourceWidthOrigin + kw * dilationWidth;
-                                    if ((uint)sourceWidth < (uint)width)
-                                        columns[destinationKernelRow + kw] = input[sourceRowBase + sourceWidth];
-                                }
+                                Array.Copy(
+                                    input,
+                                    sourceRowBase + sourceWidthOrigin + firstKernelWidth,
+                                    columns,
+                                    destinationKernelRow + firstKernelWidth,
+                                    copyLength);
                             }
+                            continue;
+                        }
+
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            int sourceWidth = sourceWidthOrigin + kw * dilationWidth;
+                            if ((uint)sourceWidth < (uint)width)
+                                columns[destinationKernelRow + kw] = input[sourceRowBase + sourceWidth];
                         }
                     }
                 }

--- a/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
+++ b/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
@@ -401,9 +401,39 @@ internal sealed class PersistentParallelExecutor
         {
             int gm = CpuParallelSettings.MaxDegreeOfParallelism;
             int md = maxDop > 0 ? Math.Min(maxDop, gm) : gm;
-            System.Threading.Tasks.Parallel.For(0, numChunks,
-                new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, md) },
-                action);
+            try
+            {
+                System.Threading.Tasks.Parallel.For(0, numChunks,
+                    new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, md) },
+                    action);
+            }
+            catch (AggregateException aggregate)
+            {
+                // The cooperative executor exposes a worker's original exception. Parallel.For
+                // wraps the same failure in AggregateException, which made caller-visible behavior
+                // depend on the operational A/B switch. Preserve the raw exception contract when
+                // every worker reported the same exception family; retain AggregateException for
+                // genuinely heterogeneous concurrent failures.
+                var failures = aggregate.Flatten().InnerExceptions;
+                if (failures.Count > 0)
+                {
+                    Type failureType = failures[0].GetType();
+                    bool sameType = true;
+                    for (int i = 1; i < failures.Count; i++)
+                    {
+                        if (failures[i].GetType() != failureType)
+                        {
+                            sameType = false;
+                            break;
+                        }
+                    }
+
+                    if (sameType)
+                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failures[0]).Throw();
+                }
+
+                throw;
+            }
             return;
         }
 

--- a/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
+++ b/src/AiDotNet.Tensors/Helpers/PersistentParallelExecutor.cs
@@ -414,7 +414,10 @@ internal sealed class PersistentParallelExecutor
                 // depend on the operational A/B switch. Preserve the raw exception contract when
                 // every worker reported the same exception family; retain AggregateException for
                 // genuinely heterogeneous concurrent failures.
-                var failures = aggregate.Flatten().InnerExceptions;
+                // Inspect the outer Parallel.For wrapper only. Flattening would destroy an
+                // AggregateException intentionally thrown by the action and expose its leaf,
+                // while the cooperative backend rethrows that action AggregateException intact.
+                var failures = aggregate.InnerExceptions;
                 if (failures.Count > 0)
                 {
                     Type failureType = failures[0].GetType();

--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -484,6 +484,80 @@ public sealed class TensorArena : IDisposable
         return arr;
     }
 
+    /// <summary>
+    /// Promotes an already-rented arena tensor from scratch storage to the pinned tier.
+    /// </summary>
+    /// <remarks>
+    /// Parameter initialization commonly flows through an engine operation and only becomes
+    /// identifiable as long-lived when the layer calls <c>RegisterPersistentTensor</c>. At that
+    /// point the wrapper may already live in the resettable tensor ring. Leaving it there lets a
+    /// later layer-boundary reset reissue the SAME tensor object as scratch, including reshaping it
+    /// in place. Remove both the wrapper and its backing array from the resettable pools so model
+    /// state remains stable for the arena's lifetime.
+    /// </remarks>
+    internal void PinExistingTensor<T>(LinearAlgebra.Tensor<T> tensor)
+    {
+        if (_disposed || tensor is null)
+            return;
+
+        T[]? backing = tensor.GetLiveBackingArrayOrNull();
+        if (backing is null)
+            return;
+
+        bool ownedByArena = false;
+
+        if (_tensorRing is not null)
+        {
+            for (int bucketIndex = 0; bucketIndex < _tensorRingCount; bucketIndex++)
+            {
+                if (_tensorRing[bucketIndex] is not List<object> bucket)
+                    continue;
+
+                for (int itemIndex = 0; itemIndex < bucket.Count; itemIndex++)
+                {
+                    if (!ReferenceEquals(bucket[itemIndex], tensor))
+                        continue;
+
+                    bucket.RemoveAt(itemIndex);
+                    if (_tensorRingCursors![bucketIndex] > itemIndex)
+                        _tensorRingCursors[bucketIndex]--;
+                    ownedByArena = true;
+                    break;
+                }
+            }
+        }
+
+        for (int i = _ringBackingArrays.Count - 1; i >= 0; i--)
+        {
+            if (!ReferenceEquals(_ringBackingArrays[i].Arr, backing))
+                continue;
+            _ringBackingArrays.RemoveAt(i);
+            ownedByArena = true;
+        }
+
+        var scratchKey = (typeof(T), backing.Length);
+        if (_pool.TryGetValue(scratchKey, out var arrays))
+        {
+            for (int i = arrays.Count - 1; i >= 0; i--)
+            {
+                if (!ReferenceEquals(arrays[i], backing))
+                    continue;
+                arrays.RemoveAt(i);
+                if (_cursor[scratchKey] > i)
+                    _cursor[scratchKey]--;
+                ownedByArena = true;
+            }
+        }
+
+        if (!ownedByArena)
+            return;
+
+        for (int i = 0; i < _pinnedArrays.Count; i++)
+            if (ReferenceEquals(_pinnedArrays[i], backing))
+                return;
+        _pinnedArrays.Add(backing);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private T[]? TryAllocateCore<T>(int elementCount, bool clear)
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
@@ -36,7 +36,7 @@ internal static class StreamingEncoding
     /// quantized write-back is native-only); otherwise explicit opt-in.</summary>
     internal const byte Int8 = 2;
 
-    /// <summary>Lossless: SIMD byte-plane shuffle + Deflate (variable size). Exact
+    /// <summary>Lossless: SIMD byte-plane shuffle + LZ4 (variable size). Exact
     /// restore and exact re-encoding after mutation, ~1.18× on typical fp weights.
     /// The <c>Auto</c> default in training (bit-exact masters); otherwise explicit opt-in.</summary>
     internal const byte Lossless = 3;

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingEncoding.cs
@@ -37,8 +37,8 @@ internal static class StreamingEncoding
     internal const byte Int8 = 2;
 
     /// <summary>Lossless: SIMD byte-plane shuffle + Deflate (variable size). Exact
-    /// restore, ~1.18× on typical fp weights. The <c>Auto</c> default in training
-    /// (bit-exact masters); otherwise explicit opt-in.</summary>
+    /// restore and exact re-encoding after mutation, ~1.18× on typical fp weights.
+    /// The <c>Auto</c> default in training (bit-exact masters); otherwise explicit opt-in.</summary>
     internal const byte Lossless = 3;
 
     /// <summary>int4: AWQ/GPTQ-style GROUP-symmetric quantization — [int32 count][int32

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -531,6 +531,10 @@ internal static class StreamingStoreCodec
         // The production Linear layout uses K divisible by the even default group size. Encode a
         // block of output columns together so each source-row read is contiguous and the packed
         // destination cache lines remain hot. This is byte-identical to materializing Wᵀ first.
+        // THREAD-SAFETY INVARIANT: an even groupSize that divides sourceRows forces sourceRows to
+        // be even, so every packed byte lies inside one transposed output row. Column tiles never
+        // read-modify-write a shared nibble byte. Do not relax this guard for odd sourceRows
+        // without serializing the packing pass.
         if ((groupSize & 1) == 0 && sourceRows % groupSize == 0)
         {
             const int columnBlock = 64;
@@ -636,6 +640,10 @@ internal static class StreamingStoreCodec
         WriteInt32(dst, 0, count);
         WriteInt32(dst, 4, groupSize);
 
+        // THREAD-SAFETY INVARIANT: an even groupSize that divides sourceRows forces sourceRows to
+        // be even, so every packed byte lies inside one transposed output row. Column tiles never
+        // read-modify-write a shared nibble byte. Do not relax this guard for odd sourceRows
+        // without serializing the packing pass.
         if ((groupSize & 1) == 0 && sourceRows % groupSize == 0)
         {
             const int columnBlock = 64;

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -225,6 +225,123 @@ internal static class StreamingStoreCodec
         }
     }
 
+    /// <summary>
+    /// Fused transpose + per-output-row int8 encoding for a logical Linear weight
+    /// <c>[sourceRows, sourceColumns]</c>. Writes the kernel-ready <c>[sourceColumns, sourceRows]</c>
+    /// layout directly, avoiding a full-size transposed fp32 temporary. Output rows are independent
+    /// and are quantized in parallel for paper-scale weights.
+    /// </summary>
+    internal static void EncodeInt8TransposedFloat(
+        float[] src, byte[] dst, int sourceRows, int sourceColumns)
+    {
+        if (sourceRows <= 0 || sourceColumns <= 0 || (long)sourceRows * sourceColumns != src.Length)
+            throw new ArgumentException("int8 transposed encode dimensions must match src.Length.", nameof(src));
+        int dataOff = Int8HeaderBytes(sourceColumns);
+        WriteInt32(dst, 0, sourceColumns);
+
+        // One-output-column tasks walk src with a sourceColumns-sized stride. On a [4096,16384]
+        // projection that fetches a separate cache line for every scalar and made first-use encoding
+        // take tens of seconds. Work in cache-line-aligned column tiles instead: each source row is
+        // consumed contiguously while only a small set of destination cache lines stays hot.
+        const int columnBlock = 64;
+        int blockCount = (sourceColumns + columnBlock - 1) / columnBlock;
+        Helpers.CpuParallelSettings.LightweightParallel(blockCount, src.Length, block =>
+        {
+            int columnStart = block * columnBlock;
+            int width = Math.Min(columnBlock, sourceColumns - columnStart);
+            var maxima = new float[width];
+
+            for (int inputRow = 0; inputRow < sourceRows; inputRow++)
+            {
+                int sourceBase = inputRow * sourceColumns + columnStart;
+                for (int column = 0; column < width; column++)
+                {
+                    int sourceIndex = sourceBase + column;
+                    float value = src[sourceIndex];
+                    if (float.IsNaN(value) || float.IsInfinity(value))
+                        throw new ArgumentException(
+                            $"int8 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                            nameof(src));
+                    float magnitude = Math.Abs(value);
+                    if (magnitude > maxima[column]) maxima[column] = magnitude;
+                }
+            }
+
+            var inverses = new double[width];
+            for (int column = 0; column < width; column++)
+            {
+                float scale = maxima[column] > 0f ? maxima[column] / 127f : 1f;
+                WriteScaleAt(dst, 4 + (columnStart + column) * 4, scale);
+                inverses[column] = 1.0 / scale;
+            }
+
+            for (int inputRow = 0; inputRow < sourceRows; inputRow++)
+            {
+                int sourceBase = inputRow * sourceColumns + columnStart;
+                for (int column = 0; column < width; column++)
+                {
+                    int outputRow = columnStart + column;
+                    dst[dataOff + outputRow * sourceRows + inputRow]
+                        = QuantOne(src[sourceBase + column], inverses[column]);
+                }
+            }
+        });
+    }
+
+    /// <summary>fp64 counterpart of <see cref="EncodeInt8TransposedFloat"/>.</summary>
+    internal static void EncodeInt8TransposedDouble(
+        double[] src, byte[] dst, int sourceRows, int sourceColumns)
+    {
+        if (sourceRows <= 0 || sourceColumns <= 0 || (long)sourceRows * sourceColumns != src.Length)
+            throw new ArgumentException("int8 transposed encode dimensions must match src.Length.", nameof(src));
+        int dataOff = Int8HeaderBytes(sourceColumns);
+        WriteInt32(dst, 0, sourceColumns);
+
+        const int columnBlock = 64;
+        int blockCount = (sourceColumns + columnBlock - 1) / columnBlock;
+        Helpers.CpuParallelSettings.LightweightParallel(blockCount, src.Length, block =>
+        {
+            int columnStart = block * columnBlock;
+            int width = Math.Min(columnBlock, sourceColumns - columnStart);
+            var maxima = new double[width];
+
+            for (int inputRow = 0; inputRow < sourceRows; inputRow++)
+            {
+                int sourceBase = inputRow * sourceColumns + columnStart;
+                for (int column = 0; column < width; column++)
+                {
+                    int sourceIndex = sourceBase + column;
+                    double value = src[sourceIndex];
+                    if (double.IsNaN(value) || double.IsInfinity(value))
+                        throw new ArgumentException(
+                            $"int8 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                            nameof(src));
+                    double magnitude = Math.Abs(value);
+                    if (magnitude > maxima[column]) maxima[column] = magnitude;
+                }
+            }
+
+            var inverses = new double[width];
+            for (int column = 0; column < width; column++)
+            {
+                float scale = maxima[column] > 0.0 ? (float)(maxima[column] / 127.0) : 1f;
+                WriteScaleAt(dst, 4 + (columnStart + column) * 4, scale);
+                inverses[column] = 1.0 / scale;
+            }
+
+            for (int inputRow = 0; inputRow < sourceRows; inputRow++)
+            {
+                int sourceBase = inputRow * sourceColumns + columnStart;
+                for (int column = 0; column < width; column++)
+                {
+                    int outputRow = columnStart + column;
+                    dst[dataOff + outputRow * sourceRows + inputRow]
+                        = QuantOne(src[sourceBase + column], inverses[column]);
+                }
+            }
+        });
+    }
+
     /// <summary>per-row int8 → fp32 (dequant fallback). <paramref name="src"/> is the encoded buffer.</summary>
     internal static void DecodeInt8Float(ReadOnlySpan<byte> src, Span<float> dst)
     {
@@ -388,6 +505,225 @@ internal static class StreamingStoreCodec
             double inv = 1.0 / scale;
             for (int j = 0; j < len; j++) PackNibble(dst, dataOff, baseI + j, QuantOneInt4(src[baseI + j], inv));
         }
+    }
+
+    /// <summary>
+    /// Fused transpose + int4 group encoding for a logical Linear weight
+    /// <c>[sourceRows, sourceColumns]</c>. The encoded element at flat index <c>i</c> is read from
+    /// the corresponding position in the transposed <c>[sourceColumns, sourceRows]</c> view, so no
+    /// full-size floating-point transpose is allocated. Even-sized groups occupy disjoint packed
+    /// bytes and can therefore be encoded independently in parallel.
+    /// </summary>
+    internal static void EncodeInt4TransposedFloat(
+        float[] src, byte[] dst, int sourceRows, int sourceColumns, int groupSize)
+    {
+        if (sourceRows <= 0 || sourceColumns <= 0 || (long)sourceRows * sourceColumns != src.Length)
+            throw new ArgumentException("int4 transposed encode dimensions must match src.Length.", nameof(src));
+        if (groupSize <= 0)
+            throw new ArgumentException($"int4 encode: groupSize ({groupSize}) must be > 0.", nameof(groupSize));
+
+        int count = src.Length;
+        int numGroups = Int4NumGroups(count, groupSize);
+        int dataOff = Int4HeaderBytes(numGroups);
+        WriteInt32(dst, 0, count);
+        WriteInt32(dst, 4, groupSize);
+
+        // The production Linear layout uses K divisible by the even default group size. Encode a
+        // block of output columns together so each source-row read is contiguous and the packed
+        // destination cache lines remain hot. This is byte-identical to materializing Wᵀ first.
+        if ((groupSize & 1) == 0 && sourceRows % groupSize == 0)
+        {
+            const int columnBlock = 64;
+            int blockCount = (sourceColumns + columnBlock - 1) / columnBlock;
+            Helpers.CpuParallelSettings.LightweightParallel(blockCount, count, block =>
+            {
+                int columnStart = block * columnBlock;
+                int width = Math.Min(columnBlock, sourceColumns - columnStart);
+                var maxima = new float[width];
+                var inverses = new double[width];
+
+                for (int rowStart = 0; rowStart < sourceRows; rowStart += groupSize)
+                {
+                    Array.Clear(maxima, 0, width);
+                    for (int inputRow = rowStart; inputRow < rowStart + groupSize; inputRow++)
+                    {
+                        int sourceBase = inputRow * sourceColumns + columnStart;
+                        for (int column = 0; column < width; column++)
+                        {
+                            int sourceIndex = sourceBase + column;
+                            float value = src[sourceIndex];
+                            if (float.IsNaN(value) || float.IsInfinity(value))
+                                throw new ArgumentException(
+                                    $"int4 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                                    nameof(src));
+                            float magnitude = Math.Abs(value);
+                            if (magnitude > maxima[column]) maxima[column] = magnitude;
+                        }
+                    }
+
+                    for (int column = 0; column < width; column++)
+                    {
+                        float scale = maxima[column] > 0f ? maxima[column] / 7f : 1f;
+                        int transposedIndex = (columnStart + column) * sourceRows + rowStart;
+                        WriteScaleAt(dst, 8 + (transposedIndex / groupSize) * 4, scale);
+                        inverses[column] = 1.0 / scale;
+                    }
+
+                    for (int inputRow = rowStart; inputRow < rowStart + groupSize; inputRow++)
+                    {
+                        int sourceBase = inputRow * sourceColumns + columnStart;
+                        for (int column = 0; column < width; column++)
+                        {
+                            int transposedIndex = (columnStart + column) * sourceRows + inputRow;
+                            PackNibble(dst, dataOff, transposedIndex,
+                                QuantOneInt4(src[sourceBase + column], inverses[column]));
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        void EncodeGroup(int group)
+        {
+            int baseI = group * groupSize;
+            int len = Math.Min(groupSize, count - baseI);
+            float amax = 0f;
+            for (int j = 0; j < len; j++)
+            {
+                int transposedIndex = baseI + j;
+                int sourceIndex = (transposedIndex % sourceRows) * sourceColumns
+                    + transposedIndex / sourceRows;
+                float value = src[sourceIndex];
+                if (float.IsNaN(value) || float.IsInfinity(value))
+                    throw new ArgumentException(
+                        $"int4 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                        nameof(src));
+                float magnitude = Math.Abs(value);
+                if (magnitude > amax) amax = magnitude;
+            }
+
+            float scale = amax > 0f ? amax / 7f : 1f;
+            WriteScaleAt(dst, 8 + group * 4, scale);
+            double inv = 1.0 / scale;
+            for (int j = 0; j < len; j++)
+            {
+                int transposedIndex = baseI + j;
+                int sourceIndex = (transposedIndex % sourceRows) * sourceColumns
+                    + transposedIndex / sourceRows;
+                PackNibble(dst, dataOff, transposedIndex, QuantOneInt4(src[sourceIndex], inv));
+            }
+        }
+
+        if ((groupSize & 1) == 0)
+            Helpers.CpuParallelSettings.LightweightParallel(numGroups, count, EncodeGroup);
+        else
+            for (int group = 0; group < numGroups; group++) EncodeGroup(group);
+    }
+
+    /// <summary>fp64 counterpart of <see cref="EncodeInt4TransposedFloat"/>.</summary>
+    internal static void EncodeInt4TransposedDouble(
+        double[] src, byte[] dst, int sourceRows, int sourceColumns, int groupSize)
+    {
+        if (sourceRows <= 0 || sourceColumns <= 0 || (long)sourceRows * sourceColumns != src.Length)
+            throw new ArgumentException("int4 transposed encode dimensions must match src.Length.", nameof(src));
+        if (groupSize <= 0)
+            throw new ArgumentException($"int4 encode: groupSize ({groupSize}) must be > 0.", nameof(groupSize));
+
+        int count = src.Length;
+        int numGroups = Int4NumGroups(count, groupSize);
+        int dataOff = Int4HeaderBytes(numGroups);
+        WriteInt32(dst, 0, count);
+        WriteInt32(dst, 4, groupSize);
+
+        if ((groupSize & 1) == 0 && sourceRows % groupSize == 0)
+        {
+            const int columnBlock = 64;
+            int blockCount = (sourceColumns + columnBlock - 1) / columnBlock;
+            Helpers.CpuParallelSettings.LightweightParallel(blockCount, count, block =>
+            {
+                int columnStart = block * columnBlock;
+                int width = Math.Min(columnBlock, sourceColumns - columnStart);
+                var maxima = new double[width];
+                var inverses = new double[width];
+
+                for (int rowStart = 0; rowStart < sourceRows; rowStart += groupSize)
+                {
+                    Array.Clear(maxima, 0, width);
+                    for (int inputRow = rowStart; inputRow < rowStart + groupSize; inputRow++)
+                    {
+                        int sourceBase = inputRow * sourceColumns + columnStart;
+                        for (int column = 0; column < width; column++)
+                        {
+                            int sourceIndex = sourceBase + column;
+                            double value = src[sourceIndex];
+                            if (double.IsNaN(value) || double.IsInfinity(value))
+                                throw new ArgumentException(
+                                    $"int4 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                                    nameof(src));
+                            double magnitude = Math.Abs(value);
+                            if (magnitude > maxima[column]) maxima[column] = magnitude;
+                        }
+                    }
+
+                    for (int column = 0; column < width; column++)
+                    {
+                        float scale = maxima[column] > 0.0 ? (float)(maxima[column] / 7.0) : 1f;
+                        int transposedIndex = (columnStart + column) * sourceRows + rowStart;
+                        WriteScaleAt(dst, 8 + (transposedIndex / groupSize) * 4, scale);
+                        inverses[column] = 1.0 / scale;
+                    }
+
+                    for (int inputRow = rowStart; inputRow < rowStart + groupSize; inputRow++)
+                    {
+                        int sourceBase = inputRow * sourceColumns + columnStart;
+                        for (int column = 0; column < width; column++)
+                        {
+                            int transposedIndex = (columnStart + column) * sourceRows + inputRow;
+                            PackNibble(dst, dataOff, transposedIndex,
+                                QuantOneInt4(src[sourceBase + column], inverses[column]));
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        void EncodeGroup(int group)
+        {
+            int baseI = group * groupSize;
+            int len = Math.Min(groupSize, count - baseI);
+            double amax = 0.0;
+            for (int j = 0; j < len; j++)
+            {
+                int transposedIndex = baseI + j;
+                int sourceIndex = (transposedIndex % sourceRows) * sourceColumns
+                    + transposedIndex / sourceRows;
+                double value = src[sourceIndex];
+                if (double.IsNaN(value) || double.IsInfinity(value))
+                    throw new ArgumentException(
+                        $"int4 streaming-store encoder cannot encode non-finite value at index {sourceIndex} (got {value}).",
+                        nameof(src));
+                double magnitude = Math.Abs(value);
+                if (magnitude > amax) amax = magnitude;
+            }
+
+            float scale = amax > 0.0 ? (float)(amax / 7.0) : 1f;
+            WriteScaleAt(dst, 8 + group * 4, scale);
+            double inv = 1.0 / scale;
+            for (int j = 0; j < len; j++)
+            {
+                int transposedIndex = baseI + j;
+                int sourceIndex = (transposedIndex % sourceRows) * sourceColumns
+                    + transposedIndex / sourceRows;
+                PackNibble(dst, dataOff, transposedIndex, QuantOneInt4(src[sourceIndex], inv));
+            }
+        }
+
+        if ((groupSize & 1) == 0)
+            Helpers.CpuParallelSettings.LightweightParallel(numGroups, count, EncodeGroup);
+        else
+            for (int group = 0; group < numGroups; group++) EncodeGroup(group);
     }
 
     /// <summary>int4 group-quant → fp32 (dequant). <paramref name="src"/> is the encoded buffer.</summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -314,7 +314,7 @@ public sealed class StreamingTensorPool : IDisposable
             // The new bytes have NOT been written to the backing file, so force the
             // next eviction to (re-)write them rather than dropping the resident copy
             // as if the file already held it. Also reset the compressed/uncompressed
-            // metadata: the caller supplies the canonical (native-encoded) bytes, so a
+            // metadata: the caller supplies canonical native or lossless bytes, so a
             // prior compressed page-out's sizes no longer describe this content.
             entry.BackingFileCurrent = false;
             entry.IsCompressed = false;

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -23,6 +23,10 @@ internal interface IStreamingDroppable
     /// -1 when not registered.</summary>
     long StreamingPoolHandle { get; }
 
+    /// <summary>Whether the pool encoding is an immutable quantized inference format whose
+    /// registered snapshot remains authoritative without write-back.</summary>
+    bool StreamingStoreIsReadOnly { get; }
+
     /// <summary>Drops this tensor's resident in-memory data (the streaming
     /// pool keeps the canonical copy). Returns <c>false</c> without dropping
     /// when the storage is still shared (refcount &gt; 1) — e.g. an autodiff
@@ -32,7 +36,8 @@ internal interface IStreamingDroppable
     /// <summary>Re-serializes this tensor's CURRENT resident data into its streaming-pool entry
     /// under the same handle, so a later drop + rehydrate returns the current (possibly mutated)
     /// values rather than the stale snapshot taken at register time (#1715). Returns <c>false</c>
-    /// (no-op) when the weight isn't a resident, full-precision streaming weight. Call BEFORE
+    /// (no-op) when the weight isn't resident or its encoding is not writable. Native and lossless
+    /// stores are writable; quantized inference stores are rejected before mutation. Call BEFORE
     /// dropping a mutated streaming weight so the mutation is not lost.</summary>
     bool TryWriteBackResidentForStreaming();
 }
@@ -531,8 +536,9 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         // If this tensor was aliasing a zero-copy mmap slice, the mapping is no
         // longer referenced once storage is dropped — release it now.
         DisposeStreamingMmapOwner();
-        // Drop any no-upcast int8 weight too — the pool holds the canonical bytes.
+        // Drop any no-upcast quantized weight too — the pool holds the canonical bytes.
         StreamingInt8 = null;
+        StreamingInt4 = null;
         _data = Vector<T>.Empty();
         _storage = new TensorStorage<T>(_data);
         return true;
@@ -548,24 +554,29 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
 
     long IStreamingDroppable.StreamingPoolHandle => StreamingPoolHandle;
 
+    bool IStreamingDroppable.StreamingStoreIsReadOnly
+        => StreamingStoreEncoding != StreamingEncoding.Native
+            && StreamingStoreEncoding != StreamingEncoding.Lossless;
+
     bool IStreamingDroppable.TryWriteBackResidentForStreaming() => TryWriteBackResidentForStreaming();
 
     /// <summary>
     /// Re-serializes this tensor's current resident data into its streaming-pool entry (#1715).
-    /// Native (full-precision) streaming weights only: a lossy store (bf16/int8/int4) is taken by
-    /// read-only inference and its owner is never mutated, so skip it; a non-resident / view / quant
-    /// tensor has nothing to write back. The new bytes overwrite the pool entry under the same handle
-    /// (marked dirty), so the next eviction persists them to disk and a later <c>Materialize</c>
-    /// rehydrates the mutation instead of the stale register-time snapshot.
+    /// Native (full-precision) and lossless streaming weights only: a lossy store (bf16/int8/int4)
+    /// is read-only and rejected by <see cref="EnsureOwnedForWrite"/> before mutation. A non-resident,
+    /// view, or quantized tensor has nothing to write back. The new bytes overwrite the pool entry
+    /// under the same handle (marked dirty), so the next eviction persists them to disk and a later
+    /// <c>Materialize</c> rehydrates the mutation instead of the stale register-time snapshot.
     /// </summary>
     internal bool TryWriteBackResidentForStreaming()
     {
         if (StreamingPoolHandle < 0) return false;
-        if (StreamingStoreEncoding != StreamingEncoding.Native) return false;
+        if (StreamingStoreEncoding != StreamingEncoding.Native
+            && StreamingStoreEncoding != StreamingEncoding.Lossless) return false;
         if (DataVector.Length != Length) return false;            // already dropped / no-upcast quant
         if (!IsContiguous || _storageOffset != 0 || IsView) return false;
         // Streaming weights are concrete Tensor<T>; serialization needs the concrete type.
-        return this is Tensor<T> concrete && WeightRegistry.WriteBackResidentNative(concrete);
+        return this is Tensor<T> concrete && WeightRegistry.WriteBackResident(concrete);
     }
 
     /// <summary>
@@ -2675,6 +2686,22 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// </summary>
     protected void EnsureOwnedForWrite()
     {
+        // bf16/int8/int4 are read-only inference encodings. Their pool entry is the canonical
+        // quantized snapshot, and re-encoding an arbitrary mutation would compound quantization
+        // error on every eviction. Failing at the common writable-storage gate covers indexers,
+        // CopyFromArray, engine spans, retained backing arrays, and in-place kernels instead of
+        // accepting an update that a later eviction would silently discard. Lossless is writable:
+        // its exact re-encoder is used by TryWriteBackResidentForStreaming.
+        if (StreamingPoolHandle >= 0
+            && StreamingStoreEncoding != StreamingEncoding.Native
+            && StreamingStoreEncoding != StreamingEncoding.Lossless)
+        {
+            throw new InvalidOperationException(
+                "Cannot mutate a streaming tensor stored with a quantized inference encoding " +
+                "(bf16, int8, or int4). Configure StreamingStoreDtype.FullPrecision or Lossless " +
+                "before registering weights that will be updated.");
+        }
+
         var family = _cowFamily;
         if (family is null) return;
         family.DetachForWrite(this);

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -1827,12 +1827,21 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     {
         get
         {
+            // Multi-dimensional indexing is a value read just like GetFlat / AsSpan. A
+            // streaming weight may have retained its logical shape while its resident
+            // storage was dropped, so rehydrate before indexing the backing vector.
+            // Without this gate, t[i, j] reads an empty Vector even though t[i] works.
+            EnsureMaterialized();
             ThrowIfSparse();
             ValidateIndices(indices);
             return _data[GetFlatIndex(indices)];
         }
         set
         {
+            // Preserve every value other than the element being replaced when a streamed
+            // tensor is currently paged out. EnsureOwnedForWrite handles COW ownership,
+            // but it cannot restore the canonical bytes from the streaming pool.
+            EnsureMaterialized();
             ThrowIfSparse();
             ValidateIndices(indices);
             EnsureOwnedForWrite();

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -99,6 +99,14 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     }
 
     /// <summary>
+    /// Returns the CPU backing array solely for cache identity and deferred-materialization state
+    /// checks. Unlike <see cref="DataVector"/>, this owner-mediated path does not advertise mutable
+    /// vector access; callers must treat the returned array as read-only.
+    /// </summary>
+    internal T[]? GetBackingArrayForCacheLookupUnsafe()
+        => _data.GetBackingArrayForReadOnlyAccess();
+
+    /// <summary>
     /// The no-upcast resident form of a streaming int8 weight (int8 + per-row scales). Non-null
     /// only between materializing an int8-stored weight for inference and dropping it. The engine
     /// matmul fast path reads this directly (feeds the int8 GEMM, no dequant); any fp32 access
@@ -2250,7 +2258,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         // before the caller touches the buffer.
         if (_device != TensorDevice.CPU)
             return null;
-        return _storage.TryGetBackingArraySegment(out var array, out int baseOffset)
+        return _storage.TryGetBackingArraySegmentForReadOnlyAccess(out var array, out int baseOffset)
             && baseOffset == 0
             ? array
             : null;
@@ -2332,7 +2340,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             storageOffset = 0;
             return null;
         }
-        if (_storage.TryGetBackingArraySegment(out var array, out int baseOffset))
+        if (_storage.TryGetBackingArraySegmentForReadOnlyAccess(out var array, out int baseOffset))
         {
             storageOffset = checked(baseOffset + _storageOffset);
             return array;

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -40,6 +40,11 @@ internal interface IStreamingDroppable
     /// stores are writable; quantized inference stores are rejected before mutation. Call BEFORE
     /// dropping a mutated streaming weight so the mutation is not lost.</summary>
     bool TryWriteBackResidentForStreaming();
+
+    /// <summary>Promotes a quantized inference snapshot to an exact writable streaming
+    /// encoding before a model enters training. Implemented on the closed generic owner so
+    /// the non-generic registry can migrate mixed element types one tensor at a time.</summary>
+    void PromoteStreamingStoreForTraining();
 }
 
 /// <summary>
@@ -559,6 +564,12 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
             && StreamingStoreEncoding != StreamingEncoding.Lossless;
 
     bool IStreamingDroppable.TryWriteBackResidentForStreaming() => TryWriteBackResidentForStreaming();
+
+    void IStreamingDroppable.PromoteStreamingStoreForTraining()
+    {
+        if (this is Tensor<T> tensor)
+            WeightRegistry.PromoteStoreForTraining(tensor);
+    }
 
     /// <summary>
     /// Re-serializes this tensor's current resident data into its streaming-pool entry (#1715).

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -86,7 +86,17 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// Internal accessor for the backing vector. Used by DirectGpuTensorEngine to check
     /// activation cache without triggering CPU materialization.
     /// </summary>
-    internal Vector<T> DataVector => _data;
+    internal Vector<T> DataVector
+    {
+        get
+        {
+            // DataVector is intentionally available to trusted engine code, but the returned
+            // Vector is mutable. Attach the tensor owner's guard before exposing it so a direct
+            // AsWritableSpan/indexer/in-place call cannot bypass streaming or COW safety.
+            _data.SetBeforeWriteGuard(EnsureDataVectorWriteAllowed);
+            return _data;
+        }
+    }
 
     /// <summary>
     /// The no-upcast resident form of a streaming int8 weight (int8 + per-row scales). Non-null
@@ -2695,7 +2705,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// shares storage with an independent family. Moving the whole family preserves the normal
     /// rule that writes through a source or any of its metadata views remain mutually visible.
     /// </summary>
-    protected void EnsureOwnedForWrite()
+    private void EnsureStreamingStoreWritable()
     {
         // bf16/int8/int4 are read-only inference encodings. Their pool entry is the canonical
         // quantized snapshot, and re-encoding an arbitrary mutation would compound quantization
@@ -2712,6 +2722,23 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
                 "(bf16, int8, or int4). Configure StreamingStoreDtype.FullPrecision or Lossless " +
                 "before registering weights that will be updated.");
         }
+    }
+
+    /// <summary>Validates mutations attempted through the trusted backing-vector accessor.</summary>
+    private void EnsureDataVectorWriteAllowed()
+    {
+        EnsureStreamingStoreWritable();
+        if (_cowFamily?.RequiresDetach == true)
+        {
+            throw new InvalidOperationException(
+                "Cannot mutate a copy-on-write tensor through DataVector. Use the tensor writable " +
+                "span or indexer so its alias family can detach before the write.");
+        }
+    }
+
+    protected void EnsureOwnedForWrite()
+    {
+        EnsureStreamingStoreWritable();
 
         var family = _cowFamily;
         if (family is null) return;

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -250,6 +250,11 @@ internal sealed class TensorStorage<T>
     internal bool TryGetBackingArraySegment(out T[]? array, out int offset)
         => _data.TryGetBackingArraySegment(out array, out offset);
 
+    /// <summary>Read-only backing lookup that does not request a mutable vector escape.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetBackingArraySegmentForReadOnlyAccess(out T[]? array, out int offset)
+        => _data.TryGetBackingArraySegmentForReadOnlyAccess(out array, out offset);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfReadOnlyMapped()
     {

--- a/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
@@ -39,6 +39,19 @@ public abstract class VectorBase<T>
     private int _logicalLength;
 
     /// <summary>
+    /// Optional owner-supplied guard invoked before this vector exposes mutable storage. Tensor
+    /// owners use it to enforce streaming-store and copy-on-write invariants even when trusted
+    /// engine code reaches the backing vector directly.
+    /// </summary>
+    private System.Action? _beforeWrite;
+
+    /// <summary>Installs the owner validation that must run before mutable storage is exposed.</summary>
+    internal void SetBeforeWriteGuard(System.Action? beforeWrite)
+    {
+        _beforeWrite = beforeWrite;
+    }
+
+    /// <summary>
     /// Optional memory owner for pooled memory management.
     /// When set, the vector's memory comes from a pool and should be returned when disposed.
     /// </summary>
@@ -254,6 +267,7 @@ public abstract class VectorBase<T>
         set
         {
             ValidateIndex(index);
+            _beforeWrite?.Invoke();
             EnsureMaterialized();
             _memory.Span[index] = value;
         }
@@ -334,6 +348,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     internal Span<T> AsWritableSpan()
     {
+        _beforeWrite?.Invoke();
         EnsureMaterialized();
         return _memory.Span;
     }
@@ -407,6 +422,7 @@ public abstract class VectorBase<T>
     /// </summary>
     internal T[] GetDataArray()
     {
+        _beforeWrite?.Invoke();
         // GPU-resident lazy allocation: allocate backing array on first CPU access
         if (IsLazyAllocated)
         {
@@ -466,6 +482,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     internal Memory<T> AsWritableMemory()
     {
+        _beforeWrite?.Invoke();
         EnsureMaterialized();
         return _memory;
     }
@@ -826,6 +843,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     public virtual void AddInPlace(VectorBase<T> other)
     {
+        _beforeWrite?.Invoke();
         if (Length != other.Length)
             throw new ArgumentException("Vectors must have the same length");
 
@@ -938,6 +956,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     public virtual void SubtractInPlace(VectorBase<T> other)
     {
+        _beforeWrite?.Invoke();
         if (Length != other.Length)
             throw new ArgumentException("Vectors must have the same length");
 
@@ -1042,6 +1061,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     public virtual void MultiplyInPlace(T scalar)
     {
+        _beforeWrite?.Invoke();
 #if NET5_0_OR_GREATER
         var arr = _cachedArray;
         if (arr is not null)
@@ -1137,6 +1157,7 @@ public abstract class VectorBase<T>
     /// </remarks>
     public virtual void DivideInPlace(T scalar)
     {
+        _beforeWrite?.Invoke();
         EnsureMaterialized();
         _numOps.DivideScalar(_memory.Span, scalar, _memory.Span);
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
@@ -378,7 +378,19 @@ public abstract class VectorBase<T>
     /// </summary>
     internal T[]? GetBackingArrayUnsafe()
     {
-        return TryGetBackingArraySegment(out var array, out int offset) && offset == 0
+        _beforeWrite?.Invoke();
+        return TryGetBackingArraySegmentForReadOnlyAccess(out var array, out int offset) && offset == 0
+            ? array
+            : null;
+    }
+
+    /// <summary>
+    /// Gets the backing array for identity/cache lookup without granting mutation through a
+    /// tensor's guarded <c>DataVector</c> surface. Callers must treat the result as read-only.
+    /// </summary>
+    internal T[]? GetBackingArrayForReadOnlyAccess()
+    {
+        return TryGetBackingArraySegmentForReadOnlyAccess(out var array, out int offset) && offset == 0
             ? array
             : null;
     }
@@ -394,6 +406,16 @@ public abstract class VectorBase<T>
     /// historically caused compiled kernels to bind a copied snapshot.
     /// </remarks>
     internal bool TryGetBackingArraySegment(out T[]? array, out int offset)
+    {
+        _beforeWrite?.Invoke();
+        return TryGetBackingArraySegmentForReadOnlyAccess(out array, out offset);
+    }
+
+    /// <summary>
+    /// Read-only owner-mediated counterpart used by tensor cache and strided-read paths. The
+    /// returned managed array must never be mutated by the caller.
+    /// </summary>
+    internal bool TryGetBackingArraySegmentForReadOnlyAccess(out T[]? array, out int offset)
     {
         if (_cachedArray is not null)
         {

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -787,7 +787,7 @@ public static class WeightRegistry
                 //   • training → LOSSLESS (byte-shuffle + Deflate): bit-exact, so the fp32/fp64
                 //     masters are preserved EXACTLY (no convergence risk) while still reclaiming
                 //     ~1.18x. The quantized tiers are NEVER chosen here: their eviction write-back
-                //     is native-only (TryWriteBackResidentForStreaming), so a mutated quantized
+                //     is unsupported (TryWriteBackResidentForStreaming), so a mutated quantized
                 //     weight would silently lose its update. Inference weights are read-only, so
                 //     the quantized tiers below are safe only in that mode.
                 //   • inference → RAM-aware (ResolveAutoInferenceEncoding): bf16 by default, but
@@ -1255,19 +1255,33 @@ public static class WeightRegistry
     }
 
     /// <summary>
-    /// Re-serializes a resident, native-encoded streaming weight's CURRENT data into its pool entry
+    /// Re-serializes a resident, writable streaming weight's CURRENT data into its pool entry
     /// under the same handle (#1715). Called by <see cref="Tensor{T}.TryWriteBackResidentForStreaming"/>
     /// before a mutated weight is dropped, so the mutation reaches disk and a later
     /// <see cref="Materialize{T}"/> rehydrates it rather than the stale register-time snapshot.
     /// </summary>
-    internal static bool WriteBackResidentNative<T>(Tensor<T> weight)
+    internal static bool WriteBackResident<T>(Tensor<T> weight)
     {
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (weight.StreamingPoolHandle < 0) return false;
         if (weight.DataVector.Length != weight.Length) return false;
-        int byteCount = CheckedStreamingByteCount<T>(weight.Length);
-        var bytes = new byte[byteCount];
-        SerializeToBytes(weight, bytes, StreamingEncoding.Native, stochastic: false);
+        byte[] bytes;
+        if (weight.StreamingStoreEncoding == StreamingEncoding.Lossless)
+        {
+            // Training's Auto tier is lossless. Re-encode the current values exactly so an
+            // optimizer update survives owner shedding and the variable-size entry remains valid.
+            bytes = SerializeLossless(weight);
+        }
+        else if (weight.StreamingStoreEncoding == StreamingEncoding.Native)
+        {
+            int byteCount = CheckedStreamingByteCount<T>(weight.Length);
+            bytes = new byte[byteCount];
+            SerializeToBytes(weight, bytes, StreamingEncoding.Native, stochastic: false);
+        }
+        else
+        {
+            return false;
+        }
         StreamingTensorPool pool;
         lock (_lock) { pool = StreamingPoolUnlocked(); }
         pool.ReplaceEntryData(weight.StreamingPoolHandle, bytes);
@@ -1316,19 +1330,21 @@ public static class WeightRegistry
             long victim = victimNode.Value;
             _materializedBytes.TryGetValue(victim, out long victimBytes);
 
-            // Persist + drop the coldest owner, but only UNTRACK it after both succeed. If write-back
-            // returns false (non-native/aliased — nothing to persist) or the drop returns false
-            // (shared refcount), the owner must stay resident AND accounted; untracking it first
-            // would leak its bytes from the budget (the resident copy still exists). Order: write-back
-            // FIRST so the dropped bytes are recoverable from the pool/disk.
+            // Persist + drop the coldest owner, but only UNTRACK it after both succeed. Quantized
+            // inference owners are immutable, so their pool snapshot is already authoritative;
+            // native/lossless owners must write back successfully first. A write-back failure or
+            // shared refcount leaves the owner resident AND accounted so no mutation can be lost.
             bool shed;
             if (_ownerByHandle.TryGetValue(victim, out var weak) && weak.TryGetTarget(out var owner))
             {
-                bool wroteBack = false;
-                try { wroteBack = owner.TryWriteBackResidentForStreaming(); }
-                catch { /* best-effort */ }
+                bool safeToDrop = owner.StreamingStoreIsReadOnly;
+                if (!safeToDrop)
+                {
+                    try { safeToDrop = owner.TryWriteBackResidentForStreaming(); }
+                    catch { /* leave resident + accounted; correctness beats the soft budget */ }
+                }
                 shed = false;
-                if (wroteBack)
+                if (safeToDrop)
                 {
                     try { shed = owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
                     catch { /* shared refcount → leave resident + accounted */ }
@@ -1339,7 +1355,7 @@ public static class WeightRegistry
                 shed = true; // dead owner: no resident copy remains to account
             }
 
-            // Coldest owner can't be shed yet (non-native, or shared ref) — stop. Bounding is
+            // Coldest owner can't be shed yet (write-back failed, or shared ref) — stop. Bounding is
             // best-effort; never untrack/forget a still-resident owner.
             if (!shed) break;
             _materializedLru.Remove(victimNode);
@@ -2262,18 +2278,22 @@ public static class WeightRegistry
                 // #1715: the pool just paged out this handle's snapshot taken at register time. If the
                 // owner MUTATED its resident copy since (a GetParameters round-trip / optimizer step),
                 // that snapshot is stale — write the owner's CURRENT bytes back BEFORE dropping so a
-                // later Materialize rehydrates the mutation, not the stale value. Native-gated inside
-                // TryWriteBackResidentForStreaming, so read-only inference (bf16/quant store) is a no-op.
-                // Unlike the materialized-owner SHED loop (NoteMaterializedAndShed), the drop here is safe
-                // regardless of the write-back RESULT: a native owner's write-back persists the mutation
-                // before the drop, and a non-native owner's resident copy is a re-derivable dequant of the
-                // pool's quantized snapshot (re-materialize re-derives it) — so the snapshot stays
-                // authoritative either way. (Training uses the FullPrecision/native store, so a mutated
-                // owner is always native and always writes back.)
-                try { owner.TryWriteBackResidentForStreaming(); }
-                catch { /* best-effort write-back; never block the drop */ }
-                try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
-                catch (InvalidOperationException) { /* not droppable (view/non-contiguous) — leave resident */ }
+                // later Materialize rehydrates the mutation, not the stale value. Writable-encoding-gated
+                // inside TryWriteBackResidentForStreaming, so read-only inference (bf16/int8/int4) is a no-op.
+                // A quantized owner is immutable, so its registered snapshot remains authoritative.
+                // A native/lossless owner may have changed and is dropped only after exact write-back
+                // succeeds. Never convert a persistence failure into silent parameter loss.
+                bool safeToDrop = owner.StreamingStoreIsReadOnly;
+                if (!safeToDrop)
+                {
+                    try { safeToDrop = owner.TryWriteBackResidentForStreaming(); }
+                    catch { /* leave resident; correctness beats reclaiming this owner */ }
+                }
+                if (safeToDrop)
+                {
+                    try { owner.TryDropStorageForStreaming(throwOnSharedRefcount: false); }
+                    catch (InvalidOperationException) { /* not droppable (view/non-contiguous) — leave resident */ }
+                }
             }
         }
     }

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -650,7 +650,57 @@ public static class WeightRegistry
     /// </summary>
     public static void SetStreamingExecutionTraining(bool? isTraining)
     {
-        lock (_lock) { _streamingTrainingMode = isTraining; }
+        List<IStreamingDroppable>? ownersToPromote = null;
+        lock (_lock)
+        {
+            _streamingTrainingMode = isTraining;
+            if (isTraining == true && _ownerByHandle.Count > 0)
+            {
+                ownersToPromote = new List<IStreamingDroppable>(_ownerByHandle.Count);
+                foreach (var weak in _ownerByHandle.Values)
+                {
+                    if (weak.TryGetTarget(out var owner) && owner.StreamingStoreIsReadOnly)
+                        ownersToPromote.Add(owner);
+                }
+            }
+        }
+
+        // Do not hold the registry lock while decoding or replacing pool entries. Materialize
+        // takes the pool lock and may drain owner state back through the registry; keeping the
+        // outer lock here would invert that ordering. Promote one owner at a time so switching a
+        // foundation model from Predict to Train never materializes the full parameter set.
+        if (ownersToPromote is not null)
+        {
+            foreach (var owner in ownersToPromote)
+                owner.PromoteStreamingStoreForTraining();
+            DrainOwnerDropsAfterEviction();
+        }
+    }
+
+    /// <summary>
+    /// Converts one already-registered quantized inference weight to the exact lossless training
+    /// store under the same handle. The current execution mode must already be training so
+    /// <see cref="Materialize{T}"/> decodes int8/int4 into a writable floating-point owner rather
+    /// than attaching the no-upcast inference form.
+    /// </summary>
+    internal static void PromoteStoreForTraining<T>(Tensor<T> weight)
+    {
+        if (weight is null) throw new ArgumentNullException(nameof(weight));
+        if (weight.Lifetime != WeightLifetime.Streaming || weight.StreamingPoolHandle < 0) return;
+        if (weight.StreamingStoreEncoding == StreamingEncoding.Native
+            || weight.StreamingStoreEncoding == StreamingEncoding.Lossless) return;
+
+        Materialize(weight);
+        byte[] bytes = SerializeLossless(weight);
+        StreamingTensorPool pool;
+        lock (_lock) { pool = StreamingPoolUnlocked(); }
+        pool.ReplaceEntryData(weight.StreamingPoolHandle, bytes);
+        weight.StreamingStoreEncoding = StreamingEncoding.Lossless;
+
+        // The pool now owns the exact decoded snapshot. Drop this temporary owner before moving
+        // to the next weight; a failed drop merely leaves one writable tensor resident and is
+        // retried by the normal deferred-drop lifecycle.
+        ReleaseToPool(weight);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -1523,6 +1523,18 @@ public static class WeightRegistry
                 return;
             }
         }
+        // Native and lossless stores are writable. Persist the CURRENT resident values before
+        // dropping their owner; otherwise ReleaseToPool alone would resurrect the stale snapshot
+        // captured at registration. Quantized inference stores are immutable and their original
+        // pool snapshot remains authoritative.
+        bool storeIsReadOnly = weight.StreamingStoreEncoding != StreamingEncoding.Native
+            && weight.StreamingStoreEncoding != StreamingEncoding.Lossless;
+        if (!storeIsReadOnly && !weight.TryWriteBackResidentForStreaming())
+        {
+            weight.StreamingDropDeferred = true;
+            return;
+        }
+
         // Soft-defer drop — mirrors the RegisterWeight #430 fix. A streaming
         // weight's storage can be SHARED (refcount > 1) at release time when a
         // peer holds a second reference for the duration of the layer's Forward:

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -1054,16 +1054,20 @@ public static class WeightRegistry
             int rows = tensor.Int8QuantRows;
             if (typeof(T) == typeof(float))
             {
-                var srcF = (float[])(object)tensor.AsSpan().ToArray();
-                if (tensor.Int8StoreTransposed) srcF = TransposeRowMajor(srcF, tensor._shape[0], tensor._shape[1]);
-                StreamingStoreCodec.EncodeInt8Float(srcF, dst, rows);
+                var srcF = (float[])(object)tensor.GetReadOnlyDataArray();
+                if (tensor.Int8StoreTransposed)
+                    StreamingStoreCodec.EncodeInt8TransposedFloat(srcF, dst, tensor._shape[0], tensor._shape[1]);
+                else
+                    StreamingStoreCodec.EncodeInt8Float(srcF, dst, rows);
                 return;
             }
             if (typeof(T) == typeof(double))
             {
-                var srcD = (double[])(object)tensor.AsSpan().ToArray();
-                if (tensor.Int8StoreTransposed) srcD = TransposeRowMajor(srcD, tensor._shape[0], tensor._shape[1]);
-                StreamingStoreCodec.EncodeInt8Double(srcD, dst, rows);
+                var srcD = (double[])(object)tensor.GetReadOnlyDataArray();
+                if (tensor.Int8StoreTransposed)
+                    StreamingStoreCodec.EncodeInt8TransposedDouble(srcD, dst, tensor._shape[0], tensor._shape[1]);
+                else
+                    StreamingStoreCodec.EncodeInt8Double(srcD, dst, rows);
                 return;
             }
             throw new NotSupportedException(
@@ -1082,16 +1086,20 @@ public static class WeightRegistry
             int gs = StreamingStoreCodec.DefaultInt4GroupSize;
             if (typeof(T) == typeof(float))
             {
-                var srcF = (float[])(object)tensor.AsSpan().ToArray();
-                if (tensor.Int8StoreTransposed) srcF = TransposeRowMajor(srcF, tensor._shape[0], tensor._shape[1]);
-                StreamingStoreCodec.EncodeInt4Float(srcF, dst, gs);
+                var srcF = (float[])(object)tensor.GetReadOnlyDataArray();
+                if (tensor.Int8StoreTransposed)
+                    StreamingStoreCodec.EncodeInt4TransposedFloat(srcF, dst, tensor._shape[0], tensor._shape[1], gs);
+                else
+                    StreamingStoreCodec.EncodeInt4Float(srcF, dst, gs);
                 return;
             }
             if (typeof(T) == typeof(double))
             {
-                var srcD = (double[])(object)tensor.AsSpan().ToArray();
-                if (tensor.Int8StoreTransposed) srcD = TransposeRowMajor(srcD, tensor._shape[0], tensor._shape[1]);
-                StreamingStoreCodec.EncodeInt4Double(srcD, dst, gs);
+                var srcD = (double[])(object)tensor.GetReadOnlyDataArray();
+                if (tensor.Int8StoreTransposed)
+                    StreamingStoreCodec.EncodeInt4TransposedDouble(srcD, dst, tensor._shape[0], tensor._shape[1], gs);
+                else
+                    StreamingStoreCodec.EncodeInt4Double(srcD, dst, gs);
                 return;
             }
             throw new NotSupportedException(

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/Conv2DDegenerateSpatialGradientTests.cs
@@ -73,6 +73,37 @@ public sealed class Conv2DDegenerateSpatialGradientTests : IDisposable
     }
 
     [Fact]
+    public async Task FusedConv2D_SevenBySevenStrideFourPaddingThree_MatchesFiniteDifferences()
+    {
+        await Task.Yield();
+
+        // Mirrors the stem used by the point-cloud segmentation families in AiDotNet.
+        // A weighted (non-uniform) scalar objective exercises every output coordinate;
+        // ReduceSum alone can hide stride/padding indexing defects behind equal upstream grads.
+        var input = CreateSequence([1, 3, 8, 8], 0.05f, 0.001f);
+        var kernel = CreateSequence([4, 3, 7, 7], -0.02f, 0.00005f);
+        var bias = CreateTensor([4], 0.30f, 0.35f, 0.40f, 0.45f);
+
+        Tensor<float> Forward() => _engine.FusedConv2D(
+            input,
+            kernel,
+            bias,
+            strideH: 4,
+            strideW: 4,
+            padH: 3,
+            padW: 3,
+            dilationH: 1,
+            dilationW: 1,
+            FusedActivationType.ReLU);
+
+        var weights = CreateSequence([1, 4, 2, 2], 0.2f, 0.03f);
+        AssertGradientsMatch(
+            () => _engine.TensorMultiply(Forward(), weights),
+            kernel,
+            bias);
+    }
+
+    [Fact]
     public async Task Conv2DBackwardInput_PaddedThreeByThreeOverOneByOne_MatchesReference()
     {
         await Task.Yield();

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicModeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicModeTests.cs
@@ -22,8 +22,19 @@ public class DeterministicModeTests
         {
             BlasProvider.SetDeterministicMode(true);
             Assert.True(BlasProvider.IsDeterministicMode);
+            if (BlasProvider.HasRawSgemm)
+                Assert.Equal(1, BlasProvider.GetOpenBlasThreadCount());
+
             BlasProvider.SetDeterministicMode(false);
             Assert.False(BlasProvider.IsDeterministicMode);
+            if (BlasProvider.HasRawSgemm)
+            {
+                // Regression: passing zero to openblas_set_num_threads did not restore the
+                // provider default on several builds, leaving every production GEMM pinned to
+                // one thread after a deterministic test. The cached applied count must always be
+                // an explicit positive value now.
+                Assert.True(BlasProvider.GetOpenBlasThreadCount() > 0);
+            }
         }
         finally
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackAOnlyStrategyTailTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/PackAOnlyStrategyTailTests.cs
@@ -105,6 +105,30 @@ public class PackAOnlyStrategyTailTests
         }
     }
 
+    [Theory]
+    [InlineData(12, 8, 9, 5, 4, 4)]
+    [InlineData(24, 16, 11, 10, 6, 8)]
+    public void Run_MisalignedMc_DoesNotCreatePartialPackedStripe(
+        int m, int n, int k, int mc, int mr, int nr)
+    {
+        var rng = new Random(1409 + m + n + k + mc + mr + nr);
+        var a = RandD(m * k, rng);
+        var b = RandD(k * n, rng);
+        var c = new double[m * n];
+
+        PackAOnlyStrategy.Run<double>(
+            a, k, false, b, n, c, n, m, n, k,
+            mc: mc, kc: 7, mr: mr, nr: nr,
+            options: new BlasOptions<double> { NumThreads = -1 });
+
+        var expected = Reference(a, b, m, n, k);
+        double tol = 1e-9 * Math.Max(1, k);
+        for (int i = 0; i < c.Length; i++)
+            Assert.True(Math.Abs(expected[i] - c[i]) <= tol,
+                $"[m={m},n={n},k={k},mc={mc},mr={mr},nr={nr}] idx {i}: " +
+                $"{expected[i]} vs {c[i]} (tol={tol})");
+    }
+
     private static double[] Reference(double[] a, double[] b, int m, int n, int k)
     {
         var e = new double[m * n];

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
@@ -61,9 +61,9 @@ public sealed class CompiledTrainingPlanCleanupTests
     private static void AssertContainsTensorKeys(HashSet<object> protect, Tensor<float> tensor)
     {
         Assert.Contains(tensor.DataVector, protect);
-        var backing = tensor.GetBackingArrayForCacheLookupUnsafe();
-        if (backing is not null)
-            Assert.Contains(backing, protect);
+        var backing = tensor.GetBackingArrayForCacheLookupUnsafe()
+            ?? throw new InvalidOperationException("Expected CPU tensor to expose a backing array.");
+        Assert.Contains(backing, protect);
     }
 
     private static CompiledTrainingPlan<float> CreatePlan(

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingPlanCleanupTests.cs
@@ -37,7 +37,7 @@ public sealed class CompiledTrainingPlanCleanupTests
     {
         var loss = new Tensor<float>(new float[] { 1.0f }, new[] { 1 });
         var plan = CreatePlan(loss, Array.Empty<Tensor<float>>(), new Tensor<float>(new[] { 1 }), null);
-        var backing = loss.DataVector.GetBackingArrayUnsafe()
+        var backing = loss.GetBackingArrayForCacheLookupUnsafe()
             ?? throw new InvalidOperationException("Expected CPU tensor to expose a backing array.");
         int backingCalls = 0;
         int vectorCalls = 0;
@@ -61,7 +61,7 @@ public sealed class CompiledTrainingPlanCleanupTests
     private static void AssertContainsTensorKeys(HashSet<object> protect, Tensor<float> tensor)
     {
         Assert.Contains(tensor.DataVector, protect);
-        var backing = tensor.DataVector.GetBackingArrayUnsafe();
+        var backing = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backing is not null)
             Assert.Contains(backing, protect);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -2174,11 +2174,11 @@ public class GpuCpuConsistencyTests
                 sparseValues, sparseBias, FusedActivationType.None);
 
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                actualLora.DataVector.GetBackingArrayUnsafe()!));
+                actualLora.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                actualDdim.DataVector.GetBackingArrayUnsafe()!));
+                actualDdim.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                actualSparse.DataVector.GetBackingArrayUnsafe()!));
+                actualSparse.GetBackingArrayForCacheLookupUnsafe()!));
             AssertTensorClose(expectedLora, actualLora, "fused LoRA");
             AssertTensorClose(expectedDdim, actualDdim, "fused DDIM");
             AssertTensorClose(expectedSparse, actualSparse, "fused sparse linear");
@@ -2212,9 +2212,9 @@ public class GpuCpuConsistencyTests
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
                 testElements.DataVector));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                selected.DataVector.GetBackingArrayUnsafe()!));
+                selected.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                inverted.DataVector.GetBackingArrayUnsafe()!));
+                inverted.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.Equal(new[] { false, true, false, true, true, false },
                 selected.GetDataArray().Select(value => (bool)value).ToArray());
             Assert.Equal(new[] { true, false, true, false, false, true },
@@ -2245,7 +2245,7 @@ public class GpuCpuConsistencyTests
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
                 values.DataVector));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                mask.DataVector.GetBackingArrayUnsafe()!));
+                mask.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
                 selected.DataVector));
             Assert.Equal(new[] { -3f, -1f, 2f }, selected.GetDataArray());
@@ -2375,13 +2375,13 @@ public class GpuCpuConsistencyTests
             var interfaceEmbedded = engine.Embedding(indices, embeddingTable);
 
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                indices.DataVector.GetBackingArrayUnsafe()!));
+                indices.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                rowIndices.DataVector.GetBackingArrayUnsafe()!));
+                rowIndices.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                columnIndices.DataVector.GetBackingArrayUnsafe()!));
+                columnIndices.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-                mask.DataVector.GetBackingArrayUnsafe()!));
+                mask.GetBackingArrayForCacheLookupUnsafe()!));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(copied.DataVector));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(filled.DataVector));
             Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(put.DataVector));
@@ -2511,11 +2511,11 @@ public class GpuCpuConsistencyTests
 
         Assert.Equal(0, GpuLaunchProbe.Readbacks);
         Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-            sourceIndices.DataVector.GetBackingArrayUnsafe()!));
+            sourceIndices.GetBackingArrayForCacheLookupUnsafe()!));
         Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
-            targetIndices.DataVector.GetBackingArrayUnsafe()!));
-        var actualBacking = actual.DataVector.GetBackingArrayUnsafe();
-        var coefficientBacking = actualCoefficients.DataVector.GetBackingArrayUnsafe();
+            targetIndices.GetBackingArrayForCacheLookupUnsafe()!));
+        var actualBacking = actual.GetBackingArrayForCacheLookupUnsafe();
+        var coefficientBacking = actualCoefficients.GetBackingArrayForCacheLookupUnsafe();
         Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(actual.DataVector)
             || (actualBacking is not null &&
                 AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(actualBacking)));
@@ -2565,7 +2565,7 @@ public class GpuCpuConsistencyTests
             vertices, residentFaces, LaplacianType.Uniform);
 
         Assert.Equal(0, GpuLaunchProbe.Readbacks);
-        var faceBacking = residentFaces.DataVector.GetBackingArrayUnsafe();
+        var faceBacking = residentFaces.GetBackingArrayForCacheLookupUnsafe();
         Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(
                 residentFaces.DataVector)
             || (faceBacking is not null &&

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmFusedBackwardGradientTests.cs
@@ -125,4 +125,33 @@ public class LstmFusedBackwardGradientTests
         CheckFiniteDiff("wIh", eng, wIh, grads[wIh], L, wIh);
         CheckFiniteDiff("wHh", eng, wHh, grads[wHh], L, wHh);
     }
+
+    [Fact]
+    public void GradientTape_NonContiguousSequenceView_PropagatesToOriginalTensor()
+    {
+        var eng = new CpuEngine();
+        var rng = new Random(2027);
+        const int batch = 2, seq = 3, inF = 4, hidden = 3;
+        int gates = 4 * hidden;
+
+        var channelsFirst = Rand(new[] { batch, inF, seq }, rng);
+        var wIh = Rand(new[] { gates, inF }, rng);
+        var wHh = Rand(new[] { gates, hidden }, rng);
+
+        Dictionary<Tensor<float>, Tensor<float>> grads;
+        using (var tape = new GradientTape<float>())
+        {
+            var sequenceView = eng.TensorPermute(channelsFirst, new[] { 0, 2, 1 });
+            Assert.False(sequenceView.IsContiguous);
+            var output = eng.LstmSequenceForward(
+                sequenceView, null, null, wIh, wHh, null, null, returnSequences: true);
+            var loss = eng.ReduceSum(output, null);
+            grads = tape.ComputeGradients(loss, new[] { channelsFirst, wIh, wHh });
+        }
+
+        Assert.True(grads.ContainsKey(channelsFirst));
+        Assert.Equal(channelsFirst.Length, grads[channelsFirst].Length);
+        foreach (float value in grads[channelsFirst].Contiguous().AsSpan())
+            Assert.True(!float.IsNaN(value) && !float.IsInfinity(value));
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/LstmSequenceForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/LstmSequenceForwardTests.cs
@@ -83,6 +83,32 @@ public class LstmSequenceForwardTests
     }
 
     [Fact]
+    public void LstmSequenceForward_NonContiguousSequenceView_MatchesContiguousInput()
+    {
+        const int batch = 2, seq = 4, inFeatures = 3, hidden = 5;
+        var rng = new Random(2027);
+
+        // Model the layout produced by audio models: [B, channels, seq] is
+        // permuted to [B, seq, channels] without copying before it reaches LSTM.
+        var channelsFirst = MakeRandom(rng, batch, inFeatures, seq);
+        var sequenceView = _engine.TensorPermute(channelsFirst, new[] { 0, 2, 1 });
+        var contiguous = sequenceView.Contiguous();
+        var wIh = MakeRandom(rng, 4 * hidden, inFeatures);
+        var wHh = MakeRandom(rng, 4 * hidden, hidden);
+        var bIh = MakeRandom1D(rng, 4 * hidden);
+        var bHh = MakeRandom1D(rng, 4 * hidden);
+
+        Assert.False(sequenceView.IsContiguous);
+
+        var expected = _engine.LstmSequenceForward(
+            contiguous, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+        var actual = _engine.LstmSequenceForward(
+            sequenceView, null, null, wIh, wHh, bIh, bHh, returnSequences: true);
+
+        AssertClose(actual, expected, atol: 1e-6f);
+    }
+
+    [Fact]
     public void LstmSequenceForward_FinalStates_EnableChunkedInference()
     {
         const int batch = 2, seq = 6, inFeatures = 3, hidden = 5, half = 3;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
@@ -205,6 +205,21 @@ public class SgemmWithInt8RowScaledCachedBTests
             Assert.Equal(0f, c[i]);
     }
 
+    [Theory]
+    [InlineData(-1, 0, 0, "m")]
+    [InlineData(0, -1, 0, "k")]
+    [InlineData(0, 0, -1, "n")]
+    public void NegativeDimensions_ThrowBeforeTheZeroDimensionFastPath(
+        int m, int k, int n, string parameterName)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimdGemm.SgemmWithInt8RowScaledCachedB(
+                Array.Empty<float>(), Array.Empty<sbyte>(), ReadOnlySpan<float>.Empty,
+                Array.Empty<float>(), m, k, n));
+
+        Assert.Equal(parameterName, exception.ParamName);
+    }
+
     [Fact]
     public void RowScalesTooShort_Throws()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/SgemmWithInt8RowScaledCachedBTests.cs
@@ -87,7 +87,7 @@ public class SgemmWithInt8RowScaledCachedBTests
     [InlineData(32, 256, 64, 5)]    // medium k inside Kc
     [InlineData(8, 1024, 16, 6)]    // k > Kc — exercise pcIter loop
     [InlineData(8, 600, 32, 7)]     // k % Kc != 0 — tail Kc panel
-    [InlineData(4, 32, 5000, 8)]    // n > Nc — large-n fallback path
+    [InlineData(4, 32, 5000, 8)]    // n > Nc — multi-panel no-upcast path
     // CodeRabbit #427 review comment regression: canParallelize=true AND
     // NumColSubBlocks=1 (n < Nr*4 ≈ 64). m*k*n = 64*1024*32 = 2 MiB hits
     // ParallelWorkThreshold's 2 MiB floor on any core count; n=32 < 64 forces
@@ -98,9 +98,12 @@ public class SgemmWithInt8RowScaledCachedBTests
         var tc = BuildRandomCase(m, k, n, seed);
         var c = new float[m * n];
 
+        // Arrays exercise the engine hot-path overload. In particular n=5000 must cross the
+        // Nc=4096 boundary while remaining in the no-upcast multi-panel path; the former fallback
+        // expanded every wide quantized projection into a full fp32 temporary.
         SimdGemm.SgemmWithInt8RowScaledCachedB(
-            tc.a.AsSpan(), tc.bInt8, tc.rowScales.AsSpan(),
-            c.AsSpan(), m, k, n);
+            tc.a, tc.bInt8, tc.rowScales.AsSpan(),
+            c, m, k, n);
 
         double snr = SnrDb(tc.cRef, c);
         Assert.True(snr >= 30.0, $"SNR {snr:F1} dB below 30 dB threshold (m={m}, k={k}, n={n})");

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Im2Col3DHelperTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Im2Col3DHelperTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class Im2Col3DHelperTests
+{
+    [Fact]
+    public void BuildColumnsRange_TilesAreByteEquivalentToFullMatrix()
+    {
+        const int batch = 2, channels = 2, depth = 4, height = 5, width = 6;
+        const int kernelDepth = 2, kernelHeight = 3, kernelWidth = 2;
+        const int outputDepth = 3, outputHeight = 3, outputWidth = 5;
+        const int columnsPerRow = channels * kernelDepth * kernelHeight * kernelWidth;
+        const int totalRows = batch * outputDepth * outputHeight * outputWidth;
+
+        var input = new float[batch * channels * depth * height * width];
+        for (int i = 0; i < input.Length; i++)
+            input[i] = (float)Math.Sin(i * 0.13);
+
+        var full = new float[totalRows * columnsPerRow];
+        CpuIm2Col3DHelper.BuildColumns(
+            input, full,
+            batch, channels, depth, height, width,
+            kernelDepth, kernelHeight, kernelWidth,
+            outputDepth, outputHeight, outputWidth,
+            1, 1, 1,
+            0, 0, 0,
+            1, 1, 1);
+
+        var tiled = new float[full.Length];
+        const int tileCapacity = 17;
+        for (int rowStart = 0; rowStart < totalRows; rowStart += tileCapacity)
+        {
+            int rowCount = Math.Min(tileCapacity, totalRows - rowStart);
+            var tile = new float[rowCount * columnsPerRow];
+            CpuIm2Col3DHelper.BuildColumnsRange(
+                input, tile, rowStart, rowCount,
+                batch, channels, depth, height, width,
+                kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                1, 1, 1,
+                0, 0, 0,
+                1, 1, 1);
+            Array.Copy(tile, 0, tiled, rowStart * columnsPerRow, tile.Length);
+        }
+
+        Assert.Equal(full, tiled);
+    }
+
+    [Fact]
+    public void BuildColumnsRange_RejectsRangesOutsideTheOutputVolume()
+    {
+        var input = new float[2 * 2 * 2];
+        var columns = new float[2];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CpuIm2Col3DHelper.BuildColumnsRange(
+                input, columns, 7, 2,
+                1, 1, 2, 2, 2,
+                1, 1, 1,
+                2, 2, 2,
+                1, 1, 1,
+                0, 0, 0,
+                1, 1, 1));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPinnedTests.cs
@@ -6,6 +6,7 @@
 // later Rent return the same backing array as the weight tensor and
 // downstream writes would corrupt the weight in place.
 
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -30,6 +31,33 @@ public sealed class TensorArenaPinnedTestsCollection { }
 [Collection(nameof(TensorArenaPinnedTests))]
 public class TensorArenaPinnedTests
 {
+    /// <summary>
+    /// Engine-created parameters are first rented as ordinary operation outputs and are only
+    /// known to be long-lived when the owning layer registers them. Registration must promote
+    /// both the tensor wrapper and its backing array out of the resettable scratch tier.
+    /// Otherwise a later same-size operation can receive and reshape the parameter object itself.
+    /// </summary>
+    [Fact]
+    public void RegisterPersistentTensor_PromotesExistingScratchTensor()
+    {
+        using var arena = TensorArena.Create();
+        var engine = new CpuEngine();
+
+        var parameter = TensorAllocator.RentUninitialized<float>(new[] { 2, 3 });
+        parameter.AsWritableSpan().Fill(17f);
+
+        engine.RegisterPersistentTensor(parameter, PersistentTensorRole.Weights);
+        Assert.Equal(1, arena.PinnedArrayCount);
+
+        arena.Reset();
+        var scratch = TensorAllocator.RentUninitialized<float>(new[] { 3, 2 });
+        scratch.AsWritableSpan().Fill(-4f);
+
+        Assert.NotSame(parameter, scratch);
+        Assert.Equal(new[] { 2, 3 }, parameter.Shape.ToArray());
+        Assert.All(parameter.ToArray(), value => Assert.Equal(17f, value));
+    }
+
     /// <summary>
     /// Pinned allocations must persist across Reset() — the backing array
     /// stays valid and its contents survive. Without this, every Train

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
@@ -260,6 +260,7 @@ public class StreamingInt4NoUpcastTests
     {
         var a = actual.AsSpan();
         var e = expected.AsSpan();
+        Assert.Equal(e.Length, a.Length);
         double errorSquared = 0.0, expectedSquared = 0.0;
         for (int i = 0; i < a.Length; i++)
         {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt4NoUpcastTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -137,6 +138,139 @@ public class StreamingInt4NoUpcastTests
         }
         finally { Cleanup(dir); }
     }
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public void Int4Weight_ThroughTensorMatMul2DAndBatched_StaysQuantized()
+    {
+        const int inDim = 64, outDim = 48, rows = 6;
+        var engine = new CpuEngine();
+        var weights = CreateWeightData(inDim * outDim, 0.08f);
+        var inputs = CreateWeightData(rows * inDim, 0.4f);
+        var dequantized = DequantizeInt4PerOutput(weights, inDim, outDim);
+        var referenceWeight = new Tensor<float>(dequantized, new[] { inDim, outDim });
+        var x2 = new Tensor<float>(inputs, new[] { rows, inDim });
+        var x3 = new Tensor<float>(inputs, new[] { 2, rows / 2, inDim });
+        var expected2 = engine.TensorMatMul(x2, referenceWeight);
+        var expected3 = engine.TensorMatMul(x3, referenceWeight);
+
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int4mm-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int4,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+        try
+        {
+            var streamed = new Tensor<float>(weights, new[] { inDim, outDim })
+            {
+                Lifetime = WeightLifetime.Streaming,
+            };
+            WeightRegistry.RegisterWeight(streamed);
+
+            AssertRelativeClose(engine.TensorMatMul(x2, streamed), expected2, 0.01);
+            Assert.NotNull(streamed.StreamingInt4);
+            Assert.Equal(0, streamed.DataVector.Length);
+
+            AssertRelativeClose(engine.TensorMatMul(x3, streamed), expected3, 0.01);
+            Assert.NotNull(streamed.StreamingInt4);
+            Assert.Equal(0, streamed.DataVector.Length);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Int4Weights_ThroughMultiHeadAttention_StayQuantized()
+    {
+        const int batch = 2, seq = 3, dModel = 32, heads = 4;
+        var engine = new CpuEngine();
+        var inputData = CreateWeightData(batch * seq * dModel, 0.3f);
+        var input = new Tensor<float>(inputData, new[] { batch, seq, dModel });
+        var qData = CreateWeightData(dModel * dModel, 0.05f, 1);
+        var kData = CreateWeightData(dModel * dModel, 0.05f, 2);
+        var vData = CreateWeightData(dModel * dModel, 0.05f, 3);
+        var oData = CreateWeightData(dModel * dModel, 0.05f, 4);
+        Tensor<float> Reference(float[] data) => new(
+            DequantizeInt4PerOutput(data, dModel, dModel), new[] { dModel, dModel });
+        var expected = engine.MultiHeadAttentionForward(
+            input, Reference(qData), Reference(kData), Reference(vData), Reference(oData), heads);
+
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int4mha-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 4L * 1024 * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int4,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+        try
+        {
+            Tensor<float> Stream(float[] data)
+            {
+                var weight = new Tensor<float>(data, new[] { dModel, dModel })
+                {
+                    Lifetime = WeightLifetime.Streaming,
+                };
+                WeightRegistry.RegisterWeight(weight);
+                return weight;
+            }
+
+            var q = Stream(qData);
+            var k = Stream(kData);
+            var v = Stream(vData);
+            var o = Stream(oData);
+            var actual = engine.MultiHeadAttentionForward(input, q, k, v, o, heads);
+
+            foreach (var weight in new[] { q, k, v, o })
+            {
+                Assert.NotNull(weight.StreamingInt4);
+                Assert.Equal(0, weight.DataVector.Length);
+            }
+            AssertRelativeClose(actual, expected, 0.02);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    private static float[] DequantizeInt4PerOutput(float[] logical, int inputColumns, int outputColumns)
+    {
+        int groupSize = StreamingStoreCodec.DefaultInt4GroupSize;
+        var encoded = new byte[StreamingStoreCodec.Int4BufferBytes(logical.Length, groupSize)];
+        StreamingStoreCodec.EncodeInt4TransposedFloat(
+            logical, encoded, inputColumns, outputColumns, groupSize);
+        var transposed = new float[logical.Length];
+        StreamingStoreCodec.DecodeInt4Float(encoded, transposed);
+        var result = new float[logical.Length];
+        for (int input = 0; input < inputColumns; input++)
+            for (int output = 0; output < outputColumns; output++)
+                result[input * outputColumns + output] = transposed[output * inputColumns + input];
+        return result;
+    }
+
+    private static float[] CreateWeightData(int count, float magnitude, int phase = 0)
+    {
+        var result = new float[count];
+        for (int i = 0; i < count; i++)
+            result[i] = (float)Math.Sin((i + phase * 19) * 0.017) * magnitude;
+        return result;
+    }
+
+    private static void AssertRelativeClose(Tensor<float> actual, Tensor<float> expected, double tolerance)
+    {
+        var a = actual.AsSpan();
+        var e = expected.AsSpan();
+        double errorSquared = 0.0, expectedSquared = 0.0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            double error = a[i] - e[i];
+            errorSquared += error * error;
+            expectedSquared += (double)e[i] * e[i];
+        }
+        double relative = Math.Sqrt(errorSquared / Math.Max(1e-30, expectedSquared));
+        Assert.True(relative < tolerance, $"relative RMS error {relative:E3} exceeded {tolerance:E3}");
+    }
+#endif
 
     private static void Cleanup(string dir)
     {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt8MatMulRoutingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingInt8MatMulRoutingTests.cs
@@ -110,6 +110,144 @@ public class StreamingInt8MatMulRoutingTests
         }
     }
 
+    [Fact]
+    public void Int8Weight_ThroughTensorMatMul2DAndBatched_StaysQuantized()
+    {
+        const int inDim = 64, outDim = 48, rows = 6;
+        var engine = new CpuEngine();
+        var rng = new Rng(8108);
+        var wData = new float[inDim * outDim];
+        var xData = new float[rows * inDim];
+        for (int i = 0; i < wData.Length; i++) wData[i] = rng.Next(0.1);
+        for (int i = 0; i < xData.Length; i++) xData[i] = rng.Next(1.0);
+
+        var deq = DequantizePerOutput(wData, inDim, outDim);
+        var referenceWeight = new Tensor<float>(deq, new[] { inDim, outDim });
+        var x2 = new Tensor<float>(xData, new[] { rows, inDim });
+        var x3 = new Tensor<float>(xData, new[] { 2, rows / 2, inDim });
+        var expected2 = engine.TensorMatMul(x2, referenceWeight);
+        var expected3 = engine.TensorMatMul(x3, referenceWeight);
+
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int8mm-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int8,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+        try
+        {
+            var streamed = new Tensor<float>(wData, new[] { inDim, outDim })
+            {
+                Lifetime = WeightLifetime.Streaming,
+            };
+            WeightRegistry.RegisterWeight(streamed);
+
+            var actual2 = engine.TensorMatMul(x2, streamed);
+            Assert.NotNull(streamed.StreamingInt8);
+            Assert.Equal(0, streamed.DataVector.Length);
+            AssertRelativeClose(actual2, expected2, 0.01);
+
+            var actual3 = engine.TensorMatMul(x3, streamed);
+            Assert.NotNull(streamed.StreamingInt8);
+            Assert.Equal(0, streamed.DataVector.Length);
+            AssertRelativeClose(actual3, expected3, 0.01);
+        }
+        finally
+        {
+            WeightRegistry.SetStreamingExecutionTraining(null);
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Int8Weights_ThroughMultiHeadAttention_StayQuantized()
+    {
+        const int batch = 2, seq = 3, dModel = 32, heads = 4;
+        var engine = new CpuEngine();
+        var rng = new Rng(8808);
+        var inputData = new float[batch * seq * dModel];
+        for (int i = 0; i < inputData.Length; i++) inputData[i] = rng.Next(0.4);
+        var input = new Tensor<float>(inputData, new[] { batch, seq, dModel });
+
+        float[] NewWeight()
+        {
+            var data = new float[dModel * dModel];
+            for (int i = 0; i < data.Length; i++) data[i] = rng.Next(0.08);
+            return data;
+        }
+
+        var qData = NewWeight();
+        var kData = NewWeight();
+        var vData = NewWeight();
+        var oData = NewWeight();
+        var expected = engine.MultiHeadAttentionForward(
+            input,
+            new Tensor<float>(DequantizePerOutput(qData, dModel, dModel), new[] { dModel, dModel }),
+            new Tensor<float>(DequantizePerOutput(kData, dModel, dModel), new[] { dModel, dModel }),
+            new Tensor<float>(DequantizePerOutput(vData, dModel, dModel), new[] { dModel, dModel }),
+            new Tensor<float>(DequantizePerOutput(oData, dModel, dModel), new[] { dModel, dModel }),
+            heads);
+
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int8mha-{Guid.NewGuid():N}");
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 4L * 1024 * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int8,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+        try
+        {
+            Tensor<float> Stream(float[] data)
+            {
+                var weight = new Tensor<float>(data, new[] { dModel, dModel })
+                {
+                    Lifetime = WeightLifetime.Streaming,
+                };
+                WeightRegistry.RegisterWeight(weight);
+                return weight;
+            }
+
+            var q = Stream(qData);
+            var k = Stream(kData);
+            var v = Stream(vData);
+            var o = Stream(oData);
+            var actual = engine.MultiHeadAttentionForward(input, q, k, v, o, heads);
+
+            foreach (var weight in new[] { q, k, v, o })
+            {
+                Assert.NotNull(weight.StreamingInt8);
+                Assert.Equal(0, weight.DataVector.Length);
+            }
+            AssertRelativeClose(actual, expected, 0.015);
+        }
+        finally
+        {
+            WeightRegistry.SetStreamingExecutionTraining(null);
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static void AssertRelativeClose(Tensor<float> actual, Tensor<float> expected, double tolerance)
+    {
+        var a = actual.AsSpan();
+        var e = expected.AsSpan();
+        Assert.Equal(e.Length, a.Length);
+        double errorSquared = 0.0, expectedSquared = 0.0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            double error = a[i] - e[i];
+            errorSquared += error * error;
+            expectedSquared += (double)e[i] * e[i];
+        }
+        double relative = Math.Sqrt(errorSquared / Math.Max(1e-30, expectedSquared));
+        Assert.True(relative < tolerance, $"relative RMS error {relative:E3} exceeded {tolerance:E3}");
+    }
+
     /// <summary>
     /// The RAM-aware <see cref="StreamingStoreDtype.Auto"/> path (not the explicit Int8 opt-in):
     /// a large inference weight, under a footprint+cap where bf16 would overflow the resident cap

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingMaterializedOwnerBoundTests.cs
@@ -25,8 +25,10 @@ public class StreamingMaterializedOwnerBoundTests
 
     private static float Base(int i, int j) => (i * 31 + j) % 251 * 0.5f - 60f;
 
-    [Fact]
-    public void ManyMaterializedOwners_StayBounded_AndMutationsSurviveShed()
+    [Theory]
+    [InlineData(StreamingStoreDtype.FullPrecision)]
+    [InlineData(StreamingStoreDtype.Lossless)]
+    public void ManyMaterializedOwners_StayBounded_AndMutationsSurviveShed(StreamingStoreDtype storeDtype)
     {
         var dir = Path.Combine(Path.GetTempPath(), "aidotnet-1715-" + Guid.NewGuid().ToString("N"));
         try
@@ -36,9 +38,10 @@ public class StreamingMaterializedOwnerBoundTests
                 StreamingBackingStorePath = dir,
                 StreamingPoolMaxResidentBytes = Cap,
                 TransparentAutoEviction = true,
-                // Full precision so the write-back round-trip is exact (the round-trip contract test
-                // asserts exact equality; bf16/lossy stores would lose the mutation's low bits).
-                StreamingStoreDtype = StreamingStoreDtype.FullPrecision,
+                // Both native and lossless are exact writable encodings. Running the same forced
+                // owner-shed round trip for each prevents training's Auto/Lossless tier from
+                // accepting optimizer updates that disappear on eviction.
+                StreamingStoreDtype = storeDtype,
             });
 
             // Register N streaming weights. RegisterWeight snapshots each into the pool and drops its

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
 
 using System;
+using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Tensors.NumericOperations;
 using Xunit;
@@ -13,6 +14,7 @@ namespace AiDotNet.Tensors.Tests.LinearAlgebra;
 /// handling, and — the key training-safety property — that STOCHASTIC rounding
 /// is unbiased (the decoded mean of many quantizations equals the original).
 /// </summary>
+[Collection("BlasManaged-Pool-Serial")]
 public class StreamingStoreCodecTests
 {
     private struct Rng
@@ -200,10 +202,12 @@ public class StreamingStoreCodecTests
         Assert.True(Math.Sqrt(sum2 / ref2) < 0.02, "fp64→int8 RMS error ~1%");
     }
 
-    [Fact]
-    public void Int8_TransposedEncoders_AreByteEquivalentToMaterializedTranspose()
+    [Theory]
+    [InlineData(56, 17)]
+    [InlineData(56, 200)]
+    public void Int8_TransposedEncoders_AreByteEquivalentToMaterializedTranspose(
+        int sourceRows, int sourceColumns)
     {
-        const int sourceRows = 56, sourceColumns = 17;
         var sourceFloat = new float[sourceRows * sourceColumns];
         var sourceDouble = new double[sourceFloat.Length];
         for (int i = 0; i < sourceFloat.Length; i++)
@@ -323,11 +327,14 @@ public class StreamingStoreCodecTests
     }
 
     [Theory]
-    [InlineData(8)]  // even groups can encode in parallel without sharing packed bytes
-    [InlineData(7)]  // odd groups intentionally use the sequential nibble-safe path
-    public void Int4_TransposedEncoders_AreByteEquivalentToMaterializedTranspose(int groupSize)
+    [InlineData(56, 17, 8)]   // tiled fast path, one column tile
+    [InlineData(56, 200, 8)]  // tiled fast path, multiple parallel column tiles
+    [InlineData(56, 17, 7)]   // odd groups use the sequential nibble-safe fallback
+    [InlineData(56, 17, 16)]  // even, non-dividing rows: parallel per-group fallback
+    [InlineData(56, 17, 9)]   // odd with a partial final group
+    public void Int4_TransposedEncoders_AreByteEquivalentToMaterializedTranspose(
+        int sourceRows, int sourceColumns, int groupSize)
     {
-        const int sourceRows = 56, sourceColumns = 17;
         var sourceFloat = new float[sourceRows * sourceColumns];
         var sourceDouble = new double[sourceFloat.Length];
         for (int i = 0; i < sourceFloat.Length; i++)
@@ -358,6 +365,48 @@ public class StreamingStoreCodecTests
         StreamingStoreCodec.EncodeInt4TransposedDouble(
             sourceDouble, actualDouble, sourceRows, sourceColumns, groupSize);
         Assert.Equal(expectedDouble, actualDouble);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TransposedQuantizedEncoders_PreserveArgumentExceptionAcrossParallelBackends(
+        bool useCooperativePool)
+    {
+        const int sourceRows = 256, sourceColumns = 512, groupSize = 16;
+        int count = sourceRows * sourceColumns;
+        var sourceFloat = new float[count];
+        var sourceDouble = new double[count];
+        sourceFloat[200] = float.NaN;
+        sourceDouble[200] = double.PositiveInfinity;
+
+        bool previous = CpuParallelSettings.UseCooperativePool;
+        try
+        {
+            CpuParallelSettings.UseCooperativePool = useCooperativePool;
+
+            var int8Float = new byte[StreamingStoreCodec.Int8BufferBytes(count, sourceColumns)];
+            var int8Double = new byte[int8Float.Length];
+            var int4Float = new byte[StreamingStoreCodec.Int4BufferBytes(count, groupSize)];
+            var int4Double = new byte[int4Float.Length];
+
+            Assert.Contains("index 200", Assert.Throws<ArgumentException>(() =>
+                StreamingStoreCodec.EncodeInt8TransposedFloat(
+                    sourceFloat, int8Float, sourceRows, sourceColumns)).Message);
+            Assert.Contains("index 200", Assert.Throws<ArgumentException>(() =>
+                StreamingStoreCodec.EncodeInt8TransposedDouble(
+                    sourceDouble, int8Double, sourceRows, sourceColumns)).Message);
+            Assert.Contains("index 200", Assert.Throws<ArgumentException>(() =>
+                StreamingStoreCodec.EncodeInt4TransposedFloat(
+                    sourceFloat, int4Float, sourceRows, sourceColumns, groupSize)).Message);
+            Assert.Contains("index 200", Assert.Throws<ArgumentException>(() =>
+                StreamingStoreCodec.EncodeInt4TransposedDouble(
+                    sourceDouble, int4Double, sourceRows, sourceColumns, groupSize)).Message);
+        }
+        finally
+        {
+            CpuParallelSettings.UseCooperativePool = previous;
+        }
     }
 
     [Theory]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
@@ -410,6 +410,31 @@ public class StreamingStoreCodecTests
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LightweightParallel_PreservesActionAggregateExceptionAcrossBackends(
+        bool useCooperativePool)
+    {
+        bool previous = CpuParallelSettings.UseCooperativePool;
+        try
+        {
+            CpuParallelSettings.UseCooperativePool = useCooperativePool;
+            var exception = Assert.Throws<AggregateException>(() =>
+                CpuParallelSettings.LightweightParallel(
+                    8, 128 * 1024,
+                    _ => throw new AggregateException(new InvalidOperationException("action failure"))));
+
+            var inner = Assert.Single(exception.InnerExceptions);
+            Assert.IsType<InvalidOperationException>(inner);
+            Assert.Equal("action failure", inner.Message);
+        }
+        finally
+        {
+            CpuParallelSettings.UseCooperativePool = previous;
+        }
+    }
+
+    [Theory]
     [InlineData(1)]
     [InlineData(7)]
     [InlineData(8)]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingStoreCodecTests.cs
@@ -201,6 +201,40 @@ public class StreamingStoreCodecTests
     }
 
     [Fact]
+    public void Int8_TransposedEncoders_AreByteEquivalentToMaterializedTranspose()
+    {
+        const int sourceRows = 56, sourceColumns = 17;
+        var sourceFloat = new float[sourceRows * sourceColumns];
+        var sourceDouble = new double[sourceFloat.Length];
+        for (int i = 0; i < sourceFloat.Length; i++)
+        {
+            sourceFloat[i] = (float)(Math.Sin(i * 0.17) * (1 + i % 11));
+            sourceDouble[i] = Math.Cos(i * 0.11) * (1 + i % 7);
+        }
+
+        var transposedFloat = new float[sourceFloat.Length];
+        var transposedDouble = new double[sourceDouble.Length];
+        for (int row = 0; row < sourceRows; row++)
+        for (int column = 0; column < sourceColumns; column++)
+        {
+            transposedFloat[column * sourceRows + row] = sourceFloat[row * sourceColumns + column];
+            transposedDouble[column * sourceRows + row] = sourceDouble[row * sourceColumns + column];
+        }
+
+        var expectedFloat = new byte[StreamingStoreCodec.Int8BufferBytes(sourceFloat.Length, sourceColumns)];
+        var actualFloat = new byte[expectedFloat.Length];
+        StreamingStoreCodec.EncodeInt8Float(transposedFloat, expectedFloat, sourceColumns);
+        StreamingStoreCodec.EncodeInt8TransposedFloat(sourceFloat, actualFloat, sourceRows, sourceColumns);
+        Assert.Equal(expectedFloat, actualFloat);
+
+        var expectedDouble = new byte[StreamingStoreCodec.Int8BufferBytes(sourceDouble.Length, sourceColumns)];
+        var actualDouble = new byte[expectedDouble.Length];
+        StreamingStoreCodec.EncodeInt8Double(transposedDouble, expectedDouble, sourceColumns);
+        StreamingStoreCodec.EncodeInt8TransposedDouble(sourceDouble, actualDouble, sourceRows, sourceColumns);
+        Assert.Equal(expectedDouble, actualDouble);
+    }
+
+    [Fact]
     public void Int4_RoundTrip_8xSmaller_WithinGroupPrecision()
     {
         var rng = new Rng(13);
@@ -286,6 +320,44 @@ public class StreamingStoreCodecTests
         double sum2 = 0, ref2 = 0;
         for (int i = 0; i < n; i++) { double e = dec[i] - src[i]; sum2 += e * e; ref2 += src[i] * src[i]; }
         Assert.True(Math.Sqrt(sum2 / ref2) < 0.18, "fp64→int4 group-quant RMS error ~12-15%");
+    }
+
+    [Theory]
+    [InlineData(8)]  // even groups can encode in parallel without sharing packed bytes
+    [InlineData(7)]  // odd groups intentionally use the sequential nibble-safe path
+    public void Int4_TransposedEncoders_AreByteEquivalentToMaterializedTranspose(int groupSize)
+    {
+        const int sourceRows = 56, sourceColumns = 17;
+        var sourceFloat = new float[sourceRows * sourceColumns];
+        var sourceDouble = new double[sourceFloat.Length];
+        for (int i = 0; i < sourceFloat.Length; i++)
+        {
+            sourceFloat[i] = (float)(Math.Sin(i * 0.17) * (1 + i % 11));
+            sourceDouble[i] = Math.Cos(i * 0.11) * (1 + i % 7);
+        }
+
+        var transposedFloat = new float[sourceFloat.Length];
+        var transposedDouble = new double[sourceDouble.Length];
+        for (int row = 0; row < sourceRows; row++)
+        for (int column = 0; column < sourceColumns; column++)
+        {
+            transposedFloat[column * sourceRows + row] = sourceFloat[row * sourceColumns + column];
+            transposedDouble[column * sourceRows + row] = sourceDouble[row * sourceColumns + column];
+        }
+
+        var expectedFloat = new byte[StreamingStoreCodec.Int4BufferBytes(sourceFloat.Length, groupSize)];
+        var actualFloat = new byte[expectedFloat.Length];
+        StreamingStoreCodec.EncodeInt4Float(transposedFloat, expectedFloat, groupSize);
+        StreamingStoreCodec.EncodeInt4TransposedFloat(
+            sourceFloat, actualFloat, sourceRows, sourceColumns, groupSize);
+        Assert.Equal(expectedFloat, actualFloat);
+
+        var expectedDouble = new byte[StreamingStoreCodec.Int4BufferBytes(sourceDouble.Length, groupSize)];
+        var actualDouble = new byte[expectedDouble.Length];
+        StreamingStoreCodec.EncodeInt4Double(transposedDouble, expectedDouble, groupSize);
+        StreamingStoreCodec.EncodeInt4TransposedDouble(
+            sourceDouble, actualDouble, sourceRows, sourceColumns, groupSize);
+        Assert.Equal(expectedDouble, actualDouble);
     }
 
     [Theory]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightRegistryStreamingTests.cs
@@ -304,6 +304,39 @@ public class WeightRegistryStreamingTests : IDisposable
         Assert.Equal(30f, span[2]);
     }
 
+    [Theory]
+    [InlineData(StreamingStoreDtype.FullPrecision)]
+    [InlineData(StreamingStoreDtype.Lossless)]
+    public void ReleaseToPool_WritesBackMutableStoresBeforeDropping(
+        StreamingStoreDtype storeDtype)
+    {
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingBackingStorePath = _backingDir,
+            StreamingStoreDtype = storeDtype,
+        });
+
+        var t = new Tensor<float>(new[] { 1f, 2f, 3f }, new[] { 3 })
+        {
+            Lifetime = WeightLifetime.Streaming,
+        };
+        WeightRegistry.RegisterWeight(t);
+        WeightRegistry.Materialize(t);
+        t[1] = 99f;
+
+        // Release is the only lifecycle call after mutation. It must persist the current values
+        // before dropping the owner rather than restoring the registration-time snapshot later.
+        WeightRegistry.ReleaseToPool(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        WeightRegistry.Materialize(t);
+        Assert.Equal(1f, t[0]);
+        Assert.Equal(99f, t[1]);
+        Assert.Equal(3f, t[2]);
+    }
+
     [Fact]
     public void ReleaseToPool_RefcountTwo_DefersDrop_DoesNotThrow()
     {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -168,6 +169,47 @@ public class WeightStreamingTransparentAccessTests : IDisposable
         // The rejected write must leave the canonical store readable rather than accepting a
         // mutation that disappears on the next page-out/page-in cycle.
         Assert.NotEqual(99f, t[0, 1]);
+    }
+
+    [Theory]
+    [InlineData(StreamingStoreDtype.Bf16)]
+    [InlineData(StreamingStoreDtype.Bf16Stochastic)]
+    [InlineData(StreamingStoreDtype.Int8)]
+    [InlineData(StreamingStoreDtype.Int4)]
+    public void QuantizedStreamingEmbeddingLookup_IsReadOnlyAndSurvivesEviction(
+        StreamingStoreDtype storeDtype)
+    {
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+            StreamingStoreDtype = storeDtype,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+
+        var embeddings = new Tensor<float>(
+            new[] { -4f, -3f, -2f, -1f, 0f, 1f, 2f, 3f, 4f, 5f, 6f, 7f },
+            new[] { 3, 4 });
+        embeddings.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(embeddings);
+        Assert.Equal(0, embeddings.DataVector.Length);
+
+        var indices = new Tensor<int>(new[] { 2, 0 }, new[] { 2 });
+        var result = new CpuEngine().TensorEmbeddingLookup<float, int>(embeddings, indices);
+
+        // Compare against the canonical decoded values, rather than the original fp32 values:
+        // int8/int4 are intentionally lossy. The important contract is that a pure engine read
+        // neither requests mutation nor changes which rows the gather returns.
+        var decoded = embeddings.AsSpan();
+        var actual = result.AsSpan();
+        Assert.Equal(8, actual.Length);
+        for (int column = 0; column < 4; column++)
+        {
+            Assert.Equal(decoded[8 + column], actual[column]);
+            Assert.Equal(decoded[column], actual[4 + column]);
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -137,6 +137,39 @@ public class WeightStreamingTransparentAccessTests : IDisposable
         Assert.Equal(4f, t[1, 1]);
     }
 
+    [Theory]
+    [InlineData(StreamingStoreDtype.Bf16)]
+    [InlineData(StreamingStoreDtype.Bf16Stochastic)]
+    [InlineData(StreamingStoreDtype.Int8)]
+    [InlineData(StreamingStoreDtype.Int4)]
+    public void QuantizedStreamingWeight_RejectsMutationBeforeItCanBeLost(StreamingStoreDtype storeDtype)
+    {
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+            StreamingStoreDtype = storeDtype,
+        });
+
+        float[] expected = { 1f, -2f, 3f, -4f };
+        var t = new Tensor<float>(expected, new[] { 2, 2 });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        var error = Assert.Throws<InvalidOperationException>(() => t[0, 1] = 99f);
+        Assert.Contains("quantized inference encoding", error.Message, StringComparison.Ordinal);
+        Assert.Throws<InvalidOperationException>(() => t.SetFlat(1, 99f));
+        Assert.Throws<InvalidOperationException>(() => t.CopyFromArray(new[] { 9f, 9f, 9f, 9f }));
+        Assert.Throws<InvalidOperationException>(() => _ = t.Memory);
+
+        // The rejected write must leave the canonical store readable rather than accepting a
+        // mutation that disappears on the next page-out/page-in cycle.
+        Assert.NotEqual(99f, t[0, 1]);
+    }
+
     [Fact]
     public void ToArray_OnDroppedStreamingWeight_AutoRehydrates()
     {

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -167,6 +167,20 @@ public class WeightStreamingTransparentAccessTests : IDisposable
         Assert.Throws<InvalidOperationException>(() => _ = t.Memory);
         Assert.Throws<InvalidOperationException>(() => t.DataVector.AsWritableSpan());
 
+        // Materialize a floating-point owner, then attempt both raw-array escape paths. Each
+        // closure would mutate the backing storage if the DataVector guard were bypassed.
+        _ = t[0, 0];
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var backing = t.DataVector.GetBackingArrayUnsafe();
+            backing![0] = 99f;
+        });
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            if (t.DataVector.TryGetBackingArraySegment(out var backing, out int offset))
+                backing![offset] = 99f;
+        });
+
         // The rejected write must leave the canonical store readable rather than accepting a
         // mutation that disappears on the next page-out/page-in cycle.
         Assert.NotEqual(99f, t[0, 1]);

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -104,6 +104,40 @@ public class WeightStreamingTransparentAccessTests : IDisposable
     }
 
     [Fact]
+    public void MultiDimensionalIndexer_OnDroppedStreamingWeight_AutoRehydrates()
+    {
+        float[] expected = { 10f, 20f, 30f, 40f, 50f, 60f };
+        var t = new Tensor<float>(expected, new[] { 2, 3 });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        // DenseLayer's adaptive resize copies weights through t[input, output]. The
+        // multi-index accessor must provide the same transparent streaming contract as
+        // flat indexing rather than reading the dropped, zero-length backing Vector.
+        Assert.Equal(30f, t[0, 2]);
+        Assert.Equal(50f, t[1, 1]);
+        Assert.Equal(expected.Length, t.DataVector.Length);
+    }
+
+    [Fact]
+    public void MultiDimensionalIndexerWrite_OnDroppedStreamingWeight_PreservesOtherValues()
+    {
+        float[] expected = { 1f, 2f, 3f, 4f };
+        var t = new Tensor<float>(expected, new[] { 2, 2 });
+        t.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(t);
+        Assert.Equal(0, t.DataVector.Length);
+
+        t[1, 0] = 99f;
+
+        Assert.Equal(1f, t[0, 0]);
+        Assert.Equal(2f, t[0, 1]);
+        Assert.Equal(99f, t[1, 0]);
+        Assert.Equal(4f, t[1, 1]);
+    }
+
+    [Fact]
     public void ToArray_OnDroppedStreamingWeight_AutoRehydrates()
     {
         // ToArray() routes through EnsureMaterialized too, and GetDataArray's

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -165,6 +165,7 @@ public class WeightStreamingTransparentAccessTests : IDisposable
         Assert.Throws<InvalidOperationException>(() => t.SetFlat(1, 99f));
         Assert.Throws<InvalidOperationException>(() => t.CopyFromArray(new[] { 9f, 9f, 9f, 9f }));
         Assert.Throws<InvalidOperationException>(() => _ = t.Memory);
+        Assert.Throws<InvalidOperationException>(() => t.DataVector.AsWritableSpan());
 
         // The rejected write must leave the canonical store readable rather than accepting a
         // mutation that disappears on the next page-out/page-in cycle.

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -212,6 +212,43 @@ public class WeightStreamingTransparentAccessTests : IDisposable
         }
     }
 
+    [Theory]
+    [InlineData(StreamingStoreDtype.Bf16)]
+    [InlineData(StreamingStoreDtype.Bf16Stochastic)]
+    [InlineData(StreamingStoreDtype.Int8)]
+    [InlineData(StreamingStoreDtype.Int4)]
+    public void QuantizedInferenceStore_EnteringTraining_PromotesToWritableLossless(
+        StreamingStoreDtype storeDtype)
+    {
+        WeightRegistry.Reset();
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = 1024L * 1024,
+            StreamingBackingStorePath = _backingDir,
+            TransparentAutoEviction = true,
+            StreamingStoreDtype = storeDtype,
+        });
+        WeightRegistry.SetStreamingExecutionTraining(false);
+
+        var weight = new Tensor<float>(new[] { 1f, -2f, 3f, -4f }, new[] { 2, 2 });
+        weight.Lifetime = WeightLifetime.Streaming;
+        WeightRegistry.RegisterWeight(weight);
+        Assert.NotEqual(StreamingEncoding.Lossless, weight.StreamingStoreEncoding);
+
+        WeightRegistry.SetStreamingExecutionTraining(true);
+
+        Assert.Equal(StreamingEncoding.Lossless, weight.StreamingStoreEncoding);
+        weight[0, 1] = 99f;
+        Assert.Equal(99f, weight[0, 1]);
+
+        // Prove the promoted canonical store is writable, not merely that the resident owner
+        // bypassed the quantized guard: write back, evict the owner, and rehydrate the update.
+        Assert.True(WeightRegistry.WriteBackResident(weight));
+        WeightRegistry.ReleaseToPool(weight);
+        Assert.Equal(0, weight.DataVector.Length);
+        Assert.Equal(99f, weight[0, 1]);
+    }
+
     [Fact]
     public void ToArray_OnDroppedStreamingWeight_AutoRehydrates()
     {


### PR DESCRIPTION
## Summary
- rehydrate paged-out streaming tensors before multi-dimensional reads and writes
- reject mutation through every common writable-storage path for bf16/int8/int4 inference stores
- re-encode native and lossless stores before owner eviction so optimizer/parameter updates survive rehydration
- leave writable owners resident if write-back fails instead of silently losing their current values
- clear both no-upcast int8 and int4 resident forms when their owners are dropped

## Why
`TensorBase<T>.this[params int[]]` bypassed the shared materialization gate even though flat indexing and spans use it. Adaptive base-layer code could therefore index a logically valid but resident-empty streamed tensor.

The original write fix exposed a second integrity contract: bf16/int8/int4 pool snapshots cannot persist arbitrary mutations without compounding quantization, while training's lossless tier must persist them exactly. This change makes quantized inference stores explicitly immutable and implements exact variable-size lossless write-back.

## Verification
- focused access + mutation contracts: 16 passed, 0 failed
- all streaming-focused tests: 225 passed, 0 failed (`net10.0`, Release)
- exact writable round trips cover both FullPrecision and Lossless under forced owner shedding
- mutation rejection covers Bf16, Bf16Stochastic, Int8, and Int4 plus indexer, `SetFlat`, `CopyFromArray`, and writable `Memory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Streaming tensors automatically restore paged-out data for multidimensional reads and writes.
- Training mode promotes quantized inference storage to writable, lossless storage.
- Lossless streaming data preserves exact values after edits and write-back.
- Matrix multiplication and multi-head attention process quantized weights without floating-point expansion.
- Conv3D operations use an optimized, memory-conscious CPU path.

## Bug Fixes

- Unsupported mutations on quantized streaming tensors now fail clearly.
- Read-only embedding lookups remain safe during eviction.
- Streaming cleanup preserves successfully written changes.
- CPU parallel processing better respects configured thread settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
### Quantized projection and timeout evidence (2026-08-14)

The latest common-engine revision `7f4983d6fa54d2e04377e100b8bdffa297a36ae0` removes full-weight expansion from int8/int4 2-D and batched TensorMatMul plus fused multi-head attention. It also fuses streaming-store encoding and keeps the wide-output route bounded. No model-specific dispatch was added.

- Release solution build: **0 errors**.
- Focused streaming/quantized suite: **86/86** on .NET 10 and **65/65** on .NET Framework 4.7.1.
- Regression coverage asserts no-upcast behavior and numerical parity for int8/int4 TensorMatMul and MHA.
- Exact UNet3D workload improved from **175,143 ms** to **11,285.9 ms** (**15.5x**).
- A post-fix Transfusion trace no longer contains `TensorBase.AsSpan` / full int8 dequantization in the hot stack. Its remaining paper-scale CPU cold forward is measured by AiDotNet's per-model census rather than hidden by a larger timeout.
- Current GitHub checks: solution build, AVX-512 verification, Codecov, and completed GPU parity shards pass.
