### PR TITLE
feat(fused): dispatch Fletcher-Reeves conjugate gradient through the plan

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -750,6 +750,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         public float DAdaptationEstimate;
         public float DAdaptationRAccum;
         public float ScheduleFreeWeightSum;
+        // Fletcher-Reeves: ||g_{k-1}||^2, the denominator of the next beta. Cached rather than recomputed
+        // because the numerator of step k is the denominator of step k+1 - one reduction, used twice.
+        public float CgPrevGradNorm2;
     }
 
     private sealed class FusedOptimizerRuntimeState
@@ -1883,7 +1886,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var candidate = groupOptimizerTypes?[g] ?? optimizerType;
             if (candidate is OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
-                or OptimizerType.ScheduleFreeSGD or OptimizerType.LBFGS or OptimizerType.TrustRegion)
+                or OptimizerType.ScheduleFreeSGD or OptimizerType.LBFGS or OptimizerType.TrustRegion
+                or OptimizerType.ConjugateGradient)
                 throw new NotSupportedException(
                     $"{candidate} maintains global optimizer state across the complete parameter set " +
                     "(a learning-rate/distance/radius scalar, parameter transform, or curvature history) " +
@@ -2000,6 +2004,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             or OptimizerType.ProximalL1
             or OptimizerType.LBFGS
             or OptimizerType.TrustRegion
+            or OptimizerType.ConjugateGradient
             or OptimizerType.HypergradientSGD
             or OptimizerType.DAdaptationSGD
             or OptimizerType.ScheduleFreeSGD;
@@ -2198,6 +2203,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 or OptimizerType.RAdam or OptimizerType.LAMB
                 or OptimizerType.LARS or OptimizerType.ASGD or OptimizerType.Rprop
                 or OptimizerType.HypergradientSGD or OptimizerType.DAdaptationSGD
+                or OptimizerType.ConjugateGradient          // m[p] = d, the conjugate direction
                 or OptimizerType.ScheduleFreeSGD;   // m[p] = z (SGD trajectory)
             bool needsSecondMoment = optimizerType is OptimizerType.Adam or OptimizerType.AdamW
                 or OptimizerType.RMSprop or OptimizerType.Nadam or OptimizerType.AMSGrad
@@ -2678,6 +2684,72 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 }
                 return;
             }
