### PR TITLE
feat: add differentiable UPRNet warp operations

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1626,11 +1626,10 @@ internal static class BackwardFunctions<T>
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
         bool normalize = (bool)savedState[0];
-        double epsilon = (double)savedState[1];
         var gradInput = engine.ForwardSplatBackwardInput(
-            gradOutput, inputs[0], inputs[1], normalize, epsilon);
+            gradOutput, inputs[0], inputs[1], normalize);
         var gradFlow = engine.ForwardSplatBackwardFlow(
-            gradOutput, inputs[0], inputs[1], output, normalize, epsilon);
+            gradOutput, inputs[0], inputs[1], output, normalize);
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradFlow, engine);
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -6130,7 +6130,8 @@ internal static class BackwardFunctions<T>
         int inputFeatures = inputs[0]._shape[inputs[0].Rank - 1];
         int outputFeatures = inputs[1]._shape[1];
         if (inputs[1]._shape[0] != inputFeatures
-            || gradOutput.Length != checked(rows * outputFeatures))
+            || gradOutput.Length != checked(rows * outputFeatures)
+            || inputs.Length > 2 && inputs[2].Length != outputFeatures)
             return false;
 
         bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
@@ -6150,7 +6151,10 @@ internal static class BackwardFunctions<T>
             if (needsInputGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-                var data = (float[])(object)result.GetDataArray();
+                var data = (float[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Engines.BlasManaged.BlasManaged.Gemm<float>(
                     grad, outputFeatures, false, weight, outputFeatures, true,
                     data.AsSpan(0, rows * inputFeatures), inputFeatures,
@@ -6160,7 +6164,10 @@ internal static class BackwardFunctions<T>
             if (needsWeightGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-                var data = (float[])(object)result.GetDataArray();
+                var data = (float[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Engines.BlasManaged.BlasManaged.Gemm<float>(
                     input, inputFeatures, true, grad, outputFeatures, false,
                     data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
@@ -6170,7 +6177,10 @@ internal static class BackwardFunctions<T>
             if (needsBiasGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
-                var data = (float[])(object)result.GetDataArray();
+                var data = (float[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Array.Clear(data, 0, result.Length);
                 for (int row = 0; row < rows; row++)
                 {
@@ -6196,7 +6206,10 @@ internal static class BackwardFunctions<T>
             if (needsInputGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-                var data = (double[])(object)result.GetDataArray();
+                var data = (double[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Engines.BlasManaged.BlasManaged.Gemm<double>(
                     grad, outputFeatures, false, weight, outputFeatures, true,
                     data.AsSpan(0, rows * inputFeatures), inputFeatures,
@@ -6206,7 +6219,10 @@ internal static class BackwardFunctions<T>
             if (needsWeightGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-                var data = (double[])(object)result.GetDataArray();
+                var data = (double[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Engines.BlasManaged.BlasManaged.Gemm<double>(
                     input, inputFeatures, true, grad, outputFeatures, false,
                     data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
@@ -6216,7 +6232,10 @@ internal static class BackwardFunctions<T>
             if (needsBiasGradient)
             {
                 var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
-                var data = (double[])(object)result.GetDataArray();
+                var data = (double[])(object)(
+                    result.GetLiveBackingArrayAllowingPaddingOrNull()
+                    ?? throw new InvalidOperationException(
+                        "Selective linear backward requires writable contiguous CPU storage."));
                 Array.Clear(data, 0, result.Length);
                 for (int row = 0; row < rows; row++)
                 {

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -549,6 +549,18 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        if (!needsInputGradient && !needsWeightGradient) return;
+
+        // Requested-source training commonly crosses a frozen linear projection to reach an
+        // earlier activation. The historical kernels still formed BOTH full GEMMs and merely let
+        // AccumulateGrad discard the frozen weight result. At foundation scale that materialized
+        // tens of GiB of gradients which could never be returned. Run only the requested GEMM.
+        if (needsInputGradient != needsWeightGradient
+            && TrySelectiveLinearBackward(gradOutput, inputs, engine, grads))
+            return;
+
         // Float32 + 2D fast paths (SimdGemm and BLAS): compute transposed GEMMs
         // into pooled buffers, then accumulate. Both bypass engine recording
         // (the kernels write directly to managed arrays without going through
@@ -992,6 +1004,10 @@ internal static class BackwardFunctions<T>
         var stride = (int[])savedState[0];
         var padding = (int[])savedState[1];
         var dilation = (int[])savedState[2];
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsKernelGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+
+        if (!needsInputGradient && !needsKernelGradient) return;
 
         // #1662 lever #4: route the conv backward OUTPUT gradients through the per-step arena
         // (AutoTensorCache -> TensorAllocator -> TensorArena) instead of the raw `new float[]`
@@ -1000,26 +1016,38 @@ internal static class BackwardFunctions<T>
         // 98-99.9% for matmul/attention backward). The *Into variants fill a rented buffer and
         // zero it first (accumulate:false -> Array.Clear), so renting uninitialized memory is
         // safe. CPU-only; the GPU engine keeps the allocating path.
-        Tensor<T> gradInput, gradKernel;
         if (engine is CpuEngine cpu)
         {
-            gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-            gradKernel = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-            cpu.Conv2DBackwardInputInto(
-                gradInput, gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation, accumulate: false);
-            cpu.Conv2DBackwardKernelInto(
-                gradKernel, gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation, accumulate: false);
+            if (needsInputGradient)
+            {
+                var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                cpu.Conv2DBackwardInputInto(
+                    gradInput, gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation, accumulate: false);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+            }
+            if (needsKernelGradient)
+            {
+                var gradKernel = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                cpu.Conv2DBackwardKernelInto(
+                    gradKernel, gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation, accumulate: false);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+            }
         }
         else
         {
-            gradInput = engine.Conv2DBackwardInput(
-                gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
-            gradKernel = engine.Conv2DBackwardKernel(
-                gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+            if (needsInputGradient)
+            {
+                var gradInput = engine.Conv2DBackwardInput(
+                    gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+            }
+            if (needsKernelGradient)
+            {
+                var gradKernel = engine.Conv2DBackwardKernel(
+                    gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+            }
         }
-
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
     }
 
     /// <summary>Conv1D backward: reshapes 3D inputs to 4D, delegates to Conv2DBackward logic, reshapes back</summary>
@@ -1066,13 +1094,18 @@ internal static class BackwardFunctions<T>
         var padding = (int[])savedState[1];
         var dilation = (int[])savedState[2];
 
-        var gradInput = engine.Conv3DBackwardInput(
-            gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
-        var gradKernel = engine.Conv3DBackwardKernel(
-            gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
-
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        if (DifferentiableOps.IsGradientRequired(inputs[0]))
+        {
+            var gradInput = engine.Conv3DBackwardInput(
+                gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
+            DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        }
+        if (DifferentiableOps.IsGradientRequired(inputs[1]))
+        {
+            var gradKernel = engine.Conv3DBackwardKernel(
+                gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+            DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        }
     }
 
     /// <summary>GridSample backward: uses engine.GridSampleBackwardInput and GridSampleBackwardGrid</summary>
@@ -2469,7 +2502,6 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        var numOps = MathHelper.GetNumericOperations<T>();
         int dim = (int)savedState[0];
         int start = (int)savedState[1];
         int length = (int)savedState[2];
@@ -2481,17 +2513,19 @@ internal static class BackwardFunctions<T>
         for (int i = 0; i < dim; i++) outerSize *= inShape[i];
         for (int i = dim + 1; i < inShape.Length; i++) innerSize *= inShape[i];
 
+        // A narrow slice is contiguous within each outer-axis slab. Copy one complete slab instead
+        // of indexing every scalar through three managed loops. SegMamba creates thousands of these
+        // nodes; the scalar version dominated its backward pass despite moving contiguous data.
+        int copyLength = checked(length * innerSize);
+        var source = gradOutput.IsContiguous ? gradOutput : gradOutput.Contiguous();
+        ReadOnlySpan<T> sourceSpan = source.AsSpan();
+        Span<T> destinationSpan = inputGrad.AsWritableSpan();
         for (int outer = 0; outer < outerSize; outer++)
-        for (int d = 0; d < length; d++)
-        for (int inner = 0; inner < innerSize; inner++)
         {
-            int srcFlat = (outer * dimSize + (start + d)) * innerSize + inner;
-            int gradFlat = (outer * length + d) * innerSize + inner;
-            if (srcFlat < 0 || srcFlat >= inputGrad.Length)
-                throw new InvalidOperationException($"NarrowBackward: source index {srcFlat} out of range [0, {inputGrad.Length}).");
-            if (gradFlat < 0 || gradFlat >= gradOutput.Length)
-                throw new InvalidOperationException($"NarrowBackward: gradient index {gradFlat} out of range [0, {gradOutput.Length}).");
-            inputGrad[srcFlat] = gradOutput[gradFlat];
+            int destinationOffset = checked((outer * dimSize + start) * innerSize);
+            int sourceOffset = checked(outer * copyLength);
+            sourceSpan.Slice(sourceOffset, copyLength)
+                .CopyTo(destinationSpan.Slice(destinationOffset, copyLength));
         }
         DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
     }
@@ -5814,6 +5848,18 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        bool needsBiasGradient = inputs.Length > 2 && DifferentiableOps.IsGradientRequired(inputs[2]);
+        if (!needsInputGradient && !needsWeightGradient && !needsBiasGradient) return;
+
+        int requiredGradientCount = (needsInputGradient ? 1 : 0)
+            + (needsWeightGradient ? 1 : 0)
+            + (needsBiasGradient ? 1 : 0);
+        if (requiredGradientCount < inputs.Length
+            && TrySelectiveLinearBackward(gradOutput, inputs, engine, grads))
+            return;
+
         // Float32 + 2D fast paths: transposed GEMMs + inline bias sum, no transpose allocation.
         // Same parallel-SimdGemm preference as MatMulBackward to avoid getting
         // single-thread-trapped on installs whose BLAS provider lacks internal
@@ -6064,6 +6110,126 @@ internal static class BackwardFunctions<T>
             var biasGrad = SumToShape(gradOutput, inputs[2]._shape, engine);
             DifferentiableOps.AccumulateGrad(grads, inputs[2], biasGrad, engine);
         }
+    }
+
+    /// <summary>
+    /// Computes only requested gradients for the common contiguous ND-by-2D linear projection.
+    /// </summary>
+    private static bool TrySelectiveLinearBackward(
+        Tensor<T> gradOutput,
+        Tensor<T>[] inputs,
+        IEngine engine,
+        Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        if (engine.SupportsGpu || inputs.Length < 2 || inputs[0].Rank < 2 || inputs[1].Rank != 2
+            || !inputs[0].IsContiguous || !inputs[1].IsContiguous || !gradOutput.IsContiguous)
+            return false;
+
+        int rows = 1;
+        for (int d = 0; d < inputs[0].Rank - 1; d++) rows = checked(rows * inputs[0]._shape[d]);
+        int inputFeatures = inputs[0]._shape[inputs[0].Rank - 1];
+        int outputFeatures = inputs[1]._shape[1];
+        if (inputs[1]._shape[0] != inputFeatures
+            || gradOutput.Length != checked(rows * outputFeatures))
+            return false;
+
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        bool needsBiasGradient = inputs.Length > 2 && DifferentiableOps.IsGradientRequired(inputs[2]);
+
+        if (typeof(T) == typeof(float))
+        {
+            var grad = (float[])(object)gradOutput.GetDataArray();
+            var input = (float[])(object)inputs[0].GetDataArray();
+            var weight = (float[])(object)inputs[1].GetDataArray();
+            var options = new Engines.BlasManaged.BlasOptions<float>
+            {
+                PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune
+            };
+
+            if (needsInputGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                    grad, outputFeatures, false, weight, outputFeatures, true,
+                    data.AsSpan(0, rows * inputFeatures), inputFeatures,
+                    rows, inputFeatures, outputFeatures, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], result, engine);
+            }
+            if (needsWeightGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                    input, inputFeatures, true, grad, outputFeatures, false,
+                    data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
+                    inputFeatures, outputFeatures, rows, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], result, engine);
+            }
+            if (needsBiasGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Array.Clear(data, 0, result.Length);
+                for (int row = 0; row < rows; row++)
+                {
+                    int offset = row * outputFeatures;
+                    for (int column = 0; column < outputFeatures; column++)
+                        data[column] += grad[offset + column];
+                }
+                DifferentiableOps.AccumulateGrad(grads, inputs[2], result, engine);
+            }
+            return true;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            var grad = (double[])(object)gradOutput.GetDataArray();
+            var input = (double[])(object)inputs[0].GetDataArray();
+            var weight = (double[])(object)inputs[1].GetDataArray();
+            var options = new Engines.BlasManaged.BlasOptions<double>
+            {
+                PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune
+            };
+
+            if (needsInputGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<double>(
+                    grad, outputFeatures, false, weight, outputFeatures, true,
+                    data.AsSpan(0, rows * inputFeatures), inputFeatures,
+                    rows, inputFeatures, outputFeatures, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], result, engine);
+            }
+            if (needsWeightGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<double>(
+                    input, inputFeatures, true, grad, outputFeatures, false,
+                    data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
+                    inputFeatures, outputFeatures, rows, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], result, engine);
+            }
+            if (needsBiasGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Array.Clear(data, 0, result.Length);
+                for (int row = 0; row < rows; row++)
+                {
+                    int offset = row * outputFeatures;
+                    for (int column = 0; column < outputFeatures; column++)
+                        data[column] += grad[offset + column];
+                }
+                DifferentiableOps.AccumulateGrad(grads, inputs[2], result, engine);
+            }
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1700,7 +1700,7 @@ internal static class BackwardFunctions<T>
 
         Tensor<T> gradInput;
         Tensor<T> gradFlow;
-        if (engine is IForwardSplatBackwardEngine optimized)
+        if (engine is CpuEngine optimized)
         {
             // The normalization field depends only on flow and is identical for both adjoints.
             // Compute it once instead of launching the full splat-weight pass twice.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1620,6 +1620,21 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[2], gradV, engine);
     }
 
+    /// <summary>Average forward-splat backward for source values and pixel flow.</summary>
+    internal static void ForwardSplatBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        bool normalize = (bool)savedState[0];
+        double epsilon = (double)savedState[1];
+        var gradInput = engine.ForwardSplatBackwardInput(
+            gradOutput, inputs[0], inputs[1], normalize, epsilon);
+        var gradFlow = engine.ForwardSplatBackwardFlow(
+            gradOutput, inputs[0], inputs[1], output, normalize, epsilon);
+        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradFlow, engine);
+    }
+
     /// <summary>
     /// DeformableConv2D backward (DCN v1 / mask=null): routes gradient to
     /// input, kernel, offset. Engine has separate Input/Kernel/Offset

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -1620,16 +1620,105 @@ internal static class BackwardFunctions<T>
         DifferentiableOps.AccumulateGrad(grads, inputs[2], gradV, engine);
     }
 
+    /// <summary>Backward for the bounded local correlation volume.</summary>
+    internal static void PartialCorrelationVolumeBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        const string op = nameof(PartialCorrelationVolumeBackward);
+        RequireSavedState(op, savedState, 1);
+        int radius = SavedInt(op, savedState, 0, "radius");
+        var first = inputs[0];
+        var second = inputs[1];
+        int batch = first.Shape[0], channels = first.Shape[1];
+        int height = first.Shape[2], width = first.Shape[3];
+        int diameter = radius * 2 + 1;
+        var numOps = MathHelper.GetNumericOperations<T>();
+        T channelCount = numOps.FromDouble(channels);
+
+        Tensor<T>? gradFirst = null;
+        Tensor<T>? gradSecond = null;
+        using (GradientTape<T>.NoGrad())
+        {
+            var paddedSecond = engine.Pad(
+                second, radius, radius, radius, radius, numOps.Zero);
+            int offset = 0;
+            for (int offsetY = 0; offsetY < diameter; offsetY++)
+            for (int offsetX = 0; offsetX < diameter; offsetX++, offset++)
+            {
+                var gradPlane = engine.TensorSlice(
+                    gradOutput,
+                    [0, offset, 0, 0],
+                    [batch, 1, height, width]);
+                var expandedGradient = engine.TensorBroadcastTo(
+                    gradPlane, [batch, channels, height, width]);
+                expandedGradient = engine.TensorDivideScalar(expandedGradient, channelCount);
+
+                var shiftedSecond = engine.TensorSlice(
+                    paddedSecond,
+                    [0, 0, offsetY, offsetX],
+                    [batch, channels, height, width]);
+                var firstContribution = engine.TensorMultiply(expandedGradient, shiftedSecond);
+                gradFirst = gradFirst is null
+                    ? firstContribution
+                    : engine.TensorAdd(gradFirst, firstContribution);
+
+                var unshiftedContribution = engine.TensorMultiply(expandedGradient, first);
+                int displacementY = offsetY - radius;
+                int displacementX = offsetX - radius;
+                int padTop = Math.Max(displacementY, 0);
+                int padBottom = Math.Max(-displacementY, 0);
+                int padLeft = Math.Max(displacementX, 0);
+                int padRight = Math.Max(-displacementX, 0);
+                var paddedContribution = engine.Pad(
+                    unshiftedContribution,
+                    padTop, padBottom, padLeft, padRight, numOps.Zero);
+                var secondContribution = engine.TensorSlice(
+                    paddedContribution,
+                    [0, 0, Math.Max(-displacementY, 0), Math.Max(-displacementX, 0)],
+                    [batch, channels, height, width]);
+                gradSecond = gradSecond is null
+                    ? secondContribution
+                    : engine.TensorAdd(gradSecond, secondContribution);
+            }
+        }
+
+        if (gradFirst is not null)
+            DifferentiableOps.AccumulateGrad(grads, first, gradFirst, engine);
+        if (gradSecond is not null)
+            DifferentiableOps.AccumulateGrad(grads, second, gradSecond, engine);
+    }
+
     /// <summary>Average forward-splat backward for source values and pixel flow.</summary>
     internal static void ForwardSplatBackward(
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        bool normalize = (bool)savedState[0];
-        var gradInput = engine.ForwardSplatBackwardInput(
-            gradOutput, inputs[0], inputs[1], normalize);
-        var gradFlow = engine.ForwardSplatBackwardFlow(
-            gradOutput, inputs[0], inputs[1], output, normalize);
+        const string op = nameof(ForwardSplatBackward);
+        RequireSavedState(op, savedState, 1);
+        bool normalize = SavedBool(op, savedState, 0, "normalize");
+
+        Tensor<T> gradInput;
+        Tensor<T> gradFlow;
+        if (engine is IForwardSplatBackwardEngine optimized)
+        {
+            // The normalization field depends only on flow and is identical for both adjoints.
+            // Compute it once instead of launching the full splat-weight pass twice.
+            Tensor<T>? normalizationWeights = normalize
+                ? optimized.GetForwardSplatNormalizationWeights(inputs[1])
+                : null;
+            gradInput = optimized.ForwardSplatBackwardInputWithWeights(
+                gradOutput, inputs[0], inputs[1], normalize, normalizationWeights);
+            gradFlow = optimized.ForwardSplatBackwardFlowWithWeights(
+                gradOutput, inputs[0], inputs[1], output, normalize, normalizationWeights);
+        }
+        else
+        {
+            gradInput = engine.ForwardSplatBackwardInput(
+                gradOutput, inputs[0], inputs[1], normalize);
+            gradFlow = engine.ForwardSplatBackwardFlow(
+                gradOutput, inputs[0], inputs[1], output, normalize);
+        }
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradFlow, engine);
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -211,6 +211,8 @@ public sealed class CompiledBackwardGraph<T>
             {
                 ref var entry = ref _entries[i];
 
+                if (!DifferentiableOps.IsGradientRequired(entry.Output))
+                    continue;
                 if (!grads.TryGetValue(entry.Output, out var gradOutput))
                     continue;
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -219,6 +219,8 @@ internal sealed class CompiledDelegateChain<T>
         for (int i = 0; i < _count; i++)
         {
             ref var step = ref _steps[i];
+            if (!DifferentiableOps.IsGradientRequired(step.Output))
+                continue;
             if (!grads.TryGetValue(step.Output, out var gradOutput))
                 continue;
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -549,6 +549,11 @@ internal static class DifferentiableOps
         Tensor<T> grad,
         IEngine engine)
     {
+        // This overload explicitly transfers disposal responsibility back to its caller.
+        // An irrelevant contribution was never donated to an accumulator, so the caller may
+        // immediately return its scratch buffer instead of leaking the rental.
+        if (!IsGradientRequired(tensor)) return true;
+
         bool needsOutOfPlace = _isBackwardCreateGraph;
         bool wasAlreadyOwned = !needsOutOfPlace && IsAccumulatorBufferOwned(grad);
         int idx = tensor._gradIndex;
@@ -598,12 +603,13 @@ internal static class DifferentiableOps
         Tensor<T> grad,
         IEngine engine)
     {
-        // Requested-source pruning: do not retain or propagate gradients that cannot reach a
-        // requested source. GradientTape installs the reachability set before every backward
-        // implementation (compiled chain, GradFn graph, and tape walk), so this also terminates
-        // traversal at the first frozen boundary instead of computing the entire upstream graph
-        // and discarding it only when the final dictionary is filtered.
-        if (!IsGradientRequired(tensor)) return;
+        // Requested-source traversal is pruned by the tape/compiled execution loops, and the
+        // expensive multi-input backward functions query IsGradientRequired before allocating.
+        // Do not drop an arbitrary contribution here: many older backward functions rent a
+        // buffer before calling AccumulateGrad, while others pass a borrowed gradOutput reused
+        // by a later input. Silently returning from this donation point either leaked the rental
+        // or made generic reclamation unsafe. Storing the contribution preserves ownership until
+        // the normal filtered-gradient cleanup; AccumulateGradPoolable handles disposable scratch.
 
         // PR #638 A2: mark this scope as grad accumulation so the DirectGpu engine's resident in-place add
         // fast path engages ONLY here (the dedicated, non-aliased gradient leaf) and never hijacks forward

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -186,6 +186,52 @@ internal static class DifferentiableOps
     internal static bool _isBackwardCreateGraph;
 
     /// <summary>
+    /// Requested-source reachability for the current backward pass. A null set preserves the
+    /// historical unfiltered behavior; a non-null set contains exactly the tensors whose
+    /// gradients can reach one of the caller's requested sources.
+    /// </summary>
+    private static class GradientRelevance<T>
+    {
+        [ThreadStatic]
+        internal static HashSet<Tensor<T>>? Current;
+    }
+
+    /// <summary>Installs a requested-source gradient filter for one nested backward scope.</summary>
+    internal static GradientRelevanceScope<T> PushGradientRelevance<T>(
+        HashSet<Tensor<T>>? relevantTensors)
+    {
+        var previous = GradientRelevance<T>.Current;
+        GradientRelevance<T>.Current = relevantTensors;
+        return new GradientRelevanceScope<T>(previous);
+    }
+
+    /// <summary>
+    /// Returns whether backward work for <paramref name="tensor"/> can contribute to a requested
+    /// source. With no explicit source filter every gradient remains required.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsGradientRequired<T>(Tensor<T> tensor)
+    {
+        var relevant = GradientRelevance<T>.Current;
+        return relevant is null || relevant.Contains(tensor);
+    }
+
+    internal readonly struct GradientRelevanceScope<T> : IDisposable
+    {
+        private readonly HashSet<Tensor<T>>? _previous;
+
+        internal GradientRelevanceScope(HashSet<Tensor<T>>? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            GradientRelevance<T>.Current = _previous;
+        }
+    }
+
+    /// <summary>
     /// Returns true if a gradient tape is active and not suppressed.
     /// Use this to guard savedState allocation: only create new object[]
     /// when IsRecording is true, avoiding unnecessary GC pressure during inference.
@@ -552,6 +598,13 @@ internal static class DifferentiableOps
         Tensor<T> grad,
         IEngine engine)
     {
+        // Requested-source pruning: do not retain or propagate gradients that cannot reach a
+        // requested source. GradientTape installs the reachability set before every backward
+        // implementation (compiled chain, GradFn graph, and tape walk), so this also terminates
+        // traversal at the first frozen boundary instead of computing the entire upstream graph
+        // and discarding it only when the final dictionary is filtered.
+        if (!IsGradientRequired(tensor)) return;
+
         // PR #638 A2: mark this scope as grad accumulation so the DirectGpu engine's resident in-place add
         // fast path engages ONLY here (the dedicated, non-aliased gradient leaf) and never hijacks forward
         // in-place ops on aliased activations (that hijack threw CUDA-700). No-op for non-DirectGpu engines.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Autodiff;
@@ -29,6 +30,33 @@ public static class GradientCheckpointing<T>
         IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
         Tensor<T> input,
         int segmentSize = 2)
+        => CheckpointCore(functions, input, parameterSourceFactory: null, segmentSize);
+
+    /// <summary>
+    /// Runs a checkpointed sequence while differentiating only the explicitly selected parameters.
+    /// </summary>
+    /// <remarks>
+    /// The source factory is evaluated after the no-grad forward has materialized lazy parameters.
+    /// This is the activation-checkpointing equivalent of freezing a backbone: the recompute still
+    /// calculates the input VJP needed to cross the frozen block, but it neither allocates nor returns
+    /// gradients for parameters outside <paramref name="parameterSourceFactory"/>.
+    /// </remarks>
+    public static Tensor<T> Checkpoint(
+        IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
+        Tensor<T> input,
+        Func<IReadOnlyList<Tensor<T>>> parameterSourceFactory,
+        int segmentSize = 2)
+    {
+        if (parameterSourceFactory is null)
+            throw new ArgumentNullException(nameof(parameterSourceFactory));
+        return CheckpointCore(functions, input, parameterSourceFactory, segmentSize);
+    }
+
+    private static Tensor<T> CheckpointCore(
+        IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
+        Tensor<T> input,
+        Func<IReadOnlyList<Tensor<T>>>? parameterSourceFactory,
+        int segmentSize)
     {
         if (functions == null || functions.Count == 0) return input;
         if (segmentSize <= 0)
@@ -56,23 +84,46 @@ public static class GradientCheckpointing<T>
 
             // Run segment forward WITHOUT recording (save memory)
             Tensor<T> segmentOutput;
+            using (var segmentArena = TensorArena.Create(poolWhenNested: true))
             using (GradientTape<T>.NoGrad())
             {
                 segmentOutput = segmentInput;
                 for (int i = startIdx; i < endIdx; i++)
                     segmentOutput = functions[i](segmentOutput);
+                // Only the segment boundary escapes. Copy it out, then release every internal
+                // activation instead of letting the caller's outer training arena retain the
+                // no-grad scratch until the end of the whole model step. A nested arena does not
+                // return its buffers to the shared pool because layers may cache internal tensors.
+                segmentOutput = new Tensor<T>(segmentOutput.AsSpan().ToArray(), segmentOutput.Shape.ToArray());
             }
 
-            // Record a single "checkpoint" op that recomputes during backward
+            // Record a single "checkpoint" op that recomputes during backward. A selective
+            // checkpoint records its chosen parameters as logical inputs as well as the segment
+            // boundary. Besides making the dependency explicit, this lets requested-source graph
+            // pruning retain the checkpoint when a caller asks only for trainable parameters.
+            Tensor<T>[]? checkpointInputs = null;
+            if (parameterSourceFactory is not null)
+            {
+                var selected = parameterSourceFactory();
+                var unique = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                checkpointInputs = new Tensor<T>[selected.Count + 1];
+                checkpointInputs[0] = segmentInput;
+                int write = 1;
+                for (int i = 0; i < selected.Count; i++)
+                {
+                    var parameter = selected[i];
+                    if (parameter is not null && !ReferenceEquals(parameter, segmentInput) && unique.Add(parameter))
+                        checkpointInputs[write++] = parameter;
+                }
+                if (write != checkpointInputs.Length)
+                    Array.Resize(ref checkpointInputs, write);
+            }
+
             int capturedStart = startIdx;
             int capturedEnd = endIdx;
             var capturedFunctions = functions;
 
-            DifferentiableOps.RecordUnary<T>(
-                $"Checkpoint_seg{seg}",
-                segmentOutput,
-                segmentInput,
-                (gradOutput, inputs, output, savedState, eng, grads) =>
+            BackwardFunction<T> backward = (gradOutput, inputs, output, savedState, eng, grads) =>
                 {
                     // RECOMPUTE: run the segment forward again WITH recording so
                     // backward can flow through the ops. Use a fresh, NON-persistent
@@ -85,13 +136,14 @@ public static class GradientCheckpointing<T>
                     // which produces NullReferenceException in
                     // SymbolicBackwardGraphBuilder.Analyze when the cached pattern
                     // does not match the current tape's reachable entries).
-                    using var recomputeTape = new GradientTape<T>(
-                        // SuppressArenaScope: this inner tape runs mid-backward, where the outer
-                        // tape has nulled the thread-current tape, so it would otherwise look like a
-                        // step-boundary tape and Reset() the OUTER tape's arena — corrupting the
-                        // accumulating gradients (#734). It borrows the arena for scratch only.
-                        new GradientTapeOptions { Persistent = false, SuppressArenaScope = true });
                     var reInput = inputs[0];
+                    List<(Tensor<T> Key, Tensor<T> Gradient)> detachedGradients;
+                    using (var recomputeArena = TensorArena.Create(poolWhenNested: true))
+                    using (var recomputeTape = new GradientTape<T>(
+                        // A dedicated nested arena owns this segment's replay. SuppressArenaScope
+                        // keeps the tape from resetting it before gradients are copied out below.
+                        new GradientTapeOptions { Persistent = false, SuppressArenaScope = true }))
+                    {
                     // Detach the segment input so the recompute graph is SELF-CONTAINED: its backward
                     // stops at the segment boundary instead of following reInput's producer into an
                     // EARLIER checkpoint segment. Without this, ComputeGradients(sources: null) below
@@ -101,10 +153,10 @@ public static class GradientCheckpointing<T>
                     // mirrors torch.utils.checkpoint's detach_variable(inputs). StopGradient returns a
                     // fresh leaf (data copy, no GradFn); the input gradient it produces is remapped
                     // back onto the original reInput tensor when scattering below.
-                    var reInputDetached = eng.StopGradient(reInput);
-                    var reOutput = reInputDetached;
-                    for (int i = capturedStart; i < capturedEnd; i++)
-                        reOutput = capturedFunctions[i](reOutput);
+                        var reInputDetached = eng.StopGradient(reInput);
+                        var reOutput = reInputDetached;
+                        for (int i = capturedStart; i < capturedEnd; i++)
+                            reOutput = capturedFunctions[i](reOutput);
 
                     // Vector-Jacobian product (VJP) seed. The previous
                     // implementation computed gradients with the inner tape's
@@ -140,8 +192,8 @@ public static class GradientCheckpointing<T>
                     // tensor — both ops are recorded on the inner tape via the
                     // DifferentiableOps backward registry, so ComputeGradients
                     // walks them and computes the correct VJP into reInput.
-                    var weighted = eng.TensorMultiply(reOutput, gradOutput);
-                    var pseudoLoss = eng.ReduceSum(weighted);
+                        var weighted = eng.TensorMultiply(reOutput, gradOutput);
+                        var pseudoLoss = eng.ReduceSum(weighted);
 
                     // Differentiate the recomputed segment w.r.t. EVERY leaf it touched — the
                     // (detached) segment input AND every weight/parameter the segment's functions
@@ -159,33 +211,50 @@ public static class GradientCheckpointing<T>
                     // instances the caller never queries — harmless. The sole exclusion is gradOutput:
                     // an outer-tape constant folded into the pseudo-loss only to seed the VJP, whose
                     // inner "gradient" (== reOutput) is not a real gradient and must not leak back.
-                    var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: null);
+                        Tensor<T>[]? recomputeSources = null;
+                        if (checkpointInputs is not null)
+                        {
+                            recomputeSources = new Tensor<T>[inputs.Length];
+                            recomputeSources[0] = reInputDetached;
+                            for (int i = 1; i < inputs.Length; i++) recomputeSources[i] = inputs[i];
+                        }
+                        var segGrads = recomputeTape.ComputeGradients(pseudoLoss, recomputeSources);
 
-                    bool accumulatedAny = false;
-                    foreach (var kvp in segGrads)
-                    {
-                        if (ReferenceEquals(kvp.Key, gradOutput)) continue;
-                        if (kvp.Value is null) continue;
-                        // The detached input's gradient belongs to the ORIGINAL segment-input tensor
-                        // the caller tracks (and that the outer walk hands to the previous segment);
-                        // remap it. Every other key is a live parameter the segment read directly.
-                        var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
-                        DifferentiableOps.AccumulateGrad(grads, key, kvp.Value, eng);
-                        accumulatedAny = true;
+                        // Segment-recompute arrays must not escape their bounded arena. Preserve only
+                        // the selected VJPs in ordinary owned storage; after this scope disposes, every
+                        // other activation/temporary is immediately reusable by the next block.
+                        detachedGradients = new List<(Tensor<T>, Tensor<T>)>(segGrads.Count);
+                        foreach (var kvp in segGrads)
+                        {
+                            if (ReferenceEquals(kvp.Key, gradOutput) || kvp.Value is null) continue;
+                            var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
+                            var copied = new Tensor<T>(kvp.Value.AsSpan().ToArray(), kvp.Value.Shape.ToArray());
+                            detachedGradients.Add((key, copied));
+                        }
+
+                        if (detachedGradients.Count == 0 && ReferenceEquals(reOutput, reInputDetached))
+                        {
+                            var copied = new Tensor<T>(gradOutput.AsSpan().ToArray(), gradOutput.Shape.ToArray());
+                            detachedGradients.Add((reInput, copied));
+                        }
                     }
 
-                    // Identity / no-op segment (output IS input by reference, nothing recorded on
-                    // the recompute tape): pass the upstream gradient straight through. Reference-
-                    // equality is the only safe alias predicate — it covers the empty-segment case
-                    // without false positives on shape coincidence. For a genuinely input-
-                    // independent segment, leaving grads[input] untouched (zero) is the correct VJP.
-                    if (!accumulatedAny && ReferenceEquals(reOutput, reInputDetached))
+                    foreach (var (key, gradient) in detachedGradients)
                     {
-                        // Empty / no-op segment (no functions ran): pass the upstream gradient straight
-                        // through to the original input.
-                        DifferentiableOps.AccumulateGrad(grads, reInput, gradOutput, eng);
+                        DifferentiableOps.AccumulateGrad(grads, key, gradient, eng);
                     }
-                });
+                };
+
+            if (checkpointInputs is null)
+            {
+                DifferentiableOps.RecordUnary<T>(
+                    $"Checkpoint_seg{seg}", segmentOutput, segmentInput, backward);
+            }
+            else
+            {
+                DifferentiableOps.RecordIfActive<T>(
+                    $"Checkpoint_seg{seg}", segmentOutput, checkpointInputs, backward);
+            }
 
             current2 = segmentOutput;
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -94,7 +94,7 @@ public static class GradientCheckpointing<T>
                 // activation instead of letting the caller's outer training arena retain the
                 // no-grad scratch until the end of the whole model step. A nested arena does not
                 // return its buffers to the shared pool because layers may cache internal tensors.
-                segmentOutput = new Tensor<T>(segmentOutput.AsSpan().ToArray(), segmentOutput.Shape.ToArray());
+                segmentOutput = CloneCheckpointBoundary(segmentOutput);
             }
 
             // Record a single "checkpoint" op that recomputes during backward. A selective
@@ -228,13 +228,13 @@ public static class GradientCheckpointing<T>
                         {
                             if (ReferenceEquals(kvp.Key, gradOutput) || kvp.Value is null) continue;
                             var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
-                            var copied = new Tensor<T>(kvp.Value.AsSpan().ToArray(), kvp.Value.Shape.ToArray());
+                            var copied = CloneCheckpointBoundary(kvp.Value);
                             detachedGradients.Add((key, copied));
                         }
 
                         if (detachedGradients.Count == 0 && ReferenceEquals(reOutput, reInputDetached))
                         {
-                            var copied = new Tensor<T>(gradOutput.AsSpan().ToArray(), gradOutput.Shape.ToArray());
+                            var copied = CloneCheckpointBoundary(gradOutput);
                             detachedGradients.Add((reInput, copied));
                         }
                     }
@@ -260,6 +260,17 @@ public static class GradientCheckpointing<T>
         }
 
         return current2;
+    }
+
+    /// <summary>
+    /// Copies a checkpoint boundary into ordinary owned storage. Segment outputs and VJPs may
+    /// be transpose/permute views, whose logical order cannot be exposed through AsSpan until
+    /// the view is materialized.
+    /// </summary>
+    private static Tensor<T> CloneCheckpointBoundary(Tensor<T> source)
+    {
+        var contiguous = source.IsContiguous ? source : source.Contiguous();
+        return new Tensor<T>(contiguous.AsSpan().ToArray(), source.Shape.ToArray());
     }
 
     private static bool ShapesEqual(int[] a, int[] b)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -1039,47 +1039,6 @@ public sealed class GradientTape<T> : IDisposable
             bool anomalyActive = DetectAnomaly || AnomalyModeScope.IsActive;
             var numOpsForAnomaly = anomalyActive ? MathHelper.GetNumericOperations<T>() : null;
 
-            // Tape backward pruning: when sources are specified, forward-walk to find all tensors
-            // downstream of those sources. Skip entries whose output is not reachable.
-            // For persistent tapes, cache the relevance set since sources are typically the same
-            // across training steps (always the model parameters).
-            HashSet<Tensor<T>>? relevantTensors = null;
-            // Only build relevance set for large tapes — the O(n) forward-walk cost
-            // exceeds the backward pruning benefit for small tapes (< 100 entries).
-            if (sources is not null && sources.Count > 0 && _entries.Count >= 100)
-            {
-                relevantTensors = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
-                foreach (var s in sources)
-                    relevantTensors.Add(s);
-
-                // Forward pass: mark tensors reachable from sources
-                // Uses inline input fields to avoid per-entry array allocation
-                for (int i = 0; i < _entries.Count; i++)
-                {
-                    ref var entry = ref _entries[i];
-                    bool inputRelevant = false;
-
-                    if (entry.InputsOverflow is not null)
-                    {
-                        foreach (var inp in entry.InputsOverflow)
-                        {
-                            if (relevantTensors.Contains(inp)) { inputRelevant = true; break; }
-                        }
-                    }
-                    else
-                    {
-                        if (relevantTensors.Contains(entry.Input0)) inputRelevant = true;
-                        else if (entry.InputCount >= 2 && entry.Input1 is not null && relevantTensors.Contains(entry.Input1)) inputRelevant = true;
-                        else if (entry.InputCount >= 3 && entry.Input2 is not null && relevantTensors.Contains(entry.Input2)) inputRelevant = true;
-                    }
-
-                    if (inputRelevant)
-                    {
-                        relevantTensors.Add(entry.Output);
-                    }
-                }
-            }
-
             for (int i = _entries.Count - 1; i >= 0; i--)
             {
                 ref var entry = ref _entries[i];
@@ -1090,8 +1049,9 @@ public sealed class GradientTape<T> : IDisposable
                     continue;
                 }
 
-                // Tape backward pruning: skip entries that don't contribute to requested sources.
-                if (relevantTensors is not null && !relevantTensors.Contains(entry.Output))
+                // Requested-source pruning is built once before dispatch and shared by tape,
+                // graph, and compiled execution. Avoid rebuilding the same set in this loop.
+                if (!DifferentiableOps.IsGradientRequired(entry.Output))
                 {
                     continue;
                 }
@@ -1357,15 +1317,39 @@ public sealed class GradientTape<T> : IDisposable
         return grads;
     }
 
+    private Tensor<T>? _cachedGradientRelevanceLoss;
+    private Tensor<T>[]? _cachedGradientRelevanceSources;
+    private int _cachedGradientRelevanceEntryCount = -1;
+    private HashSet<Tensor<T>>? _cachedGradientRelevance;
+
     private HashSet<Tensor<T>>? BuildGradientRelevance(
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources)
     {
         if (sources is null) return null;
 
+        // The forward reachability walk costs more than it saves on small tapes. Explicitly
+        // empty sources remain special: they must install an empty set and produce no gradients.
+        if (sources.Count > 0 && _entries.Count < 100) return null;
+
+        bool canCache = _options.Persistent
+            && (_retainGrad is null || _retainGrad.Count == 0)
+            && (_hooks is null || _hooks.Count == 0);
+        if (canCache
+            && ReferenceEquals(_cachedGradientRelevanceLoss, loss)
+            && _cachedGradientRelevanceEntryCount == _entries.Count
+            && SourcesMatch(_cachedGradientRelevanceSources, sources))
+        {
+            return _cachedGradientRelevance;
+        }
+
         var relevant = new HashSet<Tensor<T>>(
             ReferenceEqualityComparer<Tensor<T>>.Instance);
         foreach (var source in sources) relevant.Add(source);
+        if (_retainGrad is not null)
+            foreach (var retained in _retainGrad) relevant.Add(retained);
+        if (_hooks is not null)
+            foreach (var hooked in _hooks.Keys) relevant.Add(hooked);
 
         // Prefer the GradFn graph because it can cross tape boundaries. Higher-order
         // differentiation intentionally returns a gradient whose producer nodes belong to an
@@ -1404,7 +1388,7 @@ public sealed class GradientTape<T> : IDisposable
                 if (inputRelevant && node.Output is not null) relevant.Add(node.Output);
             }
 
-            return relevant;
+            return CacheGradientRelevance(loss, sources, relevant, canCache);
         }
 
         // Tape entries are recorded in forward topological order. An output can contribute to a
@@ -1434,6 +1418,32 @@ public sealed class GradientTape<T> : IDisposable
             if (inputRelevant) relevant.Add(entry.Output);
         }
 
+        return CacheGradientRelevance(loss, sources, relevant, canCache);
+    }
+
+    private static bool SourcesMatch(
+        Tensor<T>[]? cached,
+        IReadOnlyList<Tensor<T>> sources)
+    {
+        if (cached is null || cached.Length != sources.Count) return false;
+        for (int i = 0; i < cached.Length; i++)
+            if (!ReferenceEquals(cached[i], sources[i])) return false;
+        return true;
+    }
+
+    private HashSet<Tensor<T>> CacheGradientRelevance(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>> sources,
+        HashSet<Tensor<T>> relevant,
+        bool canCache)
+    {
+        if (canCache)
+        {
+            _cachedGradientRelevanceLoss = loss;
+            _cachedGradientRelevanceSources = sources.ToArray();
+            _cachedGradientRelevanceEntryCount = _entries.Count;
+            _cachedGradientRelevance = relevant;
+        }
         return relevant;
     }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -835,6 +835,15 @@ public sealed class GradientTape<T> : IDisposable
         }
         int recordedEntryCount = _entries.Count;
 
+        // Build requested-source reachability once and keep it active across every backward
+        // implementation. Previously only the large-tape interpreter skipped irrelevant nodes;
+        // the normal GradFn/compiled-chain path still computed gradients for frozen parameters
+        // and discarded them at the end. This scope lets heavyweight backward functions skip
+        // individual irrelevant inputs and makes AccumulateGrad stop upstream traversal at a
+        // frozen boundary.
+        using var gradientRelevance = DifferentiableOps.PushGradientRelevance(
+            createGraph ? null : BuildGradientRelevance(loss, sources));
+
         // Auto-training compiler: highest priority — use compiled backward if available.
         // Must be checked BEFORE the graph path because DifferentiableOps always records
         // (GradFn is always set), so the graph path would always win otherwise.
@@ -1346,6 +1355,86 @@ public sealed class GradientTape<T> : IDisposable
         }
 
         return grads;
+    }
+
+    private HashSet<Tensor<T>>? BuildGradientRelevance(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>>? sources)
+    {
+        if (sources is null) return null;
+
+        var relevant = new HashSet<Tensor<T>>(
+            ReferenceEqualityComparer<Tensor<T>>.Instance);
+        foreach (var source in sources) relevant.Add(source);
+
+        // Prefer the GradFn graph because it can cross tape boundaries. Higher-order
+        // differentiation intentionally returns a gradient whose producer nodes belong to an
+        // inner tape; the outer tape records only the operations that consume that gradient.
+        // Building reachability from this tape's entries alone therefore misses the entire
+        // differentiable-gradient chain and incorrectly prunes HVP/Hessian contributions.
+        if (loss.GradFn is not null)
+        {
+            var visited = new HashSet<GradNode<T>>();
+            var topoOrder = new List<GradNode<T>>();
+            TopologicalSort(loss.GradFn, visited, topoOrder);
+
+            // TopologicalSort returns producers before consumers, so source reachability can be
+            // propagated in one forward pass across both current- and cross-tape nodes.
+            foreach (var node in topoOrder)
+            {
+                bool inputRelevant = false;
+                if (node.InputsOverflow is not null)
+                {
+                    foreach (var input in node.InputsOverflow)
+                    {
+                        if (relevant.Contains(input))
+                        {
+                            inputRelevant = true;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    inputRelevant = node.Input0 is not null && relevant.Contains(node.Input0)
+                        || node.InputCount >= 2 && node.Input1 is not null && relevant.Contains(node.Input1)
+                        || node.InputCount >= 3 && node.Input2 is not null && relevant.Contains(node.Input2);
+                }
+
+                if (inputRelevant && node.Output is not null) relevant.Add(node.Output);
+            }
+
+            return relevant;
+        }
+
+        // Tape entries are recorded in forward topological order. An output can contribute to a
+        // requested source exactly when at least one of its inputs is already source-relevant.
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            ref var entry = ref _entries[i];
+            bool inputRelevant = false;
+            if (entry.InputsOverflow is not null)
+            {
+                foreach (var input in entry.InputsOverflow)
+                {
+                    if (relevant.Contains(input))
+                    {
+                        inputRelevant = true;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                inputRelevant = relevant.Contains(entry.Input0)
+                    || entry.InputCount >= 2 && entry.Input1 is not null && relevant.Contains(entry.Input1)
+                    || entry.InputCount >= 3 && entry.Input2 is not null && relevant.Contains(entry.Input2);
+            }
+
+            if (inputRelevant) relevant.Add(entry.Output);
+        }
+
+        return relevant;
     }
 
     private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet, HashSet<Tensor<T>> intermediates)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -69,7 +69,7 @@ internal static class OpRegistry
         "Embedding", "Dropout",
         // Interleaved RoPE: orthogonal rotation, records with ApplyRoPEInterleavedBackward (inverse rotation).
         "ApplyRoPEInterleaved",
-        "GridSample", "Unfold", "Fold",
+        "GridSample", "Unfold", "Fold", "PartialCorrelationVolume", "ForwardSplat",
 
         // Spatial
         "Upsample", "Upsample3D", "PixelShuffle", "Crop", "Pad",

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -69,7 +69,7 @@ internal static class OpRegistry
         "Embedding", "Dropout",
         // Interleaved RoPE: orthogonal rotation, records with ApplyRoPEInterleavedBackward (inverse rotation).
         "ApplyRoPEInterleaved",
-        "GridSample", "Unfold", "Fold", "PartialCorrelationVolume", "ForwardSplat",
+        "GridSample", "Unfold", "Fold", "ForwardSplat",
 
         // Spatial
         "Upsample", "Upsample3D", "PixelShuffle", "Crop", "Pad",
@@ -302,6 +302,7 @@ internal static class OpRegistry
         "DeformableConv2DGroupedBackwardInput", "DeformableConv2DGroupedBackwardKernel",
         "DeformableConv2DGroupedBackwardOffset", "DeformableConv2DGroupedBackwardMask",
         "GridSampleBackwardInput", "GridSampleBackwardGrid",
+        "ForwardSplatBackwardInput", "ForwardSplatBackwardFlow",
         "BatchNormBackward", "LayerNormBackward", "GroupNormBackward", "RMSNormBackward", "InstanceNormBackward",
         "DropoutBackward", "EmbeddingBackward",
         "ReduceMaxBackward", "ReduceMaxBackwardWithTensorIndices", "ReduceMeanBackward",
@@ -439,6 +440,8 @@ internal static class OpRegistry
     /// </summary>
     internal static readonly HashSet<string> DelegatorOps = new(StringComparer.Ordinal)
     {
+        // Expressed entirely through tape-connected Unfold/reshape/multiply/reduce primitives.
+        "PartialCorrelationVolume",
         // IEngine wrappers that delegate to internal methods
         "TensorSigmoid",     // -> Sigmoid (records)
         "TensorReLU",        // -> ReLU (records)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -137,6 +137,8 @@ internal sealed class OptimizedBackwardPlan<T>
             {
                 ref var entry = ref _entries[i];
 
+                if (!DifferentiableOps.IsGradientRequired(entry.Output))
+                    continue;
                 if (!grads.TryGetValue(entry.Output, out var gradOutput))
                     continue;
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/RebindablePlanCache.cs
@@ -203,6 +203,8 @@ internal static class RebindablePlanCache<T>
                 if (idx < 0 || idx >= currentEntries.Count) return null;
                 ref var entry = ref currentEntries[idx];
 
+                if (!DifferentiableOps.IsGradientRequired(entry.Output))
+                    continue;
                 if (!grads.TryGetValue(entry.Output, out var gradOutput))
                     continue;
 

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -616,6 +616,7 @@ public static partial class BlasManaged
             && options.PackedA is null && options.PackedB is null
             && options.NumThreads == 0 // only the default (all-core) budget; explicit -1/>0 requests honored below
             && (options.PackingMode == PackingMode.Auto || options.PackingMode == PackingMode.DisableAutotune)
+            && GotoGemmFp32.IsPreferredForThreadBudget(CpuParallelSettings.MaxDegreeOfParallelism)
             && (long)m * n * k >= GotoGemmFp32.ParallelMinWork && GotoGemmFp32.BeatsPackBoth(m, n, k)
             && GotoGemmFp32.IsAvailable)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -612,11 +612,13 @@ public static partial class BlasManaged
         // tails. Gated to float, no trans, no pre-pack, no epilogue, large-shape regime. (The CCX-aware
         // pinned-pool variant beats this ~2x at the kernel level but its win is masked by per-call engine
         // overhead — deferred until that overhead is cut; prototype in tests/CcxGemmBench.)
+        int gotoThreadBudget = CpuParallelSettings.MaxDegreeOfParallelism;
+        if (gotoThreadBudget <= 0) gotoThreadBudget = Environment.ProcessorCount;
         if (typeof(T) == typeof(float) && !s_disableGotoGemm && !transA && !transB
             && options.PackedA is null && options.PackedB is null
             && options.NumThreads == 0 // only the default (all-core) budget; explicit -1/>0 requests honored below
             && (options.PackingMode == PackingMode.Auto || options.PackingMode == PackingMode.DisableAutotune)
-            && GotoGemmFp32.IsPreferredForThreadBudget(CpuParallelSettings.MaxDegreeOfParallelism)
+            && GotoGemmFp32.IsPreferredForThreadBudget(gotoThreadBudget)
             && (long)m * n * k >= GotoGemmFp32.ParallelMinWork && GotoGemmFp32.BeatsPackBoth(m, n, k)
             && GotoGemmFp32.IsAvailable)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
@@ -41,6 +41,16 @@ internal static class GotoGemmFp32
     /// dispatch (below this the per-tile pack/launch overhead dominates — stay on the existing path).</summary>
     internal const long ParallelMinWork = 8L * 1024 * 1024; // ~8.4e6
 
+    /// <summary>
+    /// Returns whether the Goto-style per-tile decomposition is appropriate for the active
+    /// CPU thread budget. This kernel was tuned on a 3990X and wins by assigning many private
+    /// L2-resident tiles concurrently. On smaller machines the redundant panel packing and
+    /// worker coordination can dominate a mixed model workload even when an isolated GEMM is
+    /// competitive. PackBoth is the safer default below this measured crossover.
+    /// </summary>
+    internal static bool IsPreferredForThreadBudget(int maxDegreeOfParallelism)
+        => maxDegreeOfParallelism >= 48;
+
     /// <summary>Shape regime where the per-tile GotoBLAS path beats the PackBoth strategy (measured on the
     /// 3990X via --ab-prod): large/balanced (M≥512) OR wide-K (K≥2N, e.g. MLP-fc2). PackBoth's wide-N
     /// N-axis path wins the small-M wide-N shapes (DiT QKV M256×N3456, MLP-fc1 M256×N4608 — GotoGemm was

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
@@ -151,9 +151,34 @@ internal sealed class LazyGraphCompiler
                 }
             }
 
-            // Kahn's algorithm with priority: prefer nodes that feed into
-            // operations that are closest to being ready (lowest remaining in-degree)
-            var ready = new List<ILazyNode>();
+            // Kahn's algorithm with a stable priority queue. The old implementation scanned the
+            // entire ready list for every emitted node. Wide autodiff graphs can have tens of
+            // thousands of simultaneously-ready parameter/gradient producers, turning compilation
+            // into O(V^2) work (SegMamba spent 7.9 of 9.3 seconds in this pass alone).
+            //
+            // The first consumer's original topological position is a stable locality score: among
+            // ready producers, emit the one needed by the earliest downstream operation. This keeps
+            // producers close to consumers without a mutable priority or a full ready-list rescan.
+            var originalOrder = new Dictionary<ILazyNode, int>(nodes.Count);
+            for (int i = 0; i < nodes.Count; i++)
+                originalOrder[nodes[i]] = i;
+
+            int GetLocalityScore(ILazyNode node)
+            {
+                var nodeDependents = dependents[node];
+                return nodeDependents.Count == 0
+                    ? int.MaxValue
+                    : originalOrder[nodeDependents[0]];
+            }
+
+            var ready = new SortedSet<ILazyNode>(Comparer<ILazyNode>.Create((left, right) =>
+            {
+                if (ReferenceEquals(left, right)) return 0;
+                int score = GetLocalityScore(left).CompareTo(GetLocalityScore(right));
+                return score != 0
+                    ? score
+                    : originalOrder[left].CompareTo(originalOrder[right]);
+            }));
             foreach (var node in nodes)
             {
                 if (inDegree[node] == 0)
@@ -163,24 +188,8 @@ internal sealed class LazyGraphCompiler
             var result = new List<ILazyNode>(nodes.Count);
             while (ready.Count > 0)
             {
-                // Pick the ready node whose first dependent has the lowest remaining in-degree
-                // (heuristic: schedule producers right before their consumer becomes ready)
-                int bestIdx = 0;
-                int bestScore = int.MaxValue;
-                for (int i = 0; i < ready.Count; i++)
-                {
-                    var deps = dependents[ready[i]];
-                    int score = deps.Count > 0 ? inDegree[deps[0]] : int.MaxValue;
-                    if (score < bestScore)
-                    {
-                        bestScore = score;
-                        bestIdx = i;
-                    }
-                }
-
-                var chosen = ready[bestIdx];
-                ready[bestIdx] = ready[ready.Count - 1];
-                ready.RemoveAt(ready.Count - 1);
+                var chosen = ready.Min!;
+                ready.Remove(chosen);
                 result.Add(chosen);
 
                 foreach (var dep in dependents[chosen])

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
@@ -1,0 +1,235 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>Portable video-warping primitives shared by CPU and all direct GPU backends.</summary>
+public partial class CpuEngine
+{
+    /// <inheritdoc />
+    public virtual Tensor<T> PartialCorrelationVolume<T>(
+        Tensor<T> first, Tensor<T> second, int radius = 4)
+    {
+        ValidateFeaturePair(first, second);
+        if (radius < 0) throw new ArgumentOutOfRangeException(nameof(radius));
+        int batch = first.Shape[0];
+        int channels = first.Shape[1];
+        int height = first.Shape[2];
+        int width = first.Shape[3];
+        int diameter = radius * 2 + 1;
+        int offsets = diameter * diameter;
+
+        // Unfold is implemented by every backend and has a registered backward. Expressing
+        // correlation through primitives keeps this operation tape-connected without a
+        // model-specific gradient implementation.
+        var neighborhoods = Unfold(
+            second, [diameter, diameter], stride: [1, 1], padding: [radius, radius]);
+        neighborhoods = Reshape(neighborhoods, [batch, channels, offsets, height, width]);
+        var reference = Reshape(first, [batch, channels, 1, height, width]);
+        var products = TensorMultiply(neighborhoods, reference);
+        return ReduceMean(products, [1], keepDims: false);
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> ForwardSplat<T>(
+        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateSplatInputs(input, flow, epsilon);
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            var capturedInput = input;
+            var capturedFlow = flow;
+            return scope.RecordBinary(
+                LazyNodeType.Custom,
+                "ForwardSplat",
+                input,
+                flow,
+                input.Shape.ToArray(),
+                (engine, output) =>
+                {
+                    var replay = engine.ForwardSplat(capturedInput, capturedFlow, normalize, epsilon);
+                    DirectGpuTensorEngine.CopyResultInto(engine, replay, output);
+                },
+                BackwardFunctions<T>.ForwardSplatBackward,
+                [normalize, epsilon]);
+        }
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int batch = input.Shape[0];
+        int channels = input.Shape[1];
+        int height = input.Shape[2];
+        int width = input.Shape[3];
+        var accum = new Tensor<T>(input.Shape.ToArray());
+        var weights = new double[batch * height * width];
+
+        for (int b = 0; b < batch; b++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            double destinationX = x + numOps.ToDouble(flow[b, 0, y, x]);
+            double destinationY = y + numOps.ToDouble(flow[b, 1, y, x]);
+            int x0 = (int)Math.Floor(destinationX);
+            int y0 = (int)Math.Floor(destinationY);
+            double fractionX = destinationX - x0;
+            double fractionY = destinationY - y0;
+            Accumulate(x0, y0, (1.0 - fractionX) * (1.0 - fractionY));
+            Accumulate(x0 + 1, y0, fractionX * (1.0 - fractionY));
+            Accumulate(x0, y0 + 1, (1.0 - fractionX) * fractionY);
+            Accumulate(x0 + 1, y0 + 1, fractionX * fractionY);
+
+            void Accumulate(int destinationPixelX, int destinationPixelY, double weight)
+            {
+                if ((uint)destinationPixelX >= (uint)width ||
+                    (uint)destinationPixelY >= (uint)height || weight == 0.0) return;
+                weights[(b * height + destinationPixelY) * width + destinationPixelX] += weight;
+                T typedWeight = numOps.FromDouble(weight);
+                for (int channel = 0; channel < channels; channel++)
+                    accum[b, channel, destinationPixelY, destinationPixelX] = numOps.Add(
+                        accum[b, channel, destinationPixelY, destinationPixelX],
+                        numOps.Multiply(input[b, channel, y, x], typedWeight));
+            }
+        }
+
+        var result = accum;
+        if (normalize)
+        {
+            result = new Tensor<T>(input.Shape.ToArray());
+            for (int b = 0; b < batch; b++)
+            for (int y = 0; y < height; y++)
+            for (int x = 0; x < width; x++)
+            {
+                T denominator = numOps.FromDouble(
+                    weights[(b * height + y) * width + x] + epsilon);
+                for (int channel = 0; channel < channels; channel++)
+                    result[b, channel, y, x] = numOps.Divide(accum[b, channel, y, x], denominator);
+            }
+        }
+
+        DifferentiableOps.RecordIfActive(
+            "ForwardSplat", result, [input, flow],
+            BackwardFunctions<T>.ForwardSplatBackward, [normalize, epsilon]);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> ForwardSplatBackwardInput<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateSplatInputs(input, flow, epsilon);
+        if (gradOutput.Shape != input.Shape)
+            throw new ArgumentException("gradOutput shape must match input shape.", nameof(gradOutput));
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int batch = input.Shape[0], channels = input.Shape[1], height = input.Shape[2], width = input.Shape[3];
+        double[] denominators = ComputeSplatWeights(flow, height, width, numOps);
+        var gradient = new Tensor<T>(input.Shape.ToArray());
+        for (int b = 0; b < batch; b++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            GetDestination(flow, b, y, x, numOps, out int x0, out int y0, out double fx, out double fy);
+            Add(x0, y0, (1 - fx) * (1 - fy)); Add(x0 + 1, y0, fx * (1 - fy));
+            Add(x0, y0 + 1, (1 - fx) * fy); Add(x0 + 1, y0 + 1, fx * fy);
+            void Add(int dx, int dy, double weight)
+            {
+                if ((uint)dx >= (uint)width || (uint)dy >= (uint)height || weight == 0) return;
+                double divisor = normalize ? denominators[(b * height + dy) * width + dx] + epsilon : 1.0;
+                T factor = numOps.FromDouble(weight / divisor);
+                for (int c = 0; c < channels; c++)
+                    gradient[b, c, y, x] = numOps.Add(
+                        gradient[b, c, y, x], numOps.Multiply(gradOutput[b, c, dy, dx], factor));
+            }
+        }
+        return gradient;
+    }
+
+    /// <inheritdoc />
+    public virtual Tensor<T> ForwardSplatBackwardFlow<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
+        bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateSplatInputs(input, flow, epsilon);
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int batch = input.Shape[0], channels = input.Shape[1], height = input.Shape[2], width = input.Shape[3];
+        double[] denominators = ComputeSplatWeights(flow, height, width, numOps);
+        var gradient = new Tensor<T>(flow.Shape.ToArray());
+        for (int b = 0; b < batch; b++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            GetDestination(flow, b, y, x, numOps, out int x0, out int y0, out double fx, out double fy);
+            Add(x0, y0, -(1 - fy), -(1 - fx));
+            Add(x0 + 1, y0, 1 - fy, -fx);
+            Add(x0, y0 + 1, -fy, 1 - fx);
+            Add(x0 + 1, y0 + 1, fy, fx);
+            void Add(int dx, int dy, double derivativeX, double derivativeY)
+            {
+                if ((uint)dx >= (uint)width || (uint)dy >= (uint)height) return;
+                double divisor = normalize ? denominators[(b * height + dy) * width + dx] + epsilon : 1.0;
+                double contribution = 0.0;
+                for (int c = 0; c < channels; c++)
+                {
+                    double source = numOps.ToDouble(input[b, c, y, x]);
+                    double normalizedSource = normalize
+                        ? source - numOps.ToDouble(output[b, c, dy, dx])
+                        : source;
+                    contribution += numOps.ToDouble(gradOutput[b, c, dy, dx]) * normalizedSource / divisor;
+                }
+                gradient[b, 0, y, x] = numOps.Add(
+                    gradient[b, 0, y, x], numOps.FromDouble(contribution * derivativeX));
+                gradient[b, 1, y, x] = numOps.Add(
+                    gradient[b, 1, y, x], numOps.FromDouble(contribution * derivativeY));
+            }
+        }
+        return gradient;
+    }
+
+    private static void ValidateFeaturePair<T>(Tensor<T> first, Tensor<T> second)
+    {
+        if (first.Rank != 4 || second.Rank != 4 || first.Shape != second.Shape)
+            throw new ArgumentException("Correlation inputs must have equal [B,C,H,W] shapes.");
+    }
+
+    private static void ValidateSplatInputs<T>(Tensor<T> input, Tensor<T> flow, double epsilon)
+    {
+        if (input.Rank != 4 || flow.Rank != 4 || flow.Shape[0] != input.Shape[0] ||
+            flow.Shape[1] != 2 || flow.Shape[2] != input.Shape[2] || flow.Shape[3] != input.Shape[3])
+            throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
+        if (epsilon <= 0 || double.IsNaN(epsilon)) throw new ArgumentOutOfRangeException(nameof(epsilon));
+    }
+
+    private static double[] ComputeSplatWeights<T>(
+        Tensor<T> flow, int height, int width, INumericOperations<T> numOps)
+    {
+        int batch = flow.Shape[0];
+        var weights = new double[batch * height * width];
+        for (int b = 0; b < batch; b++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            GetDestination(flow, b, y, x, numOps, out int x0, out int y0, out double fx, out double fy);
+            Add(x0, y0, (1 - fx) * (1 - fy)); Add(x0 + 1, y0, fx * (1 - fy));
+            Add(x0, y0 + 1, (1 - fx) * fy); Add(x0 + 1, y0 + 1, fx * fy);
+            void Add(int dx, int dy, double weight)
+            {
+                if ((uint)dx < (uint)width && (uint)dy < (uint)height)
+                    weights[(b * height + dy) * width + dx] += weight;
+            }
+        }
+        return weights;
+    }
+
+    private static void GetDestination<T>(
+        Tensor<T> flow, int b, int y, int x, INumericOperations<T> numOps,
+        out int x0, out int y0, out double fractionX, out double fractionY)
+    {
+        double destinationX = x + numOps.ToDouble(flow[b, 0, y, x]);
+        double destinationY = y + numOps.ToDouble(flow[b, 1, y, x]);
+        x0 = (int)Math.Floor(destinationX); y0 = (int)Math.Floor(destinationY);
+        fractionX = destinationX - x0; fractionY = destinationY - y0;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
@@ -35,9 +35,9 @@ public partial class CpuEngine
 
     /// <inheritdoc />
     public virtual Tensor<T> ForwardSplat<T>(
-        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7)
+        Tensor<T> input, Tensor<T> flow, bool normalize = true)
     {
-        ValidateSplatInputs(input, flow, epsilon);
+        ValidateSplatInputs(input, flow);
 
         if (GraphMode.IsActive && GraphMode.Current is { } scope)
         {
@@ -51,11 +51,11 @@ public partial class CpuEngine
                 input.Shape.ToArray(),
                 (engine, output) =>
                 {
-                    var replay = engine.ForwardSplat(capturedInput, capturedFlow, normalize, epsilon);
+                    var replay = engine.ForwardSplat(capturedInput, capturedFlow, normalize);
                     DirectGpuTensorEngine.CopyResultInto(engine, replay, output);
                 },
                 BackwardFunctions<T>.ForwardSplatBackward,
-                [normalize, epsilon]);
+                [normalize]);
         }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -102,8 +102,8 @@ public partial class CpuEngine
             for (int y = 0; y < height; y++)
             for (int x = 0; x < width; x++)
             {
-                T denominator = numOps.FromDouble(
-                    weights[(b * height + y) * width + x] + epsilon);
+                double weight = weights[(b * height + y) * width + x];
+                T denominator = numOps.FromDouble(weight == 0.0 ? 1.0 : weight);
                 for (int channel = 0; channel < channels; channel++)
                     result[b, channel, y, x] = numOps.Divide(accum[b, channel, y, x], denominator);
             }
@@ -111,16 +111,16 @@ public partial class CpuEngine
 
         DifferentiableOps.RecordIfActive(
             "ForwardSplat", result, [input, flow],
-            BackwardFunctions<T>.ForwardSplatBackward, [normalize, epsilon]);
+            BackwardFunctions<T>.ForwardSplatBackward, [normalize]);
         return result;
     }
 
     /// <inheritdoc />
     public virtual Tensor<T> ForwardSplatBackwardInput<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
-        bool normalize = true, double epsilon = 1e-7)
+        bool normalize = true)
     {
-        ValidateSplatInputs(input, flow, epsilon);
+        ValidateSplatInputs(input, flow);
         if (gradOutput.Shape != input.Shape)
             throw new ArgumentException("gradOutput shape must match input shape.", nameof(gradOutput));
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -137,7 +137,8 @@ public partial class CpuEngine
             void Add(int dx, int dy, double weight)
             {
                 if ((uint)dx >= (uint)width || (uint)dy >= (uint)height || weight == 0) return;
-                double divisor = normalize ? denominators[(b * height + dy) * width + dx] + epsilon : 1.0;
+                double weightSum = denominators[(b * height + dy) * width + dx];
+                double divisor = normalize && weightSum != 0.0 ? weightSum : 1.0;
                 T factor = numOps.FromDouble(weight / divisor);
                 for (int c = 0; c < channels; c++)
                     gradient[b, c, y, x] = numOps.Add(
@@ -150,9 +151,9 @@ public partial class CpuEngine
     /// <inheritdoc />
     public virtual Tensor<T> ForwardSplatBackwardFlow<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
-        bool normalize = true, double epsilon = 1e-7)
+        bool normalize = true)
     {
-        ValidateSplatInputs(input, flow, epsilon);
+        ValidateSplatInputs(input, flow);
         var numOps = MathHelper.GetNumericOperations<T>();
         int batch = input.Shape[0], channels = input.Shape[1], height = input.Shape[2], width = input.Shape[3];
         double[] denominators = ComputeSplatWeights(flow, height, width, numOps);
@@ -169,7 +170,8 @@ public partial class CpuEngine
             void Add(int dx, int dy, double derivativeX, double derivativeY)
             {
                 if ((uint)dx >= (uint)width || (uint)dy >= (uint)height) return;
-                double divisor = normalize ? denominators[(b * height + dy) * width + dx] + epsilon : 1.0;
+                double weightSum = denominators[(b * height + dy) * width + dx];
+                double divisor = normalize && weightSum != 0.0 ? weightSum : 1.0;
                 double contribution = 0.0;
                 for (int c = 0; c < channels; c++)
                 {
@@ -194,12 +196,11 @@ public partial class CpuEngine
             throw new ArgumentException("Correlation inputs must have equal [B,C,H,W] shapes.");
     }
 
-    private static void ValidateSplatInputs<T>(Tensor<T> input, Tensor<T> flow, double epsilon)
+    private static void ValidateSplatInputs<T>(Tensor<T> input, Tensor<T> flow)
     {
         if (input.Rank != 4 || flow.Rank != 4 || flow.Shape[0] != input.Shape[0] ||
             flow.Shape[1] != 2 || flow.Shape[2] != input.Shape[2] || flow.Shape[3] != input.Shape[3])
             throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
-        if (epsilon <= 0 || double.IsNaN(epsilon)) throw new ArgumentOutOfRangeException(nameof(epsilon));
     }
 
     private static double[] ComputeSplatWeights<T>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
@@ -6,25 +6,8 @@ using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines;
 
-/// <summary>
-/// Internal fused backward surface for sharing a forward-splat normalization field across both
-/// adjoints without expanding the public <see cref="IEngine"/> contract.
-/// </summary>
-internal interface IForwardSplatBackwardEngine
-{
-    Tensor<T> GetForwardSplatNormalizationWeights<T>(Tensor<T> flow);
-
-    Tensor<T> ForwardSplatBackwardInputWithWeights<T>(
-        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
-        bool normalize, Tensor<T>? normalizationWeights);
-
-    Tensor<T> ForwardSplatBackwardFlowWithWeights<T>(
-        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
-        bool normalize, Tensor<T>? normalizationWeights);
-}
-
 /// <summary>Portable video-warping primitives shared by CPU and all direct GPU backends.</summary>
-public partial class CpuEngine : IForwardSplatBackwardEngine
+public partial class CpuEngine
 {
     /// <inheritdoc />
     public virtual Tensor<T> PartialCorrelationVolume<T>(
@@ -310,21 +293,6 @@ public partial class CpuEngine : IForwardSplatBackwardEngine
         return gradient;
     }
 
-    Tensor<T> IForwardSplatBackwardEngine.GetForwardSplatNormalizationWeights<T>(Tensor<T> flow)
-        => GetForwardSplatNormalizationWeights(flow);
-
-    Tensor<T> IForwardSplatBackwardEngine.ForwardSplatBackwardInputWithWeights<T>(
-        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
-        bool normalize, Tensor<T>? normalizationWeights)
-        => ForwardSplatBackwardInputWithWeights(
-            gradOutput, input, flow, normalize, normalizationWeights);
-
-    Tensor<T> IForwardSplatBackwardEngine.ForwardSplatBackwardFlowWithWeights<T>(
-        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
-        bool normalize, Tensor<T>? normalizationWeights)
-        => ForwardSplatBackwardFlowWithWeights(
-            gradOutput, input, flow, output, normalize, normalizationWeights);
-
     /// <summary>
     /// Computes the safe [B,1,H,W] normalization field once for both splat adjoints. Empty
     /// destination pixels use one, matching the released average-soft-splat zero fallback.
@@ -387,14 +355,14 @@ public partial class CpuEngine : IForwardSplatBackwardEngine
             throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
     }
 
-    private static void ValidateSplatFlow<T>(Tensor<T> flow)
+    protected static void ValidateSplatFlow<T>(Tensor<T> flow)
     {
         if (flow is null) throw new ArgumentNullException(nameof(flow));
         if (flow.Rank != 4 || flow.Shape[1] != 2 || flow.Shape[2] <= 0 || flow.Shape[3] <= 0)
             throw new ArgumentException("ForwardSplat flow must have shape [B,2,H,W].", nameof(flow));
     }
 
-    private static void ValidateNormalizationWeights<T>(
+    protected static void ValidateNormalizationWeights<T>(
         Tensor<T>? normalizationWeights, Tensor<T> input)
     {
         if (normalizationWeights is null) return;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.VideoWarp.cs
@@ -6,8 +6,25 @@ using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines;
 
+/// <summary>
+/// Internal fused backward surface for sharing a forward-splat normalization field across both
+/// adjoints without expanding the public <see cref="IEngine"/> contract.
+/// </summary>
+internal interface IForwardSplatBackwardEngine
+{
+    Tensor<T> GetForwardSplatNormalizationWeights<T>(Tensor<T> flow);
+
+    Tensor<T> ForwardSplatBackwardInputWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize, Tensor<T>? normalizationWeights);
+
+    Tensor<T> ForwardSplatBackwardFlowWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
+        bool normalize, Tensor<T>? normalizationWeights);
+}
+
 /// <summary>Portable video-warping primitives shared by CPU and all direct GPU backends.</summary>
-public partial class CpuEngine
+public partial class CpuEngine : IForwardSplatBackwardEngine
 {
     /// <inheritdoc />
     public virtual Tensor<T> PartialCorrelationVolume<T>(
@@ -22,15 +39,56 @@ public partial class CpuEngine
         int diameter = radius * 2 + 1;
         int offsets = diameter * diameter;
 
-        // Unfold is implemented by every backend and has a registered backward. Expressing
-        // correlation through primitives keeps this operation tape-connected without a
-        // model-specific gradient implementation.
-        var neighborhoods = Unfold(
-            second, [diameter, diameter], stride: [1, 1], padding: [radius, radius]);
-        neighborhoods = Reshape(neighborhoods, [batch, channels, offsets, height, width]);
-        var reference = Reshape(first, [batch, channels, 1, height, width]);
-        var products = TensorMultiply(neighborhoods, reference);
-        return ReduceMean(products, [1], keepDims: false);
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            var capturedFirst = first;
+            var capturedSecond = second;
+            return scope.RecordBinary(
+                LazyNodeType.Custom,
+                "PartialCorrelationVolume",
+                first,
+                second,
+                [batch, offsets, height, width],
+                (engine, output) =>
+                {
+                    var replay = engine.PartialCorrelationVolume(capturedFirst, capturedSecond, radius);
+                    DirectGpuTensorEngine.CopyResultInto(engine, replay, output);
+                },
+                BackwardFunctions<T>.PartialCorrelationVolumeBackward,
+                [radius]);
+        }
+
+        Tensor<T> result;
+        using (GradientTape<T>.NoGrad())
+        {
+            // Process one displacement at a time. The previous Unfold path materialized
+            // [B,C,diameter²,H,W] neighborhoods and an equally large products buffer at once;
+            // radius=4 therefore held 162 feature maps before producing the final correlation.
+            // Each offset now retains only one shifted map and one product, while concatenate
+            // owns exactly the required [B,diameter²,H,W] result. Because this method owns one
+            // explicit backward node below, the bounded implementation remains fully tape-connected.
+            var paddedSecond = Pad(
+                second, radius, radius, radius, radius,
+                MathHelper.GetNumericOperations<T>().Zero);
+            var planes = new Tensor<T>[offsets];
+            int offset = 0;
+            for (int offsetY = 0; offsetY < diameter; offsetY++)
+            for (int offsetX = 0; offsetX < diameter; offsetX++)
+            {
+                var shifted = TensorSlice(
+                    paddedSecond,
+                    [0, 0, offsetY, offsetX],
+                    [batch, channels, height, width]);
+                var products = TensorMultiply(first, shifted);
+                planes[offset++] = ReduceMean(products, [1], keepDims: true);
+            }
+            result = TensorConcatenate(planes, axis: 1);
+        }
+
+        DifferentiableOps.RecordIfActive(
+            "PartialCorrelationVolume", result, [first, second],
+            BackwardFunctions<T>.PartialCorrelationVolumeBackward, [radius]);
+        return result;
     }
 
     /// <inheritdoc />
@@ -65,49 +123,75 @@ public partial class CpuEngine
         int width = input.Shape[3];
         var accum = new Tensor<T>(input.Shape.ToArray());
         var weights = new double[batch * height * width];
-
-        for (int b = 0; b < batch; b++)
-        for (int y = 0; y < height; y++)
-        for (int x = 0; x < width; x++)
+        Tensor<T> contiguousInput;
+        Tensor<T> contiguousFlow;
+        using (GradientTape<T>.NoGrad())
         {
-            double destinationX = x + numOps.ToDouble(flow[b, 0, y, x]);
-            double destinationY = y + numOps.ToDouble(flow[b, 1, y, x]);
-            int x0 = (int)Math.Floor(destinationX);
-            int y0 = (int)Math.Floor(destinationY);
-            double fractionX = destinationX - x0;
-            double fractionY = destinationY - y0;
-            Accumulate(x0, y0, (1.0 - fractionX) * (1.0 - fractionY));
-            Accumulate(x0 + 1, y0, fractionX * (1.0 - fractionY));
-            Accumulate(x0, y0 + 1, (1.0 - fractionX) * fractionY);
-            Accumulate(x0 + 1, y0 + 1, fractionX * fractionY);
-
-            void Accumulate(int destinationPixelX, int destinationPixelY, double weight)
-            {
-                if ((uint)destinationPixelX >= (uint)width ||
-                    (uint)destinationPixelY >= (uint)height || weight == 0.0) return;
-                weights[(b * height + destinationPixelY) * width + destinationPixelX] += weight;
-                T typedWeight = numOps.FromDouble(weight);
-                for (int channel = 0; channel < channels; channel++)
-                    accum[b, channel, destinationPixelY, destinationPixelX] = numOps.Add(
-                        accum[b, channel, destinationPixelY, destinationPixelX],
-                        numOps.Multiply(input[b, channel, y, x], typedWeight));
-            }
+            contiguousInput = input.IsContiguous ? input : input.Contiguous();
+            contiguousFlow = flow.IsContiguous ? flow : flow.Contiguous();
         }
+        ReadOnlyMemory<T> inputMemory = contiguousInput.ReadOnlyData;
+        ReadOnlyMemory<T> flowMemory = contiguousFlow.ReadOnlyData;
+        Memory<T> accumMemory = accum.Data;
+        int spatial = height * width;
+        long totalWork = checked((long)batch * channels * spatial * 4L);
 
-        var result = accum;
-        if (normalize)
+        // A batch owns disjoint accumulation and weight ranges, so batch-level partitioning has no
+        // scatter conflicts and is deterministic for every thread count. Flat NCHW offsets keep the
+        // channel loop contiguous within each plane and avoid the rank-4 indexer's repeated bounds,
+        // stride, copy-on-write, and version machinery in the hottest four-neighbor loop.
+        CpuParallelSettings.ParallelForOrSerial(0, batch, totalWork, b =>
         {
-            result = new Tensor<T>(input.Shape.ToArray());
-            for (int b = 0; b < batch; b++)
+            var inputValues = inputMemory.Span;
+            var flowValues = flowMemory.Span;
+            var accumulationValues = accumMemory.Span;
+            int batchSpatialOffset = b * spatial;
+            int flowBatchOffset = b * 2 * spatial;
+            int inputBatchOffset = b * channels * spatial;
+
             for (int y = 0; y < height; y++)
             for (int x = 0; x < width; x++)
             {
-                double weight = weights[(b * height + y) * width + x];
+                int sourcePixel = y * width + x;
+                double destinationX = x + numOps.ToDouble(flowValues[flowBatchOffset + sourcePixel]);
+                double destinationY = y + numOps.ToDouble(flowValues[flowBatchOffset + spatial + sourcePixel]);
+                int x0 = (int)Math.Floor(destinationX);
+                int y0 = (int)Math.Floor(destinationY);
+                double fractionX = destinationX - x0;
+                double fractionY = destinationY - y0;
+                AccumulateForwardSplatPixel(
+                    inputValues, accumulationValues, weights, numOps,
+                    channels, height, width, spatial, batchSpatialOffset, inputBatchOffset,
+                    sourcePixel, x0, y0, (1.0 - fractionX) * (1.0 - fractionY));
+                AccumulateForwardSplatPixel(
+                    inputValues, accumulationValues, weights, numOps,
+                    channels, height, width, spatial, batchSpatialOffset, inputBatchOffset,
+                    sourcePixel, x0 + 1, y0, fractionX * (1.0 - fractionY));
+                AccumulateForwardSplatPixel(
+                    inputValues, accumulationValues, weights, numOps,
+                    channels, height, width, spatial, batchSpatialOffset, inputBatchOffset,
+                    sourcePixel, x0, y0 + 1, (1.0 - fractionX) * fractionY);
+                AccumulateForwardSplatPixel(
+                    inputValues, accumulationValues, weights, numOps,
+                    channels, height, width, spatial, batchSpatialOffset, inputBatchOffset,
+                    sourcePixel, x0 + 1, y0 + 1, fractionX * fractionY);
+            }
+
+            if (!normalize) return;
+            for (int pixel = 0; pixel < spatial; pixel++)
+            {
+                double weight = weights[batchSpatialOffset + pixel];
                 T denominator = numOps.FromDouble(weight == 0.0 ? 1.0 : weight);
                 for (int channel = 0; channel < channels; channel++)
-                    result[b, channel, y, x] = numOps.Divide(accum[b, channel, y, x], denominator);
+                {
+                    int index = inputBatchOffset + channel * spatial + pixel;
+                    accumulationValues[index] = numOps.Divide(
+                        accumulationValues[index], denominator);
+                }
             }
-        }
+        }, deterministicSafe: true);
+
+        var result = accum;
 
         DifferentiableOps.RecordIfActive(
             "ForwardSplat", result, [input, flow],
@@ -119,13 +203,25 @@ public partial class CpuEngine
     public virtual Tensor<T> ForwardSplatBackwardInput<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
         bool normalize = true)
+        => ForwardSplatBackwardInputWithWeights(
+            gradOutput, input, flow, normalize, normalizationWeights: null);
+
+    /// <summary>
+    /// Input adjoint using an optional normalization field already computed by the backward owner.
+    /// </summary>
+    internal virtual Tensor<T> ForwardSplatBackwardInputWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize, Tensor<T>? normalizationWeights)
     {
         ValidateSplatInputs(input, flow);
         if (gradOutput.Shape != input.Shape)
             throw new ArgumentException("gradOutput shape must match input shape.", nameof(gradOutput));
+        ValidateNormalizationWeights(normalizationWeights, input);
         var numOps = MathHelper.GetNumericOperations<T>();
         int batch = input.Shape[0], channels = input.Shape[1], height = input.Shape[2], width = input.Shape[3];
-        double[] denominators = ComputeSplatWeights(flow, height, width, numOps);
+        double[]? denominators = normalize && normalizationWeights is null
+            ? ComputeSplatWeights(flow, height, width, numOps)
+            : null;
         var gradient = new Tensor<T>(input.Shape.ToArray());
         for (int b = 0; b < batch; b++)
         for (int y = 0; y < height; y++)
@@ -137,7 +233,9 @@ public partial class CpuEngine
             void Add(int dx, int dy, double weight)
             {
                 if ((uint)dx >= (uint)width || (uint)dy >= (uint)height || weight == 0) return;
-                double weightSum = denominators[(b * height + dy) * width + dx];
+                double weightSum = normalizationWeights is null
+                    ? denominators?[(b * height + dy) * width + dx] ?? 1.0
+                    : numOps.ToDouble(normalizationWeights[b, 0, dy, dx]);
                 double divisor = normalize && weightSum != 0.0 ? weightSum : 1.0;
                 T factor = numOps.FromDouble(weight / divisor);
                 for (int c = 0; c < channels; c++)
@@ -152,11 +250,31 @@ public partial class CpuEngine
     public virtual Tensor<T> ForwardSplatBackwardFlow<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
         bool normalize = true)
+        => ForwardSplatBackwardFlowWithWeights(
+            gradOutput, input, flow, output, normalize, normalizationWeights: null);
+
+    /// <summary>
+    /// Flow adjoint using an optional normalization field already computed by the backward owner.
+    /// </summary>
+    internal virtual Tensor<T> ForwardSplatBackwardFlowWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
+        bool normalize, Tensor<T>? normalizationWeights)
     {
         ValidateSplatInputs(input, flow);
+        if (gradOutput.Shape != input.Shape)
+            throw new ArgumentException("gradOutput shape must match input shape.", nameof(gradOutput));
+        if (normalize)
+        {
+            if (output is null) throw new ArgumentNullException(nameof(output));
+            if (output.Shape != input.Shape)
+                throw new ArgumentException("output shape must match input shape.", nameof(output));
+        }
+        ValidateNormalizationWeights(normalizationWeights, input);
         var numOps = MathHelper.GetNumericOperations<T>();
         int batch = input.Shape[0], channels = input.Shape[1], height = input.Shape[2], width = input.Shape[3];
-        double[] denominators = ComputeSplatWeights(flow, height, width, numOps);
+        double[]? denominators = normalize && normalizationWeights is null
+            ? ComputeSplatWeights(flow, height, width, numOps)
+            : null;
         var gradient = new Tensor<T>(flow.Shape.ToArray());
         for (int b = 0; b < batch; b++)
         for (int y = 0; y < height; y++)
@@ -170,14 +288,16 @@ public partial class CpuEngine
             void Add(int dx, int dy, double derivativeX, double derivativeY)
             {
                 if ((uint)dx >= (uint)width || (uint)dy >= (uint)height) return;
-                double weightSum = denominators[(b * height + dy) * width + dx];
+                double weightSum = normalizationWeights is null
+                    ? denominators?[(b * height + dy) * width + dx] ?? 1.0
+                    : numOps.ToDouble(normalizationWeights[b, 0, dy, dx]);
                 double divisor = normalize && weightSum != 0.0 ? weightSum : 1.0;
                 double contribution = 0.0;
                 for (int c = 0; c < channels; c++)
                 {
                     double source = numOps.ToDouble(input[b, c, y, x]);
                     double normalizedSource = normalize
-                        ? source - numOps.ToDouble(output[b, c, dy, dx])
+                        ? source - numOps.ToDouble(output![b, c, dy, dx])
                         : source;
                     contribution += numOps.ToDouble(gradOutput[b, c, dy, dx]) * normalizedSource / divisor;
                 }
@@ -188,6 +308,70 @@ public partial class CpuEngine
             }
         }
         return gradient;
+    }
+
+    Tensor<T> IForwardSplatBackwardEngine.GetForwardSplatNormalizationWeights<T>(Tensor<T> flow)
+        => GetForwardSplatNormalizationWeights(flow);
+
+    Tensor<T> IForwardSplatBackwardEngine.ForwardSplatBackwardInputWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize, Tensor<T>? normalizationWeights)
+        => ForwardSplatBackwardInputWithWeights(
+            gradOutput, input, flow, normalize, normalizationWeights);
+
+    Tensor<T> IForwardSplatBackwardEngine.ForwardSplatBackwardFlowWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
+        bool normalize, Tensor<T>? normalizationWeights)
+        => ForwardSplatBackwardFlowWithWeights(
+            gradOutput, input, flow, output, normalize, normalizationWeights);
+
+    /// <summary>
+    /// Computes the safe [B,1,H,W] normalization field once for both splat adjoints. Empty
+    /// destination pixels use one, matching the released average-soft-splat zero fallback.
+    /// </summary>
+    internal virtual Tensor<T> GetForwardSplatNormalizationWeights<T>(Tensor<T> flow)
+    {
+        ValidateSplatFlow(flow);
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int batch = flow.Shape[0], height = flow.Shape[2], width = flow.Shape[3];
+        var rawWeights = ComputeSplatWeights(flow, height, width, numOps);
+        var result = new Tensor<T>([batch, 1, height, width]);
+        var values = result.AsWritableSpan();
+        for (int index = 0; index < rawWeights.Length; index++)
+            values[index] = numOps.FromDouble(rawWeights[index] == 0.0 ? 1.0 : rawWeights[index]);
+        return result;
+    }
+
+    private static void AccumulateForwardSplatPixel<T>(
+        ReadOnlySpan<T> inputValues,
+        Span<T> accumulationValues,
+        double[] weights,
+        INumericOperations<T> numOps,
+        int channels,
+        int height,
+        int width,
+        int spatial,
+        int batchSpatialOffset,
+        int inputBatchOffset,
+        int sourcePixel,
+        int destinationPixelX,
+        int destinationPixelY,
+        double weight)
+    {
+        if ((uint)destinationPixelX >= (uint)width ||
+            (uint)destinationPixelY >= (uint)height || weight == 0.0) return;
+
+        int destinationPixel = destinationPixelY * width + destinationPixelX;
+        weights[batchSpatialOffset + destinationPixel] += weight;
+        T typedWeight = numOps.FromDouble(weight);
+        for (int channel = 0; channel < channels; channel++)
+        {
+            int sourceIndex = inputBatchOffset + channel * spatial + sourcePixel;
+            int destinationIndex = inputBatchOffset + channel * spatial + destinationPixel;
+            accumulationValues[destinationIndex] = numOps.Add(
+                accumulationValues[destinationIndex],
+                numOps.Multiply(inputValues[sourceIndex], typedWeight));
+        }
     }
 
     private static void ValidateFeaturePair<T>(Tensor<T> first, Tensor<T> second)
@@ -201,6 +385,29 @@ public partial class CpuEngine
         if (input.Rank != 4 || flow.Rank != 4 || flow.Shape[0] != input.Shape[0] ||
             flow.Shape[1] != 2 || flow.Shape[2] != input.Shape[2] || flow.Shape[3] != input.Shape[3])
             throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
+    }
+
+    private static void ValidateSplatFlow<T>(Tensor<T> flow)
+    {
+        if (flow is null) throw new ArgumentNullException(nameof(flow));
+        if (flow.Rank != 4 || flow.Shape[1] != 2 || flow.Shape[2] <= 0 || flow.Shape[3] <= 0)
+            throw new ArgumentException("ForwardSplat flow must have shape [B,2,H,W].", nameof(flow));
+    }
+
+    private static void ValidateNormalizationWeights<T>(
+        Tensor<T>? normalizationWeights, Tensor<T> input)
+    {
+        if (normalizationWeights is null) return;
+        if (normalizationWeights.Rank != 4 ||
+            normalizationWeights.Shape[0] != input.Shape[0] ||
+            normalizationWeights.Shape[1] != 1 ||
+            normalizationWeights.Shape[2] != input.Shape[2] ||
+            normalizationWeights.Shape[3] != input.Shape[3])
+        {
+            throw new ArgumentException(
+                "normalizationWeights must have shape [B,1,H,W] matching input.",
+                nameof(normalizationWeights));
+        }
     }
 
     private static double[] ComputeSplatWeights<T>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20148,6 +20148,27 @@ public partial class CpuEngine : ITensorLevelEngine
         int outputHeight = gradOutput._shape[3];
         int outputWidth = gradOutput._shape[4];
 
+        // Conv3D forward already lowers primitive floating-point tensors to im2col + GEMM.
+        // Use the corresponding matrix identity for dInput as well:
+        //   dColumns[rows, C*KD*KH*KW] = dOutput[rows, OC] * kernel[OC, C*KD*KH*KW]
+        // followed by a race-free col2im scatter over independent (batch, input-channel) slices.
+        // The previous implementation evaluated that contraction through seven scalar loops and was
+        // the dominant hot path in paper-scale video-diffusion training. Keep the bounded-workspace
+        // guard and the generic loop below as the fallback for oversized or non-primitive tensors.
+        if ((typeof(T) == typeof(float) || typeof(T) == typeof(double))
+            && TryConv3DBackwardInputGemm(
+                gradOutput, kernel, inputShape,
+                batch, inChannels, depth, height, width,
+                outChannels, kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideD, strideH, strideW,
+                padD, padH, padW,
+                dilationD, dilationH, dilationW,
+                out var gemmGradInput))
+        {
+            return gemmGradInput;
+        }
+
         var gradInputData = new T[batch * inChannels * depth * height * width];
         var gradOutputData = gradOutput.GetDataArray();
         var kernelData = kernel.GetDataArray();
@@ -20340,6 +20361,24 @@ public partial class CpuEngine : ITensorLevelEngine
         int outputHeight = gradOutput._shape[3];
         int outputWidth = gradOutput._shape[4];
 
+        // dKernel is another im2col contraction:
+        //   dKernel^T[K, OC] = columns^T[K, rows] * dOutput[rows, OC].
+        // This shares the exact receptive-field lowering used by Conv3D forward, so stride,
+        // padding, and dilation semantics cannot drift between the forward and backward paths.
+        if ((typeof(T) == typeof(float) || typeof(T) == typeof(double))
+            && TryConv3DBackwardKernelGemm(
+                gradOutput, input, kernelShape,
+                batch, inChannels, depth, height, width,
+                outChannels, kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideD, strideH, strideW,
+                padD, padH, padW,
+                dilationD, dilationH, dilationW,
+                out var gemmGradKernel))
+        {
+            return gemmGradKernel;
+        }
+
         var gradKernelData = new T[outChannels * inChannels * kernelDepth * kernelHeight * kernelWidth];
         var gradOutputData = gradOutput.GetDataArray();
         var inputData = input.GetDataArray();
@@ -20485,6 +20524,338 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         return TensorAllocator.Rent<T>(kernelShape, gradKernelData);
+    }
+
+    private static bool TryConv3DBackwardInputGemm<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> kernel,
+        int[] inputShape,
+        int batch,
+        int inChannels,
+        int depth,
+        int height,
+        int width,
+        int outChannels,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth,
+        out Tensor<T> result)
+    {
+        result = null!;
+        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
+        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
+        int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
+        long workspaceBytes = checked((gradOutputElementsLong + columnElementsLong) * elementSize);
+        if (rowsLong <= 0 || columnsPerRowLong <= 0
+            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
+            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
+            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        {
+            return false;
+        }
+
+        int rows = (int)rowsLong;
+        int columnsPerRow = (int)columnsPerRowLong;
+        int spatial = checked(outputDepth * outputHeight * outputWidth);
+        T[]? flatGradOutput = null;
+        T[]? gradColumns = null;
+        try
+        {
+            flatGradOutput = System.Buffers.ArrayPool<T>.Shared.Rent((int)gradOutputElementsLong);
+            gradColumns = System.Buffers.ArrayPool<T>.Shared.Rent((int)columnElementsLong);
+            var gradOutputData = gradOutput.GetReadOnlyDataArray();
+            var kernelData = kernel.GetReadOnlyDataArray();
+            PackConv3DOutputRows(gradOutputData, flatGradOutput, batch, outChannels, spatial);
+
+            bool multiplied;
+            if (typeof(T) == typeof(float))
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    rows, columnsPerRow, outChannels,
+                    (float[])(object)flatGradOutput, 0, outChannels, false,
+                    (float[])(object)kernelData, 0, columnsPerRow, false,
+                    (float[])(object)gradColumns, 0, columnsPerRow);
+            }
+            else
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    rows, columnsPerRow, outChannels,
+                    (double[])(object)flatGradOutput, 0, outChannels, false,
+                    (double[])(object)kernelData, 0, columnsPerRow, false,
+                    (double[])(object)gradColumns, 0, columnsPerRow);
+            }
+            if (!multiplied) return false;
+
+            var gradInputData = new T[checked(batch * inChannels * depth * height * width)];
+            ScatterConv3DColumnsToInput(
+                gradColumns, gradInputData,
+                batch, inChannels, depth, height, width,
+                kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideDepth, strideHeight, strideWidth,
+                padDepth, padHeight, padWidth,
+                dilationDepth, dilationHeight, dilationWidth);
+            result = TensorAllocator.Rent<T>(inputShape, gradInputData);
+            return true;
+        }
+        finally
+        {
+            if (flatGradOutput is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(flatGradOutput);
+            if (gradColumns is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(gradColumns);
+        }
+    }
+
+    private static bool TryConv3DBackwardKernelGemm<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        int[] kernelShape,
+        int batch,
+        int inChannels,
+        int depth,
+        int height,
+        int width,
+        int outChannels,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth,
+        out Tensor<T> result)
+    {
+        result = null!;
+        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
+        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
+        long transposedKernelElementsLong = columnsPerRowLong * outChannels;
+        int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
+        long workspaceBytes = checked(
+            (gradOutputElementsLong + columnElementsLong + transposedKernelElementsLong) * elementSize);
+        if (rowsLong <= 0 || columnsPerRowLong <= 0
+            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
+            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
+            || transposedKernelElementsLong > int.MaxValue
+            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        {
+            return false;
+        }
+
+        int rows = (int)rowsLong;
+        int columnsPerRow = (int)columnsPerRowLong;
+        int spatial = checked(outputDepth * outputHeight * outputWidth);
+        T[]? columns = null;
+        T[]? flatGradOutput = null;
+        T[]? transposedGradKernel = null;
+        try
+        {
+            columns = System.Buffers.ArrayPool<T>.Shared.Rent((int)columnElementsLong);
+            flatGradOutput = System.Buffers.ArrayPool<T>.Shared.Rent((int)gradOutputElementsLong);
+            transposedGradKernel = System.Buffers.ArrayPool<T>.Shared.Rent((int)transposedKernelElementsLong);
+            var inputData = input.GetReadOnlyDataArray();
+            var gradOutputData = gradOutput.GetReadOnlyDataArray();
+            Helpers.CpuIm2Col3DHelper.BuildColumns(
+                inputData, columns,
+                batch, inChannels, depth, height, width,
+                kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideDepth, strideHeight, strideWidth,
+                padDepth, padHeight, padWidth,
+                dilationDepth, dilationHeight, dilationWidth);
+            PackConv3DOutputRows(gradOutputData, flatGradOutput, batch, outChannels, spatial);
+
+            bool multiplied;
+            if (typeof(T) == typeof(float))
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    columnsPerRow, outChannels, rows,
+                    (float[])(object)columns, 0, columnsPerRow, true,
+                    (float[])(object)flatGradOutput, 0, outChannels, false,
+                    (float[])(object)transposedGradKernel, 0, outChannels);
+            }
+            else
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    columnsPerRow, outChannels, rows,
+                    (double[])(object)columns, 0, columnsPerRow, true,
+                    (double[])(object)flatGradOutput, 0, outChannels, false,
+                    (double[])(object)transposedGradKernel, 0, outChannels);
+            }
+            if (!multiplied) return false;
+
+            var gradKernelData = new T[checked(outChannels * columnsPerRow)];
+            CpuParallelSettings.ParallelForOrSerial(0, outChannels,
+                (long)outChannels * columnsPerRow, oc =>
+            {
+                int destinationBase = oc * columnsPerRow;
+                for (int column = 0; column < columnsPerRow; column++)
+                    gradKernelData[destinationBase + column] =
+                        transposedGradKernel[column * outChannels + oc];
+            }, deterministicSafe: true);
+            result = TensorAllocator.Rent<T>(kernelShape, gradKernelData);
+            return true;
+        }
+        finally
+        {
+            if (columns is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(columns);
+            if (flatGradOutput is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(flatGradOutput);
+            if (transposedGradKernel is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(transposedGradKernel);
+        }
+    }
+
+    private static void PackConv3DOutputRows<T>(
+        T[] source,
+        T[] destination,
+        int batch,
+        int channels,
+        int spatial)
+    {
+        int rows = checked(batch * spatial);
+        CpuParallelSettings.ParallelForOrSerial(0, rows, (long)rows * channels, row =>
+        {
+            int b = row / spatial;
+            int position = row - b * spatial;
+            int destinationBase = row * channels;
+            for (int channel = 0; channel < channels; channel++)
+                destination[destinationBase + channel] = source[(b * channels + channel) * spatial + position];
+        }, deterministicSafe: true);
+    }
+
+    private static void ScatterConv3DColumnsToInput<T>(
+        T[] columns,
+        T[] gradInput,
+        int batch,
+        int channels,
+        int depth,
+        int height,
+        int width,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth)
+    {
+        int columnsPerRow = checked(channels * kernelDepth * kernelHeight * kernelWidth);
+        int kernelPlane = checked(kernelHeight * kernelWidth);
+        int kernelVolume = checked(kernelDepth * kernelPlane);
+        int outputPlane = checked(outputHeight * outputWidth);
+        int outputSpatial = checked(outputDepth * outputPlane);
+        int inputPlane = checked(height * width);
+        int inputSpatial = checked(depth * inputPlane);
+
+        if (typeof(T) == typeof(float))
+        {
+            var source = (float[])(object)columns;
+            var destination = (float[])(object)gradInput;
+            CpuParallelSettings.ParallelForOrSerial(0, batch * channels,
+                (long)batch * channels * outputSpatial * kernelVolume, index =>
+            {
+                int b = index / channels;
+                int channel = index - b * channels;
+                int destinationChannelBase = (b * channels + channel) * inputSpatial;
+                int columnChannelOffset = channel * kernelVolume;
+                for (int od = 0; od < outputDepth; od++)
+                for (int oh = 0; oh < outputHeight; oh++)
+                for (int ow = 0; ow < outputWidth; ow++)
+                {
+                    int row = b * outputSpatial + od * outputPlane + oh * outputWidth + ow;
+                    int columnBase = row * columnsPerRow + columnChannelOffset;
+                    for (int kd = 0; kd < kernelDepth; kd++)
+                    {
+                        int id = od * strideDepth + kd * dilationDepth - padDepth;
+                        if ((uint)id >= (uint)depth) continue;
+                        for (int kh = 0; kh < kernelHeight; kh++)
+                        {
+                            int ih = oh * strideHeight + kh * dilationHeight - padHeight;
+                            if ((uint)ih >= (uint)height) continue;
+                            int inputRowBase = destinationChannelBase + id * inputPlane + ih * width;
+                            int kernelRowBase = columnBase + kd * kernelPlane + kh * kernelWidth;
+                            for (int kw = 0; kw < kernelWidth; kw++)
+                            {
+                                int iw = ow * strideWidth + kw * dilationWidth - padWidth;
+                                if ((uint)iw < (uint)width)
+                                    destination[inputRowBase + iw] += source[kernelRowBase + kw];
+                            }
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        var sourceDouble = (double[])(object)columns;
+        var destinationDouble = (double[])(object)gradInput;
+        CpuParallelSettings.ParallelForOrSerial(0, batch * channels,
+            (long)batch * channels * outputSpatial * kernelVolume, index =>
+        {
+            int b = index / channels;
+            int channel = index - b * channels;
+            int destinationChannelBase = (b * channels + channel) * inputSpatial;
+            int columnChannelOffset = channel * kernelVolume;
+            for (int od = 0; od < outputDepth; od++)
+            for (int oh = 0; oh < outputHeight; oh++)
+            for (int ow = 0; ow < outputWidth; ow++)
+            {
+                int row = b * outputSpatial + od * outputPlane + oh * outputWidth + ow;
+                int columnBase = row * columnsPerRow + columnChannelOffset;
+                for (int kd = 0; kd < kernelDepth; kd++)
+                {
+                    int id = od * strideDepth + kd * dilationDepth - padDepth;
+                    if ((uint)id >= (uint)depth) continue;
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        int ih = oh * strideHeight + kh * dilationHeight - padHeight;
+                        if ((uint)ih >= (uint)height) continue;
+                        int inputRowBase = destinationChannelBase + id * inputPlane + ih * width;
+                        int kernelRowBase = columnBase + kd * kernelPlane + kh * kernelWidth;
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            int iw = ow * strideWidth + kw * dilationWidth - padWidth;
+                            if ((uint)iw < (uint)width)
+                                destinationDouble[inputRowBase + iw] += sourceDouble[kernelRowBase + kw];
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20554,19 +20554,22 @@ public partial class CpuEngine : ITensorLevelEngine
         out Tensor<T> result)
     {
         result = null!;
-        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
-        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
-        long gradOutputElementsLong = rowsLong * outChannels;
-        long columnElementsLong = rowsLong * columnsPerRowLong;
         int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
-        long workspaceBytes = checked((gradOutputElementsLong + columnElementsLong) * elementSize);
-        if (rowsLong <= 0 || columnsPerRowLong <= 0
-            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
-            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
-            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        long maxElements = Math.Min(int.MaxValue, Conv3DIm2ColWorkspaceBytes / elementSize);
+        if (outChannels <= 0
+            || !TryBoundedPositiveProduct4(
+                batch, outputDepth, outputHeight, outputWidth, maxElements, out long rowsLong)
+            || !TryBoundedPositiveProduct4(
+                inChannels, kernelDepth, kernelHeight, kernelWidth,
+                maxElements, out long columnsPerRowLong)
+            || rowsLong > maxElements / outChannels)
         {
             return false;
         }
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long remainingElements = maxElements - gradOutputElementsLong;
+        if (rowsLong > remainingElements / columnsPerRowLong) return false;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
 
         int rows = (int)rowsLong;
         int columnsPerRow = (int)columnsPerRowLong;
@@ -20649,22 +20652,25 @@ public partial class CpuEngine : ITensorLevelEngine
         out Tensor<T> result)
     {
         result = null!;
-        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
-        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
-        long gradOutputElementsLong = rowsLong * outChannels;
-        long columnElementsLong = rowsLong * columnsPerRowLong;
-        long transposedKernelElementsLong = columnsPerRowLong * outChannels;
         int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
-        long workspaceBytes = checked(
-            (gradOutputElementsLong + columnElementsLong + transposedKernelElementsLong) * elementSize);
-        if (rowsLong <= 0 || columnsPerRowLong <= 0
-            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
-            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
-            || transposedKernelElementsLong > int.MaxValue
-            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        long maxElements = Math.Min(int.MaxValue, Conv3DIm2ColWorkspaceBytes / elementSize);
+        if (outChannels <= 0
+            || !TryBoundedPositiveProduct4(
+                batch, outputDepth, outputHeight, outputWidth, maxElements, out long rowsLong)
+            || !TryBoundedPositiveProduct4(
+                inChannels, kernelDepth, kernelHeight, kernelWidth,
+                maxElements, out long columnsPerRowLong)
+            || rowsLong > maxElements / outChannels)
         {
             return false;
         }
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long remainingElements = maxElements - gradOutputElementsLong;
+        if (rowsLong > remainingElements / columnsPerRowLong) return false;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
+        remainingElements -= columnElementsLong;
+        if (columnsPerRowLong > remainingElements / outChannels) return false;
+        long transposedKernelElementsLong = columnsPerRowLong * outChannels;
 
         int rows = (int)rowsLong;
         int columnsPerRow = (int)columnsPerRowLong;
@@ -20729,6 +20735,29 @@ public partial class CpuEngine : ITensorLevelEngine
             if (transposedGradKernel is not null)
                 System.Buffers.ArrayPool<T>.Shared.Return(transposedGradKernel);
         }
+    }
+
+    private static bool TryBoundedPositiveProduct4(
+        int first,
+        int second,
+        int third,
+        int fourth,
+        long limit,
+        out long product)
+    {
+        product = 1;
+        if (first <= 0 || second <= 0 || third <= 0 || fourth <= 0 || limit <= 0)
+            return false;
+
+        if (product > limit / first) return false;
+        product *= first;
+        if (product > limit / second) return false;
+        product *= second;
+        if (product > limit / third) return false;
+        product *= third;
+        if (product > limit / fourth) return false;
+        product *= fourth;
+        return true;
     }
 
     private static void PackConv3DOutputRows<T>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -27004,6 +27004,30 @@ public partial class CpuEngine : ITensorLevelEngine
                 var capT = numOpsLocal.FromDouble(softcap);
                 scaled = TensorMultiplyScalar(Tanh(TensorMultiplyScalar(scaled, invCap)), capT);
             }
+            if (mask is not null)
+            {
+                int batchLocal = query._shape[0];
+                int headsLocal = query._shape[1];
+                int seqQLocal = query._shape[2];
+                int seqKLocal = key._shape[2];
+                if (mask.Rank != 4 || mask._shape[0] != batchLocal ||
+                    mask._shape[1] != headsLocal || mask._shape[2] != seqQLocal ||
+                    mask._shape[3] != seqKLocal)
+                {
+                    throw new ArgumentException(
+                        "Attention mask must have shape [batch, heads, querySequence, keySequence].",
+                        nameof(mask));
+                }
+
+                // SDPA defines true as an allowed edge, while TensorMaskedFill fills true
+                // positions. Invert once at trace time; the mask is non-trainable graph state.
+                var maskData = mask.GetFlattenedData();
+                var blockedData = new bool[maskData.Length];
+                for (int i = 0; i < maskData.Length; i++) blockedData[i] = !maskData[i];
+                var blocked = new Tensor<bool>(blockedData, mask._shape);
+                scaled = TensorMaskedFill(
+                    scaled, blocked, numOpsLocal.FromDouble(double.NegativeInfinity));
+            }
             // softmax over last axis (S_k) — Softmax records its own lazy node
             // and the backward kernel handles the per-row Jacobian.
             attentionWeights = Softmax(scaled);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -39,7 +39,7 @@ public partial class DirectGpuTensorEngine
             // These are all direct-GPU resident primitives. Keeping the operation in the shared
             // engine gives CUDA, HIP, Metal, OpenCL, Vulkan, and WebGPU identical displacement
             // ordering without six backend-specific correlation kernels or a host readback.
-            var paddedSecond = Pad(
+            var paddedSecond = ((IEngine)this).Pad(
                 second, radius, radius, radius, radius,
                 MathHelper.GetNumericOperations<T>().Zero);
             int offset = 0;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -17,9 +17,11 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> PartialCorrelationVolume<T>(
         Tensor<T> first, Tensor<T> second, int radius = 4)
     {
-        // CpuEngine's implementation is a pure composition of virtual Unfold, Reshape,
-        // TensorMultiply, and ReduceMean calls. On this instance those dispatch to the resident
-        // GPU implementations, while their normal tape nodes provide the exact gradient.
+        // CpuEngine's bounded implementation composes virtual Pad, TensorSlice, TensorMultiply,
+        // ReduceMean, and TensorConcatenate calls under NoGrad, then records one custom backward.
+        // On this instance every primitive remains GPU-resident on CUDA, HIP, Metal, OpenCL,
+        // Vulkan, and WebGPU; disabling nested tape recording also prevents ReduceMean's
+        // tape-active compatibility fallback from downloading the correlation volume to CPU.
         return base.PartialCorrelationVolume(first, second, radius);
     }
 
@@ -28,7 +30,15 @@ public partial class DirectGpuTensorEngine
         Tensor<T> input, Tensor<T> flow, bool normalize = true)
     {
         ValidateForwardSplat(input, flow);
-        if (typeof(T) != typeof(float) || Compilation.GraphMode.IsActive || !TryGetBackend(out _))
+        var placementBackend = PlacementBackend;
+        if (typeof(T) == typeof(float) && placementBackend is not null && Compilation.GraphMode.IsActive)
+        {
+            throw new NotSupportedException(
+                $"Compiled ForwardSplat is not available on the direct GPU backend " +
+                $"'{placementBackend.BackendName}'. CPU fallback is disabled during GPU graph " +
+                "capture because it would silently transfer the training path off device.");
+        }
+        if (typeof(T) != typeof(float) || !TryGetBackend(out _))
             return base.ForwardSplat(input, flow, normalize);
 
         Tensor<T> result;
@@ -47,11 +57,20 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> ForwardSplatBackwardInput<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
         bool normalize = true)
+        => ForwardSplatBackwardInputWithWeights(
+            gradOutput, input, flow, normalize, normalizationWeights: null);
+
+    /// <inheritdoc />
+    internal override Tensor<T> ForwardSplatBackwardInputWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize, Tensor<T>? normalizationWeights)
     {
         ValidateForwardSplat(input, flow);
         ValidateSameShape(gradOutput, input, nameof(gradOutput));
+        ValidateNormalizationWeights(normalizationWeights, input);
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
-            return base.ForwardSplatBackwardInput(gradOutput, input, flow, normalize);
+            return base.ForwardSplatBackwardInputWithWeights(
+                gradOutput, input, flow, normalize, normalizationWeights);
 
         using (GradientTape<T>.NoGrad())
         {
@@ -59,7 +78,7 @@ public partial class DirectGpuTensorEngine
             Tensor<T> sampledGradient = gradOutput;
             if (normalize)
             {
-                var denominator = BuildForwardSplatDenominator(flow, grid);
+                var denominator = normalizationWeights ?? BuildForwardSplatDenominator(flow, grid);
                 sampledGradient = TensorBroadcastDivide(gradOutput, denominator);
             }
 
@@ -73,12 +92,21 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> ForwardSplatBackwardFlow<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
         bool normalize = true)
+        => ForwardSplatBackwardFlowWithWeights(
+            gradOutput, input, flow, output, normalize, normalizationWeights: null);
+
+    /// <inheritdoc />
+    internal override Tensor<T> ForwardSplatBackwardFlowWithWeights<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T>? output,
+        bool normalize, Tensor<T>? normalizationWeights)
     {
         ValidateForwardSplat(input, flow);
         ValidateSameShape(gradOutput, input, nameof(gradOutput));
-        ValidateSameShape(output, input, nameof(output));
+        if (normalize) ValidateSameShape(output, input, nameof(output));
+        ValidateNormalizationWeights(normalizationWeights, input);
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
-            return base.ForwardSplatBackwardFlow(gradOutput, input, flow, output, normalize);
+            return base.ForwardSplatBackwardFlowWithWeights(
+                gradOutput, input, flow, output, normalize, normalizationWeights);
 
         using (GradientTape<T>.NoGrad())
         {
@@ -86,7 +114,7 @@ public partial class DirectGpuTensorEngine
             Tensor<T> destinationGradient = gradOutput;
             if (normalize)
             {
-                var denominator = BuildForwardSplatDenominator(flow, grid);
+                var denominator = normalizationWeights ?? BuildForwardSplatDenominator(flow, grid);
                 destinationGradient = TensorBroadcastDivide(gradOutput, denominator);
             }
 
@@ -100,7 +128,7 @@ public partial class DirectGpuTensorEngine
             if (normalize)
             {
                 // Quotient rule: subtract d grid_sample(sum_c(G_c * output_c), p_i)/dp_i.
-                var weightedOutput = TensorMultiply(destinationGradient, output);
+                var weightedOutput = TensorMultiply(destinationGradient, output!);
                 var correctionField = ReduceSum(weightedOutput, [1], keepDims: true);
                 var ones = CreateFilledTensor<T>(
                     [input.Shape[0], 1, input.Shape[2], input.Shape[3]], 1.0);
@@ -120,6 +148,20 @@ public partial class DirectGpuTensorEngine
             // returning the gradient to the tape. Keeping NHWC here silently attached the
             // wrong shape to every GPU-trained flow tensor.
             return TensorPermute(scaledGradient, [0, 3, 1, 2]).Contiguous();
+        }
+    }
+
+    /// <inheritdoc />
+    internal override Tensor<T> GetForwardSplatNormalizationWeights<T>(Tensor<T> flow)
+    {
+        ValidateForwardSplatFlow(flow);
+        if (typeof(T) != typeof(float) || !TryGetBackend(out _))
+            return base.GetForwardSplatNormalizationWeights(flow);
+
+        using (GradientTape<T>.NoGrad())
+        {
+            var grid = BuildForwardSplatGrid(flow);
+            return BuildForwardSplatDenominator(flow, grid);
         }
     }
 
@@ -192,11 +234,34 @@ public partial class DirectGpuTensorEngine
             throw new ArgumentException("ForwardSplat spatial dimensions must be positive.", nameof(input));
     }
 
-    private static void ValidateSameShape<T>(Tensor<T> actual, Tensor<T> expected, string parameterName)
+    private static void ValidateForwardSplatFlow<T>(Tensor<T> flow)
     {
-        if (actual is null) throw new ArgumentNullException(nameof(actual));
+        if (flow is null) throw new ArgumentNullException(nameof(flow));
+        if (flow.Rank != 4 || flow.Shape[1] != 2 || flow.Shape[2] <= 0 || flow.Shape[3] <= 0)
+            throw new ArgumentException("ForwardSplat flow must have shape [B,2,H,W].", nameof(flow));
+    }
+
+    private static void ValidateSameShape<T>(Tensor<T>? actual, Tensor<T> expected, string parameterName)
+    {
+        if (actual is null) throw new ArgumentNullException(parameterName);
         if (expected is null) throw new ArgumentNullException(nameof(expected));
         if (actual.Shape != expected.Shape)
             throw new ArgumentException("Tensor shape must match the input shape.", parameterName);
+    }
+
+    private static void ValidateNormalizationWeights<T>(
+        Tensor<T>? normalizationWeights, Tensor<T> input)
+    {
+        if (normalizationWeights is null) return;
+        if (normalizationWeights.Rank != 4 ||
+            normalizationWeights.Shape[0] != input.Shape[0] ||
+            normalizationWeights.Shape[1] != 1 ||
+            normalizationWeights.Shape[2] != input.Shape[2] ||
+            normalizationWeights.Shape[3] != input.Shape[3])
+        {
+            throw new ArgumentException(
+                "normalizationWeights must have shape [B,1,H,W] matching input.",
+                nameof(normalizationWeights));
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -14,28 +14,17 @@ namespace AiDotNet.Tensors.Engines;
 public partial class DirectGpuTensorEngine
 {
     /// <inheritdoc />
-    public override Tensor<T> PartialCorrelationVolume<T>(
-        Tensor<T> first, Tensor<T> second, int radius = 4)
-    {
-        // CpuEngine's bounded implementation composes virtual Pad, TensorSlice, TensorMultiply,
-        // ReduceMean, and TensorConcatenate calls under NoGrad, then records one custom backward.
-        // On this instance every primitive remains GPU-resident on CUDA, HIP, Metal, OpenCL,
-        // Vulkan, and WebGPU; disabling nested tape recording also prevents ReduceMean's
-        // tape-active compatibility fallback from downloading the correlation volume to CPU.
-        return base.PartialCorrelationVolume(first, second, radius);
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ForwardSplat<T>(
         Tensor<T> input, Tensor<T> flow, bool normalize = true)
     {
         ValidateForwardSplat(input, flow);
-        var placementBackend = PlacementBackend;
-        if (typeof(T) == typeof(float) && placementBackend is not null && Compilation.GraphMode.IsActive)
+        if (typeof(T) == typeof(float) && IsGpuAvailable && Compilation.GraphMode.IsActive)
         {
+            string backendName = PlacementBackend?.BackendName ?? Name;
             throw new NotSupportedException(
                 $"Compiled ForwardSplat is not available on the direct GPU backend " +
-                $"'{placementBackend.BackendName}'. CPU fallback is disabled during GPU graph " +
+                $"'{backendName}'. CPU fallback is disabled during GPU graph " +
                 "capture because it would silently transfer the training path off device.");
         }
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
@@ -154,7 +143,7 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc />
     internal override Tensor<T> GetForwardSplatNormalizationWeights<T>(Tensor<T> flow)
     {
-        ValidateForwardSplatFlow(flow);
+        ValidateSplatFlow(flow);
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
             return base.GetForwardSplatNormalizationWeights(flow);
 
@@ -234,13 +223,6 @@ public partial class DirectGpuTensorEngine
             throw new ArgumentException("ForwardSplat spatial dimensions must be positive.", nameof(input));
     }
 
-    private static void ValidateForwardSplatFlow<T>(Tensor<T> flow)
-    {
-        if (flow is null) throw new ArgumentNullException(nameof(flow));
-        if (flow.Rank != 4 || flow.Shape[1] != 2 || flow.Shape[2] <= 0 || flow.Shape[3] <= 0)
-            throw new ArgumentException("ForwardSplat flow must have shape [B,2,H,W].", nameof(flow));
-    }
-
     private static void ValidateSameShape<T>(Tensor<T>? actual, Tensor<T> expected, string parameterName)
     {
         if (actual is null) throw new ArgumentNullException(parameterName);
@@ -249,19 +231,4 @@ public partial class DirectGpuTensorEngine
             throw new ArgumentException("Tensor shape must match the input shape.", parameterName);
     }
 
-    private static void ValidateNormalizationWeights<T>(
-        Tensor<T>? normalizationWeights, Tensor<T> input)
-    {
-        if (normalizationWeights is null) return;
-        if (normalizationWeights.Rank != 4 ||
-            normalizationWeights.Shape[0] != input.Shape[0] ||
-            normalizationWeights.Shape[1] != 1 ||
-            normalizationWeights.Shape[2] != input.Shape[2] ||
-            normalizationWeights.Shape[3] != input.Shape[3])
-        {
-            throw new ArgumentException(
-                "normalizationWeights must have shape [B,1,H,W] matching input.",
-                nameof(normalizationWeights));
-        }
-    }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -176,8 +176,8 @@ public partial class DirectGpuTensorEngine
 
     private static void ValidateForwardSplat<T>(Tensor<T> input, Tensor<T> flow, double epsilon)
     {
-        ArgumentNullException.ThrowIfNull(input);
-        ArgumentNullException.ThrowIfNull(flow);
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (flow is null) throw new ArgumentNullException(nameof(flow));
         if (input.Rank != 4 || flow.Rank != 4 || flow.Shape[0] != input.Shape[0] ||
             flow.Shape[1] != 2 || flow.Shape[2] != input.Shape[2] || flow.Shape[3] != input.Shape[3])
             throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
@@ -189,7 +189,8 @@ public partial class DirectGpuTensorEngine
 
     private static void ValidateSameShape<T>(Tensor<T> actual, Tensor<T> expected, string parameterName)
     {
-        ArgumentNullException.ThrowIfNull(actual);
+        if (actual is null) throw new ArgumentNullException(nameof(actual));
+        if (expected is null) throw new ArgumentNullException(nameof(expected));
         if (actual.Shape != expected.Shape)
             throw new ArgumentException("Tensor shape must match the input shape.", parameterName);
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -25,33 +25,33 @@ public partial class DirectGpuTensorEngine
 
     /// <inheritdoc />
     public override Tensor<T> ForwardSplat<T>(
-        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7)
+        Tensor<T> input, Tensor<T> flow, bool normalize = true)
     {
-        ValidateForwardSplat(input, flow, epsilon);
+        ValidateForwardSplat(input, flow);
         if (typeof(T) != typeof(float) || Compilation.GraphMode.IsActive || !TryGetBackend(out _))
-            return base.ForwardSplat(input, flow, normalize, epsilon);
+            return base.ForwardSplat(input, flow, normalize);
 
         Tensor<T> result;
         using (GradientTape<T>.NoGrad())
-            result = ForwardSplatGpu(input, flow, normalize, epsilon);
+            result = ForwardSplatGpu(input, flow, normalize);
 
         // The composed implementation deliberately runs under NoGrad so the public operation owns
         // one stable tape node rather than leaking its grid-sample implementation details.
         DifferentiableOps.RecordIfActive(
             "ForwardSplat", result, [input, flow],
-            BackwardFunctions<T>.ForwardSplatBackward, [normalize, epsilon]);
+            BackwardFunctions<T>.ForwardSplatBackward, [normalize]);
         return result;
     }
 
     /// <inheritdoc />
     public override Tensor<T> ForwardSplatBackwardInput<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
-        bool normalize = true, double epsilon = 1e-7)
+        bool normalize = true)
     {
-        ValidateForwardSplat(input, flow, epsilon);
+        ValidateForwardSplat(input, flow);
         ValidateSameShape(gradOutput, input, nameof(gradOutput));
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
-            return base.ForwardSplatBackwardInput(gradOutput, input, flow, normalize, epsilon);
+            return base.ForwardSplatBackwardInput(gradOutput, input, flow, normalize);
 
         using (GradientTape<T>.NoGrad())
         {
@@ -59,7 +59,7 @@ public partial class DirectGpuTensorEngine
             Tensor<T> sampledGradient = gradOutput;
             if (normalize)
             {
-                var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+                var denominator = BuildForwardSplatDenominator(flow, grid);
                 sampledGradient = TensorBroadcastDivide(gradOutput, denominator);
             }
 
@@ -72,13 +72,13 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc />
     public override Tensor<T> ForwardSplatBackwardFlow<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
-        bool normalize = true, double epsilon = 1e-7)
+        bool normalize = true)
     {
-        ValidateForwardSplat(input, flow, epsilon);
+        ValidateForwardSplat(input, flow);
         ValidateSameShape(gradOutput, input, nameof(gradOutput));
         ValidateSameShape(output, input, nameof(output));
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
-            return base.ForwardSplatBackwardFlow(gradOutput, input, flow, output, normalize, epsilon);
+            return base.ForwardSplatBackwardFlow(gradOutput, input, flow, output, normalize);
 
         using (GradientTape<T>.NoGrad())
         {
@@ -86,7 +86,7 @@ public partial class DirectGpuTensorEngine
             Tensor<T> destinationGradient = gradOutput;
             if (normalize)
             {
-                var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+                var denominator = BuildForwardSplatDenominator(flow, grid);
                 destinationGradient = TensorBroadcastDivide(gradOutput, denominator);
             }
 
@@ -118,7 +118,7 @@ public partial class DirectGpuTensorEngine
     }
 
     private Tensor<T> ForwardSplatGpu<T>(
-        Tensor<T> input, Tensor<T> flow, bool normalize, double epsilon)
+        Tensor<T> input, Tensor<T> flow, bool normalize)
     {
         var grid = BuildForwardSplatGrid(flow);
         var accumulated = GridSampleBackwardInput(
@@ -126,19 +126,20 @@ public partial class DirectGpuTensorEngine
             GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
         if (!normalize) return accumulated;
 
-        var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+        var denominator = BuildForwardSplatDenominator(flow, grid);
         return TensorBroadcastDivide(accumulated, denominator);
     }
 
     private Tensor<T> BuildForwardSplatDenominator<T>(
-        Tensor<T> flow, Tensor<T> grid, double epsilon)
+        Tensor<T> flow, Tensor<T> grid)
     {
         var ones = CreateFilledTensor<T>(
             [flow.Shape[0], 1, flow.Shape[2], flow.Shape[3]], 1.0);
         var weights = GridSampleBackwardInput(
             ones, grid, ones.Shape.ToArray(),
             GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
-        return TensorAddScalar(weights, MathHelper.GetNumericOperations<T>().FromDouble(epsilon));
+        var ops = MathHelper.GetNumericOperations<T>();
+        return TensorWhere(TensorGreaterThan(weights, ops.Zero), weights, ones);
     }
 
     private Tensor<T> BuildForwardSplatGrid<T>(Tensor<T> flow)
@@ -174,7 +175,7 @@ public partial class DirectGpuTensorEngine
         return tensor;
     }
 
-    private static void ValidateForwardSplat<T>(Tensor<T> input, Tensor<T> flow, double epsilon)
+    private static void ValidateForwardSplat<T>(Tensor<T> input, Tensor<T> flow)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (flow is null) throw new ArgumentNullException(nameof(flow));
@@ -183,8 +184,6 @@ public partial class DirectGpuTensorEngine
             throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
         if (input.Shape[2] <= 0 || input.Shape[3] <= 0)
             throw new ArgumentException("ForwardSplat spatial dimensions must be positive.", nameof(input));
-        if (epsilon <= 0 || double.IsNaN(epsilon))
-            throw new ArgumentOutOfRangeException(nameof(epsilon));
     }
 
     private static void ValidateSameShape<T>(Tensor<T> actual, Tensor<T> expected, string parameterName)

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -1,0 +1,196 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+/// <summary>
+/// GPU-resident video-warp primitives shared by CUDA, HIP, Metal, OpenCL, Vulkan, and WebGPU.
+/// The implementation composes the existing unfold and grid-sample kernels so all six backends
+/// use the same numerics and no backend-specific model code is required.
+/// </summary>
+public partial class DirectGpuTensorEngine
+{
+    /// <inheritdoc />
+    public override Tensor<T> PartialCorrelationVolume<T>(
+        Tensor<T> first, Tensor<T> second, int radius = 4)
+    {
+        // CpuEngine's implementation is a pure composition of virtual Unfold, Reshape,
+        // TensorMultiply, and ReduceMean calls. On this instance those dispatch to the resident
+        // GPU implementations, while their normal tape nodes provide the exact gradient.
+        return base.PartialCorrelationVolume(first, second, radius);
+    }
+
+    /// <inheritdoc />
+    public override Tensor<T> ForwardSplat<T>(
+        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateForwardSplat(input, flow, epsilon);
+        if (typeof(T) != typeof(float) || Compilation.GraphMode.IsActive || !TryGetBackend(out _))
+            return base.ForwardSplat(input, flow, normalize, epsilon);
+
+        Tensor<T> result;
+        using (GradientTape<T>.NoGrad())
+            result = ForwardSplatGpu(input, flow, normalize, epsilon);
+
+        // The composed implementation deliberately runs under NoGrad so the public operation owns
+        // one stable tape node rather than leaking its grid-sample implementation details.
+        DifferentiableOps.RecordIfActive(
+            "ForwardSplat", result, [input, flow],
+            BackwardFunctions<T>.ForwardSplatBackward, [normalize, epsilon]);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override Tensor<T> ForwardSplatBackwardInput<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateForwardSplat(input, flow, epsilon);
+        ValidateSameShape(gradOutput, input, nameof(gradOutput));
+        if (typeof(T) != typeof(float) || !TryGetBackend(out _))
+            return base.ForwardSplatBackwardInput(gradOutput, input, flow, normalize, epsilon);
+
+        using (GradientTape<T>.NoGrad())
+        {
+            var grid = BuildForwardSplatGrid(flow);
+            Tensor<T> sampledGradient = gradOutput;
+            if (normalize)
+            {
+                var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+                sampledGradient = TensorBroadcastDivide(gradOutput, denominator);
+            }
+
+            // A splat's input adjoint is a bilinear gather from the destination gradient.
+            return GridSample(sampledGradient, grid,
+                GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+        }
+    }
+
+    /// <inheritdoc />
+    public override Tensor<T> ForwardSplatBackwardFlow<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
+        bool normalize = true, double epsilon = 1e-7)
+    {
+        ValidateForwardSplat(input, flow, epsilon);
+        ValidateSameShape(gradOutput, input, nameof(gradOutput));
+        ValidateSameShape(output, input, nameof(output));
+        if (typeof(T) != typeof(float) || !TryGetBackend(out _))
+            return base.ForwardSplatBackwardFlow(gradOutput, input, flow, output, normalize, epsilon);
+
+        using (GradientTape<T>.NoGrad())
+        {
+            var grid = BuildForwardSplatGrid(flow);
+            Tensor<T> destinationGradient = gradOutput;
+            if (normalize)
+            {
+                var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+                destinationGradient = TensorBroadcastDivide(gradOutput, denominator);
+            }
+
+            // GridSampleBackwardGrid differentiates a gather. Its adjoint identity gives the splat
+            // flow derivative without atomics or a backend-specific kernel:
+            //   dL/dp_i = d grid_sample(G, p_i)/dp_i weighted by source x_i.
+            var flowGradient = GridSampleBackwardGrid(
+                input, destinationGradient, grid,
+                GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+
+            if (normalize)
+            {
+                // Quotient rule: subtract d grid_sample(sum_c(G_c * output_c), p_i)/dp_i.
+                var weightedOutput = TensorMultiply(destinationGradient, output);
+                var correctionField = ReduceSum(weightedOutput, [1], keepDims: true);
+                var ones = CreateFilledTensor<T>(
+                    [input.Shape[0], 1, input.Shape[2], input.Shape[3]], 1.0);
+                var correction = GridSampleBackwardGrid(
+                    ones, correctionField, grid,
+                    GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+                flowGradient = TensorSubtract(flowGradient, correction);
+            }
+
+            // The grid stores normalized coordinates. Convert dL/d(grid) to dL/d(pixel flow).
+            var pixelScale = CreateAxisTensor<T>(
+                2.0 / input.Shape[3], 2.0 / input.Shape[2]);
+            return TensorBroadcastMultiply(flowGradient, pixelScale);
+        }
+    }
+
+    private Tensor<T> ForwardSplatGpu<T>(
+        Tensor<T> input, Tensor<T> flow, bool normalize, double epsilon)
+    {
+        var grid = BuildForwardSplatGrid(flow);
+        var accumulated = GridSampleBackwardInput(
+            input, grid, input.Shape.ToArray(),
+            GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+        if (!normalize) return accumulated;
+
+        var denominator = BuildForwardSplatDenominator(flow, grid, epsilon);
+        return TensorBroadcastDivide(accumulated, denominator);
+    }
+
+    private Tensor<T> BuildForwardSplatDenominator<T>(
+        Tensor<T> flow, Tensor<T> grid, double epsilon)
+    {
+        var ones = CreateFilledTensor<T>(
+            [flow.Shape[0], 1, flow.Shape[2], flow.Shape[3]], 1.0);
+        var weights = GridSampleBackwardInput(
+            ones, grid, ones.Shape.ToArray(),
+            GridSampleMode.Bilinear, GridSamplePadding.Zeros, alignCorners: false);
+        return TensorAddScalar(weights, MathHelper.GetNumericOperations<T>().FromDouble(epsilon));
+    }
+
+    private Tensor<T> BuildForwardSplatGrid<T>(Tensor<T> flow)
+    {
+        int batch = flow.Shape[0], height = flow.Shape[2], width = flow.Shape[3];
+        var baseGrid = new Tensor<T>([batch, height, width, 2]);
+        var values = baseGrid.AsWritableSpan();
+        var ops = MathHelper.GetNumericOperations<T>();
+        for (int b = 0; b < batch; b++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            int offset = ((b * height + y) * width + x) * 2;
+            values[offset] = ops.FromDouble(2.0 * (x + 0.5) / width - 1.0);
+            values[offset + 1] = ops.FromDouble(2.0 * (y + 0.5) / height - 1.0);
+        }
+
+        var flowNhwc = TensorPermute(flow, [0, 2, 3, 1]);
+        var pixelScale = CreateAxisTensor<T>(2.0 / width, 2.0 / height);
+        return TensorAdd(baseGrid, TensorBroadcastMultiply(flowNhwc, pixelScale));
+    }
+
+    private static Tensor<T> CreateAxisTensor<T>(double x, double y)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        return new Tensor<T>([ops.FromDouble(x), ops.FromDouble(y)], [1, 1, 1, 2]);
+    }
+
+    private static Tensor<T> CreateFilledTensor<T>(int[] shape, double value)
+    {
+        var tensor = new Tensor<T>(shape);
+        tensor.AsWritableSpan().Fill(MathHelper.GetNumericOperations<T>().FromDouble(value));
+        return tensor;
+    }
+
+    private static void ValidateForwardSplat<T>(Tensor<T> input, Tensor<T> flow, double epsilon)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(flow);
+        if (input.Rank != 4 || flow.Rank != 4 || flow.Shape[0] != input.Shape[0] ||
+            flow.Shape[1] != 2 || flow.Shape[2] != input.Shape[2] || flow.Shape[3] != input.Shape[3])
+            throw new ArgumentException("ForwardSplat requires input [B,C,H,W] and flow [B,2,H,W].");
+        if (input.Shape[2] <= 0 || input.Shape[3] <= 0)
+            throw new ArgumentException("ForwardSplat spatial dimensions must be positive.", nameof(input));
+        if (epsilon <= 0 || double.IsNaN(epsilon))
+            throw new ArgumentOutOfRangeException(nameof(epsilon));
+    }
+
+    private static void ValidateSameShape<T>(Tensor<T> actual, Tensor<T> expected, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(actual);
+        if (actual.Shape != expected.Shape)
+            throw new ArgumentException("Tensor shape must match the input shape.", parameterName);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -113,7 +113,13 @@ public partial class DirectGpuTensorEngine
             // The grid stores normalized coordinates. Convert dL/d(grid) to dL/d(pixel flow).
             var pixelScale = CreateAxisTensor<T>(
                 2.0 / input.Shape[3], 2.0 / input.Shape[2]);
-            return TensorBroadcastMultiply(flowGradient, pixelScale);
+            var scaledGradient = TensorBroadcastMultiply(flowGradient, pixelScale);
+
+            // GridSampleBackwardGrid follows the grid contract and returns NHWC coordinates.
+            // ForwardSplat's public flow contract is NCHW, so restore that layout before
+            // returning the gradient to the tape. Keeping NHWC here silently attached the
+            // wrong shape to every GPU-trained flow tensor.
+            return TensorPermute(scaledGradient, [0, 3, 1, 2]).Contiguous();
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.VideoWarp.cs
@@ -14,6 +14,54 @@ namespace AiDotNet.Tensors.Engines;
 public partial class DirectGpuTensorEngine
 {
     /// <inheritdoc />
+    public override Tensor<T> PartialCorrelationVolume<T>(
+        Tensor<T> first, Tensor<T> second, int radius = 4)
+    {
+        if (first is null) throw new ArgumentNullException(nameof(first));
+        if (second is null) throw new ArgumentNullException(nameof(second));
+        if (first.Rank != 4 || second.Rank != 4 || first.Shape != second.Shape)
+            throw new ArgumentException("Correlation inputs must have equal [B,C,H,W] shapes.");
+        if (radius < 0) throw new ArgumentOutOfRangeException(nameof(radius));
+        if (typeof(T) != typeof(float) || !TryGetBackend(out _))
+            return base.PartialCorrelationVolume(first, second, radius);
+        GradientTape<T>.Current?.BindEngineIfUnset(this);
+
+        int batch = first.Shape[0];
+        int channels = first.Shape[1];
+        int height = first.Shape[2];
+        int width = first.Shape[3];
+        int diameter = radius * 2 + 1;
+        var planes = new Tensor<T>[diameter * diameter];
+
+        Tensor<T> result;
+        using (GradientTape<T>.NoGrad())
+        {
+            // These are all direct-GPU resident primitives. Keeping the operation in the shared
+            // engine gives CUDA, HIP, Metal, OpenCL, Vulkan, and WebGPU identical displacement
+            // ordering without six backend-specific correlation kernels or a host readback.
+            var paddedSecond = Pad(
+                second, radius, radius, radius, radius,
+                MathHelper.GetNumericOperations<T>().Zero);
+            int offset = 0;
+            for (int offsetY = 0; offsetY < diameter; offsetY++)
+            for (int offsetX = 0; offsetX < diameter; offsetX++)
+            {
+                var shifted = TensorSlice(
+                    paddedSecond,
+                    [0, 0, offsetY, offsetX],
+                    [batch, channels, height, width]);
+                planes[offset++] = ReduceMean(
+                    TensorMultiply(first, shifted), [1], keepDims: true);
+            }
+            result = TensorConcatenate(planes, axis: 1);
+        }
+
+        DifferentiableOps.RecordIfActive(
+            "PartialCorrelationVolume", result, [first, second],
+            BackwardFunctions<T>.PartialCorrelationVolumeBackward, [radius]);
+        return result;
+    }
+
     /// <inheritdoc />
     public override Tensor<T> ForwardSplat<T>(
         Tensor<T> input, Tensor<T> flow, bool normalize = true)
@@ -29,6 +77,7 @@ public partial class DirectGpuTensorEngine
         }
         if (typeof(T) != typeof(float) || !TryGetBackend(out _))
             return base.ForwardSplat(input, flow, normalize);
+        GradientTape<T>.Current?.BindEngineIfUnset(this);
 
         Tensor<T> result;
         using (GradientTape<T>.NoGrad())

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -17697,10 +17697,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         if (!TryGetBackend(out var backend))
             return null;
-        var residentA = ResolveResidentBufferNoUpload(backend, a, a.Length);
-        var residentB = ResolveResidentBufferNoUpload(backend, b, b.Length);
-        if (residentA is null || residentB is null)
+        // Outside a resident/capture step, a direct buffer is usable only when it is the
+        // current tensor version and its cache owner is still live. ResolveResidentBufferNoUpload
+        // deliberately omits this gate for capture-time metadata views, so using it here could
+        // execute eager arithmetic against a stale pre-mutation buffer.
+        if (a._gpuBuffer is null || !ReferenceEquals(a._gpuBackend, backend)
+            || a._gpuBufferVersion != a.Version || !IsCachedGpuBufferLive(a, backend)
+            || a._gpuBuffer.Handle == System.IntPtr.Zero || a._gpuBuffer.Size < a.Length
+            || b._gpuBuffer is null || !ReferenceEquals(b._gpuBackend, backend)
+            || b._gpuBufferVersion != b.Version || !IsCachedGpuBufferLive(b, backend)
+            || b._gpuBuffer.Handle == System.IntPtr.Zero || b._gpuBuffer.Size < b.Length)
             return null;
+        var residentA = a._gpuBuffer;
+        var residentB = b._gpuBuffer;
         IGpuBuffer? output = null;
         try
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -17677,17 +17677,48 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // GPU-accelerated element-wise arithmetic
     // ──────────────────────────────────────────────────────────────
 
-    /// <summary>PR #638 A1: resident-step out-of-place elementwise binary — compute into a FRESH resident-bound
-    /// output (no AllocateOutputBuffer temp, no download), so the backward grad stays GPU-resident for capture.
-    /// Returns the bound output on success, else null (off the resident step / autocast / non-float → caller's
-    /// normal download path). Records nothing; the caller records the backward exactly as its eager path.</summary>
+    /// <summary>Out-of-place elementwise binary for resident float operands — compute into a FRESH resident-bound
+    /// output (no AllocateOutputBuffer temp, no download), so eager and compiled backward gradients stay on GPU.
+    /// Returns the bound output on success, else null (non-resident inputs / autocast / non-float → caller's
+    /// normal path). Records nothing; the caller records the backward exactly as its eager path.</summary>
     private Tensor<T>? TryBinaryResidentOutOfPlace<T>(Tensor<T> a, Tensor<T> b,
         System.Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> kernel)
     {
-        if (!ResidentStepActive || Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return null;
+        if (Gpu.AutocastScope.IsEnabled || typeof(T) != typeof(float)) return null;
         if (!ShapesMatch(a.Shape._dims, b.Shape._dims) || a.Length != b.Length) return null;
-        var output = new Tensor<T>(new T[a.Length], a.Shape._dims);
-        return TryRunBinaryInto(output, a, b, kernel) ? output : null;
+
+        // Compiled execution needs a stable, capture-safe scratch address. Keep the existing
+        // resident-step route rather than allocating a fresh eager buffer during graph capture.
+        if (ResidentStepActive)
+        {
+            var capturedOutput = new Tensor<T>(new T[a.Length], a.Shape._dims);
+            return TryRunBinaryInto(capturedOutput, a, b, kernel) ? capturedOutput : null;
+        }
+
+        if (!TryGetBackend(out var backend))
+            return null;
+        var residentA = ResolveResidentBufferNoUpload(backend, a, a.Length);
+        var residentB = ResolveResidentBufferNoUpload(backend, b, b.Length);
+        if (residentA is null || residentB is null)
+            return null;
+        IGpuBuffer? output = null;
+        try
+        {
+            output = backend.AllocateBuffer(a.Length);
+            kernel(backend, residentA, residentB, output, a.Length);
+            var result = DeferTensorResult<T>(backend, output, a.Length, a.Shape.ToArray());
+            output = null; // ownership transferred to the deferred tensor
+            return result;
+        }
+        catch (Exception ex)
+        {
+            AliasDiag($"binary-eager-resident FELLBACK shape=[{string.Join(",", a._shape)}]: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+        finally
+        {
+            output?.Dispose();
+        }
     }
 
     /// <summary>PR #638 A1: resident-step GEMM — [M,K]x[K,N] into a fresh resident-bound output, no temp output

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5956,6 +5956,30 @@ public interface IEngine
     Tensor<T> GridSample<T>(Tensor<T> input, Tensor<T> grid);
 
     /// <summary>
+    /// Builds a local all-pairs correlation volume for two NCHW feature maps.
+    /// Output channel order is row-major over offsets [-radius,+radius]².
+    /// </summary>
+    Tensor<T> PartialCorrelationVolume<T>(Tensor<T> first, Tensor<T> second, int radius = 4);
+
+    /// <summary>
+    /// Differentiably forward-warps an NCHW tensor using an NCHW two-channel pixel flow.
+    /// Bilinear contributions are accumulated at destination pixels; normalized mode divides
+    /// by accumulated weights and implements the average soft-splat used by UPR-Net.
+    /// </summary>
+    Tensor<T> ForwardSplat<T>(
+        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7);
+
+    /// <summary>Gradient of <see cref="ForwardSplat{T}"/> with respect to its input.</summary>
+    Tensor<T> ForwardSplatBackwardInput<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
+        bool normalize = true, double epsilon = 1e-7);
+
+    /// <summary>Gradient of <see cref="ForwardSplat{T}"/> with respect to its flow.</summary>
+    Tensor<T> ForwardSplatBackwardFlow<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
+        bool normalize = true, double epsilon = 1e-7);
+
+    /// <summary>
     /// Extracts sliding local blocks (patches) from a batched input tensor.
     /// Similar to PyTorch's torch.nn.functional.unfold (im2col).
     /// Input shape: [batch, channels, height, width]

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -5967,17 +5967,17 @@ public interface IEngine
     /// by accumulated weights and implements the average soft-splat used by UPR-Net.
     /// </summary>
     Tensor<T> ForwardSplat<T>(
-        Tensor<T> input, Tensor<T> flow, bool normalize = true, double epsilon = 1e-7);
+        Tensor<T> input, Tensor<T> flow, bool normalize = true);
 
     /// <summary>Gradient of <see cref="ForwardSplat{T}"/> with respect to its input.</summary>
     Tensor<T> ForwardSplatBackwardInput<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow,
-        bool normalize = true, double epsilon = 1e-7);
+        bool normalize = true);
 
     /// <summary>Gradient of <see cref="ForwardSplat{T}"/> with respect to its flow.</summary>
     Tensor<T> ForwardSplatBackwardFlow<T>(
         Tensor<T> gradOutput, Tensor<T> input, Tensor<T> flow, Tensor<T> output,
-        bool normalize = true, double epsilon = 1e-7);
+        bool normalize = true);
 
     /// <summary>
     /// Extracts sliding local blocks (patches) from a batched input tensor.

--- a/tests/AiDotNet.Tensors.Benchmarks/Conv3DBackwardBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Conv3DBackwardBenchmarks.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Conv3D backward acceptance benchmark for video-diffusion temporal blocks.
+/// The previous seven-loop implementation made this operation the dominant
+/// StableVideoSR training hot path. These shapes retain four-frame temporal
+/// depth and the 64/256-channel profiles used by the U-Net while keeping the
+/// benchmark practical on a developer workstation.
+///
+/// Run:
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- \
+///     --conv3d-backward
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 8)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class Conv3DBackwardBenchmarks
+{
+    private static readonly int[] Stride = [1, 1, 1];
+    private static readonly int[] Padding = [1, 1, 1];
+    private static readonly int[] Dilation = [1, 1, 1];
+
+    [Params(64, 256)]
+    public int Channels { get; set; }
+
+    private CpuEngine _engine = null!;
+    private Tensor<float> _input = null!;
+    private Tensor<float> _kernel = null!;
+    private Tensor<float> _gradOutput = null!;
+    private int[] _inputShape = null!;
+    private int[] _kernelShape = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+        _inputShape = [1, Channels, 4, 8, 8];
+        _kernelShape = [Channels, Channels, 3, 3, 3];
+        _input = Tensor<float>.CreateRandom(_inputShape);
+        _kernel = Tensor<float>.CreateRandom(_kernelShape);
+        _gradOutput = Tensor<float>.CreateRandom(_inputShape);
+    }
+
+    [Benchmark(Baseline = true, Description = "Conv3D dInput (video temporal block)")]
+    public Tensor<float> InputGradient()
+        => _engine.Conv3DBackwardInput(
+            _gradOutput, _kernel, _inputShape, Stride, Padding, Dilation);
+
+    [Benchmark(Description = "Conv3D dKernel (video temporal block)")]
+    public Tensor<float> KernelGradient()
+        => _engine.Conv3DBackwardKernel(
+            _gradOutput, _input, _kernelShape, Stride, Padding, Dilation);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -1331,6 +1331,14 @@ class Program
             return;
         }
 
+        // Conv3D backward at four-frame video-diffusion temporal-block shapes.
+        // This is the regression surface for the im2col/GEMM dInput and dKernel paths.
+        if (args[0] == "--conv3d-backward")
+        {
+            BenchmarkRunner.Run<Conv3DBackwardBenchmarks>(BenchConfig);
+            return;
+        }
+
         // FP64 primitive ops (BatchNorm, LayerNorm, Softmax, activations,
         // pools). Stage 0 baseline for Stage 4 SIMD ports of currently-scalar
         // FP64 primitives. (~10-20min).
@@ -1526,6 +1534,7 @@ class Program
         Console.WriteLine("  --dit-xl-matmul     : SimdGemm at DiT-XL shapes; compare against docs/mkl-replacement/baseline/baseline-iter17.md for vs-MKL numbers");
         Console.WriteLine("  --dit-xl-matmul-double : FP64 GEMM at DiT-XL + cluster-#6 shapes; Stage 0 baseline (docs/mkl-replacement/PLAN.md)");
         Console.WriteLine("  --conv2d-backward-double : FP64 Conv2DBackward dW+dX across cluster-#6 shapes; Stage 0 baseline");
+        Console.WriteLine("  --conv3d-backward : FP32 Conv3D dInput+dKernel at video-diffusion temporal-block shapes");
         Console.WriteLine("  --fp64-primitives   : FP64 BN/LN/Softmax/activations/pools; Stage 0 baseline for Stage 4");
         Console.WriteLine("  --dit-xl-sdpa       : ScaledDotProductAttention at DiT-XL shape [4,16,256,72] (Issue #162 SDPA fix)");
         Console.WriteLine("  --transformer-ffn   : Small-M transformer FFN matmul (Sgemm+Dgemm+batched) — Issue #245 coverage");

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -511,6 +511,12 @@ class Program
             return;
         }
 
+        if (args[0] == "--video-warp")
+        {
+            BenchmarkRunner.Run<VideoWarpBenchmarks>(BenchConfig);
+            return;
+        }
+
         // #209 close-parity: A/B test the Conv3x3Stride1 variants
         // (per-channel, 2-oc-blocked, 4-oc-blocked) on shared shapes
         // in the same process. Faster turnaround than full BDN.
@@ -1527,6 +1533,7 @@ class Program
         Console.WriteLine("A/B microkernel + dispatch benchmarks:");
         Console.WriteLine("  --ab-parallel          : head-to-head of CPU parallel-dispatch primitives (Parallel.For vs LightweightParallel)");
         Console.WriteLine("  --ab-parallel-cpu      : idle-CPU / warm-window simulation for LightweightParallel (AIDOTNET_PPE_WARMWINDOW_US)");
+        Console.WriteLine("  --video-warp           : forward-splat flat-storage/batch-parallel benchmark vs former indexer path");
         Console.WriteLine("  --ab-matmul            : A/B GEMM (FP32) across catalog shapes");
         Console.WriteLine("  --ab-conv2d            : A/B Conv2D (FP32)");
         Console.WriteLine("  --ab-conv2d-double     : A/B Conv2D (FP64)");

--- a/tests/AiDotNet.Tensors.Benchmarks/VideoWarpBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/VideoWarpBenchmarks.cs
@@ -1,0 +1,101 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Measures the production flat-storage, batch-parallel forward splat against the
+/// former rank-4-indexer implementation at representative UPRNet feature-map shapes.
+/// </summary>
+[MemoryDiagnoser]
+public class VideoWarpBenchmarks
+{
+    private readonly CpuEngine _engine = new();
+    private Tensor<float> _input = null!;
+    private Tensor<float> _flow = null!;
+
+    [Params(1, 4)]
+    public int Batch { get; set; }
+
+    [Params(32)]
+    public int Channels { get; set; }
+
+    [Params(64)]
+    public int SpatialSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(951);
+        int pixels = Batch * SpatialSize * SpatialSize;
+        _input = new Tensor<float>(
+            Enumerable.Range(0, pixels * Channels)
+                .Select(_ => random.NextSingle() * 2f - 1f).ToArray(),
+            [Batch, Channels, SpatialSize, SpatialSize]);
+        _flow = new Tensor<float>(
+            Enumerable.Range(0, pixels * 2)
+                .Select(_ => random.NextSingle() * 1.5f - 0.75f).ToArray(),
+            [Batch, 2, SpatialSize, SpatialSize]);
+    }
+
+    [Benchmark(Baseline = true)]
+    public Tensor<float> FormerIndexerImplementation()
+    {
+        int height = SpatialSize;
+        int width = SpatialSize;
+        var accumulated = new Tensor<float>(_input.Shape.ToArray());
+        var weights = new double[Batch * height * width];
+
+        for (int batch = 0; batch < Batch; batch++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            double destinationX = x + _flow[batch, 0, y, x];
+            double destinationY = y + _flow[batch, 1, y, x];
+            int x0 = (int)Math.Floor(destinationX);
+            int y0 = (int)Math.Floor(destinationY);
+            double fractionX = destinationX - x0;
+            double fractionY = destinationY - y0;
+            Accumulate(x0, y0, (1.0 - fractionX) * (1.0 - fractionY));
+            Accumulate(x0 + 1, y0, fractionX * (1.0 - fractionY));
+            Accumulate(x0, y0 + 1, (1.0 - fractionX) * fractionY);
+            Accumulate(x0 + 1, y0 + 1, fractionX * fractionY);
+
+            void Accumulate(int destinationPixelX, int destinationPixelY, double weight)
+            {
+                if ((uint)destinationPixelX >= (uint)width ||
+                    (uint)destinationPixelY >= (uint)height || weight == 0.0)
+                    return;
+
+                weights[(batch * height + destinationPixelY) * width + destinationPixelX] += weight;
+                float typedWeight = (float)weight;
+                for (int channel = 0; channel < Channels; channel++)
+                {
+                    accumulated[batch, channel, destinationPixelY, destinationPixelX] +=
+                        _input[batch, channel, y, x] * typedWeight;
+                }
+            }
+        }
+
+        var result = new Tensor<float>(_input.Shape.ToArray());
+        for (int batch = 0; batch < Batch; batch++)
+        for (int y = 0; y < height; y++)
+        for (int x = 0; x < width; x++)
+        {
+            double weight = weights[(batch * height + y) * width + x];
+            float denominator = (float)(weight == 0.0 ? 1.0 : weight);
+            for (int channel = 0; channel < Channels; channel++)
+            {
+                result[batch, channel, y, x] =
+                    accumulated[batch, channel, y, x] / denominator;
+            }
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public Tensor<float> FlatStorageBatchParallel()
+        => _engine.ForwardSplat(_input, _flow, normalize: true);
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -215,7 +215,9 @@ public class DifferentiableOpsGradCheckSweep
         [
             SafeTensor([1, 2, 3, 3], r),
             SafeTensor([1, 2, 3, 3], r),
-            true
+            // Exercise the unnormalized branch here; VideoWarpOperationsTests performs
+            // full input-and-flow finite differences for both false and true.
+            false
         ],
         ["AffineGrid"] = r => [SafeTensor([1, 2, 3], r), 3, 3],
         ["AffineGrid3D"] = r => [SafeTensor([1, 3, 4], r), 2, 2, 2, false],

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -211,6 +211,12 @@ public class DifferentiableOpsGradCheckSweep
 
         // --- sampling grids: grid is [N, H, W, 2] for 2-D, theta is [N, 2, 3] ---
         ["GridSample|T,T"] = r => [SafeTensor([1, 2, 4, 4], r), SafeTensor([1, 3, 3, 2], r)],
+        ["ForwardSplat|T,T,bool"] = r =>
+        [
+            SafeTensor([1, 2, 3, 3], r),
+            SafeTensor([1, 2, 3, 3], r),
+            true
+        ],
         ["AffineGrid"] = r => [SafeTensor([1, 2, 3], r), 3, 3],
         ["AffineGrid3D"] = r => [SafeTensor([1, 3, 4], r), 2, 2, 2, false],
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -501,6 +501,83 @@ public class GradientCorrectnessTests : IDisposable
             Assert.Equal(eager[x][i], ckpt[x][i], 3);
     }
 
+    [Fact]
+    public void Checkpoint_SelectedParameters_SkipsFrozenWeightsAndPreservesInputVjp()
+    {
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var frozen = MakeFilled([3, 3], -0.2f, 0.03f);
+        var trainable = MakeFilled([3, 2], 0.1f, 0.02f);
+        var outW = MakeFilled([2, 2], 0.3f, 0.01f);
+        Func<Tensor<float>, Tensor<float>> segment = input =>
+            _engine.TensorMatMul(_engine.ReLU(_engine.TensorMatMul(input, frozen)), trainable);
+
+        Dictionary<Tensor<float>, Tensor<float>> RunEager()
+        {
+            using var tape = new GradientTape<float>();
+            var output = segment(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(output, outW));
+            return tape.ComputeGradients(loss, sources: [x, trainable]);
+        }
+
+        Dictionary<Tensor<float>, Tensor<float>> RunCheckpointed()
+        {
+            using var tape = new GradientTape<float>();
+            bool forwardCompleted = false;
+            Func<Tensor<float>, Tensor<float>> observedSegment = input =>
+            {
+                var output = segment(input);
+                forwardCompleted = true;
+                return output;
+            };
+            var output = GradientCheckpointing<float>.Checkpoint(
+                [observedSegment],
+                x,
+                parameterSourceFactory: () =>
+                {
+                    Assert.True(forwardCompleted,
+                        "Lazy parameter selection must run after the checkpoint forward.");
+                    return [trainable];
+                },
+                segmentSize: 1);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(output, outW));
+            return tape.ComputeGradients(loss, sources: [x, trainable, frozen]);
+        }
+
+        var eager = RunEager();
+        var checkpointed = RunCheckpointed();
+
+        Assert.False(checkpointed.ContainsKey(frozen),
+            "A frozen parameter excluded from the checkpoint source set must not allocate a gradient.");
+        foreach (var tensor in new[] { x, trainable })
+        {
+            Assert.True(checkpointed.ContainsKey(tensor));
+            for (int i = 0; i < eager[tensor].Length; i++)
+                Assert.Equal(eager[tensor][i], checkpointed[tensor][i], 3);
+        }
+    }
+
+    [Fact]
+    public void Checkpoint_MultipleFusedSegments_PreservesForwardValues()
+    {
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
+        var b0 = MakeFilled([4], 0.05f, 0.01f);
+        var w1 = MakeFilled([4, 4], -0.2f, 0.02f);
+        var b1 = MakeFilled([4], 0.03f, 0.01f);
+        Func<Tensor<float>, Tensor<float>> seg0 = input =>
+            _engine.FusedLinear(input, w0, b0, FusedActivationType.None);
+        Func<Tensor<float>, Tensor<float>> seg1 = input =>
+            _engine.FusedLinear(input, w1, b1, FusedActivationType.None);
+
+        Tensor<float> eager;
+        using (GradientTape<float>.NoGrad()) eager = seg1(seg0(x));
+        using var tape = new GradientTape<float>();
+        var checkpointed = GradientCheckpointing<float>.Checkpoint([seg0, seg1], x, segmentSize: 1);
+
+        for (int i = 0; i < eager.Length; i++)
+            Assert.Equal(eager[i], checkpointed[i], 6);
+    }
+
     /// <summary>
     /// MULTI-SEGMENT variant: two matmul segments checkpointed with segmentSize=1 (one segment each).
     /// Each segment's input and weight gradients must match the eager run. Guards against cross-segment

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -458,6 +458,34 @@ public class GradientCorrectnessTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Checkpoint_NonContiguousSegmentBoundary_MatchesEagerValuesAndGradients()
+    {
+        var x = MakeFilled([2, 3], -0.4f, 0.2f);
+        var weights = MakeFilled([3, 2], 0.1f, 0.05f);
+        Func<Tensor<float>, Tensor<float>> transpose = input =>
+            _engine.TensorPermute(input, [1, 0]);
+
+        (Tensor<float> Output, Tensor<float> Gradient) Run(bool checkpoint)
+        {
+            using var tape = new GradientTape<float>();
+            var output = checkpoint
+                ? GradientCheckpointing<float>.Checkpoint([transpose], x, segmentSize: 1)
+                : transpose(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(output, weights));
+            var gradients = tape.ComputeGradients(loss, [x]);
+            return (output, gradients[x]);
+        }
+
+        var eager = Run(checkpoint: false);
+        var checkpointed = Run(checkpoint: true);
+        Assert.Equal(eager.Output.Shape, checkpointed.Output.Shape);
+        for (int i = 0; i < eager.Output.Length; i++)
+            Assert.Equal(eager.Output[i], checkpointed.Output[i], 5);
+        for (int i = 0; i < eager.Gradient.Length; i++)
+            Assert.Equal(eager.Gradient[i], checkpointed.Gradient[i], 5);
+    }
+
     /// <summary>
     /// A checkpointed segment that uses a WEIGHT (matmul) must produce a weight gradient identical to
     /// the eager (non-checkpointed) run — not just the input gradient. Activation checkpointing is a

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Verifies that requested-source reachability can omit frozen parameter gradients without
+/// changing gradients for trainable parameters earlier in the graph.
+/// </summary>
+public sealed class RequestedSourcePruningTests
+{
+    [Fact]
+    public void Conv2D_FrozenDownstreamKernel_PreservesUpstreamTrainableGradient()
+    {
+        var complete = Run(includeFrozenKernel: true);
+        var pruned = Run(includeFrozenKernel: false);
+
+        Assert.Equal(complete.TrainableGradient, pruned.TrainableGradient);
+        Assert.True(complete.FrozenGradientProduced);
+        Assert.False(pruned.FrozenGradientProduced);
+    }
+
+    [Fact]
+    public void EmptyRequestedSources_ProducesNoGradients()
+    {
+        var engine = new CpuEngine();
+        var input = Sequence([1, 2, 4, 4], 0.01f, 0.002f);
+        var kernel = Sequence([2, 2, 3, 3], -0.02f, 0.001f);
+
+        using var tape = new GradientTape<float>();
+        var output = engine.Conv2D(input, kernel, stride: 1, padding: 1, dilation: 1);
+        var loss = engine.ReduceSum(output);
+        var gradients = tape.ComputeGradients(loss, Array.Empty<Tensor<float>>());
+
+        Assert.Empty(gradients);
+        Assert.Null(input.Grad);
+        Assert.Null(kernel.Grad);
+    }
+
+    private static (float[] TrainableGradient, bool FrozenGradientProduced) Run(
+        bool includeFrozenKernel)
+    {
+        var engine = new CpuEngine();
+        var input = Sequence([1, 2, 5, 5], -0.05f, 0.003f);
+        var trainableKernel = Sequence([3, 2, 3, 3], 0.02f, -0.0007f);
+        var frozenKernel = Sequence([2, 3, 3, 3], -0.01f, 0.0005f);
+
+        using var tape = new GradientTape<float>();
+        var hidden = engine.Conv2D(
+            input, trainableKernel, stride: 1, padding: 1, dilation: 1);
+        var output = engine.Conv2D(
+            hidden, frozenKernel, stride: 1, padding: 1, dilation: 1);
+        var loss = engine.ReduceSum(engine.TensorMultiply(output, output));
+        Tensor<float>[] sources = includeFrozenKernel
+            ? [trainableKernel, frozenKernel]
+            : [trainableKernel];
+
+        var gradients = tape.ComputeGradients(loss, sources);
+
+        return (
+            gradients[trainableKernel].AsSpan().ToArray(),
+            gradients.ContainsKey(frozenKernel));
+    }
+
+    private static Tensor<float> Sequence(int[] shape, float start, float step)
+    {
+        int length = shape.Aggregate(1, (product, dimension) => product * dimension);
+        var values = new float[length];
+        for (int i = 0; i < values.Length; i++) values[i] = start + i * step;
+        return new Tensor<float>(values, shape);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
@@ -11,8 +11,21 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// Verifies that requested-source reachability can omit frozen parameter gradients without
 /// changing gradients for trainable parameters earlier in the graph.
 /// </summary>
-public sealed class RequestedSourcePruningTests
+[Collection("EngineCurrentGlobalState")]
+public sealed class RequestedSourcePruningTests : IDisposable
 {
+    private readonly IEngine _priorEngine;
+    private readonly CpuEngine _engine;
+
+    public RequestedSourcePruningTests()
+    {
+        _priorEngine = AiDotNetEngine.Current;
+        _engine = new CpuEngine();
+        AiDotNetEngine.Current = _engine;
+    }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
     [Fact]
     public void Conv2D_FrozenDownstreamKernel_PreservesUpstreamTrainableGradient()
     {
@@ -27,13 +40,12 @@ public sealed class RequestedSourcePruningTests
     [Fact]
     public void EmptyRequestedSources_ProducesNoGradients()
     {
-        var engine = new CpuEngine();
         var input = Sequence([1, 2, 4, 4], 0.01f, 0.002f);
         var kernel = Sequence([2, 2, 3, 3], -0.02f, 0.001f);
 
         using var tape = new GradientTape<float>();
-        var output = engine.Conv2D(input, kernel, stride: 1, padding: 1, dilation: 1);
-        var loss = engine.ReduceSum(output);
+        var output = _engine.Conv2D(input, kernel, stride: 1, padding: 1, dilation: 1);
+        var loss = _engine.ReduceSum(output);
         var gradients = tape.ComputeGradients(loss, Array.Empty<Tensor<float>>());
 
         Assert.Empty(gradients);
@@ -41,20 +53,71 @@ public sealed class RequestedSourcePruningTests
         Assert.Null(kernel.Grad);
     }
 
-    private static (float[] TrainableGradient, bool FrozenGradientProduced) Run(
+    [Fact]
+    public void SelectiveFusedLinear_WritesPaddedRentalBackingStorage()
+    {
+        const int size = 33; // 1089 elements: ArrayPool normally returns a padded 2048-slot array.
+        var input = new Tensor<float>(new float[size * size], [size, size]);
+        var weightData = new float[size * size];
+        for (int i = 0; i < size; i++) weightData[i * size + i] = 1f;
+        var weight = new Tensor<float>(weightData, [size, size]);
+        var bias = new Tensor<float>(new float[size], [size]);
+
+        using var tape = new GradientTape<float>();
+        var output = _engine.FusedLinear(input, weight, bias, FusedActivationType.None);
+        var loss = _engine.ReduceSum(output);
+        var gradients = tape.ComputeGradients(loss, [input]);
+
+        Assert.True(gradients.ContainsKey(input));
+        foreach (float value in gradients[input].AsSpan()) Assert.Equal(1f, value, 5);
+    }
+
+    [Fact]
+    public void LargeSourceFilter_PreservesRetainedAndHookedIntermediate()
+    {
+        var requested = new Tensor<float>([2f], [1]);
+        var unrequested = new Tensor<float>([3f], [1]);
+        using var tape = new GradientTape<float>(
+            new GradientTapeOptions { EnableHooks = true });
+
+        Tensor<float> requestedBranch = requested;
+        Tensor<float> retainedBranch = unrequested;
+        for (int i = 0; i < 105; i++)
+        {
+            requestedBranch = _engine.TensorMultiplyScalar(requestedBranch, 1f);
+            retainedBranch = _engine.TensorMultiplyScalar(retainedBranch, 1f);
+        }
+
+        bool hookCalled = false;
+        tape.RetainGrad(retainedBranch);
+        tape.RegisterHook(retainedBranch, gradient =>
+        {
+            hookCalled = true;
+            return gradient;
+        });
+
+        var loss = _engine.ReduceSum(_engine.TensorAdd(requestedBranch, retainedBranch));
+        var gradients = tape.ComputeGradients(loss, [requested]);
+
+        Assert.True(hookCalled);
+        Assert.NotNull(retainedBranch.Grad);
+        Assert.Equal(1f, retainedBranch.Grad![0], 5);
+        Assert.Equal(1f, gradients[requested][0], 5);
+    }
+
+    private (float[] TrainableGradient, bool FrozenGradientProduced) Run(
         bool includeFrozenKernel)
     {
-        var engine = new CpuEngine();
         var input = Sequence([1, 2, 5, 5], -0.05f, 0.003f);
         var trainableKernel = Sequence([3, 2, 3, 3], 0.02f, -0.0007f);
         var frozenKernel = Sequence([2, 3, 3, 3], -0.01f, 0.0005f);
 
         using var tape = new GradientTape<float>();
-        var hidden = engine.Conv2D(
+        var hidden = _engine.Conv2D(
             input, trainableKernel, stride: 1, padding: 1, dilation: 1);
-        var output = engine.Conv2D(
+        var output = _engine.Conv2D(
             hidden, frozenKernel, stride: 1, padding: 1, dilation: 1);
-        var loss = engine.ReduceSum(engine.TensorMultiply(output, output));
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(output, output));
         Tensor<float>[] sources = includeFrozenKernel
             ? [trainableKernel, frozenKernel]
             : [trainableKernel];

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GotoGemmRoutingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GotoGemmRoutingTests.cs
@@ -1,0 +1,26 @@
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+public sealed class GotoGemmRoutingTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(47)]
+    public void IsPreferredForThreadBudget_RejectsSmallAndMidSizedMachines(int threadBudget)
+    {
+        Assert.False(GotoGemmFp32.IsPreferredForThreadBudget(threadBudget));
+    }
+
+    [Theory]
+    [InlineData(48)]
+    [InlineData(64)]
+    [InlineData(128)]
+    public void IsPreferredForThreadBudget_AllowsManyCoreMachines(int threadBudget)
+    {
+        Assert.True(GotoGemmFp32.IsPreferredForThreadBudget(threadBudget));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class LazyGraphCompilerPerformanceTests
+{
+    [Fact]
+    public void Compile_WideFanInGraph_StaysBelowQuadraticRuntime()
+    {
+        const int producerCount = 50_000;
+        var producers = new StubLazyNode[producerCount];
+        var rawNodes = new List<ILazyNode>(producerCount + 1);
+        for (int i = 0; i < producers.Length; i++)
+        {
+            producers[i] = new StubLazyNode();
+            rawNodes.Add(producers[i]);
+        }
+
+        var sink = new StubLazyNode(producers);
+        rawNodes.Add(sink);
+
+        var stopwatch = Stopwatch.StartNew();
+        var compiled = new LazyGraphCompiler().Compile(rawNodes);
+        stopwatch.Stop();
+
+        Assert.Equal(producerCount + 1, compiled.Count);
+        Assert.Same(sink, compiled[^1]);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Compiling a {producerCount:N0}-producer fan-in graph took " +
+            $"{stopwatch.Elapsed.TotalSeconds:F2}s; the ready scheduler regressed toward O(V^2).");
+    }
+
+    private sealed class StubLazyNode : ILazyNode
+    {
+        private static readonly IEngine StubEngine = new CpuEngine();
+        private readonly ILazyNode[] _inputs;
+
+        public StubLazyNode(params ILazyNode[] inputs) => _inputs = inputs;
+
+        public LazyNodeType OpType => LazyNodeType.Negate;
+        public int[] OutputShape { get; } = [1];
+        public bool IsRealized { get; set; }
+        public int TopologicalIndex { get; set; }
+        public int ConsumerCount { get; set; }
+        public IEngine RecordingEngine => StubEngine;
+
+        public void Realize(IEngine engine) => IsRealized = true;
+        public ILazyNode[] GetInputNodes() => _inputs;
+        public void ClearOutputLazySource() { }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
@@ -71,6 +71,14 @@ public class GeometryGpuParityTests : IDisposable
         }
     }
 
+    private static void AssertNonDegenerate(Tensor<float> tensor, string name)
+    {
+        foreach (float value in tensor.AsSpan())
+            if (Math.Abs(value) > 1e-6f) return;
+        throw new Xunit.Sdk.XunitException(
+            $"{name} is entirely zero; parity would pass vacuously.");
+    }
+
     [SkippableTheory]
     [InlineData(InterpolateMode.Nearest, false)]
     [InlineData(InterpolateMode.Bilinear, false)]
@@ -163,6 +171,9 @@ public class GeometryGpuParityTests : IDisposable
         AssertClose(gpuOutput, cpuOutput, 2e-3f);
         AssertClose(gpuGradients[gpuFirst], cpuGradients[cpuFirst], 3e-3f);
         AssertClose(gpuGradients[gpuSecond], cpuGradients[cpuSecond], 3e-3f);
+        AssertNonDegenerate(cpuOutput, nameof(cpuOutput));
+        AssertNonDegenerate(cpuGradients[cpuFirst], "first gradient");
+        AssertNonDegenerate(cpuGradients[cpuSecond], "second gradient");
     }
 
     [SkippableTheory]

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -128,6 +129,42 @@ public class GeometryGpuParityTests : IDisposable
         AssertClose(g, c);
     }
 
+    [SkippableFact]
+    public void PartialCorrelationVolume_GpuForwardAndBackwardMatchCpu()
+    {
+        SkipIfUnavailable();
+        var gpuFirst = Rand4D(14, 1, 2, 4, 5);
+        var gpuSecond = Rand4D(15, 1, 2, 4, 5);
+        var cpuFirst = new Tensor<float>(gpuFirst.GetDataArray(), gpuFirst.Shape.ToArray());
+        var cpuSecond = new Tensor<float>(gpuSecond.GetDataArray(), gpuSecond.Shape.ToArray());
+        Tensor<float> gpuOutput;
+        Dictionary<Tensor<float>, Tensor<float>> gpuGradients;
+        using (var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<float>())
+        {
+            gpuOutput = _gpu!.PartialCorrelationVolume(gpuFirst, gpuSecond, radius: 1);
+            var loss = _gpu.ReduceSum(gpuOutput, null);
+            gpuGradients = tape.ComputeGradients(loss, [gpuFirst, gpuSecond]);
+        }
+        Assert.True(gpuOutput.IsGpuResident, "Correlation output must remain GPU-resident.");
+        Assert.True(gpuGradients[gpuFirst].IsGpuResident,
+            "First correlation gradient must remain GPU-resident.");
+        Assert.True(gpuGradients[gpuSecond].IsGpuResident,
+            "Second correlation gradient must remain GPU-resident.");
+
+        Tensor<float> cpuOutput;
+        Dictionary<Tensor<float>, Tensor<float>> cpuGradients;
+        using (var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<float>())
+        {
+            cpuOutput = _cpu.PartialCorrelationVolume(cpuFirst, cpuSecond, radius: 1);
+            var loss = _cpu.ReduceSum(cpuOutput, null);
+            cpuGradients = tape.ComputeGradients(loss, [cpuFirst, cpuSecond]);
+        }
+
+        AssertClose(gpuOutput, cpuOutput, 2e-3f);
+        AssertClose(gpuGradients[gpuFirst], cpuGradients[cpuFirst], 3e-3f);
+        AssertClose(gpuGradients[gpuSecond], cpuGradients[cpuSecond], 3e-3f);
+    }
+
     [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]
@@ -141,6 +178,22 @@ public class GeometryGpuParityTests : IDisposable
         var cpu = _cpu.ForwardSplat(input, flow, normalize);
 
         AssertClose(gpu, cpu, 2e-3f);
+    }
+
+    [SkippableFact]
+    public void ForwardSplat_GpuGraphModeRejectsCpuFallback()
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(16, 1, 2, 4, 5);
+        var flow = Rand4D(17, 1, 2, 4, 5, range: 0.35f);
+        using var cache = new CompiledModelCache<float>();
+        Func<Tensor<float>> forward = () => _gpu!.ForwardSplat(input, flow);
+
+        var error = Assert.Throws<NotSupportedException>(() =>
+            cache.GetOrCompileInference([input, flow], forward));
+
+        Assert.Contains("ForwardSplat", error.Message, StringComparison.Ordinal);
+        Assert.Contains("graph capture", error.Message, StringComparison.Ordinal);
     }
 
     [SkippableTheory]
@@ -177,5 +230,31 @@ public class GeometryGpuParityTests : IDisposable
             gradOutput, input, flow, cpuOutput, normalize);
 
         AssertClose(gpu, cpu, 3e-3f);
+    }
+
+    [SkippableFact]
+    public void ForwardSplatBackwardFlow_GpuValidationNamesArgumentsByMode()
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(18, 1, 2, 4, 5);
+        var flow = Rand4D(19, 1, 2, 4, 5, range: 0.35f);
+        var gradOutput = Rand4D(20, 1, 2, 4, 5);
+        var wrongShape = Rand4D(21, 1, 2, 2, 2);
+
+        var gradError = Assert.Throws<ArgumentException>(() =>
+            _gpu!.ForwardSplatBackwardFlow(wrongShape, input, flow, input));
+        Assert.Equal("gradOutput", gradError.ParamName);
+
+        var outputError = Assert.Throws<ArgumentException>(() =>
+            _gpu!.ForwardSplatBackwardFlow(gradOutput, input, flow, wrongShape));
+        Assert.Equal("output", outputError.ParamName);
+
+        var nullOutputError = Assert.Throws<ArgumentNullException>(() =>
+            _gpu!.ForwardSplatBackwardFlow(gradOutput, input, flow, null!));
+        Assert.Equal("output", nullOutputError.ParamName);
+
+        var unnormalized = _gpu!.ForwardSplatBackwardFlow(
+            gradOutput, input, flow, null!, normalize: false);
+        Assert.Equal(flow.Shape.ToArray(), unnormalized.Shape.ToArray());
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GeometryGpuParityTests.cs
@@ -127,4 +127,55 @@ public class GeometryGpuParityTests : IDisposable
         var c = _cpu.AffineGrid3D(theta, 2, 3, 3, alignCorners: false);
         AssertClose(g, c);
     }
+
+    [SkippableTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ForwardSplat_GpuMatchesCpu(bool normalize)
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(6, 1, 2, 4, 5);
+        var flow = Rand4D(7, 1, 2, 4, 5, range: 0.35f);
+
+        var gpu = _gpu!.ForwardSplat(input, flow, normalize);
+        var cpu = _cpu.ForwardSplat(input, flow, normalize);
+
+        AssertClose(gpu, cpu, 2e-3f);
+    }
+
+    [SkippableTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ForwardSplatBackwardInput_GpuMatchesCpu(bool normalize)
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(8, 1, 2, 4, 5);
+        var flow = Rand4D(9, 1, 2, 4, 5, range: 0.35f);
+        var gradOutput = Rand4D(10, 1, 2, 4, 5);
+
+        var gpu = _gpu!.ForwardSplatBackwardInput(gradOutput, input, flow, normalize);
+        var cpu = _cpu.ForwardSplatBackwardInput(gradOutput, input, flow, normalize);
+
+        AssertClose(gpu, cpu, 2e-3f);
+    }
+
+    [SkippableTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ForwardSplatBackwardFlow_GpuMatchesCpu(bool normalize)
+    {
+        SkipIfUnavailable();
+        var input = Rand4D(11, 1, 2, 4, 5);
+        var flow = Rand4D(12, 1, 2, 4, 5, range: 0.35f);
+        var gradOutput = Rand4D(13, 1, 2, 4, 5);
+        var gpuOutput = _gpu!.ForwardSplat(input, flow, normalize);
+        var cpuOutput = _cpu.ForwardSplat(input, flow, normalize);
+
+        var gpu = _gpu.ForwardSplatBackwardFlow(
+            gradOutput, input, flow, gpuOutput, normalize);
+        var cpu = _cpu.ForwardSplatBackwardFlow(
+            gradOutput, input, flow, cpuOutput, normalize);
+
+        AssertClose(gpu, cpu, 3e-3f);
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -483,6 +483,11 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         "PsRoIAlign(Tensor<T>,Tensor<T>,Int32,Int32,Int32,Single,Int32)",
         "PsRoIPool(Tensor<T>,Tensor<T>,Int32,Int32,Int32,Single)",
         "AffineGrid3D(Tensor<T>,Int32,Int32,Int32,Boolean)",
+        // Video forward-warp forward/backward parity is exercised for normalized and
+        // unnormalized splats in GeometryGpuParityTests.
+        "ForwardSplat(Tensor<T>,Tensor<T>,Boolean)",
+        "ForwardSplatBackwardInput(Tensor<T>,Tensor<T>,Tensor<T>,Boolean)",
+        "ForwardSplatBackwardFlow(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Boolean)",
         // backward ops — grad/input/mean/var tensors have mutually-reduced shapes
         "StdBackward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32[])",
         "VarBackward(Tensor<T>,Tensor<T>,Tensor<T>,Int32[])",

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuConsistencyTests.cs
@@ -126,6 +126,26 @@ public class GpuCpuConsistencyTests
     }
 
     [SkippableFact]
+    public void EagerResidentBinary_ReuploadsVersionBumpedInput()
+    {
+        SkipIfNoDirectGpu();
+        using var gpu = new DirectGpuTensorEngine();
+        var left = new Tensor<float>([1f, 2f, 3f, 4f], [4]);
+        var right = new Tensor<float>([2f, 2f, 2f, 2f], [4]);
+
+        var warm = gpu.TensorAdd(left, right).ToArray();
+        Assert.Equal(3f, warm[0], 5);
+
+        // SetFlat bumps Version while leaving the previous resident pointer attached. The eager
+        // resident shortcut must reject that stale snapshot and let the normal upload path refresh it.
+        left[0] = 10f;
+        var refreshed = gpu.TensorAdd(left, right).ToArray();
+
+        Assert.Equal(12f, refreshed[0], 5);
+        Assert.Equal(4f, refreshed[1], 5);
+    }
+
+    [SkippableFact]
     public void HardsigmoidBackward_IsBitIdenticalAtBoundariesAndStaysResident()
     {
         SkipIfNoDirectGpu();

--- a/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
@@ -45,6 +45,18 @@ public sealed class VideoWarpOperationsTests
     }
 
     [Fact]
+    public void ForwardSplat_AverageMatchesReleasedZeroWeightFallbackExactly()
+    {
+        var input = new Tensor<float>([2f, 6f], [1, 1, 1, 2]);
+        var flow = new Tensor<float>([1f, 0f, 0f, 0f], [1, 2, 1, 2]);
+
+        var result = _engine.ForwardSplat(input, flow);
+
+        Assert.Equal(0f, result[0, 0, 0, 0]);
+        Assert.Equal(4f, result[0, 0, 0, 1]);
+    }
+
+    [Fact]
     public void ForwardSplat_BackwardInputAndFlow_MatchFiniteDifferences()
     {
         var inputData = new[] { 0.2f, -0.4f, 0.7f, 1.1f, -0.3f, 0.5f, 0.9f, -0.8f, 0.6f };

--- a/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
@@ -1,0 +1,140 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+public sealed class VideoWarpOperationsTests
+{
+    private readonly CpuEngine _engine = new();
+
+    [Fact]
+    public void PartialCorrelationVolume_RadiusOne_MatchesNeighborhoodOrdering()
+    {
+        var first = new Tensor<float>(Enumerable.Repeat(1f, 9).ToArray(), [1, 1, 3, 3]);
+        var second = new Tensor<float>(Enumerable.Range(1, 9).Select(x => (float)x).ToArray(), [1, 1, 3, 3]);
+
+        var result = _engine.PartialCorrelationVolume(first, second, radius: 1);
+
+        Assert.Equal([1, 9, 3, 3], result.Shape.ToArray());
+        for (int offset = 0; offset < 9; offset++)
+            Assert.Equal(offset + 1f, result[0, offset, 1, 1], 5);
+    }
+
+    [Fact]
+    public void ForwardSplat_ZeroFlow_IsIdentity()
+    {
+        var input = new Tensor<float>([1f, 2f, 3f, 4f], [1, 1, 2, 2]);
+        var flow = new Tensor<float>(new float[8], [1, 2, 2, 2]);
+
+        var result = _engine.ForwardSplat(input, flow);
+
+        AssertClose(input.GetDataArray(), result.GetDataArray(), 1e-5f);
+    }
+
+    [Fact]
+    public void ForwardSplat_OnePixelRight_UsesForwardFlowConvention()
+    {
+        var input = new Tensor<float>([1f, 2f, 3f], [1, 1, 1, 3]);
+        var flow = new Tensor<float>([1f, 1f, 1f, 0f, 0f, 0f], [1, 2, 1, 3]);
+
+        var result = _engine.ForwardSplat(input, flow, normalize: false);
+
+        AssertClose([0f, 1f, 2f], result.GetDataArray(), 1e-6f);
+    }
+
+    [Fact]
+    public void ForwardSplat_BackwardInputAndFlow_MatchFiniteDifferences()
+    {
+        var inputData = new[] { 0.2f, -0.4f, 0.7f, 1.1f, -0.3f, 0.5f, 0.9f, -0.8f, 0.6f };
+        var flowData = Enumerable.Range(0, 18).Select(i => i < 9 ? 0.21f : 0.34f).ToArray();
+        var gradData = Enumerable.Range(1, 9).Select(i => i * 0.07f).ToArray();
+        var input = new Tensor<float>((float[])inputData.Clone(), [1, 1, 3, 3]);
+        var flow = new Tensor<float>((float[])flowData.Clone(), [1, 2, 3, 3]);
+        var gradOutput = new Tensor<float>(gradData, [1, 1, 3, 3]);
+        var output = _engine.ForwardSplat(input, flow);
+
+        var gradInput = _engine.ForwardSplatBackwardInput(gradOutput, input, flow).GetDataArray();
+        var gradFlow = _engine.ForwardSplatBackwardFlow(gradOutput, input, flow, output).GetDataArray();
+
+        const float step = 1e-3f;
+        for (int i = 0; i < inputData.Length; i++)
+        {
+            float numerical = CentralDifference(inputData, i, step,
+                values => Loss(new Tensor<float>(values, [1, 1, 3, 3]), flow, gradOutput));
+            Assert.True(Math.Abs(numerical - gradInput[i]) < 2e-3f,
+                $"input[{i}] analytic={gradInput[i]}, numerical={numerical}");
+        }
+
+        for (int i = 0; i < flowData.Length; i++)
+        {
+            float numerical = CentralDifference(flowData, i, step,
+                values => Loss(input, new Tensor<float>(values, [1, 2, 3, 3]), gradOutput));
+            Assert.True(Math.Abs(numerical - gradFlow[i]) < 3e-3f,
+                $"flow[{i}] analytic={gradFlow[i]}, numerical={numerical}");
+        }
+    }
+
+    [Fact]
+    public void ForwardSplat_CompiledReplay_MatchesEager()
+    {
+        var input = new Tensor<float>(Enumerable.Range(1, 9).Select(i => (float)i).ToArray(), [1, 1, 3, 3]);
+        var flow = new Tensor<float>(Enumerable.Repeat(0.25f, 18).ToArray(), [1, 2, 3, 3]);
+        Func<Tensor<float>> forward = () => _engine.ForwardSplat(input, flow);
+        var eager = forward().GetDataArray();
+        using var cache = new CompiledModelCache<float>();
+        var plan = cache.GetOrCompileInference([input, flow], forward);
+        plan.SetInputs([input, flow]);
+
+        var compiled = plan.Execute().GetDataArray();
+
+        AssertClose(eager, compiled, 1e-5f);
+    }
+
+    [Fact]
+    public void ScaledDotProductAttention_CompiledReplay_PreservesBooleanMask()
+    {
+        var q = new Tensor<float>([1f, 0f, 0f, 1f, 1f, 1f], [1, 1, 3, 2]);
+        var mask = new Tensor<bool>(
+            [true, false, false, true, true, false, true, true, true],
+            [1, 1, 3, 3]);
+        Func<Tensor<float>> forward = () =>
+            _engine.ScaledDotProductAttention(q, q, q, mask, scale: 1.0, out _);
+        var eager = forward().GetDataArray();
+        using var cache = new CompiledModelCache<float>();
+        var plan = cache.GetOrCompileInference(q, forward);
+        plan.SetInputs([q]);
+
+        var compiled = plan.Execute().GetDataArray();
+
+        AssertClose(eager, compiled, 1e-5f);
+    }
+
+    private float Loss(Tensor<float> input, Tensor<float> flow, Tensor<float> gradOutput)
+    {
+        var output = _engine.ForwardSplat(input, flow).GetDataArray();
+        var grad = gradOutput.GetDataArray();
+        float result = 0;
+        for (int i = 0; i < output.Length; i++) result += output[i] * grad[i];
+        return result;
+    }
+
+    private static float CentralDifference(
+        float[] source, int index, float step, Func<float[], float> function)
+    {
+        var plus = (float[])source.Clone();
+        var minus = (float[])source.Clone();
+        plus[index] += step;
+        minus[index] -= step;
+        return (function(plus) - function(minus)) / (2 * step);
+    }
+
+    private static void AssertClose(float[] expected, float[] actual, float tolerance)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(expected[i] - actual[i]) <= tolerance,
+                $"[{i}] expected {expected[i]}, actual {actual[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
@@ -1,10 +1,12 @@
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
+[Collection("CpuParallelSettings")]
 public sealed class VideoWarpOperationsTests
 {
     private readonly CpuEngine _engine = new();
@@ -20,6 +22,48 @@ public sealed class VideoWarpOperationsTests
         Assert.Equal([1, 9, 3, 3], result.Shape.ToArray());
         for (int offset = 0; offset < 9; offset++)
             Assert.Equal(offset + 1f, result[0, offset, 1, 1], 5);
+    }
+
+    [Fact]
+    public void PartialCorrelationVolume_BackwardMatchesFiniteDifferencesForBothInputs()
+    {
+        var firstData = Enumerable.Range(1, 18).Select(i => i * 0.03f - 0.2f).ToArray();
+        var secondData = Enumerable.Range(1, 18).Select(i => 0.4f - i * 0.02f).ToArray();
+        var outputGradient = new Tensor<float>(
+            Enumerable.Range(1, 81).Select(i => i * 0.005f).ToArray(),
+            [1, 9, 3, 3]);
+        var first = new Tensor<float>((float[])firstData.Clone(), [1, 2, 3, 3]);
+        var second = new Tensor<float>((float[])secondData.Clone(), [1, 2, 3, 3]);
+
+        Dictionary<Tensor<float>, Tensor<float>> gradients;
+        using (var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<float>())
+        {
+            var correlation = _engine.PartialCorrelationVolume(first, second, radius: 1);
+            var loss = _engine.ReduceSum(
+                _engine.TensorMultiply(correlation, outputGradient), null);
+            gradients = tape.ComputeGradients(loss, [first, second]);
+        }
+
+        var firstGradient = gradients[first].GetDataArray();
+        var secondGradient = gradients[second].GetDataArray();
+        const float step = 1e-3f;
+        for (int index = 0; index < firstData.Length; index++)
+        {
+            float numerical = CentralDifference(firstData, index, step, values =>
+                CorrelationLoss(
+                    new Tensor<float>(values, [1, 2, 3, 3]), second, outputGradient));
+            Assert.True(Math.Abs(numerical - firstGradient[index]) < 2e-3f,
+                $"first[{index}] analytic={firstGradient[index]}, numerical={numerical}");
+        }
+
+        for (int index = 0; index < secondData.Length; index++)
+        {
+            float numerical = CentralDifference(secondData, index, step, values =>
+                CorrelationLoss(
+                    first, new Tensor<float>(values, [1, 2, 3, 3]), outputGradient));
+            Assert.True(Math.Abs(numerical - secondGradient[index]) < 2e-3f,
+                $"second[{index}] analytic={secondGradient[index]}, numerical={numerical}");
+        }
     }
 
     [Fact]
@@ -56,8 +100,45 @@ public sealed class VideoWarpOperationsTests
         Assert.Equal(4f, result[0, 0, 0, 1]);
     }
 
-    [Fact]
-    public void ForwardSplat_BackwardInputAndFlow_MatchFiniteDifferences()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ForwardSplat_BatchParallelOutputIsBitwiseDeterministic(bool normalize)
+    {
+        const int batch = 4;
+        const int channels = 3;
+        const int height = 64;
+        const int width = 64;
+        var random = new Random(1789);
+        var input = new Tensor<float>(
+            Enumerable.Range(0, batch * channels * height * width)
+                .Select(_ => random.NextSingle() * 2f - 1f).ToArray(),
+            [batch, channels, height, width]);
+        var flow = new Tensor<float>(
+            Enumerable.Range(0, batch * 2 * height * width)
+                .Select(_ => random.NextSingle() * 1.5f - 0.75f).ToArray(),
+            [batch, 2, height, width]);
+        int savedParallelism = CpuParallelSettings.MaxDegreeOfParallelism;
+
+        try
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = 1;
+            var serial = _engine.ForwardSplat(input, flow, normalize).GetDataArray();
+            CpuParallelSettings.MaxDegreeOfParallelism = Math.Max(4, Environment.ProcessorCount);
+            var parallel = _engine.ForwardSplat(input, flow, normalize).GetDataArray();
+
+            Assert.Equal(serial, parallel);
+        }
+        finally
+        {
+            CpuParallelSettings.MaxDegreeOfParallelism = savedParallelism;
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ForwardSplat_BackwardInputAndFlow_MatchFiniteDifferences(bool normalize)
     {
         var inputData = new[] { 0.2f, -0.4f, 0.7f, 1.1f, -0.3f, 0.5f, 0.9f, -0.8f, 0.6f };
         var flowData = Enumerable.Range(0, 18).Select(i => i < 9 ? 0.21f : 0.34f).ToArray();
@@ -65,16 +146,19 @@ public sealed class VideoWarpOperationsTests
         var input = new Tensor<float>((float[])inputData.Clone(), [1, 1, 3, 3]);
         var flow = new Tensor<float>((float[])flowData.Clone(), [1, 2, 3, 3]);
         var gradOutput = new Tensor<float>(gradData, [1, 1, 3, 3]);
-        var output = _engine.ForwardSplat(input, flow);
+        var output = _engine.ForwardSplat(input, flow, normalize);
 
-        var gradInput = _engine.ForwardSplatBackwardInput(gradOutput, input, flow).GetDataArray();
-        var gradFlow = _engine.ForwardSplatBackwardFlow(gradOutput, input, flow, output).GetDataArray();
+        var gradInput = _engine.ForwardSplatBackwardInput(
+            gradOutput, input, flow, normalize).GetDataArray();
+        var gradFlow = _engine.ForwardSplatBackwardFlow(
+            gradOutput, input, flow, output, normalize).GetDataArray();
 
         const float step = 1e-3f;
         for (int i = 0; i < inputData.Length; i++)
         {
             float numerical = CentralDifference(inputData, i, step,
-                values => Loss(new Tensor<float>(values, [1, 1, 3, 3]), flow, gradOutput));
+                values => Loss(
+                    new Tensor<float>(values, [1, 1, 3, 3]), flow, gradOutput, normalize));
             Assert.True(Math.Abs(numerical - gradInput[i]) < 2e-3f,
                 $"input[{i}] analytic={gradInput[i]}, numerical={numerical}");
         }
@@ -82,10 +166,36 @@ public sealed class VideoWarpOperationsTests
         for (int i = 0; i < flowData.Length; i++)
         {
             float numerical = CentralDifference(flowData, i, step,
-                values => Loss(input, new Tensor<float>(values, [1, 2, 3, 3]), gradOutput));
+                values => Loss(
+                    input, new Tensor<float>(values, [1, 2, 3, 3]), gradOutput, normalize));
             Assert.True(Math.Abs(numerical - gradFlow[i]) < 3e-3f,
                 $"flow[{i}] analytic={gradFlow[i]}, numerical={numerical}");
         }
+    }
+
+    [Fact]
+    public void ForwardSplatBackwardFlow_ValidatesOnlyValuesUsedByTheSelectedMode()
+    {
+        var input = new Tensor<float>([1f, 2f, 3f, 4f], [1, 1, 2, 2]);
+        var flow = new Tensor<float>(new float[8], [1, 2, 2, 2]);
+        var gradOutput = new Tensor<float>(Enumerable.Repeat(1f, 4).ToArray(), [1, 1, 2, 2]);
+        var wrongShape = new Tensor<float>([1f, 2f], [1, 1, 1, 2]);
+
+        var gradError = Assert.Throws<ArgumentException>(() =>
+            _engine.ForwardSplatBackwardFlow(wrongShape, input, flow, input));
+        Assert.Equal("gradOutput", gradError.ParamName);
+
+        var outputError = Assert.Throws<ArgumentException>(() =>
+            _engine.ForwardSplatBackwardFlow(gradOutput, input, flow, wrongShape));
+        Assert.Equal("output", outputError.ParamName);
+
+        var nullOutputError = Assert.Throws<ArgumentNullException>(() =>
+            _engine.ForwardSplatBackwardFlow(gradOutput, input, flow, null!));
+        Assert.Equal("output", nullOutputError.ParamName);
+
+        var unnormalized = _engine.ForwardSplatBackwardFlow(
+            gradOutput, input, flow, null!, normalize: false);
+        Assert.Equal(flow.Shape.ToArray(), unnormalized.Shape.ToArray());
     }
 
     [Fact]
@@ -123,13 +233,21 @@ public sealed class VideoWarpOperationsTests
         AssertClose(eager, compiled, 1e-5f);
     }
 
-    private float Loss(Tensor<float> input, Tensor<float> flow, Tensor<float> gradOutput)
+    private float Loss(
+        Tensor<float> input, Tensor<float> flow, Tensor<float> gradOutput, bool normalize)
     {
-        var output = _engine.ForwardSplat(input, flow).GetDataArray();
+        var output = _engine.ForwardSplat(input, flow, normalize).GetDataArray();
         var grad = gradOutput.GetDataArray();
         float result = 0;
         for (int i = 0; i < output.Length; i++) result += output[i] * grad[i];
         return result;
+    }
+
+    private float CorrelationLoss(
+        Tensor<float> first, Tensor<float> second, Tensor<float> outputGradient)
+    {
+        var correlation = _engine.PartialCorrelationVolume(first, second, radius: 1);
+        return _engine.TensorSum(_engine.TensorMultiply(correlation, outputGradient));
     }
 
     private static float CentralDifference(

--- a/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
@@ -112,11 +112,11 @@ public sealed class VideoWarpOperationsTests
         var random = new Random(1789);
         var input = new Tensor<float>(
             Enumerable.Range(0, batch * channels * height * width)
-                .Select(_ => random.NextSingle() * 2f - 1f).ToArray(),
+                .Select(_ => (float)random.NextDouble() * 2f - 1f).ToArray(),
             [batch, channels, height, width]);
         var flow = new Tensor<float>(
             Enumerable.Range(0, batch * 2 * height * width)
-                .Select(_ => random.NextSingle() * 1.5f - 0.75f).ToArray(),
+                .Select(_ => (float)random.NextDouble() * 1.5f - 0.75f).ToArray(),
             [batch, 2, height, width]);
         int savedParallelism = CpuParallelSettings.MaxDegreeOfParallelism;
 


### PR DESCRIPTION
## What changed

- add `IEngine.PartialCorrelationVolume` for UPR-Net's radius-bounded local cost volume
- add differentiable `IEngine.ForwardSplat` plus analytical input and flow gradients
- match the released UPR-Net average-splat normalization semantics
- record forward splatting in eager autodiff and compiled graph replay
- preserve boolean attention masks in GraphMode SDPA, required by SVTR local mixing
- expose the shared implementation through `CpuEngine` and `DirectGpuTensorEngine`, covering CUDA, HIP, OpenCL, Metal, Vulkan, and WebGPU
- preserve the public NCHW gradient contract after the GPU flow-gradient kernel's internal NHWC computation

## Review hardening

All nine actionable review threads are fixed and resolved:

- correlation is processed one offset at a time instead of materializing two full `diameter²` buffers
- correlation forward/backward remains GPU-resident through a single explicit tape node
- forward splat uses flat storage, conflict-free batch parallelism, and in-place normalization
- normalized backward computes its denominator field once and shares it across both adjoints
- CPU and GPU backward validate `gradOutput`; `output` is required only when normalization uses it
- compiled GPU splat now fails explicitly instead of silently running on CPU
- saved state uses the established validation helpers
- finite-difference coverage exercises normalized and unnormalized flow gradients
- a BenchmarkDotNet old/new video-warp comparison is available through `--video-warp`

## Why

AiDotNet's UPR-Net implementation cannot match the CVPR 2023 reference architecture with nested model-side loops or backward warps. The released model uses partial correlation and differentiable forward average splatting. These are engine operations so every model gets one trainable contract across all six backends.

The GPU parity suite found and fixed a production defect: `ForwardSplatBackwardFlow` returned `[B,H,W,2]` on the direct-GPU path while CPU and the public API return `[B,2,H,W]`.

## Validation

- Release net10 source build: 0 warnings, 0 errors
- focused video-warp/autodiff/GPU parity suite after review fixes: 25 passed, 0 failed
- benchmark project compile: passed (existing warnings only)
- normalized and unnormalized input/flow finite differences: passed
- CPU serial vs batch-parallel output: bitwise identical
- direct-GPU forward/input-gradient/flow-gradient parity: covered in both normalization modes
- prior head: main build, AVX-512, all 17 GPU parity/tape shards, and Codecov passed
- current head CI is running after the review-fix commit

## Dependency impact

This is the engine dependency for the paper-faithful UPR-Net and SVTR corrections in AiDotNet #2006. Merge this PR before stacked #952, release AiDotNet.Tensors, then update AiDotNet #2006 to the released package and run clean package-only CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added partial correlation volumes and differentiable forward splatting with optional normalization.
  - Added input and flow gradients for video-warp operations on CPU and supported GPUs.
  - Added GPU-resident execution with CPU fallbacks where needed.
  - Added more selective gradient computation and checkpointing support.
  - Improved Conv3D backward performance and compiled graph execution.

- **Bug Fixes**
  - Preserved attention-mask behavior during compiled replay.
  - Improved deterministic results for batched forward splatting.

- **Tests**
  - Expanded CPU, GPU/CPU parity, gradient, replay, and validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->