### PR TITLE
feat(fused): surface the nesterov flag and FTRL's beta term

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -4156,6 +4156,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             D0 = extras.D0,
             DGrowthRate = extras.DGrowthRate,
             SfBeta = extras.SfBeta,
+            // Must be copied like every other field. This clone is what the runtime state — and therefore the
+            // checkpoint — records, so dropping these two here made a Nesterov or non-zero-beta FTRL plan
+            // report itself as classical/beta-0, and restore as a different algorithm than it ran.
+            Nesterov = extras.Nesterov,
+            FtrlBeta = extras.FtrlBeta,
         };
 
     private static float[]? CopyNonEmpty(float[][]? arrays, int index)

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -2669,6 +2669,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                     lr, b1, b2, wd, len);
                                 break;
                             case OptimizerType.SGDMomentum:
+                                // The GPU kernel implements CLASSICAL momentum only. Running it for a
+                                // Nesterov request would quietly train a different algorithm, which is
+                                // the exact failure this flag was added to remove — so refuse instead.
+                                if (extras.Nesterov)
+                                {
+                                    throw new NotSupportedException(
+                                        "Nesterov momentum is not implemented by the GPU fused optimizer kernel. " +
+                                        "Run this model on the CPU engine, which supports it, or use classical " +
+                                        "momentum. Refusing rather than silently applying classical momentum.");
+                                }
                                 gpuBe.SgdMomentumUpdate(gpuP, gradBuf, gpuM[p]!,
                                     lr, b1, wd, len);
                                 break;
@@ -2827,7 +2837,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.SGDMomentum:
                             if (wd != 0f)
                                 for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
-                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, false);
+                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, extras.Nesterov);
                             break;
                         case OptimizerType.AdaMax:
                             if (wd != 0f)
@@ -2850,7 +2860,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.FTRL:
                             // z=pV, n=pVMax; FTRL applies its own L1/L2 regularization.
                             FusedOptimizer.FTRLUpdateSimd(pParam, pGrad, pV, pVMax, len,
-                                lr, extras.L1, extras.L2, extras.LrPower);
+                                lr, extras.L1, extras.L2, extras.LrPower, extras.FtrlBeta);
                             break;
                         case OptimizerType.ASGD:
                             {
@@ -3291,6 +3301,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                     lr, b1, b2, wd, len);
                                 break;
                             case OptimizerType.SGDMomentum:
+                                // The GPU kernel implements CLASSICAL momentum only. Running it for a
+                                // Nesterov request would quietly train a different algorithm, which is
+                                // the exact failure this flag was added to remove — so refuse instead.
+                                if (extras.Nesterov)
+                                {
+                                    throw new NotSupportedException(
+                                        "Nesterov momentum is not implemented by the GPU fused optimizer kernel. " +
+                                        "Run this model on the CPU engine, which supports it, or use classical " +
+                                        "momentum. Refusing rather than silently applying classical momentum.");
+                                }
                                 gpuBe.SgdMomentumUpdate(gpuP, gradBuf, gpuM[p]!,
                                     lr, b1, wd, len);
                                 break;
@@ -3412,7 +3432,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                         case OptimizerType.SGDMomentum:
                             if (wd != 0f)
                                 for (int i = 0; i < len; i++) pGrad[i] += wd * pParam[i];
-                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, false);
+                            FusedOptimizer.SgdMomentumUpdateSimd(pParam, pGrad, pM, len, lr, b1, extras.Nesterov);
                             break;
                         case OptimizerType.AdaMax:
                             if (wd != 0f)
@@ -3432,7 +3452,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                             break;
                         case OptimizerType.FTRL:
                             FusedOptimizer.FTRLUpdateSimd(pParam, pGrad, pV, pVMax, len,
-                                lr, extras.L1, extras.L2, extras.LrPower);
+                                lr, extras.L1, extras.L2, extras.LrPower, extras.FtrlBeta);
                             break;
                         case OptimizerType.ASGD:
                             {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -758,6 +758,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         public bool IsGrouped;
         public LrSchedule[] Schedules = Array.Empty<LrSchedule>();
         public int[]? ParamToGroup;
+        /// <summary>
+        /// Per-group optimizer types, or null when every group runs <see cref="OptimizerType"/>.
+        /// </summary>
+        /// <remarks>
+        /// Null rather than an all-same array so that "one optimizer for the whole plan" — overwhelmingly the
+        /// common case — stays distinguishable from "several groups that happen to agree today", both here and
+        /// in the checkpoint.
+        /// </remarks>
+        public OptimizerType[]? GroupOptimizerTypes;
+        /// <summary>
+        /// Per-group weight decay, or null when every group uses <see cref="WeightDecay"/>.
+        /// </summary>
+        public float[]? GroupWeightDecays;
         public float Beta1;
         public float Beta2;
         public float Epsilon;
@@ -1735,6 +1748,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float eps = 1e-8f,
         float weightDecay = 0f,
         FusedOptimizerExtras? extras = null)
+        => ConfigureOptimizerGrouped(
+            optimizerType, groupOptimizerTypes: null, groupSchedules, paramToGroup,
+            beta1, beta2, eps, weightDecay, groupWeightDecays: null, extras);
+
+    /// <inheritdoc/>
+    public unsafe void ConfigureOptimizerGrouped(
+        OptimizerType optimizerType,
+        System.Collections.Generic.IReadOnlyList<OptimizerType>? groupOptimizerTypes,
+        System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
+        System.Collections.Generic.IReadOnlyList<int> paramToGroup,
+        float beta1 = 0.9f,
+        float beta2 = 0.999f,
+        float eps = 1e-8f,
+        float weightDecay = 0f,
+        System.Collections.Generic.IReadOnlyList<float>? groupWeightDecays = null,
+        FusedOptimizerExtras? extras = null)
     {
         if (groupSchedules is null) throw new ArgumentNullException(nameof(groupSchedules));
         if (paramToGroup is null) throw new ArgumentNullException(nameof(paramToGroup));
@@ -1796,8 +1825,30 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // optimizers without a GPU backend kernel.
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
-        ValidatePlanOptimizerSupport(
-            optimizerType, typeof(T) == typeof(float), hasGpuParams, extras?.Nesterov ?? false);
+        // Per-group types: validate EVERY group's optimizer, not just the fallback. A group whose type is
+        // unsupported would otherwise reach the closure's default case and throw on the first Step(), after
+        // earlier parameters had already been updated.
+        bool isFloatPlan = typeof(T) == typeof(float);
+        bool nesterov = extras?.Nesterov ?? false;
+        if (groupOptimizerTypes is null)
+        {
+            ValidatePlanOptimizerSupport(optimizerType, isFloatPlan, hasGpuParams, nesterov);
+        }
+        else
+        {
+            if (groupOptimizerTypes.Count != groupSchedules.Count)
+                throw new ArgumentException(
+                    $"groupOptimizerTypes.Count ({groupOptimizerTypes.Count}) must equal groupSchedules.Count " +
+                    $"({groupSchedules.Count}) — every group needs exactly one optimizer.",
+                    nameof(groupOptimizerTypes));
+            for (int g = 0; g < groupOptimizerTypes.Count; g++)
+                ValidatePlanOptimizerSupport(groupOptimizerTypes[g], isFloatPlan, hasGpuParams, nesterov);
+        }
+        if (groupWeightDecays is not null && groupWeightDecays.Count != groupSchedules.Count)
+            throw new ArgumentException(
+                $"groupWeightDecays.Count ({groupWeightDecays.Count}) must equal groupSchedules.Count " +
+                $"({groupSchedules.Count}).",
+                nameof(groupWeightDecays));
         // Drop any Schedule-Free pre-forward hook left over from a prior ungrouped
         // ConfigureOptimizer(ScheduleFreeSGD); a grouped optimizer never sets one,
         // and Step() unconditionally invokes it — leaving it active would rewrite
@@ -1805,23 +1856,38 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _preForwardParamTransform = null;
         // Global-state optimizers adapt ONE learning-rate/distance scalar across all
         // parameters — a per-group schedule is meaningless for them, so they are only
-        // supported through the ungrouped ConfigureOptimizer.
-        if (optimizerType is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
-            or OptimizerType.ScheduleFreeSGD)
-            throw new NotSupportedException(
-                $"{optimizerType} maintains a single global learning-rate/distance/weight-sum scalar " +
-                "(or a per-step parameter transform) and is not supported with per-group schedules; " +
-                "use the ungrouped ConfigureOptimizer.");
+        // supported through the ungrouped ConfigureOptimizer. Checked for every group's
+        // type, not just the fallback, or a per-group configuration could smuggle one in.
+        for (int g = -1; g < (groupOptimizerTypes?.Count ?? 0); g++)
+        {
+            var candidate = g < 0 ? optimizerType : groupOptimizerTypes![g];
+            if (candidate is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
+                or OptimizerType.ScheduleFreeSGD)
+                throw new NotSupportedException(
+                    $"{candidate} maintains a single global learning-rate/distance/weight-sum scalar " +
+                    "(or a per-step parameter transform) and is not supported with per-group schedules; " +
+                    "use the ungrouped ConfigureOptimizer.");
+        }
         var ex = extras ?? new FusedOptimizerExtras();
         ex.Validate();
+
+        // Materialize the per-group arrays once. Null means "uniform", which the closures read as
+        // "use the scalar fallback" — keeping the common single-optimizer path free of an indirection.
+        OptimizerType[]? groupTypes = groupOptimizerTypes is null
+            ? null
+            : System.Linq.Enumerable.ToArray(groupOptimizerTypes);
+        float[]? groupWds = groupWeightDecays is null
+            ? null
+            : System.Linq.Enumerable.ToArray(groupWeightDecays);
+
         if (typeof(T) == typeof(float))
         {
-            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, ex);
+            ConfigureOptimizerFloatGrouped(optimizerType, groupTypes, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, groupWds, ex);
             return;
         }
         if (typeof(T) == typeof(double))
         {
-            ConfigureOptimizerDoubleGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay);
+            ConfigureOptimizerDoubleGrouped(optimizerType, groupTypes, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, groupWds);
             return;
         }
         throw new NotSupportedException("Fused optimizer updates support float and double parameters.");
