### PR TITLE
fix(streaming): reclaim backing files when the pool's process is killed

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -137,8 +137,12 @@ public sealed class StreamingTensorPool : IDisposable
         string baseDir = opts.StreamingBackingStorePath ?? Path.GetTempPath();
         _backingDir = Path.Combine(baseDir, BackingDirPrefix + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_backingDir);
-        // Reclaim what earlier runs stranded here. Once per process, off the
-        // constructor's thread -- see SweepOrphanedBackingStores.
+        // BEFORE scheduling the sweep, not after: the sweep runs on another
+        // thread and must never observe this directory as unowned, however
+        // briefly.
+        RegisterLivePool(_backingDir);
+        // Reclaim what earlier runs stranded here. Once per base directory, off
+        // the constructor's thread -- see SweepOrphanedBackingStores.
         ScheduleOrphanSweep(baseDir);
     }
 
@@ -1095,17 +1099,79 @@ public sealed class StreamingTensorPool : IDisposable
 
     /// <summary>
     /// A backing directory younger than this is never swept, however dead it
-    /// looks. The pool creates its directory in the constructor and opens
-    /// backing.bin lazily on first page-out, so a live pool that has not
-    /// evicted anything yet is an EMPTY directory with no file to lock —
-    /// indistinguishable from an orphan except by age.
+    /// looks. It is a coarse backstop only — <see cref="_liveBackingDirs"/> is
+    /// what actually protects a live pool, at any age.
     /// </summary>
     internal static readonly TimeSpan OrphanMinimumAge = TimeSpan.FromHours(1);
 
