### PR TITLE
feat(fused): per-group optimizer types in the compiled training plan

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -758,6 +758,19 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         public bool IsGrouped;
         public LrSchedule[] Schedules = Array.Empty<LrSchedule>();
         public int[]? ParamToGroup;
+        /// <summary>
+        /// Per-group optimizer types, or null when every group runs <see cref="OptimizerType"/>.
+        /// </summary>
+        /// <remarks>
+        /// Null rather than an all-same array so that "one optimizer for the whole plan" — overwhelmingly the
+        /// common case — stays distinguishable from "several groups that happen to agree today", both here and
+        /// in the checkpoint.
+        /// </remarks>
+        public OptimizerType[]? GroupOptimizerTypes;
+        /// <summary>
+        /// Per-group weight decay, or null when every group uses <see cref="WeightDecay"/>.
+        /// </summary>
+        public float[]? GroupWeightDecays;
         public float Beta1;
         public float Beta2;
         public float Epsilon;
@@ -1735,6 +1748,22 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float eps = 1e-8f,
         float weightDecay = 0f,
         FusedOptimizerExtras? extras = null)
+        => ConfigureOptimizerGrouped(
+            optimizerType, groupOptimizerTypes: null, groupSchedules, paramToGroup,
+            beta1, beta2, eps, weightDecay, groupWeightDecays: null, extras);
+
+    /// <inheritdoc/>
+    public unsafe void ConfigureOptimizerGrouped(
+        OptimizerType optimizerType,
+        System.Collections.Generic.IReadOnlyList<OptimizerType>? groupOptimizerTypes,
+        System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
+        System.Collections.Generic.IReadOnlyList<int> paramToGroup,
+        float beta1 = 0.9f,
+        float beta2 = 0.999f,
+        float eps = 1e-8f,
+        float weightDecay = 0f,
+        System.Collections.Generic.IReadOnlyList<float>? groupWeightDecays = null,
+        FusedOptimizerExtras? extras = null)
     {
         if (groupSchedules is null) throw new ArgumentNullException(nameof(groupSchedules));
         if (paramToGroup is null) throw new ArgumentNullException(nameof(paramToGroup));
@@ -1796,8 +1825,30 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // optimizers without a GPU backend kernel.
         bool hasGpuParams = typeof(T) == typeof(float)
             && System.Array.Exists(_parameters, p => p.TryGetGpuBuffer() is not null);
-        ValidatePlanOptimizerSupport(
-            optimizerType, typeof(T) == typeof(float), hasGpuParams, extras?.Nesterov ?? false);
+        // Per-group types: validate EVERY group's optimizer, not just the fallback. A group whose type is
+        // unsupported would otherwise reach the closure's default case and throw on the first Step(), after
+        // earlier parameters had already been updated.
+        bool isFloatPlan = typeof(T) == typeof(float);
+        bool nesterov = extras?.Nesterov ?? false;
+        if (groupOptimizerTypes is null)
+        {
+            ValidatePlanOptimizerSupport(optimizerType, isFloatPlan, hasGpuParams, nesterov);
+        }
+        else
+        {
+            if (groupOptimizerTypes.Count != groupSchedules.Count)
+                throw new ArgumentException(
+                    $"groupOptimizerTypes.Count ({groupOptimizerTypes.Count}) must equal groupSchedules.Count " +
+                    $"({groupSchedules.Count}) — every group needs exactly one optimizer.",
+                    nameof(groupOptimizerTypes));
+            for (int g = 0; g < groupOptimizerTypes.Count; g++)
+                ValidatePlanOptimizerSupport(groupOptimizerTypes[g], isFloatPlan, hasGpuParams, nesterov);
+        }
+        if (groupWeightDecays is not null && groupWeightDecays.Count != groupSchedules.Count)
+            throw new ArgumentException(
+                $"groupWeightDecays.Count ({groupWeightDecays.Count}) must equal groupSchedules.Count " +
+                $"({groupSchedules.Count}).",
+                nameof(groupWeightDecays));
         // Drop any Schedule-Free pre-forward hook left over from a prior ungrouped
         // ConfigureOptimizer(ScheduleFreeSGD); a grouped optimizer never sets one,
         // and Step() unconditionally invokes it — leaving it active would rewrite
@@ -1805,23 +1856,38 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _preForwardParamTransform = null;
         // Global-state optimizers adapt ONE learning-rate/distance scalar across all
         // parameters — a per-group schedule is meaningless for them, so they are only
-        // supported through the ungrouped ConfigureOptimizer.
-        if (optimizerType is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
-            or OptimizerType.ScheduleFreeSGD)
-            throw new NotSupportedException(
-                $"{optimizerType} maintains a single global learning-rate/distance/weight-sum scalar " +
-                "(or a per-step parameter transform) and is not supported with per-group schedules; " +
-                "use the ungrouped ConfigureOptimizer.");
+        // supported through the ungrouped ConfigureOptimizer. Checked for every group's
+        // type, not just the fallback, or a per-group configuration could smuggle one in.
+        for (int g = -1; g < (groupOptimizerTypes?.Count ?? 0); g++)
+        {
+            var candidate = g < 0 ? optimizerType : groupOptimizerTypes![g];
+            if (candidate is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
+                or OptimizerType.ScheduleFreeSGD)
+                throw new NotSupportedException(
+                    $"{candidate} maintains a single global learning-rate/distance/weight-sum scalar " +
+                    "(or a per-step parameter transform) and is not supported with per-group schedules; " +
+                    "use the ungrouped ConfigureOptimizer.");
+        }
         var ex = extras ?? new FusedOptimizerExtras();
         ex.Validate();
+
+        // Materialize the per-group arrays once. Null means "uniform", which the closures read as
+        // "use the scalar fallback" — keeping the common single-optimizer path free of an indirection.
+        OptimizerType[]? groupTypes = groupOptimizerTypes is null
+            ? null
+            : System.Linq.Enumerable.ToArray(groupOptimizerTypes);
+        float[]? groupWds = groupWeightDecays is null
+            ? null
+            : System.Linq.Enumerable.ToArray(groupWeightDecays);
+
         if (typeof(T) == typeof(float))
         {
-            ConfigureOptimizerFloatGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, ex);
+            ConfigureOptimizerFloatGrouped(optimizerType, groupTypes, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, groupWds, ex);
             return;
         }
         if (typeof(T) == typeof(double))
         {
-            ConfigureOptimizerDoubleGrouped(optimizerType, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay);
+            ConfigureOptimizerDoubleGrouped(optimizerType, groupTypes, groupSchedules, canonicalParamToGroup, beta1, beta2, eps, weightDecay, groupWds);
             return;
         }
         throw new NotSupportedException("Fused optimizer updates support float and double parameters.");
