### PR TITLE
feat(ptx): bf16 tensor-core wmma GEMM (naive + staged)

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.Staged.cs
@@ -94,6 +94,12 @@ public sealed partial class PtxTensorCoreEmitter
     private int _warpTilesM = 2;
     private int _warpTilesN = 2;
 
+    // Multiplicand PTX type for the staged wmma path: "f16" (sm_70+) or "bf16" (sm_80+). Set from the plan at the
+    // top of EmitStaged; the staged loads and mma read it so bf16 is never silently emitted as f16. Byte math is
+    // identical for both (each is 2 bytes = HalfBytes), so only the load type and the mma type suffix change.
+    private string _abType = "f16";
+    private string _mmaTypes = "f32.f32";
+
     /// <summary>
     /// The only warp-tile extents the staged lowering supports, matching the ladder
     /// SelectWarpTile chooses from: (4,4), (4,2), (2,4), (2,2).
@@ -349,6 +355,11 @@ public sealed partial class PtxTensorCoreEmitter
         int aIndex = spec.ProductInputs[0], bIndex = spec.ProductInputs[1];
         int outIndex = spec.Inputs.Count;
         EmittedEntryName = MmaCeilingProbe ? spec.Name + "_ceiling_probe" : spec.Name;
+
+        // f16 uses the short mma form (.f32.f32); bf16 is not the PTX default and must name its multiplicand type
+        // explicitly (.f32.bf16.bf16.f32). TryPlan already guaranteed bf16 only reaches here on sm_80+.
+        _abType = plan.AbType;
+        _mmaTypes = _abType == "bf16" ? "f32.bf16.bf16.f32" : "f32.f32";
 
         bool doubleBuffer = !MmaCeilingProbe
             && EnableDoubleBuffering && CanDoubleBuffer(plan, out _);
