### PR TITLE
perf(autodiff): accelerate video Conv3D gradients

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -549,6 +549,18 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        if (!needsInputGradient && !needsWeightGradient) return;
+
+        // Requested-source training commonly crosses a frozen linear projection to reach an
+        // earlier activation. The historical kernels still formed BOTH full GEMMs and merely let
+        // AccumulateGrad discard the frozen weight result. At foundation scale that materialized
+        // tens of GiB of gradients which could never be returned. Run only the requested GEMM.
+        if (needsInputGradient != needsWeightGradient
+            && TrySelectiveLinearBackward(gradOutput, inputs, engine, grads))
+            return;
+
         // Float32 + 2D fast paths (SimdGemm and BLAS): compute transposed GEMMs
         // into pooled buffers, then accumulate. Both bypass engine recording
         // (the kernels write directly to managed arrays without going through
@@ -2490,7 +2502,6 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
-        var numOps = MathHelper.GetNumericOperations<T>();
         int dim = (int)savedState[0];
         int start = (int)savedState[1];
         int length = (int)savedState[2];
@@ -2502,17 +2513,19 @@ internal static class BackwardFunctions<T>
         for (int i = 0; i < dim; i++) outerSize *= inShape[i];
         for (int i = dim + 1; i < inShape.Length; i++) innerSize *= inShape[i];
 
+        // A narrow slice is contiguous within each outer-axis slab. Copy one complete slab instead
+        // of indexing every scalar through three managed loops. SegMamba creates thousands of these
+        // nodes; the scalar version dominated its backward pass despite moving contiguous data.
+        int copyLength = checked(length * innerSize);
+        var source = gradOutput.IsContiguous ? gradOutput : gradOutput.Contiguous();
+        ReadOnlySpan<T> sourceSpan = source.AsSpan();
+        Span<T> destinationSpan = inputGrad.AsWritableSpan();
         for (int outer = 0; outer < outerSize; outer++)
-        for (int d = 0; d < length; d++)
-        for (int inner = 0; inner < innerSize; inner++)
         {
-            int srcFlat = (outer * dimSize + (start + d)) * innerSize + inner;
-            int gradFlat = (outer * length + d) * innerSize + inner;
-            if (srcFlat < 0 || srcFlat >= inputGrad.Length)
-                throw new InvalidOperationException($"NarrowBackward: source index {srcFlat} out of range [0, {inputGrad.Length}).");
-            if (gradFlat < 0 || gradFlat >= gradOutput.Length)
-                throw new InvalidOperationException($"NarrowBackward: gradient index {gradFlat} out of range [0, {gradOutput.Length}).");
-            inputGrad[srcFlat] = gradOutput[gradFlat];
+            int destinationOffset = checked((outer * dimSize + start) * innerSize);
+            int sourceOffset = checked(outer * copyLength);
+            sourceSpan.Slice(sourceOffset, copyLength)
+                .CopyTo(destinationSpan.Slice(destinationOffset, copyLength));
         }
         DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
     }
@@ -5835,6 +5848,18 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        bool needsBiasGradient = inputs.Length > 2 && DifferentiableOps.IsGradientRequired(inputs[2]);
+        if (!needsInputGradient && !needsWeightGradient && !needsBiasGradient) return;
+
+        int requiredGradientCount = (needsInputGradient ? 1 : 0)
+            + (needsWeightGradient ? 1 : 0)
+            + (needsBiasGradient ? 1 : 0);
+        if (requiredGradientCount < inputs.Length
+            && TrySelectiveLinearBackward(gradOutput, inputs, engine, grads))
+            return;
+
         // Float32 + 2D fast paths: transposed GEMMs + inline bias sum, no transpose allocation.
         // Same parallel-SimdGemm preference as MatMulBackward to avoid getting
         // single-thread-trapped on installs whose BLAS provider lacks internal
@@ -6085,6 +6110,126 @@ internal static class BackwardFunctions<T>
             var biasGrad = SumToShape(gradOutput, inputs[2]._shape, engine);
             DifferentiableOps.AccumulateGrad(grads, inputs[2], biasGrad, engine);
         }
+    }
+
+    /// <summary>
+    /// Computes only requested gradients for the common contiguous ND-by-2D linear projection.
+    /// </summary>
+    private static bool TrySelectiveLinearBackward(
+        Tensor<T> gradOutput,
+        Tensor<T>[] inputs,
+        IEngine engine,
+        Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        if (engine.SupportsGpu || inputs.Length < 2 || inputs[0].Rank < 2 || inputs[1].Rank != 2
+            || !inputs[0].IsContiguous || !inputs[1].IsContiguous || !gradOutput.IsContiguous)
+            return false;
+
+        int rows = 1;
+        for (int d = 0; d < inputs[0].Rank - 1; d++) rows = checked(rows * inputs[0]._shape[d]);
+        int inputFeatures = inputs[0]._shape[inputs[0].Rank - 1];
+        int outputFeatures = inputs[1]._shape[1];
+        if (inputs[1]._shape[0] != inputFeatures
+            || gradOutput.Length != checked(rows * outputFeatures))
+            return false;
+
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsWeightGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+        bool needsBiasGradient = inputs.Length > 2 && DifferentiableOps.IsGradientRequired(inputs[2]);
+
+        if (typeof(T) == typeof(float))
+        {
+            var grad = (float[])(object)gradOutput.GetDataArray();
+            var input = (float[])(object)inputs[0].GetDataArray();
+            var weight = (float[])(object)inputs[1].GetDataArray();
+            var options = new Engines.BlasManaged.BlasOptions<float>
+            {
+                PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune
+            };
+
+            if (needsInputGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                    grad, outputFeatures, false, weight, outputFeatures, true,
+                    data.AsSpan(0, rows * inputFeatures), inputFeatures,
+                    rows, inputFeatures, outputFeatures, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], result, engine);
+            }
+            if (needsWeightGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<float>(
+                    input, inputFeatures, true, grad, outputFeatures, false,
+                    data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
+                    inputFeatures, outputFeatures, rows, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], result, engine);
+            }
+            if (needsBiasGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
+                var data = (float[])(object)result.GetDataArray();
+                Array.Clear(data, 0, result.Length);
+                for (int row = 0; row < rows; row++)
+                {
+                    int offset = row * outputFeatures;
+                    for (int column = 0; column < outputFeatures; column++)
+                        data[column] += grad[offset + column];
+                }
+                DifferentiableOps.AccumulateGrad(grads, inputs[2], result, engine);
+            }
+            return true;
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            var grad = (double[])(object)gradOutput.GetDataArray();
+            var input = (double[])(object)inputs[0].GetDataArray();
+            var weight = (double[])(object)inputs[1].GetDataArray();
+            var options = new Engines.BlasManaged.BlasOptions<double>
+            {
+                PackingMode = Engines.BlasManaged.PackingMode.DisableAutotune
+            };
+
+            if (needsInputGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<double>(
+                    grad, outputFeatures, false, weight, outputFeatures, true,
+                    data.AsSpan(0, rows * inputFeatures), inputFeatures,
+                    rows, inputFeatures, outputFeatures, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], result, engine);
+            }
+            if (needsWeightGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Engines.BlasManaged.BlasManaged.Gemm<double>(
+                    input, inputFeatures, true, grad, outputFeatures, false,
+                    data.AsSpan(0, inputFeatures * outputFeatures), outputFeatures,
+                    inputFeatures, outputFeatures, rows, options);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], result, engine);
+            }
+            if (needsBiasGradient)
+            {
+                var result = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[2]._shape);
+                var data = (double[])(object)result.GetDataArray();
+                Array.Clear(data, 0, result.Length);
+                for (int row = 0; row < rows; row++)
+                {
+                    int offset = row * outputFeatures;
+                    for (int column = 0; column < outputFeatures; column++)
+                        data[column] += grad[offset + column];
+                }
+                DifferentiableOps.AccumulateGrad(grads, inputs[2], result, engine);
+            }
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -992,6 +992,10 @@ internal static class BackwardFunctions<T>
         var stride = (int[])savedState[0];
         var padding = (int[])savedState[1];
         var dilation = (int[])savedState[2];