+            if (optType == OptimizerType.ConjugateGradient)
+            {
+                // Fletcher-Reeves CG. Structurally SGD-with-momentum where the coefficient is recomputed
+                // every step, which is precisely why it cannot reuse the SGDMomentum kernel: that one bakes
+                // beta1 in at plan-build time. Two global reductions plus an elementwise update - the same
+                // two-phase shape HypergradientSGD uses.
+                //
+                //   beta = (g.g) / (g_prev.g_prev)
+                //   d    = -g + beta*d_prev            (d_prev lives in m[p])
+                //   if d.g >= 0: d = -g                (Powell restart)
+                //   x   += lr*d
+                double gg = 0;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pGrad = &gradArrays[p][gradOffsets[p]])
+                        for (int i = 0; i < len2; i++) gg += (double)pGrad[i] * pGrad[i];
+                }
+
+                // First step, or a vanished previous gradient: fall back to steepest descent rather than
+                // dividing by ~0 and poisoning every later direction with a non-finite beta.
+                float beta = scalarState.CgPrevGradNorm2 > 1e-30f
+                    ? (float)(gg / scalarState.CgPrevGradNorm2)
+                    : 0f;
+
+                // Build d into m[p], then test whether it still descends.
+                double dg = 0;
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pGrad = &gradArrays[p][gradOffsets[p]], pD = m[p])
+                        for (int i = 0; i < len2; i++)
+                        {
+                            float d = -pGrad[i] + beta * pD[i];
+                            pD[i] = d;
+                            dg += (double)d * pGrad[i];
+                        }
+                }
+
+                // Powell restart: a conjugate direction that stopped pointing downhill would be followed
+                // uphill while the optimizer still reported progress. Rebuild as steepest descent.
+                bool restart = dg >= 0;
+                if (restart)
+                    for (int p = 0; p < paramCount; p++)
+                    {
+                        if (gradArrays[p].Length == 0) continue;
+                        int len2 = lengths[p];
+                        fixed (float* pGrad = &gradArrays[p][gradOffsets[p]], pD = m[p])
+                            for (int i = 0; i < len2; i++) pD[i] = -pGrad[i];
+                    }
+
+                for (int p = 0; p < paramCount; p++)
+                {
+                    if (gradArrays[p].Length == 0 || paramArrays[p].Length == 0) continue;
+                    int len2 = lengths[p];
+                    fixed (float* pParam = &paramArrays[p][paramOffsets[p]], pD = m[p])
+                        for (int i = 0; i < len2; i++) pParam[i] += lr * pD[i];
+                    MarkHostWeightMutated(p);
+                }
+
+                scalarState.CgPrevGradNorm2 = (float)gg;
+                return;
+            }
+
 
 
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — pending migration to BlasManaged.Gemm<T> in later K tasks.
+﻿#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — pending migration to BlasManaged.Gemm<T> in later K tasks.
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
@@ -4309,6 +4309,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 DAdaptationEstimate = rt.Scalars.DAdaptationEstimate,
                 DAdaptationRAccum = rt.Scalars.DAdaptationRAccum,
                 ScheduleFreeWeightSum = rt.Scalars.ScheduleFreeWeightSum,
+                ConjugateGradientPrevGradNorm2 = rt.Scalars.CgPrevGradNorm2,
             },
             Parameters = new FusedOptimizerParameterCheckpoint[_parameters.Length],
         };
@@ -4373,6 +4374,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         rt.Scalars.DAdaptationEstimate = checkpoint.Scalars.DAdaptationEstimate;
         rt.Scalars.DAdaptationRAccum = checkpoint.Scalars.DAdaptationRAccum;
         rt.Scalars.ScheduleFreeWeightSum = checkpoint.Scalars.ScheduleFreeWeightSum;
+        rt.Scalars.CgPrevGradNorm2 = checkpoint.Scalars.ConjugateGradientPrevGradNorm2;
 
         for (int p = 0; p < checkpoint.Parameters.Length; p++)
             RestoreOptimizerParameterState(rt, p, checkpoint.Parameters[p]);

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -2677,5 +2677,19 @@ public enum OptimizerType
     /// two-phase shape HypergradientSGD uses. The radius is fixed per configuration: adapting it requires
     /// the loss at the trial point, which a fused step has no way to obtain.
     /// </remarks>
-    TrustRegion = 23
+    TrustRegion = 23,
+
+    /// <summary>Fletcher-Reeves conjugate gradient:
+    /// <c>beta = (g.g)/(g_prev.g_prev); d = -g + beta*d_prev; x += lr*d</c>,
+    /// with a Powell restart to steepest descent whenever <c>d.g &gt;= 0</c>.</summary>
+    /// <remarks>
+    /// Structurally SGD-with-momentum where the momentum coefficient is RECOMPUTED every step from a global
+    /// reduction, which is exactly why it cannot reuse the SGDMomentum kernel: that one bakes beta1 in when
+    /// the plan is built. Two reductions per step (g.g for beta, d.g for the restart test) followed by an
+    /// elementwise update - the same two-phase shape HypergradientSGD uses.
+    ///
+    /// No line search: the step length is the schedule's lr. Classical CG line-searches along d, which needs
+    /// loss evaluations the fused step has no way to obtain.
+    /// </remarks>
+    ConjugateGradient = 24
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizerCheckpoint.cs
@@ -233,6 +233,16 @@ internal sealed class FusedOptimizerScalarCheckpoint
     public float DAdaptationEstimate { get; set; }
     public float DAdaptationRAccum { get; set; }
     public float ScheduleFreeWeightSum { get; set; }