@@ -840,7 +851,7 @@ public sealed partial class PtxTensorCoreEmitter
         {
             string addr = NextRd();
             L($"add.u64 {addr}, %rd3, {warpAOffset};");
-            L($"wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 " +
+            L($"wmma.load.a.sync.aligned.row.m16n16k16.shared.{_abType} " +
               $"{Fragment("%fa", i * FragmentRegisters)}, " +
               $"[{addr}+{I(bufferBase + i * TileM * ASharedRowBytes)}], {I(BlockTileK + SharedPadHalves)};");
         }
@@ -849,7 +860,7 @@ public sealed partial class PtxTensorCoreEmitter
         {
             string addr = NextRd();
             L($"add.u64 {addr}, %rd3, {warpBOffset};");
-            L($"wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 " +
+            L($"wmma.load.b.sync.aligned.row.m16n16k16.shared.{_abType} " +
               $"{Fragment("%fb", j * FragmentRegisters)}, " +
               $"[{addr}+{I(bufferBase + BSlabOffset + j * TileN * HalfBytes)}], {I(BlockTileN + SharedPadHalves)};");
         }
@@ -862,7 +873,7 @@ public sealed partial class PtxTensorCoreEmitter
             for (int j = 0; j < WarpTilesN; j++)
             {
                 int t = i * WarpTilesN + j;
-                L($"wmma.mma.sync.aligned.row.row.m16n16k16.f32.f32 " +
+                L($"wmma.mma.sync.aligned.row.row.m16n16k16.{_mmaTypes} " +
                   $"{Fragment("%fc", t * FragmentRegisters)}, {Fragment("%fa", i * FragmentRegisters)}, " +
                   $"{Fragment("%fb", j * FragmentRegisters)}, {Fragment("%fc", t * FragmentRegisters)};");
                 MmaInstructions++;

--- a/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Codegen/Ptx/PtxTensorCoreEmitter.cs
@@ -89,9 +89,9 @@ public sealed partial class PtxTensorCoreEmitter
     /// </summary>
     public sealed class Plan
     {
-        internal Plan(int m, int n, int k, bool aRowMajor, bool bRowMajor)
+        internal Plan(int m, int n, int k, bool aRowMajor, bool bRowMajor, string abType)
         {
-            M = m; N = n; K = k; ARowMajor = aRowMajor; BRowMajor = bRowMajor;
+            M = m; N = n; K = k; ARowMajor = aRowMajor; BRowMajor = bRowMajor; AbType = abType;
         }
 
         /// <summary>Rows of the output.</summary>
@@ -108,6 +108,10 @@ public sealed partial class PtxTensorCoreEmitter
 
         /// <summary>Whether B is stored [K, N] rather than [N, K].</summary>
         public bool BRowMajor { get; }
+
+        /// <summary>PTX multiplicand element type for the wmma load/mma: "f16" (sm_70+) or "bf16" (sm_80+).
+        /// Both accumulate and store fp32; the two differ only in the load type and the mma type suffix.</summary>
+        public string AbType { get; }
 
         /// <summary>Output tiles, one warp each.</summary>
         public int TileCount => (M / TileM) * (N / TileN);
@@ -190,11 +194,21 @@ public sealed partial class PtxTensorCoreEmitter
         var a = spec.Inputs[spec.ProductInputs[0]];
         var b = spec.Inputs[spec.ProductInputs[1]];
 
-        if (a.ElementType != CodegenElementType.Float16 ||
-            b.ElementType != CodegenElementType.Float16)
+        if (a.ElementType != b.ElementType ||
+            (a.ElementType != CodegenElementType.Float16 &&
+             a.ElementType != CodegenElementType.BFloat16))
         {
-            reason = "wmma multiplicands must be fp16; got " + a.ElementType + " and " +
-                b.ElementType;
+            reason = "wmma multiplicands must both be fp16 or both be bf16; got " +
+                a.ElementType + " and " + b.ElementType;
+            return false;
+        }
+
+        // bf16 wmma multiplicands were added in Ampere (sm_80); fp16 wmma works from sm_70. Refuse bf16 on
+        // older targets with a named reason rather than emit PTX the driver cannot load.
+        if (a.ElementType == CodegenElementType.BFloat16 && computeMajor < 8)
+        {
+            reason = "bf16 tensor-core wmma requires sm_80+ (Ampere); target is sm_" +
+                computeMajor + computeMinor;
             return false;
         }
 
@@ -228,7 +242,8 @@ public sealed partial class PtxTensorCoreEmitter
 
         // TryOrientation reports "first named axis is the row". For B the axes are handed
         // over as (N, K), so a "row-major" answer means [N, K] -- which is B TRANSPOSED.
-        plan = new Plan(m, n, k, aRowMajor, bRowMajor: !bColumnOfN);
+        string abType = a.ElementType == CodegenElementType.BFloat16 ? "bf16" : "f16";
+        plan = new Plan(m, n, k, aRowMajor, bRowMajor: !bColumnOfN, abType: abType);
         reason = "eligible";
         return true;
     }
@@ -449,6 +464,12 @@ public sealed partial class PtxTensorCoreEmitter
         string bLayout = plan.BRowMajor ? "row" : "col";
         string fragA = Fragment("%fa"), fragB = Fragment("%fb"), fragC = Fragment("%fc");
 
+        // f16 uses the short mma form (.f32.f32, with f16 multiplicands implied by the fragment); bf16 is not
+        // the PTX default, so its multiplicand type must be named explicitly: .f32.bf16.bf16.f32. The a/b LOAD
+        // type is the plan's element type in both cases. Byte stride is unchanged: bf16 is 2 bytes, like f16.
+        string abType = plan.AbType;
+        string mmaTypes = abType == "bf16" ? "f32.bf16.bf16.f32" : "f32.f32";
+
         // Unrolling matters more here than on the scalar path: each step is three
         // instructions, so a runtime loop's compare-and-branch is a large fraction of the
         // body, and an unrolled walk lets ptxas overlap the loads of step i+1 with the mma
@@ -465,9 +486,9 @@ public sealed partial class PtxTensorCoreEmitter
         int emitted = Unrolled ? steps : 1;
         for (int s = 0; s < emitted; s++)
         {
-            L($"wmma.load.a.sync.aligned.{aLayout}.m16n16k16.global.f16 {fragA}, [%rd4], {I(aLeading)};");
-            L($"wmma.load.b.sync.aligned.{bLayout}.m16n16k16.global.f16 {fragB}, [%rd6], {I(bLeading)};");
-            L($"wmma.mma.sync.aligned.{aLayout}.{bLayout}.m16n16k16.f32.f32 {fragC}, {fragA}, {fragB}, {fragC};");
+            L($"wmma.load.a.sync.aligned.{aLayout}.m16n16k16.global.{abType} {fragA}, [%rd4], {I(aLeading)};");
+            L($"wmma.load.b.sync.aligned.{bLayout}.m16n16k16.global.{abType} {fragB}, [%rd6], {I(bLeading)};");
+            L($"wmma.mma.sync.aligned.{aLayout}.{bLayout}.m16n16k16.{mmaTypes} {fragC}, {fragA}, {fragB}, {fragC};");
             MmaInstructions++;
 
             if (s < emitted - 1 || !Unrolled)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreStagingTests.cs
@@ -51,7 +51,8 @@ public class CodegenTensorCoreStagingTests
     private static CodegenKernelSpec MatMul(
         int m, int k, int n,
         CodegenActivationKind activation = CodegenActivationKind.None,
-        bool transposeB = false)
+        bool transposeB = false,
+        CodegenElementType operands = CodegenElementType.Float16)
     {
         var space = new CodegenIterationSpace(
             CodegenAxis.Parallel("m", m), CodegenAxis.Parallel("n", n),
@@ -59,15 +60,15 @@ public class CodegenTensorCoreStagingTests
 
         var a = new CodegenTensorBinding(0, "a", new[] { m, k },
             new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(2) },
-            elementType: CodegenElementType.Float16);
+            elementType: operands);
 
         var b = transposeB
             ? new CodegenTensorBinding(1, "b", new[] { n, k },
                 new[] { CodegenAffineExpr.Axis(1), CodegenAffineExpr.Axis(2) },
-                elementType: CodegenElementType.Float16)
+                elementType: operands)
             : new CodegenTensorBinding(1, "b", new[] { k, n },
                 new[] { CodegenAffineExpr.Axis(2), CodegenAffineExpr.Axis(1) },
-                elementType: CodegenElementType.Float16);
+                elementType: operands);
 
         var output = new CodegenTensorBinding(2, "out", new[] { m, n },
             new[] { CodegenAffineExpr.Axis(0), CodegenAffineExpr.Axis(1) }, isOutput: true);
@@ -81,6 +82,20 @@ public class CodegenTensorCoreStagingTests
         Assert.True(PtxTensorCoreEmitter.TryPlan(
             spec, Sm86Major, Sm86Minor, out var plan, out string reason), reason);
         return plan!;
+    }
+
+    /// <summary>The staged bf16 kernel loads bf16 fragments from shared memory and issues the explicit-type
+    /// bf16 mma; it must not fall back to the f16 shared-load form.</summary>
+    [Fact]
+    public void StagedKernel_Bf16_UsesBf16Wmma()
+    {
+        string ptx = Tile2x2().Emit(
+            MatMul(512, 512, 512, operands: CodegenElementType.BFloat16), Sm86Major, Sm86Minor);
+
+        Assert.Contains("wmma.load.a.sync.aligned.row.m16n16k16.shared.bf16", ptx, StringComparison.Ordinal);
+        Assert.Contains("wmma.load.b.sync.aligned.row.m16n16k16.shared.bf16", ptx, StringComparison.Ordinal);
+        Assert.Contains("wmma.mma.sync.aligned.row.row.m16n16k16.f32.bf16.bf16.f32", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("shared.f16", ptx, StringComparison.Ordinal);
     }
 
     /// <summary>A whole number of 64x64 block tiles is what staging needs.</summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/CodegenTensorCoreTests.cs
@@ -97,6 +97,50 @@ public class CodegenTensorCoreTests
         Assert.Contains("wmma.store.d.sync.aligned.row.m16n16k16.global.f32", ptx, StringComparison.Ordinal);
     }
 
+    /// <summary>bf16 multiplicands with fp32 accumulate are eligible on sm_80+ and tag the plan "bf16".</summary>
+    [Theory]
+    [InlineData(16, 16, 16)]
+    [InlineData(64, 64, 64)]
+    [InlineData(256, 2048, 256)]
+    public void PlainBf16MatMul_IsEligible(int m, int k, int n)
+    {
+        Assert.True(PtxTensorCoreEmitter.TryPlan(
+            MatMul(m, k, n, CodegenElementType.BFloat16), Sm86Major, Sm86Minor,
+            out var plan, out string reason), reason);
+
+        Assert.NotNull(plan);
+        Assert.Equal("bf16", plan!.AbType);
+    }
+
+    /// <summary>The bf16 kernel loads bf16 fragments and issues the explicit-type bf16 mma, still fp32 out, and
+    /// must NOT fall back to the f16 forms.</summary>
+    [Fact]
+    public void EmittedKernel_Bf16_UsesBf16Wmma()
+    {
+        string ptx = Naive().Emit(MatMul(64, 64, 64, CodegenElementType.BFloat16), Sm86Major, Sm86Minor);
+
+        Assert.Contains("wmma.load.a.sync.aligned.row.m16n16k16.global.bf16", ptx, StringComparison.Ordinal);
+        Assert.Contains("wmma.load.b.sync.aligned.row.m16n16k16.global.bf16", ptx, StringComparison.Ordinal);
+        // bf16 is not the PTX default, so the multiplicand types are named explicitly.
+        Assert.Contains("wmma.mma.sync.aligned.row.row.m16n16k16.f32.bf16.bf16.f32", ptx, StringComparison.Ordinal);
+        Assert.Contains("wmma.store.d.sync.aligned.row.m16n16k16.global.f32", ptx, StringComparison.Ordinal);
+        Assert.DoesNotContain("global.f16", ptx, StringComparison.Ordinal);
+    }
+
+    /// <summary>bf16 wmma is Ampere+ (sm_80); on sm_70 the recogniser must refuse it with a reason rather than
+    /// emit PTX the target cannot load.</summary>
+    [Fact]
+    public void Bf16_BelowSm80_IsRefused()
+    {
+        bool ok = PtxTensorCoreEmitter.TryPlan(
+            MatMul(64, 64, 64, CodegenElementType.BFloat16), computeMajor: 7, computeMinor: 5,
+            out var plan, out string reason);
+
+        Assert.False(ok);
+        Assert.Null(plan);
+        Assert.Contains("sm_80", reason, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// The tile index must come from the WARP, not the thread. wmma instructions are
     /// warp-synchronous: if lanes of one warp reached different tiles, or if some lanes took


### PR DESCRIPTION
## What

Adds **BF16** multiplicand support to `PtxTensorCoreEmitter` alongside the existing FP16 path, on **both** the naive and staged wmma lowerings. This is the BF16 GEMM slice of #837 (the direct-PTX mixed-precision linear kernels), split out of the #860 stack because the tensor-core emitter is already on `main`, so it can land independently.

## How

- **Recogniser** (`TryPlan`): accepts matched bf16 multiplicands with fp32 accumulate; refuses bf16 below **sm_80** (bf16 wmma is Ampere+, fp16 is sm_70+) with a named reason. `Plan.AbType` carries the type.
- **Emission** (naive + staged): `.global`/`.shared.bf16` fragment loads and the **explicit** `wmma.mma…m16n16k16.f32.bf16.bf16.f32` (bf16 is not the PTX default). Byte math is unchanged — bf16 is 2 bytes like f16. FP16 emission is byte-identical.

## Tests

New codegen tests on both paths: `PlainBf16MatMul_IsEligible`, `EmittedKernel_Bf16_UsesBf16Wmma`, `Bf16_BelowSm80_IsRefused`, `StagedKernel_Bf16_UsesBf16Wmma`. `CodegenTensorCore` suite **74/74 green** off `main`, no fp16 regression.

GPU championship (p15 + Nsight zero-spill) for the bf16 path remains pending on Ampere+ hardware; this PR lands the assembler-correct codegen. Part of #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)