+        bool needsInputGradient = DifferentiableOps.IsGradientRequired(inputs[0]);
+        bool needsKernelGradient = DifferentiableOps.IsGradientRequired(inputs[1]);
+
+        if (!needsInputGradient && !needsKernelGradient) return;
 
         // #1662 lever #4: route the conv backward OUTPUT gradients through the per-step arena
         // (AutoTensorCache -> TensorAllocator -> TensorArena) instead of the raw `new float[]`
@@ -1000,26 +1004,38 @@ internal static class BackwardFunctions<T>
         // 98-99.9% for matmul/attention backward). The *Into variants fill a rented buffer and
         // zero it first (accumulate:false -> Array.Clear), so renting uninitialized memory is
         // safe. CPU-only; the GPU engine keeps the allocating path.
-        Tensor<T> gradInput, gradKernel;
         if (engine is CpuEngine cpu)
         {
-            gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
-            gradKernel = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
-            cpu.Conv2DBackwardInputInto(
-                gradInput, gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation, accumulate: false);
-            cpu.Conv2DBackwardKernelInto(
-                gradKernel, gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation, accumulate: false);
+            if (needsInputGradient)
+            {
+                var gradInput = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[0]._shape);
+                cpu.Conv2DBackwardInputInto(
+                    gradInput, gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation, accumulate: false);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+            }
+            if (needsKernelGradient)
+            {
+                var gradKernel = Helpers.AutoTensorCache.RentOrAllocate<T>(inputs[1]._shape);
+                cpu.Conv2DBackwardKernelInto(
+                    gradKernel, gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation, accumulate: false);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+            }
         }
         else
         {
-            gradInput = engine.Conv2DBackwardInput(
-                gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
-            gradKernel = engine.Conv2DBackwardKernel(
-                gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+            if (needsInputGradient)
+            {
+                var gradInput = engine.Conv2DBackwardInput(
+                    gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
+                DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+            }
+            if (needsKernelGradient)
+            {
+                var gradKernel = engine.Conv2DBackwardKernel(
+                    gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+                DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+            }
         }
-
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
     }
 
     /// <summary>Conv1D backward: reshapes 3D inputs to 4D, delegates to Conv2DBackward logic, reshapes back</summary>
@@ -1066,13 +1082,18 @@ internal static class BackwardFunctions<T>
         var padding = (int[])savedState[1];
         var dilation = (int[])savedState[2];
 
-        var gradInput = engine.Conv3DBackwardInput(
-            gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
-        var gradKernel = engine.Conv3DBackwardKernel(
-            gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
-
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        if (DifferentiableOps.IsGradientRequired(inputs[0]))
+        {
+            var gradInput = engine.Conv3DBackwardInput(
+                gradOutput, inputs[1], inputs[0]._shape, stride, padding, dilation);
+            DifferentiableOps.AccumulateGrad(grads, inputs[0], gradInput, engine);
+        }
+        if (DifferentiableOps.IsGradientRequired(inputs[1]))
+        {
+            var gradKernel = engine.Conv3DBackwardKernel(
+                gradOutput, inputs[0], inputs[1]._shape, stride, padding, dilation);
+            DifferentiableOps.AccumulateGrad(grads, inputs[1], gradKernel, engine);
+        }
     }
 
     /// <summary>GridSample backward: uses engine.GridSampleBackwardInput and GridSampleBackwardGrid</summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -186,6 +186,52 @@ internal static class DifferentiableOps
     internal static bool _isBackwardCreateGraph;
 
     /// <summary>
+    /// Requested-source reachability for the current backward pass. A null set preserves the
+    /// historical unfiltered behavior; a non-null set contains exactly the tensors whose
+    /// gradients can reach one of the caller's requested sources.
+    /// </summary>
+    private static class GradientRelevance<T>
+    {
+        [ThreadStatic]
+        internal static HashSet<Tensor<T>>? Current;
+    }
+
+    /// <summary>Installs a requested-source gradient filter for one nested backward scope.</summary>
+    internal static GradientRelevanceScope<T> PushGradientRelevance<T>(
+        HashSet<Tensor<T>>? relevantTensors)
+    {
+        var previous = GradientRelevance<T>.Current;
+        GradientRelevance<T>.Current = relevantTensors;
+        return new GradientRelevanceScope<T>(previous);
+    }
+
+    /// <summary>
+    /// Returns whether backward work for <paramref name="tensor"/> can contribute to a requested
+    /// source. With no explicit source filter every gradient remains required.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsGradientRequired<T>(Tensor<T> tensor)
+    {
+        var relevant = GradientRelevance<T>.Current;
+        return relevant is null || relevant.Contains(tensor);
+    }
+
+    internal readonly struct GradientRelevanceScope<T> : IDisposable
+    {
+        private readonly HashSet<Tensor<T>>? _previous;
+
+        internal GradientRelevanceScope(HashSet<Tensor<T>>? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            GradientRelevance<T>.Current = _previous;
+        }
+    }
+
+    /// <summary>
     /// Returns true if a gradient tape is active and not suppressed.
     /// Use this to guard savedState allocation: only create new object[]
     /// when IsRecording is true, avoiding unnecessary GC pressure during inference.
@@ -552,6 +598,13 @@ internal static class DifferentiableOps
         Tensor<T> grad,
         IEngine engine)
     {
+        // Requested-source pruning: do not retain or propagate gradients that cannot reach a
+        // requested source. GradientTape installs the reachability set before every backward
+        // implementation (compiled chain, GradFn graph, and tape walk), so this also terminates
+        // traversal at the first frozen boundary instead of computing the entire upstream graph
+        // and discarding it only when the final dictionary is filtered.
+        if (!IsGradientRequired(tensor)) return;
+
         // PR #638 A2: mark this scope as grad accumulation so the DirectGpu engine's resident in-place add
         // fast path engages ONLY here (the dedicated, non-aliased gradient leaf) and never hijacks forward
         // in-place ops on aliased activations (that hijack threw CUDA-700). No-op for non-DirectGpu engines.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientCheckpointing.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Autodiff;
@@ -29,6 +30,33 @@ public static class GradientCheckpointing<T>
         IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
         Tensor<T> input,
         int segmentSize = 2)
+        => CheckpointCore(functions, input, parameterSourceFactory: null, segmentSize);
+
+    /// <summary>
+    /// Runs a checkpointed sequence while differentiating only the explicitly selected parameters.
+    /// </summary>
+    /// <remarks>
+    /// The source factory is evaluated after the no-grad forward has materialized lazy parameters.
+    /// This is the activation-checkpointing equivalent of freezing a backbone: the recompute still
+    /// calculates the input VJP needed to cross the frozen block, but it neither allocates nor returns
+    /// gradients for parameters outside <paramref name="parameterSourceFactory"/>.
+    /// </remarks>
+    public static Tensor<T> Checkpoint(
+        IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
+        Tensor<T> input,
+        Func<IReadOnlyList<Tensor<T>>> parameterSourceFactory,
+        int segmentSize = 2)
+    {
+        if (parameterSourceFactory is null)
+            throw new ArgumentNullException(nameof(parameterSourceFactory));
+        return CheckpointCore(functions, input, parameterSourceFactory, segmentSize);
+    }
+
+    private static Tensor<T> CheckpointCore(
+        IReadOnlyList<Func<Tensor<T>, Tensor<T>>> functions,
+        Tensor<T> input,
+        Func<IReadOnlyList<Tensor<T>>>? parameterSourceFactory,
+        int segmentSize)
     {
         if (functions == null || functions.Count == 0) return input;
         if (segmentSize <= 0)
@@ -56,23 +84,46 @@ public static class GradientCheckpointing<T>
 
             // Run segment forward WITHOUT recording (save memory)
             Tensor<T> segmentOutput;
+            using (var segmentArena = TensorArena.Create(poolWhenNested: true))
             using (GradientTape<T>.NoGrad())
             {
                 segmentOutput = segmentInput;
                 for (int i = startIdx; i < endIdx; i++)
                     segmentOutput = functions[i](segmentOutput);
+                // Only the segment boundary escapes. Copy it out, then release every internal
+                // activation instead of letting the caller's outer training arena retain the
+                // no-grad scratch until the end of the whole model step. A nested arena does not
+                // return its buffers to the shared pool because layers may cache internal tensors.
+                segmentOutput = new Tensor<T>(segmentOutput.AsSpan().ToArray(), segmentOutput.Shape.ToArray());
             }
 
-            // Record a single "checkpoint" op that recomputes during backward
+            // Record a single "checkpoint" op that recomputes during backward. A selective
+            // checkpoint records its chosen parameters as logical inputs as well as the segment
+            // boundary. Besides making the dependency explicit, this lets requested-source graph
+            // pruning retain the checkpoint when a caller asks only for trainable parameters.
+            Tensor<T>[]? checkpointInputs = null;
+            if (parameterSourceFactory is not null)
+            {
+                var selected = parameterSourceFactory();
+                var unique = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance);
+                checkpointInputs = new Tensor<T>[selected.Count + 1];
+                checkpointInputs[0] = segmentInput;
+                int write = 1;
+                for (int i = 0; i < selected.Count; i++)
+                {
+                    var parameter = selected[i];
+                    if (parameter is not null && !ReferenceEquals(parameter, segmentInput) && unique.Add(parameter))
+                        checkpointInputs[write++] = parameter;
+                }
+                if (write != checkpointInputs.Length)
+                    Array.Resize(ref checkpointInputs, write);
+            }
+
             int capturedStart = startIdx;
             int capturedEnd = endIdx;
             var capturedFunctions = functions;
 
-            DifferentiableOps.RecordUnary<T>(
-                $"Checkpoint_seg{seg}",
-                segmentOutput,
-                segmentInput,
-                (gradOutput, inputs, output, savedState, eng, grads) =>
+            BackwardFunction<T> backward = (gradOutput, inputs, output, savedState, eng, grads) =>
                 {
                     // RECOMPUTE: run the segment forward again WITH recording so
                     // backward can flow through the ops. Use a fresh, NON-persistent
@@ -85,13 +136,14 @@ public static class GradientCheckpointing<T>
                     // which produces NullReferenceException in
                     // SymbolicBackwardGraphBuilder.Analyze when the cached pattern
                     // does not match the current tape's reachable entries).
-                    using var recomputeTape = new GradientTape<T>(
-                        // SuppressArenaScope: this inner tape runs mid-backward, where the outer
-                        // tape has nulled the thread-current tape, so it would otherwise look like a
-                        // step-boundary tape and Reset() the OUTER tape's arena — corrupting the
-                        // accumulating gradients (#734). It borrows the arena for scratch only.
-                        new GradientTapeOptions { Persistent = false, SuppressArenaScope = true });
                     var reInput = inputs[0];
+                    List<(Tensor<T> Key, Tensor<T> Gradient)> detachedGradients;
+                    using (var recomputeArena = TensorArena.Create(poolWhenNested: true))
+                    using (var recomputeTape = new GradientTape<T>(
+                        // A dedicated nested arena owns this segment's replay. SuppressArenaScope
+                        // keeps the tape from resetting it before gradients are copied out below.
+                        new GradientTapeOptions { Persistent = false, SuppressArenaScope = true }))
+                    {
                     // Detach the segment input so the recompute graph is SELF-CONTAINED: its backward
                     // stops at the segment boundary instead of following reInput's producer into an
                     // EARLIER checkpoint segment. Without this, ComputeGradients(sources: null) below
@@ -101,10 +153,10 @@ public static class GradientCheckpointing<T>
                     // mirrors torch.utils.checkpoint's detach_variable(inputs). StopGradient returns a
                     // fresh leaf (data copy, no GradFn); the input gradient it produces is remapped
                     // back onto the original reInput tensor when scattering below.
-                    var reInputDetached = eng.StopGradient(reInput);
-                    var reOutput = reInputDetached;
-                    for (int i = capturedStart; i < capturedEnd; i++)
-                        reOutput = capturedFunctions[i](reOutput);
+                        var reInputDetached = eng.StopGradient(reInput);
+                        var reOutput = reInputDetached;
+                        for (int i = capturedStart; i < capturedEnd; i++)
+                            reOutput = capturedFunctions[i](reOutput);
 
                     // Vector-Jacobian product (VJP) seed. The previous
                     // implementation computed gradients with the inner tape's
@@ -140,8 +192,8 @@ public static class GradientCheckpointing<T>
                     // tensor — both ops are recorded on the inner tape via the
                     // DifferentiableOps backward registry, so ComputeGradients
                     // walks them and computes the correct VJP into reInput.
-                    var weighted = eng.TensorMultiply(reOutput, gradOutput);
-                    var pseudoLoss = eng.ReduceSum(weighted);
+                        var weighted = eng.TensorMultiply(reOutput, gradOutput);
+                        var pseudoLoss = eng.ReduceSum(weighted);
 
                     // Differentiate the recomputed segment w.r.t. EVERY leaf it touched — the
                     // (detached) segment input AND every weight/parameter the segment's functions
@@ -159,33 +211,50 @@ public static class GradientCheckpointing<T>
                     // instances the caller never queries — harmless. The sole exclusion is gradOutput:
                     // an outer-tape constant folded into the pseudo-loss only to seed the VJP, whose
                     // inner "gradient" (== reOutput) is not a real gradient and must not leak back.
-                    var segGrads = recomputeTape.ComputeGradients(pseudoLoss, sources: null);
+                        Tensor<T>[]? recomputeSources = null;
+                        if (checkpointInputs is not null)
+                        {
+                            recomputeSources = new Tensor<T>[inputs.Length];
+                            recomputeSources[0] = reInputDetached;
+                            for (int i = 1; i < inputs.Length; i++) recomputeSources[i] = inputs[i];
+                        }
+                        var segGrads = recomputeTape.ComputeGradients(pseudoLoss, recomputeSources);
 
-                    bool accumulatedAny = false;
-                    foreach (var kvp in segGrads)
-                    {
-                        if (ReferenceEquals(kvp.Key, gradOutput)) continue;
-                        if (kvp.Value is null) continue;
-                        // The detached input's gradient belongs to the ORIGINAL segment-input tensor
-                        // the caller tracks (and that the outer walk hands to the previous segment);
-                        // remap it. Every other key is a live parameter the segment read directly.
-                        var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
-                        DifferentiableOps.AccumulateGrad(grads, key, kvp.Value, eng);
-                        accumulatedAny = true;
+                        // Segment-recompute arrays must not escape their bounded arena. Preserve only
+                        // the selected VJPs in ordinary owned storage; after this scope disposes, every
+                        // other activation/temporary is immediately reusable by the next block.
+                        detachedGradients = new List<(Tensor<T>, Tensor<T>)>(segGrads.Count);
+                        foreach (var kvp in segGrads)
+                        {
+                            if (ReferenceEquals(kvp.Key, gradOutput) || kvp.Value is null) continue;
+                            var key = ReferenceEquals(kvp.Key, reInputDetached) ? reInput : kvp.Key;
+                            var copied = new Tensor<T>(kvp.Value.AsSpan().ToArray(), kvp.Value.Shape.ToArray());
+                            detachedGradients.Add((key, copied));
+                        }
+
+                        if (detachedGradients.Count == 0 && ReferenceEquals(reOutput, reInputDetached))
+                        {
+                            var copied = new Tensor<T>(gradOutput.AsSpan().ToArray(), gradOutput.Shape.ToArray());
+                            detachedGradients.Add((reInput, copied));
+                        }
                     }
 
-                    // Identity / no-op segment (output IS input by reference, nothing recorded on
-                    // the recompute tape): pass the upstream gradient straight through. Reference-
-                    // equality is the only safe alias predicate — it covers the empty-segment case
-                    // without false positives on shape coincidence. For a genuinely input-
-                    // independent segment, leaving grads[input] untouched (zero) is the correct VJP.
-                    if (!accumulatedAny && ReferenceEquals(reOutput, reInputDetached))
+                    foreach (var (key, gradient) in detachedGradients)
                     {
-                        // Empty / no-op segment (no functions ran): pass the upstream gradient straight
-                        // through to the original input.
-                        DifferentiableOps.AccumulateGrad(grads, reInput, gradOutput, eng);
+                        DifferentiableOps.AccumulateGrad(grads, key, gradient, eng);
                     }
-                });
+                };
+
+            if (checkpointInputs is null)
+            {
+                DifferentiableOps.RecordUnary<T>(
+                    $"Checkpoint_seg{seg}", segmentOutput, segmentInput, backward);
+            }
+            else
+            {
+                DifferentiableOps.RecordIfActive<T>(
+                    $"Checkpoint_seg{seg}", segmentOutput, checkpointInputs, backward);
+            }
 
             current2 = segmentOutput;
         }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -835,6 +835,15 @@ public sealed class GradientTape<T> : IDisposable
         }
         int recordedEntryCount = _entries.Count;
 
+        // Build requested-source reachability once and keep it active across every backward
+        // implementation. Previously only the large-tape interpreter skipped irrelevant nodes;
+        // the normal GradFn/compiled-chain path still computed gradients for frozen parameters
+        // and discarded them at the end. This scope lets heavyweight backward functions skip
+        // individual irrelevant inputs and makes AccumulateGrad stop upstream traversal at a
+        // frozen boundary.
+        using var gradientRelevance = DifferentiableOps.PushGradientRelevance(
+            createGraph ? null : BuildGradientRelevance(loss, sources));
+
         // Auto-training compiler: highest priority — use compiled backward if available.
         // Must be checked BEFORE the graph path because DifferentiableOps always records
         // (GradFn is always set), so the graph path would always win otherwise.
@@ -1346,6 +1355,86 @@ public sealed class GradientTape<T> : IDisposable
         }
 
         return grads;
