### PR TITLE
fix(sdpa): broadcast the attention mask in the generic workers (#674 review)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -821,6 +821,11 @@ public partial class CpuEngine
 
     // Seed a ping-pong state buffer (#478): copy the initial state in, or zero it when none is given.
     // default(T) is the additive identity for the numeric structs this path serves, so Clear() zeroes.
+    /// <summary>Seeds a ping-pong LSTM state buffer from an initial state, or zeroes it when none is given.</summary>
+    /// <remarks>
+    /// <c>default(T)</c> is the additive identity for the numeric structs this path serves, so
+    /// <c>Clear()</c> is a correct zero rather than merely a cheap one.
+    /// </remarks>
     private static void SeedLstmState<T>(Tensor<T> buffer, Tensor<T>? source, int n)
     {
         var dst = buffer.AsWritableSpan();
@@ -830,6 +835,7 @@ public partial class CpuEngine
             source.GetFlattenedData().AsSpan(0, n).CopyTo(dst.Slice(0, n));
     }
 
+    /// <summary>Logistic sigmoid over the generic numeric abstraction: 1 / (1 + e^-x).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static T Sigmoid<T>(INumericOperations<T> ops, T x)
     {
@@ -839,6 +845,7 @@ public partial class CpuEngine
         return ops.Divide(ops.One, ops.Add(ops.One, expNeg));
     }
 
+    /// <summary>Hyperbolic tangent over the generic numeric abstraction: (e^2x - 1) / (e^2x + 1).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static T TanhScalar<T>(INumericOperations<T> ops, T x)
     {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequenceBackward.cs
@@ -533,6 +533,12 @@ public partial class CpuEngine
     //    scalar Math.Exp activations; the big GEMMs (Wx / dInput / dWih / dWhh) go through the generic
     //    parallel BlasManaged.Gemm<double>, the tiny per-step recurrent GEMMs stay sequential. ──────
 
+    /// <summary>The large, parallel double GEMM used by the fused LSTM backward pass.</summary>
+    /// <remarks>
+    /// Named to contrast with the tiny per-step recurrent GEMMs, which stay sequential: those are
+    /// too small to pay for a parallel dispatch and would oversubscribe the pool inside the
+    /// timestep loop.
+    /// </remarks>
     private static void GemmBigD(System.ReadOnlySpan<double> a, int lda, bool transA,
                                  System.ReadOnlySpan<double> b, int ldb, bool transB,
                                  System.Span<double> c, int m, int k, int n)
@@ -541,17 +547,33 @@ public partial class CpuEngine
             new BlasManaged.BlasOptions<double> { PackingMode = BlasManaged.PackingMode.DisableAutotune });
     }
 
+    /// <summary>In-place logistic sigmoid over a double span, at full precision.</summary>
+    /// <remarks>"Exact" distinguishes this from the approximated vectorized variants: the backward
+    /// pass reuses these activations to form gradients, so an approximation error here is amplified
+    /// through the whole BPTT chain.</remarks>
     private static void SigmoidExactInPlaceD(double[] buf, int off, int len)
     {
         for (int i = off; i < off + len; i++) buf[i] = 1.0 / (1.0 + Math.Exp(-buf[i]));
     }
 
+    /// <summary>In-place hyperbolic tangent over a double span, at full precision.</summary>
+    /// <remarks>Uses the overflow-safe 2/(1+e^-2x) - 1 form, so a large magnitude saturates to
+    /// +/-1 rather than producing NaN.</remarks>
     private static void TanhExactInPlaceD(double[] buf, int off, int len)
     {
         // tanh(x) = 2/(1+exp(-2x)) - 1 (overflow-safe; large |x| → ±1, never NaN).
         for (int i = off; i < off + len; i++) buf[i] = 2.0 / (1.0 + Math.Exp(-2.0 * buf[i])) - 1.0;
     }
 