@@ -2917,9 +2983,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private unsafe void ConfigureOptimizerFloatGrouped(
         OptimizerType optimizerType,
+        OptimizerType[]? groupOptimizerTypes,
         System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
         float beta1, float beta2, float eps, float weightDecay,
+        float[]? groupWeightDecays,
         FusedOptimizerExtras extras)
     {
         // CodeRabbit #425: reconfigure releases prior GPU optimizer-state.
@@ -2948,6 +3016,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         // and used only by the AMSGrad case; allocated per-param below only when
         // the optimizer is AMSGrad, else left as an empty array.
         var vMax = new float[paramCount][];
+        // Quantized/bf16 moment storage is an Adam-specific footprint optimization whose buffer layout is
+        // chosen once for the whole plan. Rather than guess how it should interact with a heterogeneous group
+        // configuration, refuse the combination outright — the alternative is silently storing one group's
+        // moments in a format its kernel does not read.
+        if (groupOptimizerTypes is not null && _momentStorageMode != FusedMomentStorageMode.Float32)
+            throw new NotSupportedException(
+                "Per-group optimizer types are supported only with Float32 moment storage; this plan uses " +
+                $"{_momentStorageMode}. bf16/int8 fused moments are an Adam-specific layout applied plan-wide.");
         bool useBf16Moments = _momentStorageMode == FusedMomentStorageMode.BFloat16
             && (optimizerType is OptimizerType.Adam or OptimizerType.AdamW);
         bool useInt8Moments = _momentStorageMode == FusedMomentStorageMode.Int8BlockQuantized;
@@ -2984,18 +3060,23 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < paramCount; p++)
         {
             lengths[p] = _parameters[p].Length;
-            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            // Which state buffers this parameter needs follows ITS OWN group's optimizer, not the plan-wide
+            // fallback. Sizing from the fallback would leave a group running (say) Adam with no second-moment
+            // buffer while its neighbours were fine — a null-deref on the first Step(), or worse, a silently
+            // shared buffer.
+            var slotType = groupOptimizerTypes is null ? optimizerType : groupOptimizerTypes[paramToGroup[p]];
+            bool needsMomentum = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
                 or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
-            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            bool needsSecondMoment = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
                 or OptimizerType.AdaDelta or OptimizerType.FTRL or OptimizerType.Rprop;
-            bool needsThirdState = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL;
+            bool needsThirdState = slotType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL;
 
             // GPU fast path — same logic as ConfigureOptimizerFloat. See
             // there for the full rationale on per-param GPU/CPU dispatch.
@@ -3149,8 +3230,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var b1 = beta1;
         var b2 = beta2;
         var epsVal = eps;
-        var wd = weightDecay;
-        var optType = optimizerType;
+        var fallbackWd = weightDecay;
+        var fallbackOptType = optimizerType;
+        // Null when every group runs the same optimizer, which keeps the common path a captured scalar
+        // rather than an array index per parameter per step.
+        var groupOptTypes = groupOptimizerTypes;
+        var groupWds = groupWeightDecays;
         var groupLrs = new float[groupCount];
 
         _optimizerRuntimeState = new FusedOptimizerRuntimeState
@@ -3159,6 +3244,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             IsGrouped = true,
             Schedules = schedules,
             ParamToGroup = paramGroup,
+            GroupOptimizerTypes = groupOptimizerTypes is null ? null : (OptimizerType[])groupOptimizerTypes.Clone(),
+            GroupWeightDecays = groupWeightDecays is null ? null : (float[])groupWeightDecays.Clone(),
             Beta1 = beta1,
             Beta2 = beta2,
             Epsilon = eps,
@@ -3208,7 +3295,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             for (int p = 0; p < paramCount; p++)
             {
                 int len = lengths[p];
-                float lr = groupLrs[paramGroup[p]];
+                int grp = paramGroup[p];
+                float lr = groupLrs[grp];
+                // Per-group optimizer and weight decay. Both fall back to the plan-wide value when the caller
+                // did not supply per-group arrays, so the uniform case costs one null check per parameter.
+                var optType = groupOptTypes is null ? fallbackOptType : groupOptTypes[grp];
+                float wd = groupWds is null ? fallbackWd : groupWds[grp];
 
                 // GPU path (mirrors ConfigureOptimizerFloat).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
@@ -3690,9 +3782,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     private unsafe void ConfigureOptimizerDoubleGrouped(
         OptimizerType optimizerType,
+        OptimizerType[]? groupOptimizerTypes,
         System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
         System.Collections.Generic.IReadOnlyList<int> paramToGroup,
-        float beta1, float beta2, float eps, float weightDecay)
+        float beta1, float beta2, float eps, float weightDecay,
+        float[]? groupWeightDecays)
     {
         foreach (var buf in _gpuOptimizerBuffers)
             buf.Dispose();
@@ -3722,6 +3816,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         for (int p = 0; p < paramCount; p++) paramGroup[p] = paramToGroup[p];
 
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
+        // GROUPED double path: buffer sizing follows each parameter's own group optimizer (slotType below).
         for (int p = 0; p < paramCount; p++)
         {
             var boundParam = BindCpuOptimizerTensor(
@@ -3739,13 +3834,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             }
             lengths[p] = _parameters[p].Length;
 
-            bool needsMomentum = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            var slotType = groupOptimizerTypes is null ? optimizerType : groupOptimizerTypes[paramToGroup[p]];
+            bool needsMomentum = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.SGDMomentum or OptimizerType.Lion or OptimizerType.Nadam
                 or OptimizerType.AdaMax or OptimizerType.AMSGrad
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
                 or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD;
-            bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
+            bool needsSecondMoment = slotType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
                 or OptimizerType.Adagrad
                 or OptimizerType.RAdam or OptimizerType.LAMB or OptimizerType.AdaMax
@@ -3753,15 +3849,17 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
             m[p] = needsMomentum ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
             v[p] = needsSecondMoment ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
-            vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
+            vMax[p] = slotType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<double>(lengths[p]) : Array.Empty<double>();
         }
 
         _optimizerStep = 0;
         double b1 = beta1;
         double b2 = beta2;
         double epsVal = eps;
-        double wd = weightDecay;
-        var optType = optimizerType;
+        double fallbackWd = weightDecay;
+        var fallbackOptType = optimizerType;
+        var groupOptTypes = groupOptimizerTypes;
+        var groupWds = groupWeightDecays;
         var groupLrs = new double[groupCount];
 
         _optimizerRuntimeState = new FusedOptimizerRuntimeState
@@ -3770,6 +3868,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             IsGrouped = true,
             Schedules = schedules,
             ParamToGroup = paramGroup,
+            GroupOptimizerTypes = groupOptimizerTypes is null ? null : (OptimizerType[])groupOptimizerTypes.Clone(),
+            GroupWeightDecays = groupWeightDecays is null ? null : (float[])groupWeightDecays.Clone(),
             Beta1 = beta1,
             Beta2 = beta2,
             Epsilon = eps,
@@ -3802,7 +3902,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // Skip params with no gradient OR no materialized weight backing (#1738).
                 if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
                 int len = lengths[p];
-                double lr = groupLrs[paramGroup[p]];
+                int grp = paramGroup[p];
+                double lr = groupLrs[grp];
+                // Per-group optimizer and weight decay; both fall back to the plan-wide value when the
+                // caller supplied no per-group array. See ConfigureOptimizerFloatGrouped.
+                var optType = groupOptTypes is null ? fallbackOptType : groupOptTypes[grp];
+                double wd = groupWds is null ? fallbackWd : groupWds[grp];
 
                 fixed (double* pParam = &paramArrays[p][paramOffsets[p]],
                        pGrad = &gradArrays[p][gradOffsets[p]],
@@ -3870,6 +3975,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             OptimizerType = rt.OptimizerType,
             IsGrouped = rt.IsGrouped,
+            // Copies, not shared references: the runtime state stays live and mutable after capture.
+            GroupOptimizerTypes = rt.GroupOptimizerTypes is null ? null : (OptimizerType[])rt.GroupOptimizerTypes.Clone(),
+            GroupWeightDecays = rt.GroupWeightDecays is null ? null : (float[])rt.GroupWeightDecays.Clone(),
             OptimizerStep = _optimizerStep,
             Beta1 = rt.Beta1,
             Beta2 = rt.Beta2,
@@ -3917,12 +4025,14 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 throw new InvalidDataException("Grouped optimizer checkpoint is missing ParamToGroup.");
             ConfigureOptimizerGrouped(
                 checkpoint.OptimizerType,
+                checkpoint.GroupOptimizerTypes,
                 schedules,
                 checkpoint.ParamToGroup,
                 checkpoint.Beta1,
                 checkpoint.Beta2,
                 checkpoint.Epsilon,
                 checkpoint.WeightDecay,
+                checkpoint.GroupWeightDecays,
                 checkpoint.Extras);
         }
         else

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
@@ -206,6 +206,23 @@ internal sealed class FusedOptimizerCheckpoint
     public FusedOptimizerExtras Extras { get; set; } = new FusedOptimizerExtras();
     public FusedLrScheduleCheckpoint[] Schedules { get; set; } = System.Array.Empty<FusedLrScheduleCheckpoint>();
     public int[]? ParamToGroup { get; set; }
+
+    /// <summary>
+    /// Per-group optimizer types, or null when every group runs <see cref="OptimizerType"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nullable so checkpoints written before per-group optimizers existed still load: absent means uniform,
+    /// which is exactly what those older plans were. Restoring WITHOUT this would silently rebuild a
+    /// heterogeneous plan as a uniform one — every group quietly switched to the fallback optimizer, mid-run,
+    /// with no error.
+    /// </remarks>
+    public OptimizerType[]? GroupOptimizerTypes { get; set; }
+
+    /// <summary>
+    /// Per-group weight decay, or null when every group uses <see cref="WeightDecay"/>.
+    /// </summary>
+    public float[]? GroupWeightDecays { get; set; }
+
     public FusedOptimizerScalarCheckpoint Scalars { get; set; } = new FusedOptimizerScalarCheckpoint();
     public FusedOptimizerParameterCheckpoint[] Parameters { get; set; } = System.Array.Empty<FusedOptimizerParameterCheckpoint>();
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
@@ -514,6 +514,51 @@ public interface ICompiledTrainingPlan<T> : IDisposable
         FusedOptimizerExtras? extras = null);
 
     /// <summary>
+    /// Configures fused optimizer updates where each parameter group may run a DIFFERENT optimizer, not just a
+    /// different learning-rate schedule.
+    /// </summary>
+    /// <param name="optimizerType">The optimizer for every group when <paramref name="groupOptimizerTypes"/> is
+    /// null, and the fallback recorded in checkpoints otherwise.</param>
+    /// <param name="groupOptimizerTypes">Per-group optimizer, parallel to <paramref name="groupSchedules"/>, or
+    /// null for "every group runs <paramref name="optimizerType"/>".</param>
+    /// <param name="groupSchedules">Per-group learning-rate schedule.
+    /// <c>groupSchedules.Count</c> = number of distinct groups.</param>
+    /// <param name="paramToGroup">For each compiled parameter (parallel order), an index into
+    /// <paramref name="groupSchedules"/>.</param>
+    /// <param name="groupWeightDecays">Per-group weight decay, parallel to <paramref name="groupSchedules"/>, or
+    /// null to apply <paramref name="weightDecay"/> everywhere.</param>
+    /// <remarks>
+    /// <para>
+    /// This exists because several published recipes are not expressible with a single optimizer per plan. The
+    /// motivating one is LARS, whose papers exclude biases and normalization parameters from the layer-wise
+    /// trust ratio AND from weight decay — so those tensors must run plain SGD or SGD-with-momentum at zero
+    /// decay while the weight tensors run LARS. With one optimizer per plan the only options were to apply LARS
+    /// to biases (wrong) or to refuse to fuse at all (useless).
+    /// </para>
+    /// <para>
+    /// Everything else stays plan-wide: beta1/beta2/eps and <see cref="FusedOptimizerExtras"/> are shared across
+    /// groups. Those are per-algorithm constants the recipes above do not vary, and keeping them global holds
+    /// the per-step hot path to one array index per parameter.
+    /// </para>
+    /// <para>
+    /// Requires <c>Float32</c> moment storage: bf16/int8 fused moments are an Adam-specific layout chosen once
+    /// for the whole plan, and would otherwise silently store one group's moments in a format its kernel does
+    /// not read.
+    /// </para>
+    /// </remarks>
+    void ConfigureOptimizerGrouped(
+        OptimizerType optimizerType,
+        System.Collections.Generic.IReadOnlyList<OptimizerType>? groupOptimizerTypes,
+        System.Collections.Generic.IReadOnlyList<LrSchedule> groupSchedules,
+        System.Collections.Generic.IReadOnlyList<int> paramToGroup,
+        float beta1 = 0.9f,
+        float beta2 = 0.999f,
+        float eps = 1e-8f,
+        float weightDecay = 0f,
+        System.Collections.Generic.IReadOnlyList<float>? groupWeightDecays = null,
+        FusedOptimizerExtras? extras = null);
+
+    /// <summary>
     /// Issue #338 Phase G.4: Enables pre-packed-B caching on the forward
     /// MatMul fast paths. The compiled training plan defaults to
     /// <c>allowCachedB=false</c> (PackB on every call) because the

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
@@ -22,6 +22,11 @@ internal static class FusedOptimizerCheckpointSerializer
         WriteExtras(writer, checkpoint.Extras);
         WriteLrSchedules(writer, checkpoint.Schedules);
         WriteIntArray(writer, checkpoint.ParamToGroup);
+        // Per-group optimizer types and weight decays. Null (uniform) is encoded as a -1 length so it stays
+        // distinguishable from an empty array, and so a restore cannot silently rebuild a heterogeneous plan
+        // as a uniform one — every group quietly switched to the fallback optimizer, mid-run, with no error.
+        WriteOptimizerTypeArray(writer, checkpoint.GroupOptimizerTypes);
+        WriteFloatArray(writer, checkpoint.GroupWeightDecays);
         WriteScalars(writer, checkpoint.Scalars);
 
         writer.Write(checkpoint.Parameters.Length);
@@ -48,6 +53,8 @@ internal static class FusedOptimizerCheckpointSerializer
             Extras = ReadExtras(reader),
             Schedules = ReadLrSchedules(reader),
             ParamToGroup = ReadIntArray(reader),
+            GroupOptimizerTypes = ReadOptimizerTypeArray(reader),
+            GroupWeightDecays = ReadFloatArray(reader),
             Scalars = ReadScalars(reader),
         };
 