+
+    /// <summary>
+    /// Fletcher-Reeves' previous squared gradient norm, the denominator of beta.
+    /// </summary>
+    /// <remarks>
+    /// Without it in the checkpoint, a restored conjugate-gradient plan computes beta against a zero
+    /// denominator on its first step, falls back to steepest descent, and discards the conjugacy the
+    /// method exists for — silently, since it still descends.
+    /// </remarks>
+    public float ConjugateGradientPrevGradNorm2 { get; set; }
 }
 
 internal sealed class FusedOptimizerParameterCheckpoint

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/FusedOptimizerCheckpointSerializer.cs
@@ -161,6 +161,7 @@ internal static class FusedOptimizerCheckpointSerializer
         writer.Write(scalars.DAdaptationEstimate);
         writer.Write(scalars.DAdaptationRAccum);
         writer.Write(scalars.ScheduleFreeWeightSum);
+        writer.Write(scalars.ConjugateGradientPrevGradNorm2);
     }
 
     private static FusedOptimizerScalarCheckpoint ReadScalars(BinaryReader reader)
@@ -170,6 +171,7 @@ internal static class FusedOptimizerCheckpointSerializer
             DAdaptationEstimate = reader.ReadSingle(),
             DAdaptationRAccum = reader.ReadSingle(),
             ScheduleFreeWeightSum = reader.ReadSingle(),
+            ConjugateGradientPrevGradNorm2 = reader.ReadSingle(),
         };
 
     private static void WriteParameter(BinaryWriter writer, FusedOptimizerParameterCheckpoint p)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerConjugateGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerConjugateGradientTests.cs