+    /// <summary>
+    /// Fused double LSTM forward that also records the activations its backward pass needs.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the inference forward because training has to retain per-timestep gate
+    /// activations for BPTT, which inference discards. <paramref name="wantState"/> is rejected
+    /// under an active gradient tape: the fused node records a backward edge only for the sequence
+    /// output, so a returned final hidden/cell would silently carry no gradient.
+    /// </remarks>
     private Tensor<double> LstmSequenceForwardDoubleTrain(
         Tensor<double> input, Tensor<double>? h0, Tensor<double>? c0,
         Tensor<double> wIh, Tensor<double> wHh, Tensor<double>? bIh, Tensor<double>? bHh,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -316,6 +316,14 @@ public partial class CpuEngine
             output.AsSpan(0, rows * dModel), rows, dModel, dModel);
     }
 
+    /// <summary>
+    /// Scatters one projection's rows into a column block of the interleaved concat buffer.
+    /// </summary>
+    /// <remarks>
+    /// The MHA fast paths keep Q, K and V side by side in a single rented buffer so the three
+    /// projection GEMMs write into one allocation; this places <paramref name="source"/> at
+    /// <paramref name="destinationColumn"/> within a row of <paramref name="destinationStride"/>.
+    /// </remarks>
     private static void CopyMhaProjection(
         float[] source, float[] destination,
         int rows, int dModel, int destinationStride, int destinationColumn)
@@ -514,6 +522,7 @@ public partial class CpuEngine
     }
 
 #if NET5_0_OR_GREATER
+    /// <summary>Horizontal sum of an AVX vector — the softmax denominator for one row.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe float HSum256(Vector256<float> v)
     {
@@ -521,6 +530,7 @@ public partial class CpuEngine
         return t[0] + t[1] + t[2] + t[3] + t[4] + t[5] + t[6] + t[7];
     }
 