@@ -2917,9 +2983,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private unsafe void ConfigureOptimizerFloatGrouped(
         OptimizerType optimizerType,
+        OptimizerType[]? groupOptimizerTypes,
         System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
         float beta1, float beta2, float eps, float weightDecay,
+        float[]? groupWeightDecays,
         FusedOptimizerExtras extras)
     {
         // CodeRabbit #425: reconfigure releases prior GPU optimizer-state.
@@ -2948,6 +3016,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // and used only by the AMSGrad case; allocated per-param below only when
         // the optimizer is AMSGrad, else left as an empty array.
         var vMax = new float[paramCount][];
+        // Quantized/bf16 moment storage is an Adam-specific footprint optimization whose buffer layout is
+        // chosen once for the whole plan. Rather than guess how it should interact with a heterogeneous group
+        // configuration, refuse the combination outright — the alternative is silently storing one group's
+        // moments in a format its kernel does not read.
+        if (groupOptimizerTypes is not null && _momentStorageMode != FusedMomentStorageMode.Float32)
+            throw new NotSupportedException(
+                "Per-group optimizer types are supported only with Float32 moment storage; this plan uses " +
+                $"{_momentStorageMode}. bf16/int8 fused moments are an Adam-specific layout applied plan-wide.");
         bool useBf16Moments = _momentStorageMode == FusedMomentStorageMode.BFloat16
             && (optimizerType is OptimizerType.Adam or OptimizerType.AdamW);
         bool useInt8Moments = _momentStorageMode == FusedMomentStorageMode.Int8BlockQuantized;
@@ -2984,18 +3060,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < paramCount; p++)
         {
             lengths[p] = _parameters[p].Length;
-            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            // Which state buffers this parameter needs follows ITS OWN group's optimizer, not the plan-wide
+            // fallback. Sizing from the fallback would leave a group running (say) Adam with no second-moment
+            // buffer while its neighbours were fine — a null-deref on the first Step(), or worse, a silently
+            // shared buffer.
+            var slotType = groupOptimizerTypes is null ? optimizerType : groupOptimizerTypes[paramToGroup[p]];
+            bool needsMomentum = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
                 or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
-            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            bool needsSecondMoment = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
                 or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
-            bool needsThirdState = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL;
+            bool needsThirdState = slotType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL;
 
             // GPU fast path — same logic as ConfigureOptimizerFloat. See
             // there for the full rationale on per-param GPU/CPU dispatch.
@@ -3149,8 +3230,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var b1 = beta1;
         var b2 = beta2;
         var epsVal = eps;
-        var wd = weightDecay;
-        var optType = optimizerType;
+        var fallbackWd = weightDecay;
+        var fallbackOptType = optimizerType;
+        // Null when every group runs the same optimizer, which keeps the common path a captured scalar
+        // rather than an array index per parameter per step.
+        var groupOptTypes = groupOptimizerTypes;
+        var groupWds = groupWeightDecays;
         var groupLrs = new float[groupCount];
 
         _optimizerRuntimeState = new FusedOptimizerRuntimeState
@@ -3159,6 +3244,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             IsGrouped = true,
             Schedules = schedules,
             ParamToGroup = paramGroup,
+            GroupOptimizerTypes = groupOptimizerTypes is null ? null : (OptimizerType[])groupOptimizerTypes.Clone(),
+            GroupWeightDecays = groupWeightDecays is null ? null : (float[])groupWeightDecays.Clone(),
             Beta1 = beta1,
             Beta2 = beta2,
             Epsilon = eps,
@@ -3208,7 +3295,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             for (int p = 0; p < paramCount; p++)
             {
                 int len = lengths[p];
-                float lr = groupLrs[paramGroup[p]];
+                int grp = paramGroup[p];
+                float lr = groupLrs[grp];
+                // Per-group optimizer and weight decay. Both fall back to the plan-wide value when the caller
+                // did not supply per-group arrays, so the uniform case costs one null check per parameter.
+                var optType = groupOptTypes is null ? fallbackOptType : groupOptTypes[grp];
+                float wd = groupWds is null ? fallbackWd : groupWds[grp];
 
                 // GPU path (mirrors ConfigureOptimizerFloat).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
@@ -3690,9 +3782,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private unsafe void ConfigureOptimizerDoubleGrouped(
         OptimizerType optimizerType,
+        OptimizerType[]? groupOptimizerTypes,
         System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
-        float beta1, float beta2, float eps, float weightDecay)
+        float beta1, float beta2, float eps, float weightDecay,
+        float[]? groupWeightDecays)
     {
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
@@ -3722,6 +3816,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < paramCount; p++) paramGroup[p] = paramToGroup[p];
 
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
+        // GROUPED double path: buffer sizing follows each parameter's own group optimizer (slotType below).
         for (int p = 0; p < paramCount; p++)
         {
             var boundParam = BindCpuOptimizerTensor(
@@ -3739,13 +3834,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
             lengths[p] = _parameters[p].Length;
 
-            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            var slotType = groupOptimizerTypes is null ? optimizerType : groupOptimizerTypes[paramToGroup[p]];
+            bool needsMomentum = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
                 or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
-            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            bool needsSecondMoment = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
@@ -3753,15 +3849,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
             v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            vMax[p] = slotType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
         double b1 = beta1;
         double b2 = beta2;
         double epsVal = eps;
-        double wd = weightDecay;
-        var optType = optimizerType;
+        double fallbackWd = weightDecay;
+        var fallbackOptType = optimizerType;
+        var groupOptTypes = groupOptimizerTypes;
+        var groupWds = groupWeightDecays;
         var groupLrs = new double[groupCount];
 
         _optimizerRuntimeState = new FusedOptimizerRuntimeState
@@ -3770,6 +3868,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             IsGrouped = true,
             Schedules = schedules,
             ParamToGroup = paramGroup,
+            GroupOptimizerTypes = groupOptimizerTypes is null ? null : (OptimizerType[])groupOptimizerTypes.Clone(),
+            GroupWeightDecays = groupWeightDecays is null ? null : (float[])groupWeightDecays.Clone(),
             Beta1 = beta1,
             Beta2 = beta2,
             Epsilon = eps,
@@ -3802,7 +3902,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // Skip params with no gradient OR no materialized weight backing (#1738).
                 if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                 int len = lengths[p];
-                double lr = groupLrs[paramGroup[p]];
+                int grp = paramGroup[p];
+                double lr = groupLrs[grp];
+                // Per-group optimizer and weight decay; both fall back to the plan-wide value when the
+                // caller supplied no per-group array. See ConfigureOptimizerFloatGrouped.
+                var optType = groupOptTypes is null ? fallbackOptType : groupOptTypes[grp];
+                double wd = groupWds is null ? fallbackWd : groupWds[grp];
 
                 fixed (double* pParam = &paramArrays[p][paramOffsets[p]],
                        pGrad = &gradArrays[p][gradOffsets[p]],
@@ -3870,6 +3975,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             OptimizerType = rt.OptimizerType,
             IsGrouped = rt.IsGrouped,
+            // Copies, not shared references: the runtime state stays live and mutable after capture.
+            GroupOptimizerTypes = rt.GroupOptimizerTypes is null ? null : (OptimizerType[])rt.GroupOptimizerTypes.Clone(),
+            GroupWeightDecays = rt.GroupWeightDecays is null ? null : (float[])rt.GroupWeightDecays.Clone(),
             OptimizerStep = _optimizerStep,
             Beta1 = rt.Beta1,
             Beta2 = rt.Beta2,
@@ -3917,12 +4025,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 throw new InvalidDataException("Grouped optimizer checkpoint is missing ParamToGroup.");
             ConfigureOptimizerGrouped(
                 checkpoint.OptimizerType,
+                checkpoint.GroupOptimizerTypes,
                 schedules,
                 checkpoint.ParamToGroup,
                 checkpoint.Beta1,
                 checkpoint.Beta2,
                 checkpoint.Epsilon,
                 checkpoint.WeightDecay,
+                checkpoint.GroupWeightDecays,
                 checkpoint.Extras);
         }
         else

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1706,8 +1706,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // optimizers without a GPU backend kernel.
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
-        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
         var ex = extras ?? new FusedOptimizerExtras();
+        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams, ex.Nesterov);
         ex.Validate();
         if (typeof(T) == typeof(float))
         {
@@ -1796,7 +1796,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // optimizers without a GPU backend kernel.
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
-        ValidatePlanOptimizerSupport(optimizerType, typeof(T) == typeof(float), hasGpuParams);
+        ValidatePlanOptimizerSupport(
+            optimizerType, typeof(T) == typeof(float), hasGpuParams, extras?.Nesterov ?? false);
         // Drop any Schedule-Free pre-forward hook left over from a prior ungrouped
         // ConfigureOptimizer(ScheduleFreeSGD); a grouped optimizer never sets one,
         // and Step() unconditionally invokes it — leaving it active would rewrite
@@ -1830,8 +1831,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// support more optimizer math than every compiled-plan/device combination
     /// can safely replay, so this keeps configure-time acceptance aligned with
     /// the available closures and backend contracts.</summary>
-    private static void ValidatePlanOptimizerSupport(OptimizerType optimizerType, bool isFloat, bool hasGpuParams)
+    private static void ValidatePlanOptimizerSupport(
+        OptimizerType optimizerType, bool isFloat, bool hasGpuParams, bool nesterov = false)
     {
+        // The GPU SgdMomentum kernel implements CLASSICAL momentum only, so a Nesterov request on a
+        // GPU-resident plan cannot be honored. Reject it HERE, at configure time, rather than from
+        // inside the per-parameter update closure: that closure runs on the first Step(), and on a
+        // mixed CPU/GPU plan it would already have mutated (and MarkHostWeightMutated'd) every CPU
+        // parameter before reaching the first GPU one, leaving a half-applied step. Failing at
+        // configuration matches FusedOptimizerExtras.Validate()'s contract.
+        if (hasGpuParams && nesterov && optimizerType is OptimizerType.SGDMomentum)
+        {
+            throw new NotSupportedException(
+                "Nesterov momentum is not implemented by the GPU fused optimizer kernel. " +
+                "Run this model on the CPU engine, which supports it, or use classical " +
+                "momentum. Refusing rather than silently applying classical momentum.");
+        }
+
         // Device-aware gate (CodeRabbit, PR #501): reject unsupported GPU
         // combinations before _optimizerUpdate is published so a mixed CPU/GPU
         // plan cannot partially update CPU parameters and then throw on the
@@ -2669,16 +2685,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                     lr, b1, b2, wd, len);
                                 break;
                             case OptimizerType.SGDMomentum:
-                                // The GPU kernel implements CLASSICAL momentum only. Running it for a
-                                // Nesterov request would quietly train a different algorithm, which is
-                                // the exact failure this flag was added to remove — so refuse instead.
-                                if (extras.Nesterov)
-                                {
-                                    throw new NotSupportedException(
-                                        "Nesterov momentum is not implemented by the GPU fused optimizer kernel. " +
-                                        "Run this model on the CPU engine, which supports it, or use classical " +
-                                        "momentum. Refusing rather than silently applying classical momentum.");
-                                }
+                                // The GPU kernel implements CLASSICAL momentum only. A Nesterov request
+                                // on a GPU-resident plan is rejected eagerly by
+                                // ValidatePlanOptimizerSupport, so reaching here means classical momentum
+                                // is what the caller asked for.
                                 gpuBe.SgdMomentumUpdate(gpuP, gradBuf, gpuM[p]!,
                                     lr, b1, wd, len);
                                 break;
@@ -3301,16 +3311,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                                     lr, b1, b2, wd, len);
                                 break;
                             case OptimizerType.SGDMomentum:
-                                // The GPU kernel implements CLASSICAL momentum only. Running it for a
-                                // Nesterov request would quietly train a different algorithm, which is
-                                // the exact failure this flag was added to remove — so refuse instead.
-                                if (extras.Nesterov)
-                                {
-                                    throw new NotSupportedException(
-                                        "Nesterov momentum is not implemented by the GPU fused optimizer kernel. " +
-                                        "Run this model on the CPU engine, which supports it, or use classical " +
-                                        "momentum. Refusing rather than silently applying classical momentum.");
-                                }
+                                // The GPU kernel implements CLASSICAL momentum only. A Nesterov request
+                                // on a GPU-resident plan is rejected eagerly by
+                                // ValidatePlanOptimizerSupport, so reaching here means classical momentum
+                                // is what the caller asked for.
                                 gpuBe.SgdMomentumUpdate(gpuP, gradBuf, gpuM[p]!,
                                     lr, b1, wd, len);
                                 break;

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -2107,7 +2107,7 @@ internal static class FusedOptimizer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static unsafe void FTRLUpdateSimd(
         float* param, float* grad, float* z, float* n, int length,
-        float lr, float l1Reg, float l2Reg, float lrPower)
+        float lr, float l1Reg, float l2Reg, float lrPower, float beta = 0f)
     {
         int i = 0;
 #if NET5_0_OR_GREATER
@@ -2159,7 +2159,7 @@ internal static class FusedOptimizer
 
                 // denom = pow(nNew, -lrPower)/lr + l2Reg
                 for (int j = 0; j < 8; j++)
-                    denomArr[j] = MathF.Pow(nNewArr[j], -lrPower) / lr + l2Reg;
+                    denomArr[j] = (beta + MathF.Pow(nNewArr[j], -lrPower)) / lr + l2Reg;
                 var denom = Avx.LoadVector256(denomArr);
 
                 // result = -(z - sign*l1Reg) / denom
@@ -2186,7 +2186,7 @@ internal static class FusedOptimizer
             else
             {
                 float sign = z[i] > 0f ? 1f : -1f;
-                param[i] = -(z[i] - sign * l1Reg) / (MathF.Pow(n[i], -lrPower) / lr + l2Reg);
+                param[i] = -(z[i] - sign * l1Reg) / ((beta + MathF.Pow(n[i], -lrPower)) / lr + l2Reg);
             }
         }
     }