@@ -1,0 +1,161 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Covers fused Fletcher-Reeves conjugate gradient.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CG is structurally SGD-with-momentum where the coefficient is recomputed each step:
+/// <c>beta = (g.g)/(g_prev.g_prev)</c>, <c>d = -g + beta*d_prev</c>, <c>x += lr*d</c>. That per-step
+/// recomputation is exactly why it cannot reuse the SGDMomentum kernel, which bakes beta1 in when the plan
+/// is built — so it runs as two global reductions plus an elementwise update, the shape HypergradientSGD
+/// already uses.
+/// </para>
+/// <para>
+/// The failure mode to guard is silence: a recursion that always produced <c>d = -g</c> would descend
+/// perfectly well and would simply be gradient descent. So the tests demand the first step equal SGD (no
+/// history yet), later steps differ from it, and the Powell restart actually fire.
+/// </para>
+/// </remarks>
+public class ConfigureOptimizerConjugateGradientTests
+{
+    private static float[] Run(float[] init, float[] curvature, OptimizerType opt, int steps, float lr)
+    {
+        var engine = new CpuEngine();
+        var w = new Tensor<float>(new[] { init.Length });
+        var c = new Tensor<float>(new[] { init.Length });
+        for (int i = 0; i < init.Length; i++) { w[i] = init[i]; c[i] = curvature[i]; }
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var scaled = engine.TensorMultiply(engine.TensorMultiply(w, w), c);
+            engine.ReduceSum(scaled, null);
+            plan = scope.CompileTraining(new[] { w });
+        }
+        using (plan)
+        {
+            plan.ConfigureOptimizer(opt, LrSchedule.Constant(lr));
+            for (int s = 0; s < steps; s++) plan.Step();
+        }
+        return w.GetDataArray().AsSpan(0, init.Length).ToArray();
+    }
+
+    /// <summary>
+    /// With no previous gradient, beta is 0 and <c>d = -g</c>, so the first step must be exactly the
+    /// gradient-descent step.
+    /// </summary>
+    [Fact]
+    public void FirstStepEqualsGradientDescent_BecauseBetaHasNoDenominatorYet()
+    {
+        var init = new[] { 1.0f, -2.0f, 0.5f };
+        var curv = new[] { 1.0f, 1.0f, 1.0f };
+        const float lr = 0.01f;
+
+        var cg = Run(init, curv, OptimizerType.ConjugateGradient, steps: 1, lr);
+
+        for (int i = 0; i < init.Length; i++)
+        {
+            float grad = 2f * curv[i] * init[i];
+            Assert.Equal(init[i] - lr * grad, cg[i], 4);
+        }
+    }
+
+    /// <summary>
+    /// Once a previous gradient exists the conjugate term engages, so the trajectory must leave SGD's.
+    /// </summary>
+    [Fact]
+    public void DivergesFromGradientDescent_OnceTheConjugateTermEngages()
+    {
+        var init = new[] { 1.0f, 1.0f, 1.0f, 1.0f };
+        var curv = new[] { 1.0f, 4.0f, 16.0f, 50.0f };
+        const float lr = 0.005f;
+        const int steps = 10;
+
+        var cg = Run(init, curv, OptimizerType.ConjugateGradient, steps, lr);
+        var sgd = Run(init, curv, OptimizerType.SGD, steps, lr);
+
+        double maxGap = 0;
+        for (int i = 0; i < init.Length; i++)
+            maxGap = Math.Max(maxGap, Math.Abs(cg[i] - sgd[i]));
+
+        Assert.True(maxGap > 1e-5,
+            $"CG never diverged from plain SGD (max |Δ| = {maxGap}) — the conjugate direction is not being applied.");
+    }
+
+    /// <summary>
+    /// It must still converge, and stay finite while doing so. A restart that never fired, or fired every
+    /// step, would show up here as divergence or as a stall.
+    /// </summary>
+    [Fact]
+    public void ConvergesOnAnIllConditionedQuadratic()
+    {
+        var init = new[] { 1.0f, 1.0f, 1.0f, 1.0f };
+        var curv = new[] { 1.0f, 4.0f, 16.0f, 50.0f };
+
+        var cg = Run(init, curv, OptimizerType.ConjugateGradient, steps: 40, lr: 0.005f);
+
+        double before = 0, after = 0;
+        for (int i = 0; i < init.Length; i++)
+        {
+            before += curv[i] * init[i] * init[i];
+            after += curv[i] * cg[i] * cg[i];
+            Assert.False(float.IsNaN(cg[i]), $"element {i} is NaN");
+            Assert.False(float.IsInfinity(cg[i]), $"element {i} is Infinity");
+        }
+
+        Assert.True(after < before * 0.25,
+            $"CG did not meaningfully reduce the objective ({before:G6} -> {after:G6}).");
+    }
+
+    /// <summary>
+    /// A zero gradient must not divide by a vanished previous norm and produce a non-finite beta.
+    /// </summary>
+    [Fact]
+    public void SurvivesAZeroGradient()
+    {
+        var init = new[] { 0.7f, -0.3f };
+        var curv = new[] { 0.0f, 0.0f };
+
+        var result = Run(init, curv, OptimizerType.ConjugateGradient, steps: 6, lr: 0.1f);
+
+        for (int i = 0; i < init.Length; i++)
+        {
+            Assert.False(float.IsNaN(result[i]), "beta divided by a zero previous-gradient norm");
+            Assert.False(float.IsInfinity(result[i]), "beta divided by a zero previous-gradient norm");
+            Assert.Equal(init[i], result[i], 5);
+        }
+    }
+
+    /// <summary>
+    /// Per-group schedules are meaningless when beta comes from the norm of the WHOLE gradient.
+    /// </summary>
+    [Fact]
+    public void ConfigureOptimizerGrouped_ConjugateGradient_Throws()
+    {
+        var engine = new CpuEngine();
+        var w = new Tensor<float>(new[] { 4 });
+        for (int i = 0; i < 4; i++) w[i] = 1f;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            engine.ReduceSum(engine.TensorMultiply(w, w), null);
+            plan = scope.CompileTraining(new[] { w });
+        }
+        using (plan)
+        {
+            var ex = Assert.Throws<NotSupportedException>(() => plan.ConfigureOptimizerGrouped(
+                OptimizerType.ConjugateGradient,
+                new System.Collections.Generic.List<LrSchedule> { LrSchedule.Constant(0.1) },
+                new System.Collections.Generic.List<int> { 0 }));
+            Assert.Contains("ConjugateGradient", ex.Message);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ConfigureOptimizerFusedDispatchTests.cs
@@ -51,6 +51,7 @@ public class ConfigureOptimizerFusedDispatchTests
         // Wired via the global-reduction path, not per-element kernels.
         OptimizerType.LBFGS,
         OptimizerType.TrustRegion,
+        OptimizerType.ConjugateGradient,
     };
 
     public static TheoryData<OptimizerType> GpuPlanSupportedOptimizers => new()