-    // One sweep per process, per base directory. Interlocked rather than a
-    // lock: the constructor is on the caller's hot path and must not block on
-    // a directory walk.
-    private static int _sweepStarted;
+    /// <summary>
+    /// Path equality as the filesystem sees it. Getting this wrong in the
+    /// permissive direction schedules a redundant sweep, which is harmless;
+    /// getting it wrong in the strict direction fails to recognise a LIVE
+    /// pool's directory and deletes it, which is not.
+    /// </summary>
+    private static readonly StringComparer PathComparer =
+        Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    private static readonly object SweepState = new();
+
+    /// <summary>
+    /// Base directories already swept, BY PATH.
+    ///
+    /// <para>This was a single process-wide flag. With it, the first pool to be
+    /// constructed swept its own base directory and every pool afterwards
+    /// skipped — so a process that used the temp directory and then a custom
+    /// <see cref="GpuOffloadOptions.StreamingBackingStorePath"/> swept only the
+    /// first, and orphans under the second accumulated forever. One sweep per
+    /// distinct base directory is the actual intent.</para>
+    /// </summary>
+    private static readonly HashSet<string> _sweptBaseDirs = new(PathComparer);
+
+    /// <summary>
+    /// Backing directories belonging to pools that are ALIVE right now.
+    ///
+    /// <para>The file lock cannot protect these on its own. A pool creates its
+    /// directory in the constructor but only opens backing.bin on its FIRST
+    /// page-out, so a pool that stays under budget has an empty directory and no
+    /// handle to detect. Once that directory ages past
+    /// <see cref="OrphanMinimumAge"/>, a later pool's sweep would delete it out
+    /// from under its living owner, and the owner's next page-out would fail
+    /// because <c>FileMode.Create</c> cannot create a file under a directory
+    /// that is gone.</para>
+    ///
+    /// <para>Registered in the constructor, removed in <see cref="Dispose"/>.</para>
+    /// </summary>
+    private static readonly HashSet<string> _liveBackingDirs = new(PathComparer);
+
+    /// <summary>Full path, with any trailing separator removed, for set comparison.</summary>
+    private static string NormalizePath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch
+        {
+            // An unresolvable path cannot match a real directory either way.
+            return path;
+        }
+    }
+
+    private static void RegisterLivePool(string backingDir)
+    {
+        lock (SweepState) _liveBackingDirs.Add(NormalizePath(backingDir));
+    }
+
+    private static void UnregisterLivePool(string backingDir)
+    {
+        lock (SweepState) _liveBackingDirs.Remove(NormalizePath(backingDir));
+    }
+
+    private static bool IsLivePool(string dir)
+    {
+        lock (SweepState) return _liveBackingDirs.Contains(NormalizePath(dir));
+    }
 
     private static void ScheduleOrphanSweep(string baseDir)
     {
@@ -1113,7 +1179,14 @@ public sealed class StreamingTensorPool : IDisposable
         // needs the evidence to still be there when they look.
         if (Environment.GetEnvironmentVariable("AIDOTNET_STREAMING_POOL_NO_SWEEP") is { Length: > 0 })
             return;
-        if (Interlocked.Exchange(ref _sweepStarted, 1) != 0) return;
+
+        // Per base directory, not per process. The lock is held only for a set
+        // insert -- the directory walk happens on the background thread, so the
+        // constructor's hot path still does not wait on I/O.
+        lock (SweepState)
+        {
+            if (!_sweptBaseDirs.Add(NormalizePath(baseDir))) return;
+        }
 
         // Background + IsBackground so a sweep of a large temp directory can
         // never delay process exit, and never delays pool construction.
@@ -1135,12 +1208,21 @@ public sealed class StreamingTensorPool : IDisposable
     /// half can clean up what a previous build already stranded — only this
     /// can.</para>
     ///
-    /// <para>HOW AN ORPHAN IS IDENTIFIED, and why it cannot take a live pool
-    /// with it: a running pool holds backing.bin open with
-    /// <see cref="FileShare.Read"/>, so an exclusive open of that file FAILS
-    /// while its owner lives and succeeds once the owner is gone. That test is
-    /// the authority. The age gate covers the one case the lock cannot: a pool
-    /// constructed moments ago that has not yet opened its backing file.</para>
+    /// <para>AN ORPHAN MUST CLEAR FOUR GATES, because this method deletes
+    /// recursively and a false positive destroys live data:</para>
+    /// <list type="number">
+    /// <item>The name is one WE mint — prefix plus a 32-digit "N" Guid. A
+    /// directory that merely starts with the prefix, such as a person's
+    /// <c>aidotnet-streaming-pool-backup</c>, is not ours to delete.</item>
+    /// <item>It is not registered in <see cref="_liveBackingDirs"/>. This is
+    /// what protects a living pool that has not paged out yet and therefore has
+    /// no file to lock.</item>
+    /// <item>It is older than <paramref name="minimumAge"/> — a backstop for
+    /// pools belonging to OTHER processes, which we cannot see registered.</item>
+    /// <item>Its backing.bin, if present, opens exclusively. A running pool
+    /// holds that file with <see cref="FileShare.Read"/>, so the probe fails
+    /// while its owner lives and succeeds once the owner is gone.</item>
+    /// </list>
     ///
     /// <para>Every failure is swallowed. A machine that cannot delete a stale
     /// temp directory has a problem this method is not entitled to escalate.</para>
@@ -1159,10 +1241,18 @@ public sealed class StreamingTensorPool : IDisposable
         {
             try
             {
-                // Age gate first: it is the cheap check, and it is the one that
-                // protects a pool that exists but has not paged out yet.
+                // Gate 1 -- is this name one we could have created at all?
+                if (!IsPoolDirectoryName(Path.GetFileName(dir))) continue;
+
+                // Gate 2 -- a pool in THIS process that is still alive. Checked
+                // before the age gate because it is authoritative at any age.
+                if (IsLivePool(dir)) continue;
+
+                // Gate 3 -- young enough that another process's pool may still
+                // be starting up inside it.
                 if (Directory.GetCreationTimeUtc(dir) > cutoff) continue;
 
+                // Gate 4 -- somebody still holds the backing file.
                 string backing = Path.Combine(dir, "backing.bin");
                 if (File.Exists(backing) && !CanOpenExclusively(backing)) continue;
 
@@ -1180,6 +1270,27 @@ public sealed class StreamingTensorPool : IDisposable
     }
 
     /// <summary>
+    /// Is this directory name one the pool itself would have minted — the
+    /// prefix followed by exactly a 32-digit hexadecimal Guid ("N" format)?
+    ///
+    /// <para>A prefix match alone is not ownership. <c>GetDirectories</c> with
+    /// <c>prefix + "*"</c> happily returns <c>aidotnet-streaming-pool-backup</c>
+    /// or <c>...-old</c>, and this method deletes recursively.</para>
+    /// </summary>
+    internal static bool IsPoolDirectoryName(string? name)
+    {
+        if (name is null || name.Length != BackingDirPrefix.Length + 32) return false;
+        if (!name.StartsWith(BackingDirPrefix, StringComparison.Ordinal)) return false;
+        for (int i = BackingDirPrefix.Length; i < name.Length; i++)
+        {
+            char c = name[i];
+            bool hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!hex) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
     /// True when nothing else holds the file — the signal that its owning pool
     /// is gone. Opening for READ with <see cref="FileShare.None"/> is refused
     /// while any other handle is open, which is precisely the question.
@@ -1193,6 +1304,31 @@ public sealed class StreamingTensorPool : IDisposable
         }
         catch (IOException) { return false; }
         catch (UnauthorizedAccessException) { return false; }
+    }
+
+    /// <summary>
+    /// Closes the backing-file handle and NOTHING else — the directory, the
+    /// entries and the pool's usability are left alone.
+    ///
+    /// <para>Exists so that delete-on-close can be tested for what it actually
+    /// is. <see cref="Dispose"/> closes the handle and then deletes the whole
+    /// directory, so "backing.bin is gone after Dispose" is true whether or not
+    /// <c>FileOptions.DeleteOnClose</c> is set — a test asserting it proves
+    /// nothing and would keep passing if the flag were dropped. Closing the
+    /// handle in isolation is the only in-process way to observe the kernel
+    /// reclaiming the file on its own.</para>
+    ///
+    /// <para>The next page-out reopens the file through <c>BackingFile()</c>
+    /// with <c>FileMode.Create</c>, so calling this does not break the pool —
+    /// it discards already-paged-out bytes, which is why it is not public.</para>
+    /// </summary>
+    internal void CloseBackingFileForTests()
+    {
+        lock (_lock)
+        {
+            try { _backingFile?.Dispose(); } catch { /* best-effort */ }
+            _backingFile = null;
+        }
     }
 
     public void Dispose()
@@ -1221,6 +1357,11 @@ public sealed class StreamingTensorPool : IDisposable
         // protect anymore.
         try { if (Directory.Exists(_backingDir)) Directory.Delete(_backingDir, recursive: true); }
         catch { /* best-effort */ }
+        // Deregister LAST. Until the directory is actually gone this pool still
+        // owns it, and a concurrent sweep must not race the delete above.
+        // Unconditional: if the delete failed, what remains is a genuine orphan
+        // and the next sweep should be free to reclaim it.
+        UnregisterLivePool(_backingDir);
     }
 
     private void ThrowIfDisposed()

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -135,8 +135,11 @@ public sealed class StreamingTensorPool : IDisposable
         // live files (the recursive-delete is unconditional). The Guid
         // sub-dir makes Dispose safe to scope to this pool's lifetime.
         string baseDir = opts.StreamingBackingStorePath ?? Path.GetTempPath();
