### PR TITLE
fix(fused): RAdam rectification precision and Nadam bias-correction placement

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1558,14 +1558,23 @@ internal static class FusedOptimizer
         float* param, float* grad, float* m, float* v, int length,
         float lr, float beta1, float beta2, float eps, int step)
     {
-        float bc1 = 1f - MathF.Pow(beta1, step);
-        float bc2 = 1f - MathF.Pow(beta2, step);
-        float rhoInf = 2f / (1f - beta2) - 1f;
-        float rhoT = rhoInf - 2f * step * MathF.Pow(beta2, step) / bc2;
-        bool rectified = rhoT > 4f;
+        // These are PER-STEP scalars, not per-element, so double costs nothing measurable and buys real
+        // accuracy where it matters most. In float, rho_t carries ~0.4% error (at beta2 = 0.999, step 3:
+        // 3.0112 against a true 2.9987), and r_t depends on sqrt(rho_t - 4) — a term that is near ZERO on
+        // the first rectified step, so that relative error is amplified rather than damped. Measured
+        // against AiDotNet's eager RAdam, which computes these in double, the float version diverged by
+        // 2.4e-3 after 40 steps versus a 6e-7 float-ordering control: a real trajectory difference, not
+        // rounding.
+        double bc1d = 1.0 - Math.Pow(beta1, step);
+        double bc2d = 1.0 - Math.Pow(beta2, step);
+        double rhoInfd = 2.0 / (1.0 - beta2) - 1.0;
+        double rhoTd = rhoInfd - 2.0 * step * Math.Pow(beta2, step) / bc2d;
+        bool rectified = rhoTd > 4.0;
+        float bc1 = (float)bc1d;
+        float bc2 = (float)bc2d;
         float rt = rectified
-            ? MathF.Sqrt(((rhoT - 4f) * (rhoT - 2f) * rhoInf) /
-                        ((rhoInf - 4f) * (rhoInf - 2f) * rhoT))
+            ? (float)Math.Sqrt(((rhoTd - 4.0) * (rhoTd - 2.0) * rhoInfd) /
+                               ((rhoInfd - 4.0) * (rhoInfd - 2.0) * rhoTd))
             : 0f;
 
         int i = 0;
@@ -1878,17 +1887,24 @@ internal static class FusedOptimizer
         float* param, int* indices, float* values, float* m, float* v, int nnz,
         float lr, float beta1, float beta2, float eps, float wd, int step)
     {
-        float bc1 = 1f - MathF.Pow(beta1, step);
-        float bc2 = 1f - MathF.Pow(beta2, step);
-        float rhoInf = 2f / (1f - beta2) - 1f;
-        float rhoT = rhoInf - 2f * step * MathF.Pow(beta2, step) / bc2;
-        bool rect = rhoT > 4f;
+        // Per-step scalars in double, for the same reason as the dense kernel: r_t depends on
+        // sqrt(rho_t - 4), which is near zero on the first rectified step, so float error in rho_t is
+        // amplified there rather than damped. Kept identical to the dense path so a parameter does not
+        // take a different trajectory depending on whether its gradient arrived sparse — the divergence
+        // that made the LARS kernel wrong.
+        double bc1d = 1.0 - Math.Pow(beta1, step);
+        double bc2d = 1.0 - Math.Pow(beta2, step);
+        double rhoInfd = 2.0 / (1.0 - beta2) - 1.0;
+        double rhoTd = rhoInfd - 2.0 * step * Math.Pow(beta2, step) / bc2d;
+        bool rect = rhoTd > 4.0;
+        float bc1 = (float)bc1d;
+        float bc2 = (float)bc2d;
         float r = 0f;
         if (rect)
         {
-            float num = (rhoT - 4f) * (rhoT - 2f) * rhoInf;
-            float den = (rhoInf - 4f) * (rhoInf - 2f) * rhoT;
-            r = MathF.Sqrt(num / den);
+            double num = (rhoTd - 4.0) * (rhoTd - 2.0) * rhoInfd;
+            double den = (rhoInfd - 4.0) * (rhoInfd - 2.0) * rhoTd;
+            r = (float)Math.Sqrt(num / den);
         }
         for (int k = 0; k < nnz; k++)
         {

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using AiDotNet.Tensors.Engines.Simd;
 #if NET5_0_OR_GREATER
 using System.Runtime.Intrinsics;
@@ -1301,9 +1301,11 @@ internal static class FusedOptimizer
                 Avx.Store(m + i, mNew);
                 var vNew = Fma.MultiplyAdd(vB2, Avx.LoadVector256(v + i), Avx.Multiply(v1mB2, Avx.Multiply(g, g)));
                 Avx.Store(v + i, vNew);
-                var mHat = Avx.Multiply(mNew, vBc1Inv);
                 var vHat = Avx.Multiply(vNew, vBc2Inv);
-                var mNesterov = Avx.Add(Avx.Multiply(vB1, mHat), Avx.Multiply(Avx.Multiply(v1mB1, g), vBc1NextInv));
+                // Dozat (2016) Alg. 8: momentum term / (1 - b1^(t+1)), gradient term / (1 - b1^t).
+                // These were swapped.
+                var mNesterovMom = Avx.Multiply(mNew, vBc1NextInv);
+                var mNesterov = Avx.Add(Avx.Multiply(vB1, mNesterovMom), Avx.Multiply(Avx.Multiply(v1mB1, g), vBc1Inv));
                 var denom = Avx.Add(Avx.Sqrt(vHat), vEps);
                 Avx.Store(param + i, Fma.MultiplyAdd(vLr, Avx.Divide(mNesterov, denom), Avx.LoadVector256(param + i)));
             }
@@ -1313,9 +1315,9 @@ internal static class FusedOptimizer
         {
             m[i] = beta1 * m[i] + (1f - beta1) * grad[i];
             v[i] = beta2 * v[i] + (1f - beta2) * grad[i] * grad[i];
-            float mHat = m[i] / bc1;
             float vHat = v[i] / bc2;
-            float mNesterov = beta1 * mHat + (1f - beta1) * grad[i] / bc1Next;
+            // Dozat (2016) Alg. 8: momentum term / (1 - b1^(t+1)), gradient term / (1 - b1^t).
+            float mNesterov = beta1 * (m[i] / bc1Next) + (1f - beta1) * grad[i] / bc1;
             param[i] -= lr * mNesterov / (MathF.Sqrt(vHat) + eps);
         }
     }