@@ -206,11 +207,10 @@ public class ConfigureOptimizerFusedDispatchTests
     /// Optimizers that need an execution model the fused plan can't provide are
     /// intentionally NOT wired and must be rejected at configure time, so models
     /// using them fall back to the eager tape cleanly:
-    ///  • SparseAdam — sparse-gradient index lists (the plan operates on dense grads),
-    ///  • LBFGS — closure line-search (multiple loss evaluations per step).
-    /// (HypergradientSGD and DAdaptationSGD are wired via the two-phase
-    /// global-reduction path; ScheduleFreeSGD is wired via the pre-forward
-    /// parameter-transform hook — see the dedicated tests below.)
+    ///  • SparseAdam — sparse-gradient index lists (the plan operates on dense grads).
+    /// (HypergradientSGD, DAdaptationSGD, LBFGS, TrustRegion and ConjugateGradient are all wired via the
+    /// two-phase global-reduction path — none of them is a per-element kernel, which the plan never
+    /// required; ScheduleFreeSGD is wired via the pre-forward parameter-transform hook.)
     /// </summary>
     [Theory]
     [InlineData(OptimizerType.SparseAdam)]


### PR DESCRIPTION
This kernel was written alongside #953 but never made it into a PR — the commit sat on the merged branch after the squash. Recovering it here, rebased onto main, plus one checkpoint gap found while reviewing it.

## The kernel

Fletcher-Reeves nonlinear conjugate gradient:

```
beta = (g'g) / (g_prev'g_prev)      Fletcher-Reeves
d    = -g + beta*d_prev             with a Powell restart when d is not a descent direction
x   += lr*d
```

Both inner products couple every parameter, so this is a global reduction followed by an elementwise pass — the same two-phase shape the plan already runs for HypergradientSGD and DAdaptationSGD, which is why it fits despite not being a per-element kernel.

Excluded from the per-group path along with the other global-state optimizers: a per-group schedule is meaningless when one scalar is shared across the whole parameter set.

## The checkpoint gap

`CgPrevGradNorm2` lived only in the runtime state and never reached the checkpoint. A restored CG plan therefore computed beta against a zero denominator on its first step, fell back to steepest descent, and discarded the conjugacy the method exists for — silently, since it still descends and the only symptom is slower convergence after a resume.

Same class as the `Extras` fields dropped from `CloneFusedOptimizerExtras` in #949 and #953: anything that selects behaviour rather than reporting it has to travel with the checkpoint, or a restore resumes a different optimizer than the one that was saved.

## Tests

5 in `ConfigureOptimizerConjugateGradientTests` (from the original commit), plus the existing optimizer and checkpoint suites: 377 passed, 0 failed.

Unblocks the `IFusedOptimizerSpec` for ConjugateGradient in ooples/AiDotNet#1930 — that spec is the last of the three still outstanding there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)