@@ -2487,6 +2487,29 @@ public sealed class FusedOptimizerExtras
     /// <c>y = (1-β)z + βx</c> (Defazio et al., 2024). Default 0.9 — the
     /// paper's momentum-equivalent default.</summary>
     public float SfBeta { get; init; } = 0.9f;
+
+    /// <summary>
+    /// SGD-with-momentum: use Nesterov accelerated gradient rather than classical momentum.
+    /// Default <c>false</c> (classical).
+    /// </summary>
+    /// <remarks>
+    /// <c>SgdMomentumUpdateSimd</c> has always accepted a nesterov flag, but the plan passed a
+    /// hardcoded <c>false</c>, so a Nesterov optimizer routed through the fused path silently ran
+    /// CLASSICAL momentum instead — a different algorithm, with no error. This surfaces the flag so
+    /// the caller's choice reaches the kernel.
+    /// </remarks>
+    public bool Nesterov { get; init; }
+
+    /// <summary>
+    /// FTRL-Proximal's β term in the per-coordinate learning rate <c>α / (β + √n)</c>. Default 0.
+    /// </summary>
+    /// <remarks>
+    /// The kernel previously computed <c>√n / α</c> for the denominator, i.e. it assumed β = 0.
+    /// Callers whose FTRL uses a non-zero β (McMahan et al. 2013 uses β = 1) therefore could not be
+    /// expressed, and fusing them would have changed the effective learning-rate schedule. Keeping the
+    /// default at 0 preserves the previous behaviour exactly for existing callers.
+    /// </remarks>
+    public float FtrlBeta { get; init; }
 
     /// <summary>
     /// Validates the hyperparameters that would otherwise produce undefined or

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
@@ -206,6 +206,23 @@ internal sealed class FusedOptimizerCheckpoint
     public FusedOptimizerExtras Extras { get; set; } = new FusedOptimizerExtras();
     public FusedLrScheduleCheckpoint[] Schedules { get; set; } = System.Array.Empty<FusedLrScheduleCheckpoint>();
     public int[]? ParamToGroup { get; set; }