-        _backingDir = Path.Combine(baseDir, "aidotnet-streaming-pool-" + Guid.NewGuid().ToString("N"));
+        _backingDir = Path.Combine(baseDir, BackingDirPrefix + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_backingDir);
+        // Reclaim what earlier runs stranded here. Once per process, off the
+        // constructor's thread -- see SweepOrphanedBackingStores.
+        ScheduleOrphanSweep(baseDir);
     }
 
     /// <summary>Total resident bytes — pool does not exceed
@@ -984,7 +987,39 @@ public sealed class StreamingTensorPool : IDisposable
             // read-only memory-mapping of the same file concurrently with the
             // pool's append handle. The pool stays the only WRITER (no other
             // handle is granted write), so the append-only contract is intact.
-            FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+            FileMode.Create, FileAccess.ReadWrite, FileShare.Read,
+            DefaultBufferSize,
+            // DELETE-ON-CLOSE IS THE ONLY RECLAIM THAT SURVIVES A KILL.
+            //
+            // Dispose() deletes _backingDir, which is correct and which never
+            // runs when the process dies first -- and a test host that OOMs or
+            // is killed is the normal case here, not the exotic one. Measured on
+            // a developer machine: 430 stranded pool directories accumulated in
+            // eight days, 257 GB total, the largest single backing.bin 117 GB.
+            // The disk hit zero and every build on the box started failing.
+            //
+            // With DeleteOnClose the kernel drops the file when the LAST handle
+            // to it closes, including the handles it closes on our behalf when
+            // the process dies abnormally. Nothing is left but an empty
+            // directory, which SweepOrphanedBackingStores below reclaims.
+            //
+            // Safe against the zero-copy mmap path: MmapTensorMemoryManager
+            // opens the same file with FileShare.Delete (a delete-pending file
+            // is legal to map), and this handle still grants FileShare.Read, so
+            // the reader's access is unchanged. The file's bytes stay live for
+            // every existing mapping until the last one is released -- Windows
+            // unlinks the name, not the data.
+            //
+            // On Unix the runtime emulates this by unlinking at close, so a
+            // SIGKILL still strands the file there. That is exactly why the
+            // sweep exists as well: belt and braces, and the sweep is the only
+            // half that can clean up what previous builds already stranded.
+            FileOptions.DeleteOnClose);
+
+    // FileStream's own default. Named because the FileOptions overload has no
+    // form that omits it, and a silently different buffer size here would be a
+    // performance change smuggled in behind a lifetime fix.
+    private const int DefaultBufferSize = 4096;
 
     // Absolute path of the single contiguous backing file. Stable for the
     // pool's lifetime; used by the zero-copy mmap path.
@@ -1053,6 +1088,111 @@ public sealed class StreamingTensorPool : IDisposable
             throw new InvalidOperationException(
                 $"Streaming backing file: short read at offset {offset} ({read}/{count} bytes).");
         return buf;