+    }
+
+    private HashSet<Tensor<T>>? BuildGradientRelevance(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>>? sources)
+    {
+        if (sources is null) return null;
+
+        var relevant = new HashSet<Tensor<T>>(
+            ReferenceEqualityComparer<Tensor<T>>.Instance);
+        foreach (var source in sources) relevant.Add(source);
+
+        // Prefer the GradFn graph because it can cross tape boundaries. Higher-order
+        // differentiation intentionally returns a gradient whose producer nodes belong to an
+        // inner tape; the outer tape records only the operations that consume that gradient.
+        // Building reachability from this tape's entries alone therefore misses the entire
+        // differentiable-gradient chain and incorrectly prunes HVP/Hessian contributions.
+        if (loss.GradFn is not null)
+        {
+            var visited = new HashSet<GradNode<T>>();
+            var topoOrder = new List<GradNode<T>>();
+            TopologicalSort(loss.GradFn, visited, topoOrder);
+
+            // TopologicalSort returns producers before consumers, so source reachability can be
+            // propagated in one forward pass across both current- and cross-tape nodes.
+            foreach (var node in topoOrder)
+            {
+                bool inputRelevant = false;
+                if (node.InputsOverflow is not null)
+                {
+                    foreach (var input in node.InputsOverflow)
+                    {
+                        if (relevant.Contains(input))
+                        {
+                            inputRelevant = true;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    inputRelevant = node.Input0 is not null && relevant.Contains(node.Input0)
+                        || node.InputCount >= 2 && node.Input1 is not null && relevant.Contains(node.Input1)
+                        || node.InputCount >= 3 && node.Input2 is not null && relevant.Contains(node.Input2);
+                }
+
+                if (inputRelevant && node.Output is not null) relevant.Add(node.Output);
+            }
+
+            return relevant;
+        }
+
+        // Tape entries are recorded in forward topological order. An output can contribute to a
+        // requested source exactly when at least one of its inputs is already source-relevant.
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            ref var entry = ref _entries[i];
+            bool inputRelevant = false;
+            if (entry.InputsOverflow is not null)
+            {
+                foreach (var input in entry.InputsOverflow)
+                {
+                    if (relevant.Contains(input))
+                    {
+                        inputRelevant = true;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                inputRelevant = relevant.Contains(entry.Input0)
+                    || entry.InputCount >= 2 && entry.Input1 is not null && relevant.Contains(entry.Input1)
+                    || entry.InputCount >= 3 && entry.Input2 is not null && relevant.Contains(entry.Input2);
+            }
+
+            if (inputRelevant) relevant.Add(entry.Output);
+        }
+
+        return relevant;
     }
 
     private void CleanupTapeEntryGrad(Tensor<T> t, HashSet<Tensor<T>>? sourceSet, HashSet<Tensor<T>> intermediates)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -616,6 +616,7 @@ public static partial class BlasManaged
             && options.PackedA is null && options.PackedB is null
             && options.NumThreads == 0 // only the default (all-core) budget; explicit -1/>0 requests honored below
             && (options.PackingMode == PackingMode.Auto || options.PackingMode == PackingMode.DisableAutotune)
+            && GotoGemmFp32.IsPreferredForThreadBudget(CpuParallelSettings.MaxDegreeOfParallelism)
             && (long)m * n * k >= GotoGemmFp32.ParallelMinWork && GotoGemmFp32.BeatsPackBoth(m, n, k)
             && GotoGemmFp32.IsAvailable)
         {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/GotoGemmFp32.cs
@@ -41,6 +41,16 @@ internal static class GotoGemmFp32
     /// dispatch (below this the per-tile pack/launch overhead dominates — stay on the existing path).</summary>
     internal const long ParallelMinWork = 8L * 1024 * 1024; // ~8.4e6
 
+    /// <summary>
+    /// Returns whether the Goto-style per-tile decomposition is appropriate for the active
+    /// CPU thread budget. This kernel was tuned on a 3990X and wins by assigning many private
+    /// L2-resident tiles concurrently. On smaller machines the redundant panel packing and
+    /// worker coordination can dominate a mixed model workload even when an isolated GEMM is
+    /// competitive. PackBoth is the safer default below this measured crossover.
+    /// </summary>
+    internal static bool IsPreferredForThreadBudget(int maxDegreeOfParallelism)
+        => maxDegreeOfParallelism >= 48;
+
     /// <summary>Shape regime where the per-tile GotoBLAS path beats the PackBoth strategy (measured on the
     /// 3990X via --ab-prod): large/balanced (M≥512) OR wide-K (K≥2N, e.g. MLP-fc2). PackBoth's wide-N
     /// N-axis path wins the small-M wide-N shapes (DiT QKV M256×N3456, MLP-fc1 M256×N4608 — GotoGemm was

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyGraphCompiler.cs
@@ -151,9 +151,34 @@ internal sealed class LazyGraphCompiler
                 }
             }
 
-            // Kahn's algorithm with priority: prefer nodes that feed into
-            // operations that are closest to being ready (lowest remaining in-degree)
-            var ready = new List<ILazyNode>();
+            // Kahn's algorithm with a stable priority queue. The old implementation scanned the
+            // entire ready list for every emitted node. Wide autodiff graphs can have tens of
+            // thousands of simultaneously-ready parameter/gradient producers, turning compilation
+            // into O(V^2) work (SegMamba spent 7.9 of 9.3 seconds in this pass alone).
+            //
+            // The first consumer's original topological position is a stable locality score: among
+            // ready producers, emit the one needed by the earliest downstream operation. This keeps
+            // producers close to consumers without a mutable priority or a full ready-list rescan.
+            var originalOrder = new Dictionary<ILazyNode, int>(nodes.Count);
+            for (int i = 0; i < nodes.Count; i++)
+                originalOrder[nodes[i]] = i;
+
+            int GetLocalityScore(ILazyNode node)
+            {
+                var nodeDependents = dependents[node];
+                return nodeDependents.Count == 0
+                    ? int.MaxValue
+                    : originalOrder[nodeDependents[0]];
+            }
+
+            var ready = new SortedSet<ILazyNode>(Comparer<ILazyNode>.Create((left, right) =>
+            {
+                if (ReferenceEquals(left, right)) return 0;
+                int score = GetLocalityScore(left).CompareTo(GetLocalityScore(right));
+                return score != 0
+                    ? score
+                    : originalOrder[left].CompareTo(originalOrder[right]);
+            }));
             foreach (var node in nodes)
             {
                 if (inDegree[node] == 0)
@@ -163,24 +188,8 @@ internal sealed class LazyGraphCompiler
             var result = new List<ILazyNode>(nodes.Count);
             while (ready.Count > 0)
             {
-                // Pick the ready node whose first dependent has the lowest remaining in-degree
-                // (heuristic: schedule producers right before their consumer becomes ready)
-                int bestIdx = 0;
-                int bestScore = int.MaxValue;
-                for (int i = 0; i < ready.Count; i++)
-                {
-                    var deps = dependents[ready[i]];
-                    int score = deps.Count > 0 ? inDegree[deps[0]] : int.MaxValue;
-                    if (score < bestScore)
-                    {
-                        bestScore = score;
-                        bestIdx = i;
-                    }
-                }
-
-                var chosen = ready[bestIdx];
-                ready[bestIdx] = ready[ready.Count - 1];
-                ready.RemoveAt(ready.Count - 1);
+                var chosen = ready.Min!;
+                ready.Remove(chosen);
                 result.Add(chosen);
 
                 foreach (var dep in dependents[chosen])

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -20148,6 +20148,27 @@ public partial class CpuEngine : ITensorLevelEngine
         int outputHeight = gradOutput._shape[3];
         int outputWidth = gradOutput._shape[4];
 
+        // Conv3D forward already lowers primitive floating-point tensors to im2col + GEMM.
+        // Use the corresponding matrix identity for dInput as well:
+        //   dColumns[rows, C*KD*KH*KW] = dOutput[rows, OC] * kernel[OC, C*KD*KH*KW]
+        // followed by a race-free col2im scatter over independent (batch, input-channel) slices.
+        // The previous implementation evaluated that contraction through seven scalar loops and was
+        // the dominant hot path in paper-scale video-diffusion training. Keep the bounded-workspace
+        // guard and the generic loop below as the fallback for oversized or non-primitive tensors.
+        if ((typeof(T) == typeof(float) || typeof(T) == typeof(double))
+            && TryConv3DBackwardInputGemm(
+                gradOutput, kernel, inputShape,
+                batch, inChannels, depth, height, width,
+                outChannels, kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideD, strideH, strideW,
+                padD, padH, padW,
+                dilationD, dilationH, dilationW,
+                out var gemmGradInput))
+        {
+            return gemmGradInput;
+        }
+
         var gradInputData = new T[batch * inChannels * depth * height * width];
         var gradOutputData = gradOutput.GetDataArray();
         var kernelData = kernel.GetDataArray();
@@ -20340,6 +20361,24 @@ public partial class CpuEngine : ITensorLevelEngine
         int outputHeight = gradOutput._shape[3];
         int outputWidth = gradOutput._shape[4];
 
+        // dKernel is another im2col contraction:
+        //   dKernel^T[K, OC] = columns^T[K, rows] * dOutput[rows, OC].
+        // This shares the exact receptive-field lowering used by Conv3D forward, so stride,
+        // padding, and dilation semantics cannot drift between the forward and backward paths.
+        if ((typeof(T) == typeof(float) || typeof(T) == typeof(double))
+            && TryConv3DBackwardKernelGemm(
+                gradOutput, input, kernelShape,
+                batch, inChannels, depth, height, width,
+                outChannels, kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideD, strideH, strideW,
+                padD, padH, padW,
+                dilationD, dilationH, dilationW,
+                out var gemmGradKernel))
+        {
+            return gemmGradKernel;
+        }
+
         var gradKernelData = new T[outChannels * inChannels * kernelDepth * kernelHeight * kernelWidth];
         var gradOutputData = gradOutput.GetDataArray();
         var inputData = input.GetDataArray();
@@ -20485,6 +20524,338 @@ public partial class CpuEngine : ITensorLevelEngine
         }
 
         return TensorAllocator.Rent<T>(kernelShape, gradKernelData);
+    }
+
+    private static bool TryConv3DBackwardInputGemm<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> kernel,
+        int[] inputShape,
+        int batch,
+        int inChannels,
+        int depth,
+        int height,
+        int width,
+        int outChannels,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth,
+        out Tensor<T> result)
+    {
+        result = null!;
+        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
+        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
+        int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
+        long workspaceBytes = checked((gradOutputElementsLong + columnElementsLong) * elementSize);
+        if (rowsLong <= 0 || columnsPerRowLong <= 0
+            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
+            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
+            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        {
+            return false;
+        }
+
+        int rows = (int)rowsLong;
+        int columnsPerRow = (int)columnsPerRowLong;
+        int spatial = checked(outputDepth * outputHeight * outputWidth);
+        T[]? flatGradOutput = null;
+        T[]? gradColumns = null;
+        try
+        {
+            flatGradOutput = System.Buffers.ArrayPool<T>.Shared.Rent((int)gradOutputElementsLong);
+            gradColumns = System.Buffers.ArrayPool<T>.Shared.Rent((int)columnElementsLong);
+            var gradOutputData = gradOutput.GetReadOnlyDataArray();
+            var kernelData = kernel.GetReadOnlyDataArray();
+            PackConv3DOutputRows(gradOutputData, flatGradOutput, batch, outChannels, spatial);
+
+            bool multiplied;
+            if (typeof(T) == typeof(float))
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    rows, columnsPerRow, outChannels,
+                    (float[])(object)flatGradOutput, 0, outChannels, false,
+                    (float[])(object)kernelData, 0, columnsPerRow, false,
+                    (float[])(object)gradColumns, 0, columnsPerRow);
+            }
+            else
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    rows, columnsPerRow, outChannels,
+                    (double[])(object)flatGradOutput, 0, outChannels, false,
+                    (double[])(object)kernelData, 0, columnsPerRow, false,
+                    (double[])(object)gradColumns, 0, columnsPerRow);
+            }
+            if (!multiplied) return false;
+
+            var gradInputData = new T[checked(batch * inChannels * depth * height * width)];
+            ScatterConv3DColumnsToInput(
+                gradColumns, gradInputData,
+                batch, inChannels, depth, height, width,
+                kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideDepth, strideHeight, strideWidth,
+                padDepth, padHeight, padWidth,
+                dilationDepth, dilationHeight, dilationWidth);
+            result = TensorAllocator.Rent<T>(inputShape, gradInputData);
+            return true;
+        }
+        finally
+        {
+            if (flatGradOutput is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(flatGradOutput);
+            if (gradColumns is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(gradColumns);
+        }
+    }
+
+    private static bool TryConv3DBackwardKernelGemm<T>(
+        Tensor<T> gradOutput,
+        Tensor<T> input,
+        int[] kernelShape,
+        int batch,
+        int inChannels,
+        int depth,
+        int height,
+        int width,
+        int outChannels,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth,
+        out Tensor<T> result)
+    {
+        result = null!;
+        long rowsLong = (long)batch * outputDepth * outputHeight * outputWidth;
+        long columnsPerRowLong = (long)inChannels * kernelDepth * kernelHeight * kernelWidth;
+        long gradOutputElementsLong = rowsLong * outChannels;
+        long columnElementsLong = rowsLong * columnsPerRowLong;
+        long transposedKernelElementsLong = columnsPerRowLong * outChannels;
+        int elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(double);
+        long workspaceBytes = checked(
+            (gradOutputElementsLong + columnElementsLong + transposedKernelElementsLong) * elementSize);
+        if (rowsLong <= 0 || columnsPerRowLong <= 0
+            || rowsLong > int.MaxValue || columnsPerRowLong > int.MaxValue
+            || gradOutputElementsLong > int.MaxValue || columnElementsLong > int.MaxValue
+            || transposedKernelElementsLong > int.MaxValue
+            || workspaceBytes > Conv3DIm2ColWorkspaceBytes)
+        {
+            return false;
+        }
+
+        int rows = (int)rowsLong;
+        int columnsPerRow = (int)columnsPerRowLong;
+        int spatial = checked(outputDepth * outputHeight * outputWidth);
+        T[]? columns = null;
+        T[]? flatGradOutput = null;
+        T[]? transposedGradKernel = null;
+        try
+        {
+            columns = System.Buffers.ArrayPool<T>.Shared.Rent((int)columnElementsLong);
+            flatGradOutput = System.Buffers.ArrayPool<T>.Shared.Rent((int)gradOutputElementsLong);
+            transposedGradKernel = System.Buffers.ArrayPool<T>.Shared.Rent((int)transposedKernelElementsLong);
+            var inputData = input.GetReadOnlyDataArray();
+            var gradOutputData = gradOutput.GetReadOnlyDataArray();
+            Helpers.CpuIm2Col3DHelper.BuildColumns(
+                inputData, columns,
+                batch, inChannels, depth, height, width,
+                kernelDepth, kernelHeight, kernelWidth,
+                outputDepth, outputHeight, outputWidth,
+                strideDepth, strideHeight, strideWidth,
+                padDepth, padHeight, padWidth,
+                dilationDepth, dilationHeight, dilationWidth);
+            PackConv3DOutputRows(gradOutputData, flatGradOutput, batch, outChannels, spatial);
+
+            bool multiplied;
+            if (typeof(T) == typeof(float))
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    columnsPerRow, outChannels, rows,
+                    (float[])(object)columns, 0, columnsPerRow, true,
+                    (float[])(object)flatGradOutput, 0, outChannels, false,
+                    (float[])(object)transposedGradKernel, 0, outChannels);
+            }
+            else
+            {
+                multiplied = Helpers.BlasProvider.TryGemmEx(
+                    columnsPerRow, outChannels, rows,
+                    (double[])(object)columns, 0, columnsPerRow, true,
+                    (double[])(object)flatGradOutput, 0, outChannels, false,
+                    (double[])(object)transposedGradKernel, 0, outChannels);
+            }
+            if (!multiplied) return false;
+
+            var gradKernelData = new T[checked(outChannels * columnsPerRow)];
+            CpuParallelSettings.ParallelForOrSerial(0, outChannels,
+                (long)outChannels * columnsPerRow, oc =>
+            {
+                int destinationBase = oc * columnsPerRow;
+                for (int column = 0; column < columnsPerRow; column++)
+                    gradKernelData[destinationBase + column] =
+                        transposedGradKernel[column * outChannels + oc];
+            }, deterministicSafe: true);
+            result = TensorAllocator.Rent<T>(kernelShape, gradKernelData);
+            return true;
+        }
+        finally
+        {
+            if (columns is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(columns);
+            if (flatGradOutput is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(flatGradOutput);
+            if (transposedGradKernel is not null)
+                System.Buffers.ArrayPool<T>.Shared.Return(transposedGradKernel);
+        }
+    }
+
+    private static void PackConv3DOutputRows<T>(
+        T[] source,
+        T[] destination,
+        int batch,
+        int channels,
+        int spatial)
+    {
+        int rows = checked(batch * spatial);
+        CpuParallelSettings.ParallelForOrSerial(0, rows, (long)rows * channels, row =>
+        {
+            int b = row / spatial;
+            int position = row - b * spatial;
+            int destinationBase = row * channels;
+            for (int channel = 0; channel < channels; channel++)
+                destination[destinationBase + channel] = source[(b * channels + channel) * spatial + position];
+        }, deterministicSafe: true);
+    }
+
+    private static void ScatterConv3DColumnsToInput<T>(
+        T[] columns,
+        T[] gradInput,
+        int batch,
+        int channels,
+        int depth,
+        int height,
+        int width,
+        int kernelDepth,
+        int kernelHeight,
+        int kernelWidth,
+        int outputDepth,
+        int outputHeight,
+        int outputWidth,
+        int strideDepth,
+        int strideHeight,
+        int strideWidth,
+        int padDepth,
+        int padHeight,
+        int padWidth,
+        int dilationDepth,
+        int dilationHeight,
+        int dilationWidth)
+    {
+        int columnsPerRow = checked(channels * kernelDepth * kernelHeight * kernelWidth);
+        int kernelPlane = checked(kernelHeight * kernelWidth);
+        int kernelVolume = checked(kernelDepth * kernelPlane);
+        int outputPlane = checked(outputHeight * outputWidth);
+        int outputSpatial = checked(outputDepth * outputPlane);
+        int inputPlane = checked(height * width);
+        int inputSpatial = checked(depth * inputPlane);
+
+        if (typeof(T) == typeof(float))
+        {
+            var source = (float[])(object)columns;
+            var destination = (float[])(object)gradInput;
+            CpuParallelSettings.ParallelForOrSerial(0, batch * channels,
+                (long)batch * channels * outputSpatial * kernelVolume, index =>
+            {
+                int b = index / channels;
+                int channel = index - b * channels;
+                int destinationChannelBase = (b * channels + channel) * inputSpatial;
+                int columnChannelOffset = channel * kernelVolume;
+                for (int od = 0; od < outputDepth; od++)
+                for (int oh = 0; oh < outputHeight; oh++)
+                for (int ow = 0; ow < outputWidth; ow++)
+                {
+                    int row = b * outputSpatial + od * outputPlane + oh * outputWidth + ow;
+                    int columnBase = row * columnsPerRow + columnChannelOffset;
+                    for (int kd = 0; kd < kernelDepth; kd++)
+                    {
+                        int id = od * strideDepth + kd * dilationDepth - padDepth;
+                        if ((uint)id >= (uint)depth) continue;
+                        for (int kh = 0; kh < kernelHeight; kh++)
+                        {
+                            int ih = oh * strideHeight + kh * dilationHeight - padHeight;
+                            if ((uint)ih >= (uint)height) continue;
+                            int inputRowBase = destinationChannelBase + id * inputPlane + ih * width;
+                            int kernelRowBase = columnBase + kd * kernelPlane + kh * kernelWidth;
+                            for (int kw = 0; kw < kernelWidth; kw++)
+                            {
+                                int iw = ow * strideWidth + kw * dilationWidth - padWidth;
+                                if ((uint)iw < (uint)width)
+                                    destination[inputRowBase + iw] += source[kernelRowBase + kw];
+                            }
+                        }
+                    }
+                }
+            });
+            return;
+        }
+
+        var sourceDouble = (double[])(object)columns;
+        var destinationDouble = (double[])(object)gradInput;
+        CpuParallelSettings.ParallelForOrSerial(0, batch * channels,
+            (long)batch * channels * outputSpatial * kernelVolume, index =>
+        {
+            int b = index / channels;
+            int channel = index - b * channels;
+            int destinationChannelBase = (b * channels + channel) * inputSpatial;
+            int columnChannelOffset = channel * kernelVolume;
+            for (int od = 0; od < outputDepth; od++)
+            for (int oh = 0; oh < outputHeight; oh++)
+            for (int ow = 0; ow < outputWidth; ow++)
+            {
+                int row = b * outputSpatial + od * outputPlane + oh * outputWidth + ow;
+                int columnBase = row * columnsPerRow + columnChannelOffset;
+                for (int kd = 0; kd < kernelDepth; kd++)
+                {
+                    int id = od * strideDepth + kd * dilationDepth - padDepth;
+                    if ((uint)id >= (uint)depth) continue;
+                    for (int kh = 0; kh < kernelHeight; kh++)
+                    {
+                        int ih = oh * strideHeight + kh * dilationHeight - padHeight;
+                        if ((uint)ih >= (uint)height) continue;
+                        int inputRowBase = destinationChannelBase + id * inputPlane + ih * width;
+                        int kernelRowBase = columnBase + kd * kernelPlane + kh * kernelWidth;
+                        for (int kw = 0; kw < kernelWidth; kw++)
+                        {
+                            int iw = ow * strideWidth + kw * dilationWidth - padWidth;
+                            if ((uint)iw < (uint)width)
+                                destinationDouble[inputRowBase + iw] += sourceDouble[kernelRowBase + kw];
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /// <inheritdoc/>

--- a/tests/AiDotNet.Tensors.Benchmarks/Conv3DBackwardBenchmarks.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Conv3DBackwardBenchmarks.cs
@@ -1,0 +1,60 @@
+#if NET8_0_OR_GREATER
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Conv3D backward acceptance benchmark for video-diffusion temporal blocks.
+/// The previous seven-loop implementation made this operation the dominant
+/// StableVideoSR training hot path. These shapes retain four-frame temporal
+/// depth and the 64/256-channel profiles used by the U-Net while keeping the
+/// benchmark practical on a developer workstation.
+///
+/// Run:
+///   dotnet run -c Release --project tests/AiDotNet.Tensors.Benchmarks -- \
+///     --conv3d-backward
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 8)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+public class Conv3DBackwardBenchmarks
+{
+    private static readonly int[] Stride = [1, 1, 1];
+    private static readonly int[] Padding = [1, 1, 1];
+    private static readonly int[] Dilation = [1, 1, 1];
+
+    [Params(64, 256)]
+    public int Channels { get; set; }
+
+    private CpuEngine _engine = null!;
+    private Tensor<float> _input = null!;
+    private Tensor<float> _kernel = null!;
+    private Tensor<float> _gradOutput = null!;
+    private int[] _inputShape = null!;
+    private int[] _kernelShape = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new CpuEngine();
+        _inputShape = [1, Channels, 4, 8, 8];
+        _kernelShape = [Channels, Channels, 3, 3, 3];
+        _input = Tensor<float>.CreateRandom(_inputShape);
+        _kernel = Tensor<float>.CreateRandom(_kernelShape);
+        _gradOutput = Tensor<float>.CreateRandom(_inputShape);
+    }
+
+    [Benchmark(Baseline = true, Description = "Conv3D dInput (video temporal block)")]
+    public Tensor<float> InputGradient()
+        => _engine.Conv3DBackwardInput(
+            _gradOutput, _kernel, _inputShape, Stride, Padding, Dilation);
+
+    [Benchmark(Description = "Conv3D dKernel (video temporal block)")]
+    public Tensor<float> KernelGradient()
+        => _engine.Conv3DBackwardKernel(
+            _gradOutput, _input, _kernelShape, Stride, Padding, Dilation);
+}
+#endif

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -1331,6 +1331,14 @@ class Program
             return;
         }
 
+        // Conv3D backward at four-frame video-diffusion temporal-block shapes.
+        // This is the regression surface for the im2col/GEMM dInput and dKernel paths.
+        if (args[0] == "--conv3d-backward")
+        {
+            BenchmarkRunner.Run<Conv3DBackwardBenchmarks>(BenchConfig);
+            return;
+        }
+
         // FP64 primitive ops (BatchNorm, LayerNorm, Softmax, activations,
         // pools). Stage 0 baseline for Stage 4 SIMD ports of currently-scalar
         // FP64 primitives. (~10-20min).
@@ -1526,6 +1534,7 @@ class Program
         Console.WriteLine("  --dit-xl-matmul     : SimdGemm at DiT-XL shapes; compare against docs/mkl-replacement/baseline/baseline-iter17.md for vs-MKL numbers");
         Console.WriteLine("  --dit-xl-matmul-double : FP64 GEMM at DiT-XL + cluster-#6 shapes; Stage 0 baseline (docs/mkl-replacement/PLAN.md)");
         Console.WriteLine("  --conv2d-backward-double : FP64 Conv2DBackward dW+dX across cluster-#6 shapes; Stage 0 baseline");
+        Console.WriteLine("  --conv3d-backward : FP32 Conv3D dInput+dKernel at video-diffusion temporal-block shapes");
         Console.WriteLine("  --fp64-primitives   : FP64 BN/LN/Softmax/activations/pools; Stage 0 baseline for Stage 4");
         Console.WriteLine("  --dit-xl-sdpa       : ScaledDotProductAttention at DiT-XL shape [4,16,256,72] (Issue #162 SDPA fix)");
         Console.WriteLine("  --transformer-ffn   : Small-M transformer FFN matmul (Sgemm+Dgemm+batched) — Issue #245 coverage");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientCorrectnessTests.cs
@@ -501,6 +501,83 @@ public class GradientCorrectnessTests : IDisposable
             Assert.Equal(eager[x][i], ckpt[x][i], 3);
     }
 
+    [Fact]
+    public void Checkpoint_SelectedParameters_SkipsFrozenWeightsAndPreservesInputVjp()
+    {
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var frozen = MakeFilled([3, 3], -0.2f, 0.03f);
+        var trainable = MakeFilled([3, 2], 0.1f, 0.02f);
+        var outW = MakeFilled([2, 2], 0.3f, 0.01f);
+        Func<Tensor<float>, Tensor<float>> segment = input =>
+            _engine.TensorMatMul(_engine.ReLU(_engine.TensorMatMul(input, frozen)), trainable);
+
+        Dictionary<Tensor<float>, Tensor<float>> RunEager()
+        {
+            using var tape = new GradientTape<float>();
+            var output = segment(x);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(output, outW));
+            return tape.ComputeGradients(loss, sources: [x, trainable]);
+        }
+
+        Dictionary<Tensor<float>, Tensor<float>> RunCheckpointed()
+        {
+            using var tape = new GradientTape<float>();
+            bool forwardCompleted = false;
+            Func<Tensor<float>, Tensor<float>> observedSegment = input =>
+            {
+                var output = segment(input);
+                forwardCompleted = true;
+                return output;
+            };
+            var output = GradientCheckpointing<float>.Checkpoint(
+                [observedSegment],
+                x,
+                parameterSourceFactory: () =>
+                {
+                    Assert.True(forwardCompleted,
+                        "Lazy parameter selection must run after the checkpoint forward.");
+                    return [trainable];
+                },
+                segmentSize: 1);
+            var loss = _engine.ReduceSum(_engine.TensorMultiply(output, outW));
+            return tape.ComputeGradients(loss, sources: [x, trainable, frozen]);
+        }
+
+        var eager = RunEager();
+        var checkpointed = RunCheckpointed();
+
+        Assert.False(checkpointed.ContainsKey(frozen),
+            "A frozen parameter excluded from the checkpoint source set must not allocate a gradient.");
+        foreach (var tensor in new[] { x, trainable })
+        {
+            Assert.True(checkpointed.ContainsKey(tensor));
+            for (int i = 0; i < eager[tensor].Length; i++)
+                Assert.Equal(eager[tensor][i], checkpointed[tensor][i], 3);
+        }
+    }
+
+    [Fact]
+    public void Checkpoint_MultipleFusedSegments_PreservesForwardValues()
+    {
+        var x = MakeFilled([2, 3], -0.4f, 0.05f);
+        var w0 = MakeFilled([3, 4], -0.3f, 0.03f);
+        var b0 = MakeFilled([4], 0.05f, 0.01f);
+        var w1 = MakeFilled([4, 4], -0.2f, 0.02f);
+        var b1 = MakeFilled([4], 0.03f, 0.01f);
+        Func<Tensor<float>, Tensor<float>> seg0 = input =>
+            _engine.FusedLinear(input, w0, b0, FusedActivationType.None);
+        Func<Tensor<float>, Tensor<float>> seg1 = input =>
+            _engine.FusedLinear(input, w1, b1, FusedActivationType.None);
+
+        Tensor<float> eager;
+        using (GradientTape<float>.NoGrad()) eager = seg1(seg0(x));
+        using var tape = new GradientTape<float>();
+        var checkpointed = GradientCheckpointing<float>.Checkpoint([seg0, seg1], x, segmentSize: 1);
+
+        for (int i = 0; i < eager.Length; i++)
+            Assert.Equal(eager[i], checkpointed[i], 6);
+    }
+
     /// <summary>
     /// MULTI-SEGMENT variant: two matmul segments checkpointed with segmentSize=1 (one segment each).
     /// Each segment's input and weight gradients must match the eager run. Guards against cross-segment

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/RequestedSourcePruningTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Verifies that requested-source reachability can omit frozen parameter gradients without
+/// changing gradients for trainable parameters earlier in the graph.
+/// </summary>
+public sealed class RequestedSourcePruningTests
+{
+    [Fact]
+    public void Conv2D_FrozenDownstreamKernel_PreservesUpstreamTrainableGradient()
+    {
+        var complete = Run(includeFrozenKernel: true);
+        var pruned = Run(includeFrozenKernel: false);
+
+        Assert.Equal(complete.TrainableGradient, pruned.TrainableGradient);
+        Assert.True(complete.FrozenGradientProduced);
+        Assert.False(pruned.FrozenGradientProduced);
+    }
+
+    [Fact]
+    public void EmptyRequestedSources_ProducesNoGradients()
+    {
+        var engine = new CpuEngine();
+        var input = Sequence([1, 2, 4, 4], 0.01f, 0.002f);
+        var kernel = Sequence([2, 2, 3, 3], -0.02f, 0.001f);
+
+        using var tape = new GradientTape<float>();
+        var output = engine.Conv2D(input, kernel, stride: 1, padding: 1, dilation: 1);
+        var loss = engine.ReduceSum(output);
+        var gradients = tape.ComputeGradients(loss, Array.Empty<Tensor<float>>());
+
+        Assert.Empty(gradients);
+        Assert.Null(input.Grad);
+        Assert.Null(kernel.Grad);
+    }
+
+    private static (float[] TrainableGradient, bool FrozenGradientProduced) Run(
+        bool includeFrozenKernel)
+    {
+        var engine = new CpuEngine();
+        var input = Sequence([1, 2, 5, 5], -0.05f, 0.003f);
+        var trainableKernel = Sequence([3, 2, 3, 3], 0.02f, -0.0007f);
+        var frozenKernel = Sequence([2, 3, 3, 3], -0.01f, 0.0005f);
+
+        using var tape = new GradientTape<float>();
+        var hidden = engine.Conv2D(
+            input, trainableKernel, stride: 1, padding: 1, dilation: 1);
+        var output = engine.Conv2D(
+            hidden, frozenKernel, stride: 1, padding: 1, dilation: 1);
+        var loss = engine.ReduceSum(engine.TensorMultiply(output, output));
+        Tensor<float>[] sources = includeFrozenKernel
+            ? [trainableKernel, frozenKernel]
+            : [trainableKernel];
+
+        var gradients = tape.ComputeGradients(loss, sources);
+
+        return (
+            gradients[trainableKernel].AsSpan().ToArray(),
+            gradients.ContainsKey(frozenKernel));
+    }
+
+    private static Tensor<float> Sequence(int[] shape, float start, float step)
+    {
+        int length = shape.Aggregate(1, (product, dimension) => product * dimension);
+        var values = new float[length];
+        for (int i = 0; i < values.Length; i++) values[i] = start + i * step;
+        return new Tensor<float>(values, shape);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GotoGemmRoutingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GotoGemmRoutingTests.cs
@@ -1,0 +1,26 @@
+using AiDotNet.Tensors.Engines.BlasManaged;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+public sealed class GotoGemmRoutingTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(47)]
+    public void IsPreferredForThreadBudget_RejectsSmallAndMidSizedMachines(int threadBudget)
+    {
+        Assert.False(GotoGemmFp32.IsPreferredForThreadBudget(threadBudget));
+    }
+
+    [Theory]
+    [InlineData(48)]
+    [InlineData(64)]
+    [InlineData(128)]
+    public void IsPreferredForThreadBudget_AllowsManyCoreMachines(int threadBudget)
+    {
+        Assert.True(GotoGemmFp32.IsPreferredForThreadBudget(threadBudget));
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Diagnostics;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class LazyGraphCompilerPerformanceTests
+{
+    [Fact]
+    public void Compile_WideFanInGraph_StaysBelowQuadraticRuntime()
+    {
+        const int producerCount = 50_000;
+        var producers = new StubLazyNode[producerCount];
+        var rawNodes = new List<ILazyNode>(producerCount + 1);
+        for (int i = 0; i < producers.Length; i++)
+        {
+            producers[i] = new StubLazyNode();
+            rawNodes.Add(producers[i]);
+        }
+
+        var sink = new StubLazyNode(producers);
+        rawNodes.Add(sink);
+
+        var stopwatch = Stopwatch.StartNew();
+        var compiled = new LazyGraphCompiler().Compile(rawNodes);
+        stopwatch.Stop();
+
+        Assert.Equal(producerCount + 1, compiled.Count);
+        Assert.Same(sink, compiled[^1]);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Compiling a {producerCount:N0}-producer fan-in graph took " +
+            $"{stopwatch.Elapsed.TotalSeconds:F2}s; the ready scheduler regressed toward O(V^2).");
+    }
+
+    private sealed class StubLazyNode : ILazyNode
+    {
+        private static readonly IEngine StubEngine = new CpuEngine();
+        private readonly ILazyNode[] _inputs;
+
+        public StubLazyNode(params ILazyNode[] inputs) => _inputs = inputs;
+
+        public LazyNodeType OpType => LazyNodeType.Negate;
+        public int[] OutputShape { get; } = [1];
+        public bool IsRealized { get; set; }
+        public int TopologicalIndex { get; set; }
+        public int ConsumerCount { get; set; }
+        public IEngine RecordingEngine => StubEngine;
+
+        public void Realize(IEngine engine) => IsRealized = true;
+        public ILazyNode[] GetInputNodes() => _inputs;
+        public void ClearOutputLazySource() { }
+    }
+}


### PR DESCRIPTION
## Goal

Remove the engine hot paths exposed by the paper-faithful StableVideoSR census without reducing the model, fixture geometry, parameter count, or training work.

This PR is stacked on #951 because AiDotNet's UPR-Net and StableVideoSR work consumes both engine changes. Merge #951 first, then retarget this PR to `main`.

## Changes

- replace scalar seven-loop Conv3D dInput and dKernel contractions with bounded-workspace im2col/GEMM paths for FP32/FP64
- compute Conv2D, Conv3D, MatMul, and fused-linear gradients only when the requested source set needs them
- checkpoint frozen-backbone blocks with bounded nested arenas, copied segment boundaries, and explicitly selected parameter VJPs
- replace the lazy-graph compiler's quadratic ready-node scan with an ordered ready set
- route the Threadripper-tuned Goto GEMM kernel only when at least 48 logical processors are available; 32-thread hosts use the faster PackBoth path
- retain generic fallbacks, create-graph behavior, and higher-order HVP/Hessian correctness
- add requested-source, checkpoint, compiler-scaling, and GEMM-routing regression coverage

## End-to-end proof

The exact StableVideoSR workload remains `[4,3,32,32]` input, `[4,3,128,128]` output, the full four-stage `[256,512,512,1024]` video U-Net, 733,249,679 parameters, and one real temporal-only training step.

| Measurement | Original | Final |
|---|---:|---:|
| result | timeout | ok |
| runner elapsed | 214.3 s | 104.05 s |
| measured wall | 208.91 s | 100.49 s |
| cold forward | 57+ s | 35.36 s |
| steady forward | 30+ s | 22.27 s |
| training step | 56.97 s | 42.61 s |
| allocated bytes | 127.12 GB | 31.28 GB |
| peak private memory | 57.9 GiB | 19.83 GiB |
| parameter count | 733,249,679 | 733,249,679 |

PerfView-compatible EventPipe traces first identified Conv3D backward at roughly 88% inclusive time. The initial GEMM conversion reduced that to 0.15%; the final trace then exposed checkpoint recomputation, frozen-gradient materialization, lazy-graph scheduling, and a 32-core Goto-kernel routing regression. The commits in this PR address those measured causes rather than changing the paper architecture.

With the paired AiDotNet harness/model fixes, the complete isolated-process census now reports **863/863 fixtures, 0 errors, and 0 warnings**. Stable's training amplification is 1.91x its measured steady forward, so it is no longer a training-path outlier even though it remains the inventory's largest paper-scale fixture.

## Validation

- Release net10.0 source build: 0 warnings, 0 errors
- full autodiff suite: 909 passed, 29 skipped, 0 failed (938 total)
- new compiler-scaling and GEMM-routing checks: 11 passed, 0 failed
- exact StableVideoSR production fixture: completed under the 240-second supervisor with the metrics above
- complete census ledger: 863/863, 0 errors, 0 warnings

## Merge order

1. merge #951
2. merge this PR
3. release AiDotNet.Tensors
4. update AiDotNet #2006 to the released package and run package-only CI