+    /// <summary>Horizontal maximum of an AVX vector — the shift that keeps softmax stable.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe float HMax256(Vector256<float> v)
     {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -26888,25 +26888,28 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<bool>? mask = null;
         if (isCausal)
         {
-            // The SDPA reads mask[b, h, i, j] with explicit head/batch indices, so materialize the full shape
-            // (the same causal plane is shared across batch and heads). true = key visible to this query.
-            // The mask depends only on (batch, qHeads, seqQ, seqK), so cache it by shape: steady-state prefill
-            // (constant shape) reuses one immutable tensor instead of allocating + filling batch·qHeads·seqQ·seqK
-            // bools every forward. Decode grows seqK by one each step, so those shapes are distinct (bounded set).
-            int batch = query._shape[0];
+            // The causal plane is identical for every batch and head, so it is built once at
+            // [1, 1, seqQ, seqK] and broadcast by the SDPA kernel. This used to be materialized at
+            // the full [batch, qHeads, seqQ, seqK] because the generic SDPA workers indexed
+            // mask[b, h, i, j] directly and would have run off the end of a size-1 axis; they now
+            // broadcast, so the batch·qHeads duplication is pure waste -- for batch 8 / 32 heads /
+            // 2048 keys that is 256 copies of the same plane, ~1 GB of bool instead of ~4 MB.
+            //
+            // true = key visible to this query. Cached by shape: steady-state prefill (constant
+            // shape) reuses one immutable tensor, and decode grows seqK by one each step, so those
+            // shapes are distinct but bounded. The cache key no longer carries batch or heads,
+            // which also means every batch size shares one entry.
             int seqQ = query._shape[2];
             int seqK = k._shape[2];
-            mask = _gqaCausalMaskCache.GetOrAdd((batch, qHeads, seqQ, seqK), static key =>
+            mask = _gqaCausalMaskCache.GetOrAdd((1, 1, seqQ, seqK), static key =>
             {
                 var (b0, h0, sq, sk) = key;
                 int offset = sk - sq; // KV-cache offset: query i is at absolute key position i + offset.
                 var maskData = new bool[b0 * h0 * sq * sk];
                 int idx = 0;
-                for (int b = 0; b < b0; b++)
-                    for (int h = 0; h < h0; h++)
-                        for (int i = 0; i < sq; i++)
-                            for (int j = 0; j < sk; j++)
-                                maskData[idx++] = j <= i + offset;
+                for (int i = 0; i < sq; i++)
+                    for (int j = 0; j < sk; j++)
+                        maskData[idx++] = j <= i + offset;
                 return new Tensor<bool>(maskData, new[] { b0, h0, sq, sk });
             });
         }
@@ -26914,9 +26917,9 @@ public partial class CpuEngine : ITensorLevelEngine
         return ScaledDotProductAttention(query, k, v, mask, scale, out _, softcap);
     }
 
-    // Causal mask is a pure function of (batch, qHeads, seqQ, seqK); cache the materialized tensor so
-    // steady-state same-shape forwards reuse it instead of re-allocating. The cached tensors are treated
-    // as read-only by the SDPA kernel.
+    // Causal mask is a pure function of (seqQ, seqK) -- it does not vary by batch or head -- so it is
+    // cached at [1, 1, seqQ, seqK] and broadcast. Steady-state same-shape forwards reuse one entry
+    // instead of re-allocating. The cached tensors are treated as read-only by the SDPA kernel.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<(int, int, int, int), Tensor<bool>>
         _gqaCausalMaskCache = new();
 
@@ -27143,6 +27146,19 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             int b = bh / heads;
             int h = bh % heads;
+
+            // Mask broadcasting (IEngine contract: the attention mask is broadcastable to
+            // [batch, heads, seq_q, seq_k]). A size-1 axis maps EVERY index to 0, so a shared
+            // mask such as [1, 1, seq, seq] or [batch, 1, seq, seq] is read correctly instead
+            // of indexing past its bounds. The MHA fast paths already did this; these generic
+            // SDPA workers did not, which is why the GQA causal path had to materialize a full
+            // batch*heads*seqQ*seqK bool plane purely to make it indexable.
+            int mskB = mask is null ? 1 : mask.Shape[0];
+            int mskH = mask is null ? 1 : mask.Shape[1];
+            int mskQ = mask is null ? 1 : mask.Shape[2];
+            int mskK = mask is null ? 1 : mask.Shape[3];
+            int mskb = BroadcastMaskIndex(b, mskB);
+            int mskh = BroadcastMaskIndex(h, mskH);
             int offset = (b * heads + h) * seqQ * seqK;
 
             for (int i = 0; i < seqQ; i++)
@@ -27152,7 +27168,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int j = 0; j < seqK; j++)
                 {
                     int idx = offset + i * seqK + j;
-                    if (mask != null && !mask[b, h, i, j])
+                    if (mask != null && !mask[mskb, mskh, BroadcastMaskIndex(i, mskQ), BroadcastMaskIndex(j, mskK)])
                     {
                         scoresData[idx] = negInf;
                     }
@@ -27271,6 +27287,19 @@ public partial class CpuEngine : ITensorLevelEngine
             int b = bh / heads;
             int h = bh % heads;
 
+            // Mask broadcasting (IEngine contract: the attention mask is broadcastable to
+            // [batch, heads, seq_q, seq_k]). A size-1 axis maps EVERY index to 0, so a shared
+            // mask such as [1, 1, seq, seq] or [batch, 1, seq, seq] is read correctly instead
+            // of indexing past its bounds. The MHA fast paths already did this; these generic
+            // SDPA workers did not, which is why the GQA causal path had to materialize a full
+            // batch*heads*seqQ*seqK bool plane purely to make it indexable.
+            int mskB = mask is null ? 1 : mask.Shape[0];
+            int mskH = mask is null ? 1 : mask.Shape[1];
+            int mskQ = mask is null ? 1 : mask.Shape[2];
+            int mskK = mask is null ? 1 : mask.Shape[3];
+            int mskb = BroadcastMaskIndex(b, mskB);
+            int mskh = BroadcastMaskIndex(h, mskH);
+
             int qOff = bh * seqQ * d_k;
             int kOff = bh * seqK * d_k;
             int sOff = bh * seqQ * seqK;
@@ -27328,7 +27357,7 @@ public partial class CpuEngine : ITensorLevelEngine
                     float v = scoresData[rowOff + j] * scaleF;
                     // Attention-logit soft-cap (Gemma-2): applied to the scaled logit before masking/softmax.
                     if (useSoftcap) v = capF * MathF.Tanh(v * invCapF);
-                    if (mask != null && !mask[b, h, i, j]) v = negInfF;
+                    if (mask != null && !mask[mskb, mskh, BroadcastMaskIndex(i, mskQ), BroadcastMaskIndex(j, mskK)]) v = negInfF;
                     if (v > maxVal) maxVal = v;
                     scoresData[rowOff + j] = v;
                 }