+    }
+
+    /// <summary>Directory-name prefix for every pool's backing store.</summary>
+    internal const string BackingDirPrefix = "aidotnet-streaming-pool-";
+
+    /// <summary>
+    /// A backing directory younger than this is never swept, however dead it
+    /// looks. The pool creates its directory in the constructor and opens
+    /// backing.bin lazily on first page-out, so a live pool that has not
+    /// evicted anything yet is an EMPTY directory with no file to lock —
+    /// indistinguishable from an orphan except by age.
+    /// </summary>
+    internal static readonly TimeSpan OrphanMinimumAge = TimeSpan.FromHours(1);
+
+    // One sweep per process, per base directory. Interlocked rather than a
+    // lock: the constructor is on the caller's hot path and must not block on
+    // a directory walk.
+    private static int _sweepStarted;
+
+    private static void ScheduleOrphanSweep(string baseDir)
+    {
+        // TOKEN: an escape hatch for anyone debugging a stranded pool, who
+        // needs the evidence to still be there when they look.
+        if (Environment.GetEnvironmentVariable("AIDOTNET_STREAMING_POOL_NO_SWEEP") is { Length: > 0 })
+            return;
+        if (Interlocked.Exchange(ref _sweepStarted, 1) != 0) return;
+
+        // Background + IsBackground so a sweep of a large temp directory can
+        // never delay process exit, and never delays pool construction.
+        var thread = new Thread(() => { try { SweepOrphanedBackingStores(baseDir); } catch { /* best-effort */ } })
+        {
+            IsBackground = true,
+            Name = "aidotnet-streaming-pool-sweep",
+        };
+        thread.Start();
+    }
+
+    /// <summary>
+    /// Deletes backing directories left behind by pools whose process died.
+    ///
+    /// <para>WHY THIS IS NEEDED AT ALL: <see cref="Dispose"/> deletes the
+    /// directory, and a killed process never reaches it. DeleteOnClose (see
+    /// <c>BackingFile</c>) reclaims the BYTES on Windows, but the empty
+    /// directory survives, and on Unix a SIGKILL strands the file too. Neither
+    /// half can clean up what a previous build already stranded — only this
+    /// can.</para>
+    ///
+    /// <para>HOW AN ORPHAN IS IDENTIFIED, and why it cannot take a live pool
+    /// with it: a running pool holds backing.bin open with
+    /// <see cref="FileShare.Read"/>, so an exclusive open of that file FAILS
+    /// while its owner lives and succeeds once the owner is gone. That test is
+    /// the authority. The age gate covers the one case the lock cannot: a pool
+    /// constructed moments ago that has not yet opened its backing file.</para>
+    ///
+    /// <para>Every failure is swallowed. A machine that cannot delete a stale
+    /// temp directory has a problem this method is not entitled to escalate.</para>
+    /// </summary>
+    /// <returns>Number of directories reclaimed.</returns>
+    internal static int SweepOrphanedBackingStores(string baseDir, TimeSpan? minimumAge = null)
+    {
+        int reclaimed = 0;
+        DateTime cutoff = DateTime.UtcNow - (minimumAge ?? OrphanMinimumAge);
+
+        string[] candidates;
+        try { candidates = Directory.GetDirectories(baseDir, BackingDirPrefix + "*"); }
+        catch { return 0; }
+
+        foreach (string dir in candidates)
+        {
+            try
+            {
+                // Age gate first: it is the cheap check, and it is the one that
+                // protects a pool that exists but has not paged out yet.
+                if (Directory.GetCreationTimeUtc(dir) > cutoff) continue;
+
+                string backing = Path.Combine(dir, "backing.bin");
+                if (File.Exists(backing) && !CanOpenExclusively(backing)) continue;
+
+                Directory.Delete(dir, recursive: true);
+                reclaimed++;
+            }
+            catch
+            {
+                // Raced with its owner, permissions, or a handle we cannot see.
+                // Leaving it is always safe; the next process sweeps again.
+            }
+        }
+
+        return reclaimed;
+    }
+
+    /// <summary>
+    /// True when nothing else holds the file — the signal that its owning pool
+    /// is gone. Opening for READ with <see cref="FileShare.None"/> is refused
+    /// while any other handle is open, which is precisely the question.
+    /// </summary>
+    private static bool CanOpenExclusively(string path)
+    {
+        try
+        {
+            using var probe = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
     }
 
     public void Dispose()

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingPoolOrphanReclaimTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingPoolOrphanReclaimTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.IO;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// A pool whose process is killed must not strand its backing file forever.
+///
+/// <para><see cref="StreamingTensorPool.Dispose"/> deletes the backing directory,
+/// and a process that OOMs or is killed never reaches it. For this pool that is
+/// the NORMAL case, not the exotic one: model-family test hosts die under memory
+/// pressure routinely. Measured on a developer machine, 430 stranded pool
+/// directories accumulated in eight days totalling 257 GB, the largest single
+/// backing.bin 117 GB, until the disk hit zero and every build on the box
+/// started failing.</para>
+///
+/// <para>Two mechanisms, tested here. DeleteOnClose makes the kernel drop the
+/// bytes when the last handle closes, including handles closed on our behalf
+/// when a process dies. The sweep reclaims the directories — and is the only
+/// half that can clean up what earlier runs already stranded.</para>
+/// </summary>
+public class StreamingPoolOrphanReclaimTests
+{
+    /// <summary>An isolated base directory, so a sweep here cannot see real pools.</summary>
+    private static string NewBaseDir() =>
+        Path.Combine(Path.GetTempPath(), "aidotnet-sweep-test-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>A stranded pool directory, aged past the sweep's minimum.</summary>
+    private static string GivenOrphan(string baseDir, long bytes = 4096)
+    {
+        var dir = Path.Combine(baseDir, StreamingTensorPool.BackingDirPrefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "backing.bin"), new byte[bytes]);
+        Age(dir);
+        return dir;
+    }
+
+    /// <summary>Backdates a directory past <c>OrphanMinimumAge</c>.</summary>
+    private static void Age(string dir) =>
+        Directory.SetCreationTimeUtc(dir, DateTime.UtcNow - TimeSpan.FromDays(1));
+
+    [Fact]
+    public void Sweep_ReclaimsAStrandedBackingStore()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var orphan = GivenOrphan(baseDir);
+
+            var reclaimed = StreamingTensorPool.SweepOrphanedBackingStores(baseDir);
+
+            Assert.Equal(1, reclaimed);
+            Assert.False(Directory.Exists(orphan));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    [Fact]
+    public void Sweep_ReclaimsAnEmptyDirectoryLeftByDeleteOnClose()
+    {
+        // The Windows shape after an abnormal exit: the kernel dropped
+        // backing.bin, the directory outlived it.
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var orphan = Path.Combine(baseDir, StreamingTensorPool.BackingDirPrefix + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(orphan);
+            Age(orphan);
+
+            Assert.Equal(1, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.False(Directory.Exists(orphan));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    /// <summary>
+    /// THE ONE THAT MATTERS. A sweep that can delete a live pool's backing store
+    /// would turn a disk-space fix into data loss under the running test.
+    /// </summary>
+    [Fact]
+    public void Sweep_LeavesALivePoolAlone_EvenWhenItsDirectoryLooksOld()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            using var pool = new StreamingTensorPool(new GpuOffloadOptions
+            {
+                // Tiny budget so Register pages out immediately and the backing
+                // file is genuinely open and held.
+                StreamingPoolMaxResidentBytes = 1,
+                StreamingBackingStorePath = baseDir,
+            });
+            var payload = new byte[4096];
+            for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i & 0xFF);
+            var handle = pool.Register(payload);
+
+            var live = Assert.Single(Directory.GetDirectories(baseDir));
+            Assert.True(File.Exists(Path.Combine(live, "backing.bin")),
+                "the pool should have paged out, so its backing file is open");
+
+            // Defeat the age gate deliberately: the file lock, not the
+            // timestamp, is what has to protect a running pool.
+            Age(live);
+
+            var reclaimed = StreamingTensorPool.SweepOrphanedBackingStores(baseDir);
+
+            Assert.Equal(0, reclaimed);
+            Assert.True(Directory.Exists(live));
+
+            // And the weight the sweep ran alongside is still readable, byte for
+            // byte. "The directory survived" would not catch a sweep that
+            // truncated the file it could not delete.
+            var got = pool.Rehydrate(handle);
+            Assert.Equal(payload.Length, got.Length);
+            for (int i = 0; i < payload.Length; i++) Assert.Equal(payload[i], got[i]);
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    /// <summary>
+    /// A pool constructed moments ago has a directory and NO backing file yet —
+    /// paging out is lazy. There is no lock to protect it, so the age gate must.
+    /// </summary>
+    [Fact]
+    public void Sweep_LeavesAFreshlyCreatedDirectoryAlone()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var fresh = Path.Combine(baseDir, StreamingTensorPool.BackingDirPrefix + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(fresh); // not aged
+
+            Assert.Equal(0, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.True(Directory.Exists(fresh));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    [Fact]
+    public void Sweep_IgnoresDirectoriesThatAreNotOurs()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var stranger = Path.Combine(baseDir, "somebody-elses-cache");
+            Directory.CreateDirectory(stranger);
+            Age(stranger);
+
+            Assert.Equal(0, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.True(Directory.Exists(stranger));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    [Fact]
+    public void Sweep_ReclaimsManyAtOnce_AndReportsTheCount()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            for (int i = 0; i < 12; i++) GivenOrphan(baseDir);
+
+            Assert.Equal(12, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.Empty(Directory.GetDirectories(baseDir));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    [Fact]
+    public void Sweep_OnAMissingDirectory_IsNotAnError()
+    {
+        // Best-effort by contract: a machine that cannot sweep a temp directory
+        // has a problem this method is not entitled to escalate.
+        Assert.Equal(0, StreamingTensorPool.SweepOrphanedBackingStores(NewBaseDir()));
+    }
+
+    /// <summary>
+    /// The bytes must be gone the moment the pool's handle closes — not merely
+    /// when Dispose gets as far as deleting the directory. That is the property
+    /// that survives a kill.
+    /// </summary>
+    [Fact]
+    public void BackingFile_IsDeletedAssoonAsTheHandleCloses()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            string backing;
+            using (var pool = new StreamingTensorPool(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 1,
+                StreamingBackingStorePath = baseDir,
+            }))
+            {
+                pool.Register(new byte[4096]);
+                backing = Path.Combine(Directory.GetDirectories(baseDir)[0], "backing.bin");
+                Assert.True(File.Exists(backing));
+            }
+
+            Assert.False(File.Exists(backing));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    /// <summary>Paging out and back in still works with the delete-on-close handle.</summary>
+    [Fact]
+    public void RoundTrip_StillWorks_WithDeleteOnClose()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            using var pool = new StreamingTensorPool(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 2048,
+                StreamingBackingStorePath = baseDir,
+            });
+
+            var payload = new byte[4096];
+            for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i & 0xFF);
+            var handle = pool.Register(payload);
+
+            var got = pool.Rehydrate(handle);
+
+            Assert.Equal(payload.Length, got.Length);
+            for (int i = 0; i < payload.Length; i++) Assert.Equal(payload[i], got[i]);
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* the OS reclaims it */ }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingPoolOrphanReclaimTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingPoolOrphanReclaimTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -161,6 +162,137 @@ public class StreamingPoolOrphanReclaimTests
         finally { Cleanup(baseDir); }
     }
 
+    /// <summary>
+    /// A prefix match is not ownership, and this sweep deletes RECURSIVELY.
+    ///
+    /// <para><c>GetDirectories(baseDir, prefix + "*")</c> returns anything
+    /// starting with the prefix, so somebody's own
+    /// <c>aidotnet-streaming-pool-backup</c> sitting next to the real pools
+    /// would have been destroyed along with whatever they put in it. Only the
+    /// exact shape we mint — prefix plus a 32-digit "N" Guid — is ours.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("backup")]
+    [InlineData("old")]
+    [InlineData("2026-08-17")]
+    [InlineData("deadbeef")]                              // hex, but too short
+    [InlineData("0123456789abcdef0123456789abcdefx")]     // right length, not hex
+    [InlineData("0123456789abcdef0123456789abcdef0")]     // one digit too long
+    public void Sweep_LeavesPrefixMatchingDirectoriesThatWeDidNotCreate(string suffix)
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            var impostor = Path.Combine(baseDir, StreamingTensorPool.BackingDirPrefix + suffix);
+            Directory.CreateDirectory(impostor);
+            var treasure = Path.Combine(impostor, "do-not-delete.txt");
+            File.WriteAllText(treasure, "someone's data");
+            Age(impostor);
+
+            Assert.Equal(0, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.True(Directory.Exists(impostor));
+            Assert.True(File.Exists(treasure));
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    [Fact]
+    public void PoolDirectoryName_AcceptsExactlyWhatThePoolMints()
+    {
+        var minted = StreamingTensorPool.BackingDirPrefix + Guid.NewGuid().ToString("N");
+        Assert.True(StreamingTensorPool.IsPoolDirectoryName(minted));
+
+        Assert.False(StreamingTensorPool.IsPoolDirectoryName(null));
+        Assert.False(StreamingTensorPool.IsPoolDirectoryName(string.Empty));
+        Assert.False(StreamingTensorPool.IsPoolDirectoryName(StreamingTensorPool.BackingDirPrefix));
+        // A Guid in "D" format has hyphens, so it is not a name we produce.
+        Assert.False(StreamingTensorPool.IsPoolDirectoryName(
+            StreamingTensorPool.BackingDirPrefix + Guid.NewGuid().ToString("D")));
+    }
+
+    /// <summary>
+    /// THE DANGEROUS ONE. A pool that stays under budget never pages out, so it
+    /// has a directory and NO backing.bin to lock. Once that directory ages past
+    /// OrphanMinimumAge, the age gate stops protecting it — and deleting it out
+    /// from under its living owner breaks the owner's next page-out, because
+    /// FileMode.Create cannot create a file under a directory that is gone.
+    ///
+    /// <para>Live-pool registration, not age, is what has to save it.</para>
+    /// </summary>
+    [Fact]
+    public void Sweep_LeavesALiveButIdlePoolAlone_EvenWhenItsDirectoryIsOld()
+    {
+        var baseDir = NewBaseDir();
+        Directory.CreateDirectory(baseDir);
+        try
+        {
+            // Budget high enough that Register never evicts: no backing.bin.
+            using var pool = new StreamingTensorPool(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 1024 * 1024,
+                StreamingBackingStorePath = baseDir,
+            });
+
+            var live = Assert.Single(Directory.GetDirectories(baseDir));
+            Assert.False(File.Exists(Path.Combine(live, "backing.bin")),
+                "this test is only meaningful while the pool has NOT paged out");
+            Age(live);
+
+            Assert.Equal(0, StreamingTensorPool.SweepOrphanedBackingStores(baseDir));
+            Assert.True(Directory.Exists(live));
+
+            // And the pool still works afterwards -- the point of not deleting
+            // it. This forces the first page-out, which would throw if its
+            // parent directory had been swept away.
+            var payload = new byte[4096];
+            for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i & 0xFF);
+            var handle = pool.Register(payload);
+            for (int i = 0; i < 40; i++) pool.Register(new byte[4096]); // force eviction
+            var got = pool.Rehydrate(handle);
+            Assert.Equal(payload.Length, got.Length);
+            for (int i = 0; i < payload.Length; i++) Assert.Equal(payload[i], got[i]);
+        }
+        finally { Cleanup(baseDir); }
+    }
+
+    /// <summary>
+    /// Sweep scheduling is per base directory, not per process.
+    ///
+    /// <para>It used to be one static flag, so the first pool constructed swept
+    /// its own base directory and every pool afterwards skipped. A process that
+    /// used the temp directory and then a custom StreamingBackingStorePath
+    /// swept only the first, and orphans under the second accumulated forever.</para>
+    /// </summary>
+    [Fact]
+    public void Sweep_ReclaimsOrphansUnderASecondBaseDirectory()
+    {
+        var first = NewBaseDir();
+        var second = NewBaseDir();
+        Directory.CreateDirectory(first);
+        Directory.CreateDirectory(second);
+        try
+        {
+            // A pool in the first directory: schedules that directory's sweep and,
+            // under the old single-flag code, permanently latched the process.
+            using (new StreamingTensorPool(new GpuOffloadOptions { StreamingBackingStorePath = first })) { }
+
+            // An orphan under a DIFFERENT base directory must still be reclaimed
+            // when a pool is created there.
+            var orphan = GivenOrphan(second);
+            using (new StreamingTensorPool(new GpuOffloadOptions { StreamingBackingStorePath = second })) { }
+
+            // Wait for the SCHEDULED sweep specifically -- calling
+            // SweepOrphanedBackingStores here instead would delete the orphan by
+            // itself and pass even when nothing was ever scheduled, which is the
+            // regression under test.
+            Assert.True(WaitUntilGone(orphan),
+                "constructing a pool under a second base directory must schedule a " +
+                "sweep for THAT directory; with one process-wide flag it never did");
+        }
+        finally { Cleanup(first); Cleanup(second); }
+    }
+
     [Fact]
     public void Sweep_ReclaimsManyAtOnce_AndReportsTheCount()
     {
@@ -185,30 +317,42 @@ public class StreamingPoolOrphanReclaimTests
     }
 
     /// <summary>
-    /// The bytes must be gone the moment the pool's handle closes — not merely
+    /// The bytes must be gone the moment the pool's HANDLE closes — not merely
     /// when Dispose gets as far as deleting the directory. That is the property
-    /// that survives a kill.
+    /// that survives a kill, and it is the only part of this change that
+    /// reclaims anything on an abnormal exit.
+    ///
+    /// <para>Asserting it after Dispose would prove nothing: Dispose closes the
+    /// handle and then deletes the whole directory, so backing.bin vanishes
+    /// either way and the test would keep passing with
+    /// <c>FileOptions.DeleteOnClose</c> removed. Closing the handle ALONE, and
+    /// checking that the directory is still standing while the file inside it
+    /// is gone, is what actually pins the flag down.</para>
     /// </summary>
     [Fact]
-    public void BackingFile_IsDeletedAssoonAsTheHandleCloses()
+    public void BackingFile_IsDeletedWhenTheHandleCloses_WithTheDirectoryStillStanding()
     {
         var baseDir = NewBaseDir();
         Directory.CreateDirectory(baseDir);
         try
         {
-            string backing;
-            using (var pool = new StreamingTensorPool(new GpuOffloadOptions
+            using var pool = new StreamingTensorPool(new GpuOffloadOptions
             {
                 StreamingPoolMaxResidentBytes = 1,
                 StreamingBackingStorePath = baseDir,
-            }))
-            {
-                pool.Register(new byte[4096]);
-                backing = Path.Combine(Directory.GetDirectories(baseDir)[0], "backing.bin");
-                Assert.True(File.Exists(backing));
-            }
+            });
+            pool.Register(new byte[4096]);
+
+            var poolDir = Assert.Single(Directory.GetDirectories(baseDir));
+            var backing = Path.Combine(poolDir, "backing.bin");
+            Assert.True(File.Exists(backing), "the pool should have paged out");
+
+            pool.CloseBackingFileForTests();
 
             Assert.False(File.Exists(backing));
+            Assert.True(Directory.Exists(poolDir),
+                "only the handle was closed, so the directory must be untouched -- " +
+                "which is what makes the vanished file attributable to DeleteOnClose");
         }
         finally { Cleanup(baseDir); }
     }
@@ -237,6 +381,21 @@ public class StreamingPoolOrphanReclaimTests
             for (int i = 0; i < payload.Length; i++) Assert.Equal(payload[i], got[i]);
         }
         finally { Cleanup(baseDir); }
