### PR TITLE
perf(compilation): bound lazy graph reordering cost

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
@@ -124,74 +124,239 @@ internal sealed class LazyGraphCompiler
         public string Name => "OperationReordering";
 
         public List<ILazyNode> Run(List<ILazyNode> nodes)
+            => ReorderOperations(nodes);
+    }
+
+    /// <summary>
+    /// Topologically schedules operations while preferring a producer whose first consumer is
+    /// closest to becoming ready.
+    /// </summary>
+    /// <remarks>
+    /// Ready nodes that share a first consumer also share the same priority. Grouping them by that
+    /// consumer makes priority changes O(log V) instead of rescanning every ready node after each
+    /// scheduled operation. Node identity is resolved once while building the graph; the scheduling
+    /// loop itself uses array indices and performs no dictionary lookups.
+    /// </remarks>
+    internal static List<ILazyNode> ReorderOperations(List<ILazyNode> nodes)
+    {
+        int nodeCount = nodes.Count;
+        if (nodeCount <= 2)
+            return nodes;
+
+        var nodeIndices = new Dictionary<ILazyNode, int>(nodeCount);
+        var inDegree = new int[nodeCount];
+        var dependents = new List<int>?[nodeCount];
+
+        for (int i = 0; i < nodeCount; i++)
+            nodeIndices[nodes[i]] = i;
+
+        for (int nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++)
         {
-            if (nodes.Count <= 2)
-                return nodes;
-
-            // Build dependency graph: for each node, which nodes must come before it
-            var nodeSet = new HashSet<ILazyNode>(nodes);
-            var inDegree = new Dictionary<ILazyNode, int>();
-            var dependents = new Dictionary<ILazyNode, List<ILazyNode>>();
-
-            foreach (var node in nodes)
+            foreach (var input in nodes[nodeIndex].GetInputNodes())
             {
-                inDegree[node] = 0;
-                dependents[node] = new List<ILazyNode>();
+                if (!nodeIndices.TryGetValue(input, out int inputIndex))
+                    continue;
+
+                inDegree[nodeIndex]++;
+                (dependents[inputIndex] ??= new List<int>()).Add(nodeIndex);
+            }
+        }
+
+        // A ready producer's score is the remaining in-degree of its first consumer. Producers
+        // with no consumer use the terminal group, which retains the original int.MaxValue score.
+        //
+        // Keep the original ready-list positions as the secondary key. The previous implementation
+        // removed a selected node by replacing it with the final ready node, so equal-score choices
+        // were intentionally not stable input order. Preserving those positions retains the exact
+        // historical execution plan while eliminating the full ready-list scan.
+        int terminalGroup = nodeCount;
+        var firstDependentGroups = new int[nodeCount];
+        var readyGroups = new SortedSet<int>?[nodeCount + 1];
+        var groupVersions = new int[nodeCount + 1];
+        var ready = new List<int>(nodeCount);
+        var readyGroupQueue = new ReadyGroupPriorityQueue(nodeCount);
+
+        for (int i = 0; i < nodeCount; i++)
+        {
+            firstDependentGroups[i] = dependents[i] is { Count: > 0 } nodeDependents
+                ? nodeDependents[0]
+                : terminalGroup;
+        }
+
+        void PublishGroup(int group)
+        {
+            SortedSet<int>? members = readyGroups[group];
+            if (members is null || members.Count == 0)
+                return;
+
+            int version = ++groupVersions[group];
+            int score = group == terminalGroup ? int.MaxValue : inDegree[group];
+            readyGroupQueue.Enqueue(group, version, score, members.Min);
+        }
+
+        void AddReadyNode(int nodeIndex)
+        {
+            int group = firstDependentGroups[nodeIndex];
+            SortedSet<int> members = readyGroups[group] ??= new SortedSet<int>();
+            bool wasEmpty = members.Count == 0;
+            int position = ready.Count;
+            ready.Add(nodeIndex);
+            members.Add(position);
+            if (wasEmpty)
+                PublishGroup(group);
+        }
+
+        for (int i = 0; i < nodeCount; i++)
+        {
+            if (inDegree[i] == 0)
+                AddReadyNode(i);
+        }
+
+        var result = new List<ILazyNode>(nodeCount);
+        while (readyGroupQueue.TryDequeue(out int group, out int version))
+        {
+            SortedSet<int>? members = readyGroups[group];
+            if (version != groupVersions[group] || members is null || members.Count == 0)
+                continue;
+
+            int chosenPosition = members.Min;
+            int chosenIndex = ready[chosenPosition];
+            int lastPosition = ready.Count - 1;
+            int lastIndex = ready[lastPosition];
+            int lastGroup = firstDependentGroups[lastIndex];
+
+            members.Remove(chosenPosition);
+            groupVersions[group]++;
+
+            if (chosenPosition != lastPosition)
+            {
+                SortedSet<int> lastMembers = readyGroups[lastGroup]!;
+                lastMembers.Remove(lastPosition);
+                lastMembers.Add(chosenPosition);
+                ready[chosenPosition] = lastIndex;
+
+                if (lastGroup != group)
+                    groupVersions[lastGroup]++;
             }
 
-            foreach (var node in nodes)
+            ready.RemoveAt(lastPosition);
+            PublishGroup(group);
+            if (lastGroup != group)
+                PublishGroup(lastGroup);
+
+            result.Add(nodes[chosenIndex]);
+            List<int>? chosenDependents = dependents[chosenIndex];
+            if (chosenDependents is null)
+                continue;
+
+            foreach (int dependentIndex in chosenDependents)
             {
-                foreach (var input in node.GetInputNodes())
+                int remaining = --inDegree[dependentIndex];
+
+                // Every ready producer whose first consumer is this dependent belongs to the
+                // dependent's group. Republish that group with its new shared priority.
+                if (readyGroups[dependentIndex] is { Count: > 0 })
+                    PublishGroup(dependentIndex);
+
+                if (remaining == 0)
+                    AddReadyNode(dependentIndex);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Minimal stable min-heap used by operation reordering. Kept local instead of relying on
+    /// <c>System.Collections.Generic.PriorityQueue</c>, which is unavailable on the net471 target.
+    /// </summary>
+    private sealed class ReadyGroupPriorityQueue
+    {
+        private readonly List<Entry> _entries;
+
+        internal ReadyGroupPriorityQueue(int capacity)
+        {
+            _entries = new List<Entry>(capacity);
+        }
+
+        internal void Enqueue(int group, int version, int score, int order)
+        {
+            var entry = new Entry(group, version, score, order);
+            int index = _entries.Count;
+            _entries.Add(entry);
+
+            while (index > 0)
+            {
+                int parent = (index - 1) / 2;
+                if (!ComesBefore(entry, _entries[parent]))
+                    break;
+
+                _entries[index] = _entries[parent];
+                index = parent;
+            }
+
+            _entries[index] = entry;
+        }
+
+        internal bool TryDequeue(out int group, out int version)
+        {
+            if (_entries.Count == 0)
+            {
+                group = 0;
+                version = 0;
+                return false;
+            }
+
+            Entry first = _entries[0];
+            int lastIndex = _entries.Count - 1;
+            Entry last = _entries[lastIndex];
+            _entries.RemoveAt(lastIndex);
+
+            if (lastIndex > 0)
+            {
+                int index = 0;
+                while (true)
                 {
-                    if (nodeSet.Contains(input))
-                    {
-                        inDegree[node]++;
-                        dependents[input].Add(node);
-                    }
+                    int left = index * 2 + 1;
+                    if (left >= lastIndex)
+                        break;
+
+                    int right = left + 1;
+                    int child = right < lastIndex && ComesBefore(_entries[right], _entries[left])
+                        ? right
+                        : left;
+                    if (!ComesBefore(_entries[child], last))
+                        break;
+
+                    _entries[index] = _entries[child];
+                    index = child;
                 }
+
+                _entries[index] = last;
             }
 
-            // Kahn's algorithm with priority: prefer nodes that feed into
-            // operations that are closest to being ready (lowest remaining in-degree)
-            var ready = new List<ILazyNode>();
-            foreach (var node in nodes)
+            group = first.Group;
+            version = first.Version;
+            return true;
+        }
+
+        private static bool ComesBefore(Entry left, Entry right)
+            => left.Score < right.Score || left.Score == right.Score && left.Order < right.Order;
+
+        private readonly struct Entry
+        {
+            internal Entry(int group, int version, int score, int order)
             {
-                if (inDegree[node] == 0)
-                    ready.Add(node);
+                Group = group;
+                Version = version;
+                Score = score;
+                Order = order;
             }
 
-            var result = new List<ILazyNode>(nodes.Count);
-            while (ready.Count > 0)
-            {
-                // Pick the ready node whose first dependent has the lowest remaining in-degree
-                // (heuristic: schedule producers right before their consumer becomes ready)
-                int bestIdx = 0;
-                int bestScore = int.MaxValue;
-                for (int i = 0; i < ready.Count; i++)
-                {
-                    var deps = dependents[ready[i]];
-                    int score = deps.Count > 0 ? inDegree[deps[0]] : int.MaxValue;
-                    if (score < bestScore)
-                    {
-                        bestScore = score;
-                        bestIdx = i;
-                    }
-                }
-
-                var chosen = ready[bestIdx];
-                ready[bestIdx] = ready[ready.Count - 1];
-                ready.RemoveAt(ready.Count - 1);
-                result.Add(chosen);
-
-                foreach (var dep in dependents[chosen])
-                {
-                    inDegree[dep]--;
-                    if (inDegree[dep] == 0)
-                        ready.Add(dep);
-                }
-            }
-
-            return result;
+            internal int Group { get; }
+            internal int Version { get; }
+            internal int Score { get; }
+            internal int Order { get; }
         }
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
@@ -1,0 +1,166 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class OperationReorderingPassTests
+{
+    [Fact]
+    public void ReorderOperations_PreservesEveryNodeAndDependency()
+    {
+        var first = new TestNode("first");
+        var second = new TestNode("second");
+        var join = new TestNode("join", first, second);
+        var tail = new TestNode("tail", join);
+        var independent = new TestNode("independent");
+        var input = new List<ILazyNode> { tail, second, independent, join, first };
+
+        List<ILazyNode> result = LazyGraphCompiler.ReorderOperations(input);
+
+        Assert.Equal(input.Count, result.Count);
+        Assert.Equal(input.Count, result.Distinct().Count());
+        AssertDependencyPrecedes(result, first, join);
+        AssertDependencyPrecedes(result, second, join);
+        AssertDependencyPrecedes(result, join, tail);
+    }
+
+    [Fact]
+    public void ReorderOperations_PrefersProducerWhoseConsumerIsCloserToReady()
+    {
+        var near = new TestNode("near");
+        var far = new TestNode("far");
+        var otherFarInput = new TestNode("other-far-input");
+        var nearConsumer = new TestNode("near-consumer", near);
+        var farConsumer = new TestNode("far-consumer", far, otherFarInput);
+        var input = new List<ILazyNode> { far, near, otherFarInput, farConsumer, nearConsumer };
+
+        List<ILazyNode> result = LazyGraphCompiler.ReorderOperations(input);
+
+        Assert.True(result.IndexOf(near) < result.IndexOf(far));
+        AssertDependencyPrecedes(result, near, nearConsumer);
+        AssertDependencyPrecedes(result, far, farConsumer);
+        AssertDependencyPrecedes(result, otherFarInput, farConsumer);
+    }
+
+    [Fact]
+    public void ReorderOperations_MatchesHistoricalScheduleAcrossGeneratedGraphs()
+    {
+        for (int seed = 0; seed < 100; seed++)
+        {
+            var random = new Random(seed);
+            var nodes = new List<TestNode>();
+            for (int i = 0; i < 250; i++)
+            {
+                int inputCount = i == 0 ? 0 : random.Next(0, Math.Min(i, 5) + 1);
+                var inputs = new HashSet<TestNode>();
+                while (inputs.Count < inputCount)
+                    inputs.Add(nodes[random.Next(i)]);
+
+                nodes.Add(new TestNode($"node-{i}", inputs.ToArray()));
+            }
+
+            var shuffled = nodes.OrderBy(_ => random.Next()).Cast<ILazyNode>().ToList();
+
+            List<ILazyNode> expected = ReorderOperationsReference(shuffled);
+            List<ILazyNode> actual = LazyGraphCompiler.ReorderOperations(shuffled);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ReorderOperations_LargeReadySetCompletesWithoutQuadraticScan()
+    {
+        await Task.Yield();
+        const int nodeCount = 20_000;
+        var input = new List<ILazyNode>(nodeCount);
+        for (int i = 0; i < nodeCount; i++)
+            input.Add(new TestNode($"node-{i}"));
+
+        List<ILazyNode> result = LazyGraphCompiler.ReorderOperations(input);
+
+        Assert.Equal(nodeCount, result.Count);
+        Assert.Equal(nodeCount, result.Distinct().Count());
+    }
+
+    private static List<ILazyNode> ReorderOperationsReference(List<ILazyNode> nodes)
+    {
+        var nodeSet = new HashSet<ILazyNode>(nodes);
+        var inDegree = nodes.ToDictionary(node => node, _ => 0);
+        var dependents = nodes.ToDictionary(node => node, _ => new List<ILazyNode>());
+
+        foreach (ILazyNode node in nodes)
+        {
+            foreach (ILazyNode input in node.GetInputNodes())
+            {
+                if (!nodeSet.Contains(input))
+                    continue;
+
+                inDegree[node]++;
+                dependents[input].Add(node);
+            }
+        }
+
+        var ready = nodes.Where(node => inDegree[node] == 0).ToList();
+        var result = new List<ILazyNode>(nodes.Count);
+        while (ready.Count > 0)
+        {
+            int bestIndex = 0;
+            int bestScore = int.MaxValue;
+            for (int i = 0; i < ready.Count; i++)
+            {
+                List<ILazyNode> readyDependents = dependents[ready[i]];
+                int score = readyDependents.Count > 0 ? inDegree[readyDependents[0]] : int.MaxValue;
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    bestIndex = i;
+                }
+            }
+
+            ILazyNode chosen = ready[bestIndex];
+            ready[bestIndex] = ready[^1];
+            ready.RemoveAt(ready.Count - 1);
+            result.Add(chosen);
+
+            foreach (ILazyNode dependent in dependents[chosen])
+            {
+                inDegree[dependent]--;
+                if (inDegree[dependent] == 0)
+                    ready.Add(dependent);
+            }
+        }
+
+        return result;
+    }
+
+    private static void AssertDependencyPrecedes(
+        List<ILazyNode> result,
+        ILazyNode dependency,
+        ILazyNode consumer)
+        => Assert.True(result.IndexOf(dependency) < result.IndexOf(consumer));
+
+    private sealed class TestNode : ILazyNode
+    {
+        private readonly ILazyNode[] _inputs;
+
+        internal TestNode(string name, params ILazyNode[] inputs)
+        {
+            Name = name;
+            _inputs = inputs;
+        }
+
+        internal string Name { get; }
+        public LazyNodeType OpType => LazyNodeType.Custom;
+        public int[] OutputShape { get; } = [1];
+        public bool IsRealized { get; set; }
+        public int TopologicalIndex { get; set; }
+        public int ConsumerCount { get; set; }
+        public IEngine RecordingEngine => null!;
+        public void Realize(IEngine engine) { }
+        public ILazyNode[] GetInputNodes() => _inputs;
+        public void ClearOutputLazySource() { }
+        public override string ToString() => Name;
+    }
+}


### PR DESCRIPTION
## Summary

- replace the lazy graph compiler's quadratic ready-list rescans and repeated dictionary lookups with indexed dependency storage and a grouped priority heap
- preserve the historical scheduler's exact tie-breaking and swap-removal order
- add differential coverage against the former algorithm over 100 generated DAGs plus a 20,000-node stress case

This is a shared compiler optimization. It runs before backend execution, so no per-backend implementation or model-specific override is required.

## Why

AiDotNet's full 863-model performance census identified SegMamba training as a severe outlier. PerfView attributed 36.92% of the captured CPU samples to `LazyGraphCompiler.OperationReorderingPass.Run`, dominated by dictionary lookup and full-ready-set scanning.

The old scheduler rescanned every ready node on each iteration. Large autodiff graphs therefore approached quadratic scheduling cost before backend execution began.

## Exact A/B evidence

The benchmark uses the exact AiDotNet census bundle from run `31825941228` at commit `cc210126018b8b7575f830825a959be13ebddc1b`. Only `AiDotNet.Tensors.dll` was replaced. Both control and patched DLLs were Release builds from tag `v0.122.0`; the patched build adds only this change.

SegMamba remained identical in both runs:

- input: `[1,16,16,16]`
- output: `[14,16,16,16]`
- parameters: `553,678`
- training iterations: `1`

| Metric | v0.122 source control | Patched run 1 | Patched run 2 | Result |
|---|---:|---:|---:|---:|
| Train step | 11,496.5 ms | 2,118.0 ms | 2,103.7 ms | 81.6% lower / 5.45x faster |
| Wall time | 12,369.3 ms | 3,010.1 ms | 2,983.2 ms | 75.8% lower |
| Steady forward p95 | 133.5 ms | 133.7 ms | 134.1 ms | +0.4% (noise-level) |
| Allocated | 596.4 MiB | 596.5 MiB | 596.4 MiB | unchanged |

A separately published v0.122 package binary was deliberately excluded from the final A/B because its build configuration produced materially different forward timings from a clean same-source Release build.

## Correctness and compatibility

- 4/4 focused operation-reordering tests pass
- 100 generated DAGs produce the exact same node schedule as the historical algorithm
- 20,000 independent ready nodes complete inside the 30-second regression ceiling
- 46 broader compiler tests pass; 1 pre-existing test remains skipped
- net471 Release build passes with 0 warnings and 0 errors
- no architecture defaults, tensor shapes, parameter counts, numerical operations, or backend code changed

## Follow-up

After this Tensors change is released, the AiDotNet census-performance PR will consume the package and rerun all affected fixtures plus the full 863-model census.