@@ -27456,6 +27485,19 @@ public partial class CpuEngine : ITensorLevelEngine
         {
             int b = bh / heads;
             int h = bh % heads;
+
+            // Mask broadcasting (IEngine contract: the attention mask is broadcastable to
+            // [batch, heads, seq_q, seq_k]). A size-1 axis maps EVERY index to 0, so a shared
+            // mask such as [1, 1, seq, seq] or [batch, 1, seq, seq] is read correctly instead
+            // of indexing past its bounds. The MHA fast paths already did this; these generic
+            // SDPA workers did not, which is why the GQA causal path had to materialize a full
+            // batch*heads*seqQ*seqK bool plane purely to make it indexable.
+            int mskB = mask is null ? 1 : mask.Shape[0];
+            int mskH = mask is null ? 1 : mask.Shape[1];
+            int mskQ = mask is null ? 1 : mask.Shape[2];
+            int mskK = mask is null ? 1 : mask.Shape[3];
+            int mskb = BroadcastMaskIndex(b, mskB);
+            int mskh = BroadcastMaskIndex(h, mskH);
             // Per-head storage offsets via the operands' (possibly permuted) strides.
             int qOff = qBase + b * qBatchStride + h * qHeadStride;
             int kOff = kBase + b * kBatchStride + h * kHeadStride;
@@ -27522,7 +27564,7 @@ public partial class CpuEngine : ITensorLevelEngine
                 for (int j = 0; j < seqK; j++)
                 {
                     float val = scratch[rowOff + j] * scaleF;
-                    if (mask != null && !mask[b, h, i, j]) val = negInfF;
+                    if (mask != null && !mask[mskb, mskh, BroadcastMaskIndex(i, mskQ), BroadcastMaskIndex(j, mskK)]) val = negInfF;
                     if (val > maxVal) maxVal = val;
                     scratch[rowOff + j] = val;
                 }
@@ -27631,6 +27673,19 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 int b = bh / heads;
                 int h = bh % heads;
+
+                // Mask broadcasting (IEngine contract: the attention mask is broadcastable to
+                // [batch, heads, seq_q, seq_k]). A size-1 axis maps EVERY index to 0, so a shared
+                // mask such as [1, 1, seq, seq] or [batch, 1, seq, seq] is read correctly instead
+                // of indexing past its bounds. The MHA fast paths already did this; these generic
+                // SDPA workers did not, which is why the GQA causal path had to materialize a full
+                // batch*heads*seqQ*seqK bool plane purely to make it indexable.
+                int mskB = mask is null ? 1 : mask.Shape[0];
+                int mskH = mask is null ? 1 : mask.Shape[1];
+                int mskQ = mask is null ? 1 : mask.Shape[2];
+                int mskK = mask is null ? 1 : mask.Shape[3];
+                int mskb = BroadcastMaskIndex(b, mskB);
+                int mskh = BroadcastMaskIndex(h, mskH);
                 int qOff = bh * seqQ * d_k;
                 int kOff = bh * seqK * d_k;
                 int sOff = bh * seqQ * seqK;
@@ -27669,7 +27724,7 @@ public partial class CpuEngine : ITensorLevelEngine
                         double v = scoresData[rowOff + j] * scaleValue;
                         // Attention-logit soft-cap (Gemma-2): applied to the scaled logit before masking/softmax.
                         if (softcap > 0.0) v = softcap * Math.Tanh(v / softcap);
-                        if (mask != null && !mask[b, h, i, j]) v = negInfD;
+                        if (mask != null && !mask[mskb, mskh, BroadcastMaskIndex(i, mskQ), BroadcastMaskIndex(j, mskK)]) v = negInfD;
                         if (v > maxVal) maxVal = v;
                         scoresData[rowOff + j] = v;
                     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SdpaMaskBroadcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SdpaMaskBroadcastTests.cs
@@ -1,0 +1,144 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// The attention mask is broadcastable to <c>[batch, heads, seq_q, seq_k]</c> per the IEngine
+/// contract, so a shared plane such as <c>[1, 1, seq, seq]</c> must produce the same result as the
+/// fully-materialized <c>[batch, heads, seq, seq]</c> mask.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The MHA float and double fast paths honoured this through <c>BroadcastMaskIndex</c>; the generic
+/// SDPA workers indexed <c>mask[b, h, i, j]</c> directly, which reads past a size-1 axis. Because
+/// <c>Tensor&lt;bool&gt;</c>'s indexer computes a flat offset from strides rather than bounds-checking
+/// each axis, that did not throw — it silently read a DIFFERENT element, so a broadcast mask masked
+/// the wrong positions and the attention output was quietly wrong.
+/// </para>
+/// <para>
+/// Asserted at every shape the contract permits, and against the materialized mask rather than
+/// against hand-computed numbers: the full mask exercises the path that was always correct, so any
+/// disagreement is the broadcast path being wrong rather than a fixture encoding today's behaviour.
+/// Driven at <c>double</c> and <c>float</c> because the two take different kernels.
+/// </para>
+/// </remarks>
+public class SdpaMaskBroadcastTests
+{
+    private const int Batch = 2;
+    private const int Heads = 3;
+    private const int Seq = 5;
+    private const int HeadDim = 4;
+
+    /// <summary>Deterministic, non-degenerate values so a mis-indexed mask changes the output.</summary>
+    private static Tensor<T> Fill<T>(Func<double, T> conv)
+    {
+        var data = new T[Batch * Heads * Seq * HeadDim];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = conv(Math.Sin(i * 0.7) * 1.5 + 0.25 * ((i % 7) - 3));
+        }
+
+        return new Tensor<T>(data, new[] { Batch, Heads, Seq, HeadDim });
+    }
+
+    /// <summary>A causal plane at an arbitrary broadcastable shape.</summary>
+    private static Tensor<bool> CausalMask(int b, int h)
+    {
+        var data = new bool[b * h * Seq * Seq];
+        int idx = 0;
+        for (int bi = 0; bi < b; bi++)
+            for (int hi = 0; hi < h; hi++)
+                for (int i = 0; i < Seq; i++)
+                    for (int j = 0; j < Seq; j++)
+                        data[idx++] = j <= i;
+
+        return new Tensor<bool>(data, new[] { b, h, Seq, Seq });
+    }
+
+    public static TheoryData<int, int> BroadcastShapes => new()
+    {
+        { 1, 1 },          // fully shared plane — the common causal case
+        { Batch, 1 },      // per-batch, shared across heads
+        { 1, Heads },      // per-head, shared across batch
+    };
+
+    /// <summary>
+    /// A broadcast mask must give the same output as the equivalent materialized mask (double).
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(BroadcastShapes))]
+    public void DoubleSdpa_BroadcastMask_MatchesMaterializedMask(int maskBatch, int maskHeads)
+    {
+        var engine = new CpuEngine();
+        var q = Fill<double>(v => v);
+        var k = Fill<double>(v => v * 0.5 + 0.1);
+        var v2 = Fill<double>(v => v * -0.3 + 0.2);
+
+        var expected = engine.ScaledDotProductAttention(
+            q, k, v2, CausalMask(Batch, Heads), scale: null, out _);
+        var actual = engine.ScaledDotProductAttention(
+            q, k, v2, CausalMask(maskBatch, maskHeads), scale: null, out _);
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i], precision: 12);
+        }
+    }
+
+    /// <summary>
+    /// The same contract at <c>float</c>, which takes a different kernel.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(BroadcastShapes))]
+    public void FloatSdpa_BroadcastMask_MatchesMaterializedMask(int maskBatch, int maskHeads)
+    {
+        var engine = new CpuEngine();
+        var q = Fill<float>(v => (float)v);
+        var k = Fill<float>(v => (float)(v * 0.5 + 0.1));
+        var v2 = Fill<float>(v => (float)(v * -0.3 + 0.2));
+
+        var expected = engine.ScaledDotProductAttention(
+            q, k, v2, CausalMask(Batch, Heads), scale: null, out _);
+        var actual = engine.ScaledDotProductAttention(
+            q, k, v2, CausalMask(maskBatch, maskHeads), scale: null, out _);
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i], precision: 5);
+        }
+    }
+
+    /// <summary>
+    /// The mask must actually be doing something, or the theories above would pass on a no-op.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a broadcast bug that resolved to "everything visible" would agree with a
+    /// materialized mask that also resolved to "everything visible", and both theories would pass
+    /// while masking was silently disabled.
+    /// </remarks>
+    [Fact]
+    public void CausalMask_ChangesTheOutput_SoTheBroadcastAssertionsAreNotVacuous()
+    {
+        var engine = new CpuEngine();
+        var q = Fill<double>(v => v);
+        var k = Fill<double>(v => v * 0.5 + 0.1);
+        var v2 = Fill<double>(v => v * -0.3 + 0.2);
+
+        var unmasked = engine.ScaledDotProductAttention(q, k, v2, null, scale: null, out _);
+        var masked = engine.ScaledDotProductAttention(
+            q, k, v2, CausalMask(1, 1), scale: null, out _);
+
+        bool differs = false;
+        for (int i = 0; i < unmasked.Length && !differs; i++)
+        {
+            if (Math.Abs(unmasked[i] - masked[i]) > 1e-9) differs = true;
+        }
+
+        Assert.True(differs, "The causal mask changed nothing, so the broadcast tests prove nothing.");
+    }
+}