+    }
+
+    /// <summary>
+    /// Waits for a background sweep to remove a directory. Polls rather than
+    /// sleeping a fixed span so the test is neither flaky nor slow.
+    /// </summary>
+    private static bool WaitUntilGone(string dir, int timeoutMs = 15_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (!Directory.Exists(dir)) return true;
+            Thread.Sleep(25);
+        }
+        return !Directory.Exists(dir);
     }
 
     private static void Cleanup(string dir)


### PR DESCRIPTION
## The problem

`StreamingTensorPool.Dispose()` deletes its backing directory. A process that OOMs or is killed never reaches it — and for this pool that is the **normal** case, not the exotic one: model-family test hosts die under memory pressure routinely.

Measured on a developer machine this week:

| | |
|---|---|
| Stranded pool directories | **430**, in 8 days |
| Total stranded | **257 GB** |
| Largest single `backing.bin` | **117 GB** |
| Disk free when found | **1.4 GB of 930 GB** |

Every build on the box was failing. The pool was the single largest consumer on the disk — larger than Docker, larger than every source checkout combined.

## The fix

Two mechanisms, because neither is sufficient alone.

**`FileOptions.DeleteOnClose` on the backing-file handle.** The kernel drops the file when the last handle closes — including the handles it closes on our behalf when a process dies abnormally. This is the only reclaim that survives a kill.