@@ -243,6 +250,22 @@ internal static class FusedOptimizerCheckpointSerializer
         if (length < 0) return null;
         var values = new int[length];
         for (int i = 0; i < length; i++) values[i] = reader.ReadInt32();
+        return values;
+    }
+
+    private static void WriteOptimizerTypeArray(BinaryWriter writer, OptimizerType[]? values)
+    {
+        if (values is null) { writer.Write(-1); return; }
+        writer.Write(values.Length);
+        for (int i = 0; i < values.Length; i++) writer.Write((int)values[i]);
+    }
+
+    private static OptimizerType[]? ReadOptimizerTypeArray(BinaryReader reader)
+    {
+        int length = ReadArrayLength(reader, "OptimizerType[]", sizeof(int));
+        if (length < 0) return null;
+        var values = new OptimizerType[length];
+        for (int i = 0; i < length; i++) values[i] = (OptimizerType)reader.ReadInt32();
         return values;
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PerGroupOptimizerTypeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PerGroupOptimizerTypeTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Per-group optimizer types: each parameter group may run a DIFFERENT optimizer, not merely a different
+/// learning-rate schedule.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The motivating recipe is LARS, whose papers exclude biases and normalization parameters from both the
+/// layer-wise trust ratio and weight decay. With one optimizer per plan the only options were applying LARS to
+/// biases (wrong) or refusing to fuse (useless).
+/// </para>
+/// <para>
+/// The failure mode to guard against is silence: if the per-group lookup were dropped, every group would run
+/// the fallback optimizer, training would proceed, and nothing would report an error. So the central tests
+/// compare against single-optimizer reference runs and demand EXACT agreement per group — a per-group run must
+/// reproduce, tensor by tensor, what each group's optimizer produces on its own.
+/// </para>
+/// </remarks>
+public class PerGroupOptimizerTypeTests
+{
+    private const float Lr = 0.03f, B1 = 0.9f, B2 = 0.99f, Eps = 1e-8f;
+
+    private static float[] Seed(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return a;
+    }
+
+    /// <summary>
+    /// Runs a two-parameter plan on the separable loss sum(a^2) + sum(b^2) for <paramref name="steps"/> steps.
+    /// </summary>
+    /// <remarks>
+    /// Separability is what makes the comparisons in this file valid: da/dloss depends only on a and db/dloss
+    /// only on b, so parameter a's trajectory under a given optimizer is identical whether or not b is being
+    /// optimized differently. Any cross-talk would therefore show up as a failure rather than be masked.
+    /// </remarks>
+    private static (float[] A, float[] B) RunTwoGroups(
+        float[] initA, float[] initB,
+        OptimizerType fallback,
+        IReadOnlyList<OptimizerType>? groupTypes,
+        int steps,
+        IReadOnlyList<float>? groupWeightDecays = null,
+        float weightDecay = 0f,
+        FusedOptimizerExtras? extras = null)
+    {
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            var map = new List<int> { 0, 1 };
+            plan.ConfigureOptimizerGrouped(
+                fallback, groupTypes, schedules, map, B1, B2, Eps, weightDecay, groupWeightDecays, extras);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+
+        return (a.GetDataArray().AsSpan(0, initA.Length).ToArray(),
+                b.GetDataArray().AsSpan(0, initB.Length).ToArray());
+    }
+
+    /// <summary>
+    /// The core guarantee: a plan configured with [SGD, Adam] must reproduce EXACTLY what a pure-SGD plan does
+    /// to the first tensor and what a pure-Adam plan does to the second.
+    /// </summary>
+    /// <remarks>
+    /// SGD and Adam are chosen because they differ in both trajectory and state requirements — Adam needs first
+    /// and second moment buffers, SGD needs none. So this simultaneously proves the per-parameter dispatch reads
+    /// the right group AND that buffer allocation is sized per group rather than from the plan-wide fallback.
+    /// The final assertion checks the two references genuinely disagree, so exact agreement is informative.
+    /// </remarks>
+    [Fact]
+    public void PerGroupTypes_RunEachGroupsOwnOptimizer_ExactlyMatchingSingleOptimizerRuns()
+    {
+        var initA = Seed(16, seed: 11);
+        var initB = Seed(16, seed: 12);
+        const int steps = 15;
+
+        var (pureSgdA, pureSgdB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        var (pureAdamA, pureAdamB) = RunTwoGroups(initA, initB, OptimizerType.Adam, null, steps);
+
+        var (mixedA, mixedB) = RunTwoGroups(
+            initA, initB,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, OptimizerType.Adam },
+            steps);
+
+        for (int i = 0; i < initA.Length; i++)
+            Assert.Equal(pureSgdA[i], mixedA[i], 6);
+        for (int i = 0; i < initB.Length; i++)
+            Assert.Equal(pureAdamB[i], mixedB[i], 6);
+
+        // If the per-group lookup were dropped, group 1 would have run the SGD fallback. Confirm that is a
+        // distinguishable outcome rather than a coincidence.
+        double maxRefGap = 0;
+        for (int i = 0; i < initB.Length; i++)
+            maxRefGap = Math.Max(maxRefGap, Math.Abs(pureAdamB[i] - pureSgdB[i]));
+        Assert.True(maxRefGap > 1e-3,
+            $"SGD and Adam produced near-identical trajectories (max gap {maxRefGap}), so this test proves nothing.");
+    }
+
+    /// <summary>
+    /// The same guarantee with the groups swapped, so neither "always use group 0's type" nor "always use the
+    /// last group's type" can pass.
+    /// </summary>
+    [Fact]
+    public void PerGroupTypes_AreNotOrderDependent()
+    {
+        var initA = Seed(16, seed: 21);
+        var initB = Seed(16, seed: 22);
+        const int steps = 15;
+
+        var (pureSgdA, _) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        var (pureAdamA, _) = RunTwoGroups(initA, initB, OptimizerType.Adam, null, steps);
+
+        var (mixedA, mixedB) = RunTwoGroups(
+            initA, initB,
+            fallback: OptimizerType.Adam,
+            groupTypes: new[] { OptimizerType.Adam, OptimizerType.SGD },
+            steps);
+
+        for (int i = 0; i < initA.Length; i++)
+            Assert.Equal(pureAdamA[i], mixedA[i], 6);
+
+        // Group 1 ran SGD while the fallback was Adam — so this also proves the fallback is not silently winning.
+        var (_, pureSgdB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps);
+        for (int i = 0; i < initB.Length; i++)
+            Assert.Equal(pureSgdB[i], mixedB[i], 6);
+
+        Assert.NotEqual(pureSgdA[0], pureAdamA[0], 4);
+    }
+
+    /// <summary>
+    /// The LARS recipe this feature exists for: LARS on the weight tensor, plain SGD-with-momentum and zero
+    /// weight decay on the bias tensor.
+    /// </summary>
+    [Fact]
+    public void PerGroupTypes_ExpressTheLarsBiasExclusionRecipe()
+    {
+        var initWeights = Seed(16, seed: 31);
+        var initBias = Seed(16, seed: 32);
+        const int steps = 12;
+        const float decay = 0.05f;
+
+        var (weights, bias) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.LARS,
+            groupTypes: new[] { OptimizerType.LARS, OptimizerType.SGDMomentum },
+            steps,
+            groupWeightDecays: new[] { decay, 0f },
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        // The bias must match a pure SGD-with-momentum, zero-decay run — i.e. it saw neither LARS's trust ratio
+        // nor any weight decay, which is exactly what the LARS papers prescribe for biases.
+        var (_, referenceBias) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.SGDMomentum, groupTypes: null, steps,
+            weightDecay: 0f,
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        for (int i = 0; i < initBias.Length; i++)
+            Assert.Equal(referenceBias[i], bias[i], 6);
+
+        foreach (var w in weights)
+            Assert.True(!float.IsNaN(w) && !float.IsInfinity(w), "LARS group produced a non-finite parameter.");
+
+        // And the weights must NOT match what SGD-with-momentum would have done to them, or LARS was not applied.
+        var (referenceWeightsIfSgdm, _) = RunTwoGroups(
+            initWeights, initBias,
+            fallback: OptimizerType.SGDMomentum, groupTypes: null, steps,
+            weightDecay: decay,
+            extras: new FusedOptimizerExtras { Momentum = 0.9f, TrustCoefficient = 0.001f });
+
+        double maxGap = 0;
+        for (int i = 0; i < initWeights.Length; i++)
+            maxGap = Math.Max(maxGap, Math.Abs(referenceWeightsIfSgdm[i] - weights[i]));
+        Assert.True(maxGap > 1e-6,
+            $"The LARS group's trajectory is indistinguishable from SGD-with-momentum (max gap {maxGap}).");
+    }
+
+    /// <summary>
+    /// Per-group weight decay must apply per group, under a single shared optimizer.
+    /// </summary>
+    [Fact]
+    public void PerGroupWeightDecay_AppliesPerGroup()
+    {
+        var initA = Seed(16, seed: 41);
+        var initB = Seed(16, seed: 42);
+        const int steps = 10;
+        const float decay = 0.1f;
+
+        var (a, b) = RunTwoGroups(
+            initA, initB, OptimizerType.SGD, groupTypes: null, steps,
+            groupWeightDecays: new[] { 0f, decay });
+
+        var (refNoDecayA, _) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps, weightDecay: 0f);
+        var (_, refDecayB) = RunTwoGroups(initA, initB, OptimizerType.SGD, null, steps, weightDecay: decay);
+
+        for (int i = 0; i < initA.Length; i++) Assert.Equal(refNoDecayA[i], a[i], 6);
+        for (int i = 0; i < initB.Length; i++) Assert.Equal(refDecayB[i], b[i], 6);
+    }
+
+    /// <summary>
+    /// Omitting the per-group arrays entirely must behave exactly like the original single-optimizer overload —
+    /// the uniform path is the overwhelmingly common one and must not have shifted.
+    /// </summary>
+    [Fact]
+    public void NullGroupTypes_BehaveIdenticallyToTheSingleOptimizerOverload()
+    {
+        var initA = Seed(16, seed: 51);
+        var initB = Seed(16, seed: 52);
+        const int steps = 10;
+
+        var (viaNew, viaNewB) = RunTwoGroups(initA, initB, OptimizerType.Adam, groupTypes: null, steps);
+
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            plan.ConfigureOptimizerGrouped(OptimizerType.Adam, schedules, new List<int> { 0, 1 }, B1, B2, Eps);
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+
+        var legacyA = a.GetDataArray().AsSpan(0, initA.Length).ToArray();
+        var legacyB = b.GetDataArray().AsSpan(0, initB.Length).ToArray();
+        for (int i = 0; i < initA.Length; i++) Assert.Equal(legacyA[i], viaNew[i], 6);
+        for (int i = 0; i < initB.Length; i++) Assert.Equal(legacyB[i], viaNewB[i], 6);
+    }
+
+    /// <summary>
+    /// A per-group array whose length disagrees with the schedule count is rejected, rather than silently
+    /// leaving trailing groups on the fallback.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]    // wrong groupOptimizerTypes length
+    [InlineData(false)]   // wrong groupWeightDecays length
+    public void MismatchedPerGroupArrayLength_Throws(bool badTypes)
+    {
+        var init = Seed(8, seed: 61);
+
+        Assert.Throws<ArgumentException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: badTypes ? new[] { OptimizerType.SGD } : null,
+            steps: 1,
+            groupWeightDecays: badTypes ? null : new[] { 0f }));
+    }
+
+    /// <summary>
+    /// A global-state optimizer smuggled in through a per-group array must be rejected just as it is when passed
+    /// as the plan-wide type — those maintain one scalar across all parameters, which per-group configuration
+    /// cannot express.
+    /// </summary>
+    [Theory]
+    [InlineData(OptimizerType.HypergradientSGD)]
+    [InlineData(OptimizerType.DAdaptationSGD)]
+    [InlineData(OptimizerType.ScheduleFreeSGD)]
+    public void GlobalStateOptimizerInAnyGroup_Throws(OptimizerType global)
+    {
+        var init = Seed(8, seed: 71);
+
+        Assert.Throws<NotSupportedException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, global },
+            steps: 1));
+    }
+
+    /// <summary>
+    /// An unsupported optimizer in ANY group must be caught at configure time, not on the first Step() after
+    /// earlier parameters have already been updated.
+    /// </summary>
+    [Fact]
+    public void UnsupportedOptimizerInAnyGroup_ThrowsAtConfigureTime()
+    {
+        var init = Seed(8, seed: 81);
+
+        Assert.Throws<NotSupportedException>(() => RunTwoGroups(
+            init, init,
+            fallback: OptimizerType.SGD,
+            groupTypes: new[] { OptimizerType.SGD, OptimizerType.LBFGS },
+            steps: 1));
+    }
+
+    /// <summary>
+    /// The per-group configuration must survive a checkpoint round trip. Without this, saving and resuming a
+    /// heterogeneous plan would silently rebuild it as a uniform one — every group switched to the fallback
+    /// optimizer, mid-run, with no error anywhere.
+    /// </summary>
+    [Fact]
+    public void CheckpointRoundTrip_PreservesPerGroupTypesAndWeightDecays()
+    {
+        var initA = Seed(8, seed: 91);
+        var initB = Seed(8, seed: 92);
+        var groupTypes = new[] { OptimizerType.SGD, OptimizerType.Adam };
+        var groupWds = new[] { 0f, 0.02f };
+
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { initA.Length });
+        var b = new Tensor<float>(new[] { initB.Length });
+        for (int i = 0; i < initA.Length; i++) a[i] = initA[i];
+        for (int i = 0; i < initB.Length; i++) b[i] = initB[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var sumA = engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            var sumB = engine.ReduceSum(engine.TensorMultiply(b, b), null);
+            engine.TensorAdd(sumA, sumB);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+
+        using (plan)
+        {
+            var schedules = new List<LrSchedule> { LrSchedule.Constant(Lr), LrSchedule.Constant(Lr) };
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD, groupTypes, schedules, new List<int> { 0, 1 },
+                B1, B2, Eps, 0f, groupWds);
+            for (int s = 0; s < 3; s++) plan.Step();
+
+            var checkpoint = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(checkpoint);
+            Assert.Equal(groupTypes, checkpoint!.GroupOptimizerTypes);
+            Assert.Equal(groupWds, checkpoint.GroupWeightDecays);
+
+            // Restoring the captured checkpoint into the same plan must reinstate the per-group configuration,
+            // not collapse it onto the SGD fallback.
+            Assert.IsType<CompiledTrainingPlan<float>>(plan).RestoreFusedOptimizerCheckpoint(checkpoint);
+            var afterRestore = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(afterRestore);
+            Assert.Equal(groupTypes, afterRestore!.GroupOptimizerTypes);
+            Assert.Equal(groupWds, afterRestore.GroupWeightDecays);
+        }
+    }
+
+    /// <summary>
+    /// A uniform plan must checkpoint as uniform (null arrays), so "one optimizer everywhere" stays
+    /// distinguishable from "several groups that happen to agree today".
+    /// </summary>
+    [Fact]
+    public void CheckpointRoundTrip_UniformPlanRecordsNoPerGroupArrays()
+    {
+        var init = Seed(8, seed: 93);
+        var engine = new CpuEngine();
+        var a = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) a[i] = init[i];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            engine.ReduceSum(engine.TensorMultiply(a, a), null);
+            plan = scope.CompileTraining(new[] { a });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.Adam,
+                new List<LrSchedule> { LrSchedule.Constant(Lr) },
+                new List<int> { 0 },
+                B1, B2, Eps);
+            plan.Step();
+
+            var checkpoint = Assert.IsType<CompiledTrainingPlan<float>>(plan).CaptureFusedOptimizerCheckpoint();
+            Assert.NotNull(checkpoint);
+            Assert.Null(checkpoint!.GroupOptimizerTypes);
+            Assert.Null(checkpoint.GroupWeightDecays);
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #949 — review that one first; this PR's base will retarget to main once #949 merges.