+
+    /// <summary>
+    /// Per-group optimizer types, or null when every group runs <see cref="OptimizerType"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nullable so checkpoints written before per-group optimizers existed still load: absent means uniform,
+    /// which is exactly what those older plans were. Restoring WITHOUT this would silently rebuild a
+    /// heterogeneous plan as a uniform one — every group quietly switched to the fallback optimizer, mid-run,
+    /// with no error.
+    /// </remarks>
+    public OptimizerType[]? GroupOptimizerTypes { get; set; }
+
+    /// <summary>
+    /// Per-group weight decay, or null when every group uses <see cref="WeightDecay"/>.
+    /// </summary>
+    public float[]? GroupWeightDecays { get; set; }
+
     public FusedOptimizerScalarCheckpoint Scalars { get; set; } = new FusedOptimizerScalarCheckpoint();
     public FusedOptimizerParameterCheckpoint[] Parameters { get; set; } = System.Array.Empty<FusedOptimizerParameterCheckpoint>();
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
@@ -514,6 +514,51 @@ public interface ICompiledTrainingPlan<T> : IDisposable
         FusedOptimizerExtras? extras = null);
 
     /// <summary>
+    /// Configures fused optimizer updates where each parameter group may run a DIFFERENT optimizer, not just a
+    /// different learning-rate schedule.
+    /// </summary>
+    /// <param name="optimizerType">The optimizer for every group when <paramref name="groupOptimizerTypes"/> is
+    /// null, and the fallback recorded in checkpoints otherwise.</param>
+    /// <param name="groupOptimizerTypes">Per-group optimizer, parallel to <paramref name="groupSchedules"/>, or
+    /// null for "every group runs <paramref name="optimizerType"/>".</param>
+    /// <param name="groupSchedules">Per-group learning-rate schedule.
+    /// <c>groupSchedules.Count</c> = number of distinct groups.</param>
+    /// <param name="paramToGroup">For each compiled parameter (parallel order), an index into
+    /// <paramref name="groupSchedules"/>.</param>
+    /// <param name="groupWeightDecays">Per-group weight decay, parallel to <paramref name="groupSchedules"/>, or
+    /// null to apply <paramref name="weightDecay"/> everywhere.</param>
+    /// <remarks>
+    /// <para>
+    /// This exists because several published recipes are not expressible with a single optimizer per plan. The
+    /// motivating one is LARS, whose papers exclude biases and normalization parameters from the layer-wise
+    /// trust ratio AND from weight decay — so those tensors must run plain SGD or SGD-with-momentum at zero
+    /// decay while the weight tensors run LARS. With one optimizer per plan the only options were to apply LARS
+    /// to biases (wrong) or to refuse to fuse at all (useless).
+    /// </para>
+    /// <para>
+    /// Everything else stays plan-wide: beta1/beta2/eps and <see cref="FusedOptimizerExtras"/> are shared across
+    /// groups. Those are per-algorithm constants the recipes above do not vary, and keeping them global holds
+    /// the per-step hot path to one array index per parameter.
+    /// </para>
+    /// <para>
+    /// Requires <c>Float32</c> moment storage: bf16/int8 fused moments are an Adam-specific layout chosen once
+    /// for the whole plan, and would otherwise silently store one group's moments in a format its kernel does
+    /// not read.
+    /// </para>
+    /// </remarks>
+    void ConfigureOptimizerGrouped(
+        OptimizerType optimizerType,
+        System.Collections.Generic.IReadOnlyList<OptimizerType>? groupOptimizerTypes,
+        System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
+        System.Collections.Generic.IReadOnlyList<int> paramToGroup,
+        float beta1 = 0.9f,
+        float beta2 = 0.999f,
+        float eps = 1e-8f,
+        float weightDecay = 0f,
+        System.Collections.Generic.IReadOnlyList<float>? groupWeightDecays = null,
+        FusedOptimizerExtras? extras = null);
+
+    /// <summary>
     /// Issue #338 Phase G.4: Enables pre-packed-B caching on the forward
     /// MatMul fast paths. The compiled training plan defaults to
     /// <c>allowCachedB=false</c> (PackB on every call) because the

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
@@ -22,6 +22,11 @@ internal static class FusedOptimizerCheckpointSerializer
         WriteExtras(writer, checkpoint.Extras);
         WriteLrSchedules(writer, checkpoint.Schedules);
         WriteIntArray(writer, checkpoint.ParamToGroup);
+        // Per-group optimizer types and weight decays. Null (uniform) is encoded as a -1 length so it stays
+        // distinguishable from an empty array, and so a restore cannot silently rebuild a heterogeneous plan
+        // as a uniform one — every group quietly switched to the fallback optimizer, mid-run, with no error.
+        WriteOptimizerTypeArray(writer, checkpoint.GroupOptimizerTypes);
+        WriteFloatArray(writer, checkpoint.GroupWeightDecays);
         WriteScalars(writer, checkpoint.Scalars);
 
         writer.Write(checkpoint.Parameters.Length);
@@ -48,6 +53,8 @@ internal static class FusedOptimizerCheckpointSerializer
             Extras = ReadExtras(reader),
             Schedules = ReadLrSchedules(reader),
             ParamToGroup = ReadIntArray(reader),
+            GroupOptimizerTypes = ReadOptimizerTypeArray(reader),
+            GroupWeightDecays = ReadFloatArray(reader),
             Scalars = ReadScalars(reader),
         };
 
@@ -243,6 +250,22 @@ internal static class FusedOptimizerCheckpointSerializer
         if (length < 0) return null;
         var values = new int[length];
         for (int i = 0; i < length; i++) values[i] = reader.ReadInt32();
+        return values;
+    }
+
+    private static void WriteOptimizerTypeArray(BinaryWriter writer, OptimizerType[]? values)
+    {
+        if (values is null) { writer.Write(-1); return; }
+        writer.Write(values.Length);
+        for (int i = 0; i < values.Length; i++) writer.Write((int)values[i]);
+    }
+
+    private static OptimizerType[]? ReadOptimizerTypeArray(BinaryReader reader)
+    {
+        int length = ReadArrayLength(reader, "OptimizerType[]", sizeof(int));
+        if (length < 0) return null;
+        var values = new OptimizerType[length];
+        for (int i = 0; i < length; i++) values[i] = (OptimizerType)reader.ReadInt32();
         return values;
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
@@ -83,6 +83,11 @@ internal static class FusedOptimizerCheckpointSerializer
         writer.Write(extras.D0);
         writer.Write(extras.DGrowthRate);
         writer.Write(extras.SfBeta);
+        // Appended in the same PR that introduced them. Both change WHICH ALGORITHM runs rather than only its
+        // constants — Nesterov vs classical momentum, and FTRL's per-coordinate learning-rate denominator — so
+        // omitting them here would let a checkpoint round trip into a quietly different optimizer.
+        writer.Write(extras.Nesterov);
+        writer.Write(extras.FtrlBeta);
     }
 
     private static FusedOptimizerExtras ReadExtras(BinaryReader reader)