Safe against the zero-copy mmap path: `MmapTensorMemoryManager` already opens the same file with `FileShare.Delete`, this handle still grants `FileShare.Read` so the reader's access is unchanged, and existing mappings keep their bytes — Windows unlinks the *name*, not the data.

**`SweepOrphanedBackingStores`.** Reclaims the directories, covers the Unix gap (the runtime emulates DeleteOnClose at close, so a SIGKILL still strands the file there), and is the only half that can clean up what earlier runs **already** stranded. Runs once per process on a background thread, so it never delays construction or exit.

### How an orphan is identified, and why it cannot take a live pool with it

A running pool holds `backing.bin` open with `FileShare.Read`, so an exclusive open **fails while its owner lives** and succeeds once the owner is gone. That probe is the authority — not a timestamp.

The age gate covers the one case the lock cannot: a pool constructed moments ago has a directory and no backing file yet, because paging out is lazy. There is no handle to probe, so age protects it.

`AIDOTNET_STREAMING_POOL_NO_SWEEP` preserves the evidence for anyone debugging a stranded pool.

## Verification

- **9 new tests**, including the one that matters — a sweep running alongside a live pool leaves its weights readable byte for byte, with the age gate deliberately defeated so the file lock is what is actually under test.
- **301 existing tests pass** across streaming, mmap, zero-copy and weight-registry.
- **net10.0, net8.0 and net471 all build clean**, 0 warnings.

## Note on scope

Authored in a separate worktree from `origin/main`, so the 14 uncommitted deletions under `artifacts/perf/` on `agent/direct-ptx-mseloss-847` are untouched. Two files changed.

## Draft

The DeleteOnClose half is proven on Windows here. The Unix behaviour (runtime emulation at close, sweep as the safety net) is reasoned from the runtime's documented semantics rather than measured on a Linux host — worth a CI run on Linux before this comes out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic cleanup of temporary tensor storage after unexpected interruptions.
  * Removed backing files immediately when their associated storage is closed.
  * Preserved active and recently created storage during cleanup.
  * Added safeguards for missing directories and cleanup failures.

* **Bug Fixes**
  * Reduced leftover temporary storage from abandoned sessions.
  * Confirmed tensor paging and round-trip operations continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->