### PR DESCRIPTION
Two fused-kernel update rules that disagreed with AiDotNet's eager implementations. Both were found by AiDotNet's fused-vs-eager parity gate **after fixing a bug that had made that gate compare fused against fused** — it disabled compilation by mutating `TensorCodecOptions.Current`, which returns a fresh instance per read when unset, so every numerical assertion in it had been passing vacuously since it was written.

## RAdam: rectification scalars in float

`r_t` depends on `sqrt(rho_t - 4)`, and `rho_t - 4` is near **zero** on the first rectified step — so float error in `rho_t` is amplified there rather than damped. At the default `beta2 = 0.999`:

| step | rho_t (double) | rho_t (float) |
|---|---|---|
| 3 | 2.9987 | 3.0112 |
| 5 | 4.9960 | 4.9865 |

At step 5 that's a ~1% error in `(rho_t - 4)` exactly where `r_t` is most sensitive to it. The branch itself (`rho_t > 4`) was *not* flipping — both precisions agree on which step rectification starts — so this is purely the magnitude of `r_t`.

Measured divergence after 40 training steps: **2.4e-3 → 5.1e-7**, against a 6.1e-7 float-ordering control.

These are per-step scalars, not per-element, so double costs nothing measurable; only the narrowed `r_t`, `bc1` and `bc2` enter the element loop. Applied to `SparseRAdamUpdate` too, so a parameter doesn't take a different trajectory depending on whether its gradient arrived sparse — the dense/sparse divergence that made the LARS kernel wrong in #955.

## Nadam: the two bias corrections were swapped

Dozat (2016), Algorithm 8:

```
m_bar = (1 - b1) * g / (1 - b1^t)  +  b1 * m / (1 - b1^(t+1))
```

The **gradient** term takes the `t` correction; the **momentum** term takes `t+1`. This kernel had them the other way round. At `b1 = 0.9`, step 1, those divisors are 0.19 and 0.1 — each term off by nearly 2×, in opposite directions, largest exactly where Nesterov momentum is meant to help most.

AiDotNet's eager Nadam was *also* wrong, differently (it used `t` for both). Both sides are corrected in the same change, so the paths agree with each other **and** with the paper rather than merely with each other.

Measured divergence: **0.182 → 4.6e-5**, against a 4.6e-7 control.

## Verification

Tensors optimizer suites: 351 passed, 0 failed. On the AiDotNet side the full parity gate is 22/22 with these kernels, and the optimizer suite is stable at the 8 known pre-existing failures across consecutive runs.

Refs ooples/AiDotNet#1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Nadam optimizer bias correction for more accurate parameter updates.
  - Improved RAdam’s bias-correction and rectification calculations, increasing numerical accuracy for dense and sparse training workloads.
  - Updated optimizer behavior consistently across supported execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->