@@ -105,6 +110,8 @@ internal static class FusedOptimizerCheckpointSerializer
             D0 = reader.ReadSingle(),
             DGrowthRate = reader.ReadSingle(),
             SfBeta = reader.ReadSingle(),
+            Nesterov = reader.ReadBoolean(),
+            FtrlBeta = reader.ReadSingle(),
         };
 
     private static void WriteLrSchedules(BinaryWriter writer, FusedLrScheduleCheckpoint[] schedules)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -91,6 +91,41 @@ public class ConfigureOptimizerFusedDispatchTests
     }
 
     /// <summary>
+    /// The GPU SgdMomentum kernel implements classical momentum only, so a Nesterov request on a
+    /// GPU-resident plan must be refused by the EARLY gate.
+    /// </summary>
+    /// <remarks>
+    /// The rejection deliberately lives here rather than in the per-parameter update closure. That closure
+    /// first runs on the initial Step(), by which point a mixed CPU/GPU plan would already have mutated every
+    /// CPU parameter before reaching the first GPU one — a half-applied step, from a misconfiguration that was
+    /// knowable at configure time.
+    /// </remarks>
+    [Fact]
+    public void ConfigureOptimizer_GpuPlanWithNesterov_ThrowsAtEarlyGate()
+    {
+        var ex = Assert.Throws<NotSupportedException>(
+            () => InvokeValidatePlanOptimizerSupport(
+                OptimizerType.SGDMomentum, isFloat: true, hasGpuParams: true, nesterov: true));
+
+        Assert.Contains("Nesterov", ex.Message);
+    }
+
+    /// <summary>
+    /// The same gate must NOT reject the CPU case, which does implement Nesterov, nor classical momentum on
+    /// the GPU. Without these the test above would pass just as well against a gate that rejected everything.
+    /// </summary>
+    [Theory]
+    [InlineData(false, true)]    // CPU plan, Nesterov requested -> supported
+    [InlineData(true, false)]    // GPU plan, classical momentum -> supported
+    [InlineData(false, false)]   // CPU plan, classical momentum -> supported
+    public void ConfigureOptimizer_SgdMomentumNesterov_PassesEarlyGateWhereverItIsImplemented(
+        bool hasGpuParams, bool nesterov)
+    {
+        InvokeValidatePlanOptimizerSupport(
+            OptimizerType.SGDMomentum, isFloat: true, hasGpuParams: hasGpuParams, nesterov: nesterov);
+    }
+
+    /// <summary>
     /// Every wired float optimizer must dispatch through the fused plan (no
     /// NotSupportedException), update the parameter in place, stay finite, and
     /// move it meaningfully over several steps. Catches a missing buffer
@@ -390,7 +425,8 @@ public class ConfigureOptimizerFusedDispatchTests
         }
     }
 