## The gap

`CompiledTrainingPlan` applied ONE `OptimizerType` to every parameter tensor, so several published recipes were not expressible. The motivating one is **LARS**, whose papers exclude biases and normalization parameters from both the layer-wise trust ratio and weight decay. With one optimizer per plan the only options were applying LARS to biases (wrong) or refusing to fuse at all (useless) — which is why `LARSOptimizer` could not be wired to the fused path in AiDotNet#1930.

## Approach

`ConfigureOptimizerGrouped` **already** mapped each parameter to a group; it just varied only the LR schedule. This extends that mechanism rather than adding a parallel one — a new overload takes optional per-group `OptimizerType` and weight-decay arrays, and the original overload delegates with both null.

Null means uniform, so the common single-optimizer path stays a captured scalar plus one null check per parameter, not an array index per parameter per step.

## Three things had to follow the per-group type

| | Why it matters |
|---|---|
| **Buffer allocation** | Sizing from the fallback leaves a group running Adam with no second-moment buffer — null-deref on the first `Step()` |
| **Validation** | Every group's type is now validated at configure time, incl. the global-state optimizers a per-group array could otherwise smuggle past the fallback-only check. An unsupported type must not reach the closure's `default` and throw after earlier parameters were already updated |
| **The checkpoint** | Both arrays go through runtime state, the POCO, **and** the binary serializer. Missing any layer silently rebuilds a heterogeneous plan as uniform on restore — every group switched to the fallback, mid-run, no error |

## Deliberately not per-group

`beta1`/`beta2`/`eps` and `FusedOptimizerExtras` stay plan-wide — per-algorithm constants the target recipes do not vary, and keeping them global holds the hot path to one array index per parameter.

Per-group types require `Float32` moment storage. bf16/int8 moments are an Adam-specific layout chosen once for the whole plan and would silently store one group's moments in a format its kernel does not read, so that combination is refused outright.

## Tests (13)

The central ones compare against single-optimizer reference runs on a **separable** loss and demand exact per-tensor agreement: a `[SGD, Adam]` plan must reproduce what pure SGD does to the first tensor and what pure Adam does to the second — with an explicit assertion that the two references genuinely disagree, so exact agreement is informative rather than vacuous. Repeated with the groups swapped, so neither "always group 0" nor "always the last group" can pass.

Plus: the LARS bias-exclusion recipe end to end, per-group weight decay, null-arrays-match-the-old-overload, mismatched array lengths, global-state and unsupported optimizers in any group, and checkpoint round trips for both the heterogeneous and uniform cases.

**1156 passed** across the fused / optimizer / compiled-plan / serialization suites on net10.0; **43** on net471.

Refs ooples/AiDotNet#1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)