### PR DESCRIPTION
Resolves the unresolved review finding on #674, plus the pre-merge Docstring Coverage check it left failing.

## The finding

The IEngine contract says the attention mask is broadcastable to `[batch, heads, seq_q, seq_k]`. The MHA float and double fast paths honoured that through `BroadcastMaskIndex`; the four generic SDPA workers in `CpuEngine` indexed `mask[b, h, i, j]` directly.

**That did not throw.** `Tensor<bool>`'s indexer computes a flat offset from strides rather than bounds-checking each axis, so reading `b=1` on a size-1 batch axis silently returned a *different element* — a broadcast mask masked the wrong positions and the attention output was quietly wrong.

All four workers now hoist the mask's real dimensions once per `(batch, head)` and read through `BroadcastMaskIndex`.

## The workaround it forced

`GroupedQueryAttention` materialized its causal mask at the full `[batch, qHeads, seqQ, seqK]`, with a comment saying *"the SDPA reads mask[b, h, i, j] with explicit head/batch indices, so materialize the full shape"*. The plane is identical for every batch and head, so it is now built once at `[1, 1, seqQ, seqK]` and broadcast:

| batch 8, 32 heads, 2048 keys | before | after |
|---|---|---|
| causal mask | 256 copies of one plane, ~1 GB of `bool` | ~4 MB |

The shape cache key drops batch and heads with it, so every batch size shares one entry.

## Verification

`SdpaMaskBroadcastTests` asserts a broadcast mask matches the materialized one at every shape the contract allows — `[1,1]`, `[batch,1]`, `[1,heads]` — for both `double` and `float`, which take different kernels. It compares against the materialized mask rather than hand-computed numbers, so a disagreement means the broadcast path is wrong rather than a fixture encoding today's behaviour, and it carries a non-vacuity check proving the causal mask changes the output at all.

- 7/7 pass on net10.0 and net471
- All 7 **fail** with the `CpuEngine` change reverted
- Attention/SDPA/MHA/GQA suites: 385 passed, 0 failed

## Docstrings

Documents the ten members #674 left undocumented, which is what put the pre-merge check at 71.43% against its 80% threshold: `CopyMhaProjection`, `HSum256`, `HMax256`, `SeedLstmState`, `Sigmoid`, `TanhScalar`, `GemmBigD`, `SigmoidExactInPlaceD`, `TanhExactInPlaceD`, `LstmSequenceForwardDoubleTrain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