-    private static void InvokeValidatePlanOptimizerSupport(OptimizerType opt, bool isFloat, bool hasGpuParams)
+    private static void InvokeValidatePlanOptimizerSupport(
+        OptimizerType opt, bool isFloat, bool hasGpuParams, bool nesterov = false)
     {
         var method = typeof(CompiledTrainingPlan<float>).GetMethod(
             "ValidatePlanOptimizerSupport",
@@ -399,7 +435,10 @@ public class ConfigureOptimizerFusedDispatchTests
 
         try
         {
-            method!.Invoke(null, [opt, isFloat, hasGpuParams]);
+            // Every parameter must be supplied explicitly: MethodInfo.Invoke does not apply C# optional-
+            // parameter defaults, so an arity mismatch here surfaces as a TargetParameterCountException
+            // rather than as the gate decision under test.
+            method!.Invoke(null, [opt, isFloat, hasGpuParams, nesterov]);
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PerGroupOptimizerTypeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PerGroupOptimizerTypeTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Per-group optimizer types: each parameter group may run a DIFFERENT optimizer, not merely a different
+/// learning-rate schedule.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The motivating recipe is LARS, whose papers exclude biases and normalization parameters from both the
+/// layer-wise trust ratio and weight decay. With one optimizer per plan the only options were applying LARS to
+/// biases (wrong) or refusing to fuse (useless).
+/// </para>
+/// <para>
+/// The failure mode to guard against is silence: if the per-group lookup were dropped, every group would run
+/// the fallback optimizer, training would proceed, and nothing would report an error. So the central tests
+/// compare against single-optimizer reference runs and demand EXACT agreement per group — a per-group run must
+/// reproduce, tensor by tensor, what each group's optimizer produces on its own.
+/// </para>
+/// </remarks>
+public class PerGroupOptimizerTypeTests
+{
+    private const float Lr = 0.03f, B1 = 0.9f, B2 = 0.99f, Eps = 1e-8f;
+
+    private static float[] Seed(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return a;
+    }
+
+    /// <summary>
+    /// Runs a two-parameter plan on the separable loss sum(a^2) + sum(b^2) for <paramref name="steps"/> steps.
+    /// </summary>
+    /// <remarks>
+    /// Separability is what makes the comparisons in this file valid: da/dloss depends only on a and db/dloss
+    /// only on b, so parameter a's trajectory under a given optimizer is identical whether or not b is being
+    /// optimized differently. Any cross-talk would therefore show up as a failure rather than be masked.
+    /// </remarks>
+    private static (float[] A, float[] B) RunTwoGroups(
+        float[] initA, float[] initB,
+        OptimizerType fallback,
+        IReadOnlyList<OptimizerType>? groupTypes,
+        int steps,
+        IReadOnlyList<float>? groupWeightDecays = null,
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null)
+    {
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            var map = new List<int> { 0, 1 };
+            plan.ConfigureOptimizerGrouped(
+                fallback, groupTypes, schedules, map, B1, B2, Eps, weightDecay, groupWeightDecays, extras);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+
+        return (a.GetDataArray().AsSpan(0, initA.Length).ToArray(),
+                b.GetDataArray().AsSpan(0, initB.Length).ToArray());
+    }
+
+    /// <summary>
+    /// The core guarantee: a plan configured with [SGD, Adam] must reproduce EXACTLY what a pure-SGD plan does
+    /// to the first tensor and what a pure-Adam plan does to the second.
+    /// </summary>
+    /// <remarks>
+    /// SGD and Adam are chosen because they differ in both trajectory and state requirements — Adam needs first
+    /// and second moment buffers, SGD needs none. So this simultaneously proves the per-parameter dispatch reads
+    /// the right group AND that buffer allocation is sized per group rather than from the plan-wide fallback.
+    /// The final assertion checks the two references genuinely disagree, so exact agreement is informative.
+    /// </remarks>
+    [Fact]
+    public void PerGroupTypes_RunEachGroupsOwnOptimizer_ExactlyMatchingSingleOptimizerRuns()
+    {
+        var initA = Seed(16, seed: 11);
+        var initB = Seed(16, seed: 12);
+        const int steps = 15;
+
+        var (pureSgdA, pureSgdB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        var (pureAdamA, pureAdamB) = RunTwoGroups(initA, initB, OptimizerType.Adam, null, steps);
+
+        var (mixedA, mixedB) = RunTwoGroups(
+            initA, initB,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, OptimizerType.Adam },
+            steps);
+
+        for (int i = 0; i < initA.Length; i++)
+            Assert.Equal(pureSgdA[i], mixedA[i], 6);
+        for (int i = 0; i < initB.Length; i++)
+            Assert.Equal(pureAdamB[i], mixedB[i], 6);
+
+        // If the per-group lookup were dropped, group 1 would have run the SGD fallback. Confirm that is a
+        // distinguishable outcome rather than a coincidence.
+        double maxRefGap = 0;
+        for (int i = 0; i < initB.Length; i++)
+            maxRefGap = Math.Max(maxRefGap, Math.Abs(pureAdamB[i] - pureSgdB[i]));
+        Assert.True(maxRefGap > 1e-3,
+            $"SGD and Adam produced near-identical trajectories (max gap {maxRefGap}), so this test proves nothing.");
+    }
+
+    /// <summary>
+    /// The same guarantee with the groups swapped, so neither "always use group 0's type" nor "always use the
+    /// last group's type" can pass.
+    /// </summary>
+    [Fact]
+    public void PerGroupTypes_AreNotOrderDependent()
+    {
+        var initA = Seed(16, seed: 21);
+        var initB = Seed(16, seed: 22);
+        const int steps = 15;
+
+        var (pureSgdA, _) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        var (pureAdamA, _) = RunTwoGroups(initA, initB, OptimizerType.Adam, null, steps);
+
+        var (mixedA, mixedB) = RunTwoGroups(
+            initA, initB,
+            fallback: OptimizerType.Adam,
+            groupTypes: new[] { OptimizerType.Adam, OptimizerType.SGD },
+            steps);
+
+        for (int i = 0; i < initA.Length; i++)
+            Assert.Equal(pureAdamA[i], mixedA[i], 6);
+
+        // Group 1 ran SGD while the fallback was Adam — so this also proves the fallback is not silently winning.
+        var (_, pureSgdB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        for (int i = 0; i < initB.Length; i++)
+            Assert.Equal(pureSgdB[i], mixedB[i], 6);
+
+        Assert.NotEqual(pureSgdA[0], pureAdamA[0], 4);
+    }
+
+    /// <summary>
+    /// The LARS recipe this feature exists for: LARS on the weight tensor, plain SGD-with-momentum and zero
+    /// weight decay on the bias tensor.
+    /// </summary>
+    [Fact]
+    public void PerGroupTypes_ExpressTheLarsBiasExclusionRecipe()
+    {
+        var initWeights = Seed(16, seed: 31);
+        var initBias = Seed(16, seed: 32);
+        const int steps = 12;
+        const float decay = 0.05f;
+
+        var (weights, bias) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.LARS,
+            groupTypes: new[] { OptimizerType.LARS, OptimizerType.SGDMomentum },
+            steps,
+            groupWeightDecays: new[] { decay, 0f },
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        // The bias must match a pure SGD-with-momentum, zero-decay run — i.e. it saw neither LARS's trust ratio
+        // nor any weight decay, which is exactly what the LARS papers prescribe for biases.
+        var (_, referenceBias) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.SGDMomentum, groupTypes: null, steps,
+            weightDecay: 0f,
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        for (int i = 0; i < initBias.Length; i++)
+            Assert.Equal(referenceBias[i], bias[i], 6);
+
+        foreach (var w in weights)
+            Assert.True(!float.IsNaN(w) && !float.IsInfinity(w), "LARS group produced a non-finite parameter.");
+
+        // And the weights must NOT match what SGD-with-momentum would have done to them, or LARS was not applied.
+        var (referenceWeightsIfSgdm, _) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.SGDMomentum, groupTypes: null, steps,
+            weightDecay: decay,
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        double maxGap = 0;
+        for (int i = 0; i < initWeights.Length; i++)
+            maxGap = Math.Max(maxGap, Math.Abs(referenceWeightsIfSgdm[i] - weights[i]));
+        Assert.True(maxGap > 1e-6,
+            $"The LARS group's trajectory is indistinguishable from SGD-with-momentum (max gap {maxGap}).");
+    }
+
+    /// <summary>
+    /// Per-group weight decay must apply per group, under a single shared optimizer.
+    /// </summary>
+    [Fact]
+    public void PerGroupWeightDecay_AppliesPerGroup()
+    {
+        var initA = Seed(16, seed: 41);
+        var initB = Seed(16, seed: 42);
+        const int steps = 10;
+        const float decay = 0.1f;
+
+        var (a, b) = RunTwoGroups(
+            initA, initB, OptimizerType.SGD, groupTypes: null, steps,
+            groupWeightDecays: new[] { 0f, decay });
+
+        var (refNoDecayA, _) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps, weightDecay: 0f);
+        var (_, refDecayB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps, weightDecay: decay);
+
+        for (int i = 0; i < initA.Length; i++) Assert.Equal(refNoDecayA[i], a[i], 6);
+        for (int i = 0; i < initB.Length; i++) Assert.Equal(refDecayB[i], b[i], 6);
+    }
+
+    /// <summary>
+    /// Omitting the per-group arrays entirely must behave exactly like the original single-optimizer overload —
+    /// the uniform path is the overwhelmingly common one and must not have shifted.
+    /// </summary>
+    [Fact]
+    public void NullGroupTypes_BehaveIdenticallyToTheSingleOptimizerOverload()
+    {
+        var initA = Seed(16, seed: 51);
+        var initB = Seed(16, seed: 52);
+        const int steps = 10;
+
+        var (viaNew, viaNewB) = RunTwoGroups(initA, initB, OptimizerType.Adam, groupTypes: null, steps);
+
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            plan.ConfigureOptimizerGrouped(OptimizerType.Adam, schedules, new List<int> { 0, 1 }, B1, B2, Eps);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+
+        var legacyA = a.GetDataArray().AsSpan(0, initA.Length).ToArray();
+        var legacyB = b.GetDataArray().AsSpan(0, initB.Length).ToArray();
+        for (int i = 0; i < initA.Length; i++) Assert.Equal(legacyA[i], viaNew[i], 6);
+        for (int i = 0; i < initB.Length; i++) Assert.Equal(legacyB[i], viaNewB[i], 6);
+    }
+
+    /// <summary>
+    /// A per-group array whose length disagrees with the schedule count is rejected, rather than silently
+    /// leaving trailing groups on the fallback.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]    // wrong groupOptimizerTypes length
+    [InlineData(false)]   // wrong groupWeightDecays length
+    public void MismatchedPerGroupArrayLength_Throws(bool badTypes)
+    {
+        var init = Seed(8, seed: 61);
+
+        Assert.Throws<ArgumentException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: badTypes ? new[] { OptimizerType.SGD } : null,
+            steps: 1,
+            groupWeightDecays: badTypes ? null : new[] { 0f }));
+    }
+
+    /// <summary>
+    /// A global-state optimizer smuggled in through a per-group array must be rejected just as it is when passed
+    /// as the plan-wide type — those maintain one scalar across all parameters, which per-group configuration
+    /// cannot express.
+    /// </summary>
+    [Theory]
+    [InlineData(OptimizerType.HypergradientSGD)]
+    [InlineData(OptimizerType.DAdaptationSGD)]
+    [InlineData(OptimizerType.ScheduleFreeSGD)]
+    public void GlobalStateOptimizerInAnyGroup_Throws(OptimizerType global)
+    {
+        var init = Seed(8, seed: 71);
+
+        Assert.Throws<NotSupportedException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, global },
+            steps: 1));
+    }
+
+    /// <summary>
+    /// An unsupported optimizer in ANY group must be caught at configure time, not on the first Step() after
+    /// earlier parameters have already been updated.
+    /// </summary>
+    [Fact]
+    public void UnsupportedOptimizerInAnyGroup_ThrowsAtConfigureTime()
+    {
+        var init = Seed(8, seed: 81);
+
+        Assert.Throws<NotSupportedException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, OptimizerType.LBFGS },
+            steps: 1));
+    }
+
+    /// <summary>
+    /// The per-group configuration must survive a checkpoint round trip. Without this, saving and resuming a
+    /// heterogeneous plan would silently rebuild it as a uniform one — every group switched to the fallback
+    /// optimizer, mid-run, with no error anywhere.
+    /// </summary>
+    [Fact]
+    public void CheckpointRoundTrip_PreservesPerGroupTypesAndWeightDecays()
+    {
+        var initA = Seed(8, seed: 91);
+        var initB = Seed(8, seed: 92);
+        var groupTypes = new[] { OptimizerType.SGD, OptimizerType.Adam };
+        var groupWds = new[] { 0f, 0.02f };
+
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD, groupTypes, schedules, new List<int> { 0, 1 },
+                B1, B2, Eps, 0f, groupWds);
+            for (int s = 0; s < 3; s++) plan.Step();
+
+            var checkpoint = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(checkpoint);
+            Assert.Equal(groupTypes, checkpoint!.GroupOptimizerTypes);
+            Assert.Equal(groupWds, checkpoint.GroupWeightDecays);
+
+            // Restoring the captured checkpoint into the same plan must reinstate the per-group configuration,
+            // not collapse it onto the SGD fallback.
+            Assert.IsType<CompiledTrainingPlan<float>>(plan).RestoreFusedOptimizerCheckpoint(checkpoint);
+            var afterRestore = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(afterRestore);
+            Assert.Equal(groupTypes, afterRestore!.GroupOptimizerTypes);
+            Assert.Equal(groupWds, afterRestore.GroupWeightDecays);
+        }
+    }
+
+    /// <summary>
+    /// A uniform plan must checkpoint as uniform (null arrays), so "one optimizer everywhere" stays
+    /// distinguishable from "several groups that happen to agree today".
+    /// </summary>
+    [Fact]
+    public void CheckpointRoundTrip_UniformPlanRecordsNoPerGroupArrays()
+    {
+        var init = Seed(8, seed: 93);
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) a[i] = init[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            plan = scope.CompileTraining(new[] { a });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.Adam,
+                new List<LrSchedule> { LrSchedule.Constant(Lr) },
+                new List<int> { 0 },
+                B1, B2, Eps);
+            plan.Step();
+
+            var checkpoint = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(checkpoint);
+            Assert.Null(checkpoint!.GroupOptimizerTypes);
+            Assert.Null(checkpoint.GroupWeightDecays);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/TrainingPlanSerializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/TrainingPlanSerializationTests.cs
@@ -458,6 +458,10 @@ public class TrainingPlanSerializationTests
         D0 = 1e-4f,
         DGrowthRate = 2f,
         SfBeta = 0.75f,
+        // Deliberately NON-default (Nesterov defaults false, FtrlBeta defaults 0) so a serializer that drops
+        // them fails this round trip instead of accidentally reproducing the defaults.
+        Nesterov = true,
+        FtrlBeta = 1f,
     };
 
     private static FusedOptimizerCheckpoint CaptureCheckpoint<T>(ICompiledTrainingPlan<T> plan)
@@ -567,6 +571,11 @@ public class TrainingPlanSerializationTests
         Assert.Equal(expected.D0, actual.D0);
         Assert.Equal(expected.DGrowthRate, actual.DGrowthRate);
         Assert.Equal(expected.SfBeta, actual.SfBeta);
+        // These two select an ALGORITHM, not just a constant: Nesterov vs classical momentum, and FTRL's
+        // per-coordinate denominator. A round trip that dropped them would restore a quietly different
+        // optimizer, so they belong in this comparison as much as any other field.
+        Assert.Equal(expected.Nesterov, actual.Nesterov);
+        Assert.Equal(expected.FtrlBeta, actual.FtrlBeta);
     }
 
     private static void AssertScalarCheckpointEqual(

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgdMomentumNesterovTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgdMomentumNesterovTests.cs
@@ -1,0 +1,182 @@
+// #1930 follow-up: SgdMomentumUpdateSimd has always accepted a `nesterov` flag, but
+// CompiledTrainingPlan passed a hardcoded `false`, so a Nesterov optimizer routed through the
+// fused path silently ran CLASSICAL momentum — a different algorithm, with no error. The flag is
+// now surfaced through FusedOptimizerExtras.Nesterov. These tests pin the kernel's two branches
+// against scalar references, so "threaded the flag" cannot pass while the kernel ignores it.
+
+using System;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public class SgdMomentumNesterovTests
+{
+    private const float Tolerance = 1e-5f;
+    private const float Lr = 0.01f;
+    private const float Momentum = 0.9f;
+
+    /// <summary>
+    /// Classical momentum: v = mu*v + g; param -= lr*v.
+    /// </summary>
+    [Fact]
+    public unsafe void SgdMomentum_Classical_MatchesScalarReference()
+    {
+        const int n = 64;
+        var (paramSimd, grad, velocitySimd) = MakeInputs(n, seed: 7);
+        var paramRef = (float[])paramSimd.Clone();
+        var velocityRef = (float[])velocitySimd.Clone();
+
+        fixed (float* p = paramSimd, g = grad, v = velocitySimd)
+            FusedOptimizer.SgdMomentumUpdateSimd(p, g, v, n, Lr, Momentum, nesterov: false);
+
+        for (int i = 0; i < n; i++)
+        {
+            velocityRef[i] = Momentum * velocityRef[i] + grad[i];
+            paramRef[i] -= Lr * velocityRef[i];
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.True(Math.Abs(paramSimd[i] - paramRef[i]) < Tolerance,
+                $"param[{i}]: SIMD {paramSimd[i]} vs scalar {paramRef[i]}");
+            Assert.True(Math.Abs(velocitySimd[i] - velocityRef[i]) < Tolerance,
+                $"velocity[{i}]: SIMD {velocitySimd[i]} vs scalar {velocityRef[i]}");
+        }
+    }
+
+    /// <summary>
+    /// Nesterov: the velocity update is the same, but the step applied to the parameter looks ahead —
+    /// param -= lr*(g + mu*v) rather than param -= lr*v.
+    /// </summary>
+    [Fact]
+    public unsafe void SgdMomentum_Nesterov_MatchesScalarReference()
+    {
+        const int n = 64;
+        var (paramSimd, grad, velocitySimd) = MakeInputs(n, seed: 11);
+        var paramRef = (float[])paramSimd.Clone();
+        var velocityRef = (float[])velocitySimd.Clone();
+
+        fixed (float* p = paramSimd, g = grad, v = velocitySimd)
+            FusedOptimizer.SgdMomentumUpdateSimd(p, g, v, n, Lr, Momentum, nesterov: true);
+
+        for (int i = 0; i < n; i++)
+        {
+            velocityRef[i] = Momentum * velocityRef[i] + grad[i];
+            paramRef[i] -= Lr * (grad[i] + Momentum * velocityRef[i]);
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.True(Math.Abs(paramSimd[i] - paramRef[i]) < Tolerance,
+                $"param[{i}]: SIMD {paramSimd[i]} vs scalar {paramRef[i]}");
+        }
+    }
+
+    /// <summary>
+    /// The load-bearing assertion: the two branches must produce DIFFERENT parameters from identical
+    /// inputs. Without this, threading the flag through the plan could "pass" while the kernel quietly
+    /// ignored it — which is precisely the bug being fixed.
+    /// </summary>
+    [Fact]
+    public unsafe void SgdMomentum_NesterovAndClassical_Differ()
+    {
+        const int n = 64;
+        var (paramClassical, grad, velocityClassical) = MakeInputs(n, seed: 23);
+        var paramNesterov = (float[])paramClassical.Clone();
+        var velocityNesterov = (float[])velocityClassical.Clone();
+
+        fixed (float* p = paramClassical, g = grad, v = velocityClassical)
+            FusedOptimizer.SgdMomentumUpdateSimd(p, g, v, n, Lr, Momentum, nesterov: false);
+        fixed (float* p = paramNesterov, g = grad, v = velocityNesterov)
+            FusedOptimizer.SgdMomentumUpdateSimd(p, g, v, n, Lr, Momentum, nesterov: true);
+
+        int differing = 0;
+        for (int i = 0; i < n; i++)
+            if (Math.Abs(paramClassical[i] - paramNesterov[i]) > 1e-7f)
+                differing++;
+
+        Assert.True(differing > n / 2,
+            $"Only {differing}/{n} elements differ between classical and Nesterov momentum. " +
+            "The nesterov flag is being ignored by the kernel.");
+    }
+
+    /// <summary>The default must stay classical, so existing callers are unaffected.</summary>
+    [Fact]
+    public void FusedOptimizerExtras_DefaultsToClassicalMomentum()
+    {
+        Assert.False(new FusedOptimizerExtras().Nesterov);
+    }
+
+    /// <summary>FTRL's beta defaults to 0, preserving the kernel's previous alpha/sqrt(n) behaviour.</summary>
+    [Fact]
+    public void FusedOptimizerExtras_FtrlBetaDefaultsToZero()
+    {
+        Assert.Equal(0f, new FusedOptimizerExtras().FtrlBeta);
+    }
+
+    /// <summary>
+    /// beta = 0 must reproduce the kernel's previous output bit-for-bit, so adding the parameter
+    /// cannot change any existing caller's training.
+    /// </summary>
+    [Fact]
+    public unsafe void Ftrl_BetaZero_IsIdenticalToTheDefaultOverload()
+    {
+        const int n = 32;
+        var (paramA, grad, _) = MakeInputs(n, seed: 31);
+        var paramB = (float[])paramA.Clone();
+        var zA = new float[n]; var nA = new float[n];
+        var zB = new float[n]; var nB = new float[n];
+
+        fixed (float* p = paramA, g = grad, z = zA, acc = nA)
+            FusedOptimizer.FTRLUpdateSimd(p, g, z, acc, n, 0.005f, 0.1f, 0.1f, -0.5f);
+        fixed (float* p = paramB, g = grad, z = zB, acc = nB)
+            FusedOptimizer.FTRLUpdateSimd(p, g, z, acc, n, 0.005f, 0.1f, 0.1f, -0.5f, beta: 0f);
+
+        for (int i = 0; i < n; i++)
+            Assert.Equal(paramA[i], paramB[i]);
+    }
+
+    /// <summary>
+    /// beta &gt; 0 must actually change the result. McMahan et al. 2013 use beta = 1; before this the
+    /// kernel could only express beta = 0, so such an optimizer could not be fused faithfully.
+    /// </summary>
+    [Fact]
+    public unsafe void Ftrl_NonZeroBeta_ChangesTheResult()
+    {
+        const int n = 32;
+        var (paramZero, grad, _) = MakeInputs(n, seed: 37);
+        var paramOne = (float[])paramZero.Clone();
+        var z0 = new float[n]; var n0 = new float[n];
+        var z1 = new float[n]; var n1 = new float[n];
+
+        fixed (float* p = paramZero, g = grad, z = z0, acc = n0)
+            FusedOptimizer.FTRLUpdateSimd(p, g, z, acc, n, 0.005f, 0.1f, 0.1f, -0.5f, beta: 0f);
+        fixed (float* p = paramOne, g = grad, z = z1, acc = n1)
+            FusedOptimizer.FTRLUpdateSimd(p, g, z, acc, n, 0.005f, 0.1f, 0.1f, -0.5f, beta: 1f);
+
+        int differing = 0;
+        for (int i = 0; i < n; i++)
+            if (Math.Abs(paramZero[i] - paramOne[i]) > 1e-7f) differing++;
+
+        Assert.True(differing > 0,
+            "beta had no effect on the FTRL update — the parameter is not reaching the denominator.");
+    }
+
+    private static (float[] Param, float[] Grad, float[] Velocity) MakeInputs(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var param = new float[n];
+        var grad = new float[n];
+        var velocity = new float[n];
+        for (int i = 0; i < n; i++)
+        {
+            param[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+            grad[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+            // A non-zero starting velocity matters: with v = 0 the two branches would differ only by
+            // the single momentum*grad term, understating the divergence the third test checks for.
+            velocity[i] = (float)(rng.NextDouble() * 0.5 - 0.25);
+        }
+        return (param, grad, velocity);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgdMomentumNesterovTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgdMomentumNesterovTests.cs
@@ -17,12 +17,25 @@ public class SgdMomentumNesterovTests
     private const float Momentum = 0.9f;
 
     /// <summary>
+    /// Deliberately NOT multiples of 8.
+    /// </summary>
+    /// <remarks>
+    /// <c>SgdMomentumUpdateSimd</c> and <c>FTRLUpdateSimd</c> both compute <c>simdLen = length &amp; ~7</c> and
+    /// handle the remainder in a separate hand-written scalar loop. At a length of 64 or 32 that remainder is
+    /// empty on AVX2 hardware, so the scalar branch — a second, independent implementation of the same
+    /// Nesterov/beta math — would never execute and these assertions would cover only half the kernel. 67 and 37
+    /// leave tails of 3 and 5 elements respectively.
+    /// </remarks>
+    private const int VectorLength = 67;
+    private const int FtrlVectorLength = 37;
+
+    /// <summary>
     /// Classical momentum: v = mu*v + g; param -= lr*v.
     /// </summary>
     [Fact]
     public unsafe void SgdMomentum_Classical_MatchesScalarReference()
     {
-        const int n = 64;
+        const int n = VectorLength;
         var (paramSimd, grad, velocitySimd) = MakeInputs(n, seed: 7);
         var paramRef = (float[])paramSimd.Clone();
         var velocityRef = (float[])velocitySimd.Clone();
@@ -52,7 +65,7 @@ public class SgdMomentumNesterovTests
     [Fact]
     public unsafe void SgdMomentum_Nesterov_MatchesScalarReference()
     {
-        const int n = 64;
+        const int n = VectorLength;
         var (paramSimd, grad, velocitySimd) = MakeInputs(n, seed: 11);
         var paramRef = (float[])paramSimd.Clone();
         var velocityRef = (float[])velocitySimd.Clone();
@@ -81,7 +94,7 @@ public class SgdMomentumNesterovTests
     [Fact]
     public unsafe void SgdMomentum_NesterovAndClassical_Differ()
     {
-        const int n = 64;
+        const int n = VectorLength;
         var (paramClassical, grad, velocityClassical) = MakeInputs(n, seed: 23);
         var paramNesterov = (float[])paramClassical.Clone();
         var velocityNesterov = (float[])velocityClassical.Clone();
@@ -122,7 +135,7 @@ public class SgdMomentumNesterovTests
     [Fact]
     public unsafe void Ftrl_BetaZero_IsIdenticalToTheDefaultOverload()
     {
-        const int n = 32;
+        const int n = FtrlVectorLength;
         var (paramA, grad, _) = MakeInputs(n, seed: 31);
         var paramB = (float[])paramA.Clone();
         var zA = new float[n]; var nA = new float[n];
@@ -144,7 +157,7 @@ public class SgdMomentumNesterovTests
     [Fact]
     public unsafe void Ftrl_NonZeroBeta_ChangesTheResult()
     {
-        const int n = 32;
+        const int n = FtrlVectorLength;
         var (paramZero, grad, _) = MakeInputs(n, seed: 37);
         var paramOne = (float[])paramZero.Clone();
         var z0 = new float[n]; var n0 = new float[n];


### PR DESCRIPTION
Two fused kernels could not express what their callers actually configured, so consumers could not wire the matching optimizers without silently training a different algorithm. **Both gaps were in the plan, not the kernels.**

Found while investigating ooples/AiDotNet#1930.

## Nesterov

`SgdMomentumUpdateSimd` has **always** accepted a `nesterov` parameter. `CompiledTrainingPlan` passed a hardcoded `false` at both CPU call sites.

So a Nesterov optimizer routed through the fused path ran **classical momentum** — a different update rule — with no error and no diagnostic. Adds `FusedOptimizerExtras.Nesterov` (default `false`, existing callers unchanged) and passes it through.

The GPU backend's `SgdMomentumUpdate` implements classical momentum only and has no such parameter. Rather than let the GPU path quietly reintroduce the same bug, that case now **throws `NotSupportedException`** naming the limitation and the way out. Refusing is the point — silently applying the wrong algorithm is what this change exists to remove.

## FTRL beta

The kernel computed its denominator as `pow(n, -lrPower)/lr + l2`, i.e. `√n/α` — assuming `β = 0`.

FTRL-Proximal is `α/(β + √n)`, and McMahan et al. (2013) use `β = 1`. Any caller with a non-zero β could not be fused without changing its effective learning-rate schedule. Adds `FusedOptimizerExtras.FtrlBeta` and a `beta` kernel parameter defaulted to `0`.

`sigma` is deliberately left alone: it is a **difference** of the two powers, so β cancels out of it and only the denominator changes.

## Tests

7 new, passing on **net10.0 and net471**:

- classical and Nesterov branches each checked against a scalar reference
- **the load-bearing one**: the two branches must produce *different* parameters from identical inputs, so "the flag was threaded" cannot pass while the kernel ignores it. Fixtures start from a **non-zero velocity** on purpose — with `v = 0` the branches differ only by a single `momentum*grad` term, which would understate the divergence being asserted.
- `beta = 0` reproduces the previous output exactly, so no existing caller changes
- `beta > 0` actually moves the result, proving it reaches the denominator
- both new extras default to previous behaviour

Existing `FusedOptimizer` tests: 8 passed / 1 skipped (net10.0), 6 / 1 (net471).

## Consumer

Unblocks wiring `NesterovAcceleratedGradientOptimizer` and `FTRLOptimizer` to the fused path in AiDotNet (ooples/AiDotNet#1930), neither of which could be done faithfully before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected CPU and GPU SGD Momentum handling for configured Nesterov behavior.
  - GPU optimizers now reject unsupported Nesterov requests during configuration.
  - FTRL updates now honor the configured beta value.

- **New Features**
  - Added options for Nesterov momentum and FTRL beta.
  - Preserved existing defaults: classical momentum and zero FTRL beta.

- **Tests**
  - Added coverage for momentum modes, FTRL beta behavior, defaults, and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->