### PR TITLE
feat(gpu): add capability-aware autocast and speed-first type parity

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
+++ b/src/AiDotNet.Tensors/Engines/CuBlasNative.cs
@@ -621,6 +621,10 @@ public static class CuBlasNative
     public const int CUBLAS_COMPUTE_32F_FAST_16F = 74;
     public const int CUBLAS_COMPUTE_32F_FAST_TF32 = 77;
 
+    // cublasGemmAlgo_t. DEFAULT is -1 in cublas_api.h; zero is the first fixed algorithm,
+    // which can reject otherwise-supported datatype combinations.
+    public const int CUBLAS_GEMM_DEFAULT = -1;
+
     #endregion
 
     #region Helper Methods

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.HalfPrecision.cs
@@ -107,7 +107,7 @@ public sealed partial class CudaBackend
                 betaPtr,
                 cFp32.Handle, CuBlasNative.CUDA_R_32F, n,
                 CuBlasNative.CUBLAS_COMPUTE_32F,
-                0 /* CUBLAS_GEMM_DEFAULT — let cuBLAS pick algorithm */),
+                CuBlasNative.CUBLAS_GEMM_DEFAULT),
             "cublasGemmEx(FP16 in / FP32 out)");
     }
 
@@ -143,7 +143,7 @@ public sealed partial class CudaBackend
             betaPtr,
             Chalf.Handle, CuBlasNative.CUDA_R_16F, N,
             CuBlasNative.CUBLAS_COMPUTE_32F,
-            0 /* CUBLAS_GEMM_DEFAULT */);
+            CuBlasNative.CUBLAS_GEMM_DEFAULT);
         if (status == AiDotNet.Tensors.Engines.CublasStatus.NotSupported)
             throw new NotSupportedException($"FP16 Tensor-Core GEMM (Half out) not supported on this device (cc {_ccMajor}.{_ccMinor}).");
         CuBlasNative.CheckCublasStatus(status, "cublasGemmEx(GemmFp16HalfOut)");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -2246,7 +2246,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                             betaPtr,
                             sPtr, CuBlasNative.CUDA_R_32F, seqLen,
                             _fp32GemmComputeType,
-                            0 /* CUBLAS_GEMM_DEFAULT */),
+                            CuBlasNative.CUBLAS_GEMM_DEFAULT),
                         $"cublasGemmEx MHA score batch={batchIdx} head={headIdx}");
                 });
             }
@@ -2430,7 +2430,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                         betaPtr,
                         cPtr, CuBlasNative.CUDA_R_32F, N,
                         _fp32GemmComputeType,
-                        0 /* CUBLAS_GEMM_DEFAULT */),
+                        CuBlasNative.CUBLAS_GEMM_DEFAULT),
                     $"cublasGemmEx slice {slice}");
             });
         }
@@ -13646,7 +13646,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             betaPtr,
             C.Handle, CuBlasNative.CUDA_R_32F, N,
             CuBlasNative.CUBLAS_COMPUTE_32F,
-            0 /* CUBLAS_GEMM_DEFAULT — selects Tensor Cores under the handle's math mode */);
+            CuBlasNative.CUBLAS_GEMM_DEFAULT);
 
         // CUBLAS_STATUS_NOT_SUPPORTED is a CAPABILITY signal, not an operational failure:
         // the FP16-in / FP32-compute cublasGemmEx config isn't available on this device

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/DirectGpuEngine.cs
@@ -35,17 +35,13 @@ public sealed class DirectGpuEngine : IDisposable
         Environment.GetEnvironmentVariable("AIDOTNET_GEMM_VALIDATE") == "1";
 
     /// <summary>
-    /// Stage 8 (#415): when set, generic-T entry points that would route a
-    /// non-float T (notably <c>double</c>, <c>Half</c>, <c>BFloat16</c>)
-    /// through the FP32 GPU boundary return <c>null</c> instead — forcing
-    /// the caller to fall back to the CPU path which preserves the
-    /// requested precision. Default: ON for double (silent downcast was
-    /// the source of precision loss in cluster #6 ResNet50/VGG FP64 tests).
-    /// Override via env var <c>AIDOTNET_DIRECTGPU_STRICT_FP64=0</c> to opt
-    /// back into the legacy lossy behavior for benchmarking / smoke tests.
+    /// Compatibility switch for callers that previously opted into strict FP64 CPU fallback.
+    /// Speed-first generic GPU conversion is the package default; new code should use
+    /// <see cref="Gpu.GpuExecutionPolicyScope"/> to request preservation explicitly.
+    /// Set <c>AIDOTNET_DIRECTGPU_STRICT_FP64=1</c> to retain the legacy process-wide behavior.
     /// </summary>
     public static readonly bool StrictFp64Fallback =
-        Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_STRICT_FP64") != "0";
+        Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_STRICT_FP64") == "1";
 
     /// <summary>
     /// Stage 8 (#415): returns true when the requested element type would
@@ -55,12 +51,10 @@ public sealed class DirectGpuEngine : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool ShouldFallbackForPrecision<T>()
     {
-        if (!StrictFp64Fallback) return false;
-        // float is the GPU boundary type — never lossy. Everything else is
-        // potentially lossy. Half / BFloat16 callers are rare and usually
-        // opt into the downcast deliberately; only double is the high-
-        // leverage case for cluster #6.
-        return typeof(T) == typeof(double);
+        if (Gpu.GpuExecutionPolicyScope.CurrentPolicy.AccuracyMode == Gpu.GpuAccuracyMode.PreserveInputType)
+            return typeof(T) != typeof(float);
+
+        return StrictFp64Fallback && typeof(T) == typeof(double);
     }
 
     /// <summary>
@@ -220,6 +214,18 @@ public sealed class DirectGpuEngine : IDisposable
 
         Trace.WriteLine("[DirectGpuEngine] No GPU backends available. Falling back to CPU.");
         _isAvailable = false;
+    }
+
+    /// <summary>Creates an engine around an already-selected backend.</summary>
+    /// <remarks>
+    /// Internal so deterministic routing tests can exercise conversion and dispatch without probing
+    /// machine hardware. Production callers continue to use the public capability-detecting constructor.
+    /// </remarks>
+    internal DirectGpuEngine(IDirectGpuBackend backend)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _fusionManager = new KernelFusionManager();
+        _isAvailable = backend.IsAvailable;
     }
 
     private static IReadOnlyList<string> GetBackendOrderFromEnv()
@@ -1250,6 +1256,4 @@ public sealed class DirectGpuEngine : IDisposable
         _disposed = true;
     }
 }
-
-
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -3484,17 +3484,24 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private T[]? TryRunUnary<T>(Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        // Same precision guard as TryRunBinary: do not upload CPU-resident doubles into a
-        // single-precision kernel. Sqrt is the one that mattered for Adam. See IsGpuPrecisionSafe.
+        // PreserveInputType and the legacy strict-FP64 switch keep exact-T work on CPU.
         if (!IsGpuPrecisionSafe(input))
             return null;
 
         if (!TryGetBackend(out var backend))
             return null;
 
+        var precisionOperation = PrecisionOperationForUnary(callerName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, callerName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
+
         try
         {
-            return TryRunUnaryGpu(backend, input, op);
+            return TryRunUnaryGpu(backend, input, op, precisionOperation, precisionPlan);
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
@@ -3518,35 +3525,32 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
-    private T[]? TryRunUnaryGpu<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunUnaryGpu<T>(
+        IDirectGpuBackend backend,
+        Tensor<T> input,
+        Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op,
+        Gpu.GpuPrecisionOperation precisionOperation,
+        Gpu.GpuComputePlan precisionPlan)
     {
         using var bufferA = GetOrAllocateBuffer(backend, input);
         var bufferB = AllocateOutputBuffer(backend, input.Length);
         try
         {
-            // AutocastScope: convert to fp16 for compute, back to fp32 for output.
-            // try/finally guarantees fp16Input is released even if op() or
-            // ConvertToFp32 throws.
-            IGpuBuffer? fp16Input = null;
-            try
+            if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
             {
-                fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, input.Length);
-                if (fp16Input is not null)
-                {
-                    using var fp16Output = AllocateOutputBuffer(backend, input.Length);
-                    op(backend, fp16Input, fp16Output.Buffer, input.Length);
-                    backend.ConvertToFp32(fp16Output.Buffer, bufferB.Buffer, input.Length);
-                }
-                else
-                {
-                    op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
-                }
+                using var fp16Input = AllocateReducedPrecisionInput(
+                    backend, bufferA.Buffer, input.Length, precisionPlan);
+                using var fp16Output = AllocateReducedPrecisionOutput(backend, input.Length, precisionPlan);
+                ExecuteFp16Unary(backend, precisionOperation, fp16Input, fp16Output, input.Length);
+                backend.ConvertToFp32(fp16Output, bufferB.Buffer, input.Length);
             }
-            finally
+            else
             {
-                fp16Input?.Dispose();
+                op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
             }
-            return FinishGpuOp<T>(backend, bufferB, input.Length);
+            var result = FinishGpuOp<T>(backend, bufferB, input.Length);
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return result;
         }
         catch
         {
@@ -3572,6 +3576,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal T[]? TryRunUnaryChunked<T>(IDirectGpuBackend backend, Tensor<T> input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent, string opName = "Unary")
     {
         emittedEvent = false;
+        var precisionOperation = PrecisionOperationForUnary(opName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, opName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
         long capBytes = ex.DeviceMaxAllocBytes;
         if (capBytes <= 0) return null;
         int totalElements = input.Length;
@@ -3622,33 +3633,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
                 using var bufferIn = new OwnedBuffer(backend.AllocateBuffer(slice), ownsBuffer: true);
                 using var bufferOut = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                // Mirror the AutocastScope behaviour from TryRunUnaryGpu: when
-                // autocast is enabled, run the kernel on fp16 and convert back
-                // to fp32 for the downloaded result. Without this the chunked
-                // fallback would silently change numeric / perf behaviour vs
-                // the normal GPU path.
-                IGpuBuffer? fp16Input = null;
-                try
+                if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
                 {
-                    fp16Input = Gpu.AutocastScope.MaybeConvertInput(backend, bufferIn.Buffer, len);
-                    if (fp16Input is not null)
-                    {
-                        using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                        op(backend, fp16Input, fp16Out.Buffer, len);
-                        backend.ConvertToFp32(fp16Out.Buffer, bufferOut.Buffer, len);
-                    }
-                    else
-                    {
-                        op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
-                    }
+                    using var fp16Input = AllocateReducedPrecisionInput(
+                        backend, bufferIn.Buffer, len, precisionPlan);
+                    using var fp16Out = AllocateReducedPrecisionOutput(backend, len, precisionPlan);
+                    ExecuteFp16Unary(backend, precisionOperation, fp16Input, fp16Out, len);
+                    backend.ConvertToFp32(fp16Out, bufferOut.Buffer, len);
                 }
-                finally
+                else
                 {
-                    fp16Input?.Dispose();
+                    op(backend, bufferIn.Buffer, bufferOut.Buffer, len);
                 }
                 var chunkResult = backend.DownloadBuffer(bufferOut.Buffer);
                 Array.Copy(chunkResult, 0, resultFloat, offset, len);
             }
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
             return (T[])(object)resultFloat;
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException)
@@ -3675,42 +3675,78 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// Tensor-aware TryRunBinary: checks GPU activation cache BEFORE triggering CPU materialization.
     /// </summary>
     /// <summary>
-    /// True when running <typeparamref name="T"/> through a single-precision GPU kernel cannot
-    /// silently lose precision the caller asked for.
+    /// True when the active execution policy permits conversion through the FP32 GPU boundary.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Narrowing double -> float is intended only at a real device boundary, for data that already
-    /// lives on the device. The upload-compute-download paths are the opposite case: the operands
-    /// are CPU-resident, so they get copied into a float kernel and the caller receives
-    /// float-accurate answers despite having asked for double.
-    /// </para>
-    /// <para>
-    /// Measured before this guard: <c>AiDotNetEngine.Current.Multiply</c> on a CPU-resident
-    /// <c>Vector&lt;double&gt;</c> returned 0.30000001192092896 where double gives
-    /// 0.30000000000000004 -- 3.974E-008 relative, which is float32 epsilon (~1.19e-7), not double
-    /// (~2.2e-16). The same ops on an explicitly constructed <c>CpuEngine</c> were exact, so the
-    /// kernels were never the problem; the dispatch was. It also cost a host-&gt;device-&gt;host round
-    /// trip PER OP on data that never needed to leave the CPU.
-    /// </para>
-    /// <para>
-    /// Tensors that really are device-resident are unaffected: they are served by the resident
-    /// paths (<c>TryBinaryResidentOutOfPlace</c> and friends), which run before this check.
-    /// </para>
+    /// Speed-first is the default and accepts T -&gt; FP32 -&gt; T conversion for every numeric T.
+    /// PreserveInputType (and the legacy strict-FP64 environment switch) returns false so the
+    /// caller falls through to the generic CPU implementation.
     /// </remarks>
     private static bool IsGpuPrecisionSafe<T>(Tensor<T> a, Tensor<T>? b = null)
+        // The planner that immediately follows this check can honor PreserveInputType with an
+        // exact backend route (for example Half ReLU). Only the legacy process-wide FP64 switch
+        // must short-circuit before planning.
+        => !(DirectGpuEngine.StrictFp64Fallback && typeof(T) == typeof(double));
+
+    private static Gpu.GpuPrecisionOperation PrecisionOperationForUnary(string operationName)
     {
-        if (typeof(T) != typeof(double)) return true;          // float/half already match the kernels
-        if (a.IsGpuResident) return true;                      // already on the device by the caller's choice
-        if (b is not null && b.IsGpuResident) return true;
-        return false;
+        if (operationName.IndexOf("gelu", StringComparison.OrdinalIgnoreCase) >= 0)
+            return Gpu.GpuPrecisionOperation.Gelu;
+        if (operationName.IndexOf("relu", StringComparison.OrdinalIgnoreCase) >= 0)
+            return Gpu.GpuPrecisionOperation.Relu;
+        return Gpu.GpuPrecisionOperation.Elementwise;
+    }
+
+    private static Gpu.GpuPrecisionOperation PrecisionOperationForBinary(string operationName)
+        => operationName.IndexOf("add", StringComparison.OrdinalIgnoreCase) >= 0
+            ? Gpu.GpuPrecisionOperation.Add
+            : Gpu.GpuPrecisionOperation.Elementwise;
+
+    private static void ExecuteFp16Unary(
+        IDirectGpuBackend backend,
+        Gpu.GpuPrecisionOperation operation,
+        IGpuBuffer input,
+        IGpuBuffer output,
+        int size)
+    {
+        if (backend is not Gpu.IGpuFp16ElementwiseBackend fp16 || !fp16.SupportsFp16NativeOps)
+            throw new NotSupportedException($"{backend.BackendName} advertised typed FP16 element-wise support without a dispatch implementation.");
+
+        switch (operation)
+        {
+            case Gpu.GpuPrecisionOperation.Relu:
+                fp16.Fp16Relu(input, output, size);
+                break;
+            case Gpu.GpuPrecisionOperation.Gelu:
+                fp16.Fp16Gelu(input, output, size);
+                break;
+            default:
+                throw new NotSupportedException($"No typed FP16 unary dispatch exists for {operation}.");
+        }
+    }
+
+    private static void ExecuteFp16Binary(
+        IDirectGpuBackend backend,
+        Gpu.GpuPrecisionOperation operation,
+        IGpuBuffer left,
+        IGpuBuffer right,
+        IGpuBuffer output,
+        int size)
+    {
+        if (operation != Gpu.GpuPrecisionOperation.Add
+            || backend is not Gpu.IGpuFp16ElementwiseBackend fp16
+            || !fp16.SupportsFp16NativeOps)
+        {
+            throw new NotSupportedException($"No typed FP16 binary dispatch exists for {operation} on {backend.BackendName}.");
+        }
+
+        fp16.Fp16Add(left, right, output, size);
     }
 
     private T[]? TryRunBinary<T>(Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        // Fall through to base (CpuEngine), which computes in the declared T, rather than uploading
-        // CPU-resident doubles into a single-precision kernel. See IsGpuPrecisionSafe.
+        // Exact-T policies fall through to the generic CPU implementation.
         if (!IsGpuPrecisionSafe(left, right))
             return null;
 
@@ -3719,9 +3755,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (left.Length != right.Length)
             return null;
 
+        var precisionOperation = PrecisionOperationForBinary(callerName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, callerName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
+
         try
         {
-            return TryRunBinaryGpu(backend, left, right, op);
+            return TryRunBinaryGpu(backend, left, right, op, precisionOperation, precisionPlan);
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex)
         {
@@ -3737,39 +3781,36 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
-    private T[]? TryRunBinaryGpu<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op)
+    private T[]? TryRunBinaryGpu<T>(
+        IDirectGpuBackend backend,
+        Tensor<T> left,
+        Tensor<T> right,
+        Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
+        Gpu.GpuPrecisionOperation precisionOperation,
+        Gpu.GpuComputePlan precisionPlan)
     {
         using var bufferA = GetOrAllocateBuffer(backend, left);
         using var bufferB = GetOrAllocateBuffer(backend, right);
         var bufferC = AllocateOutputBuffer(backend, left.Length);
         try
         {
-            // fp16A / fp16B are raw IGpuBuffer? (no IDisposable wrapper) so we
-            // must guarantee Dispose() runs even if op() or ConvertToFp32 throws.
-            // Previously these leaked on any exception inside the if-branch.
-            IGpuBuffer? fp16A = null;
-            IGpuBuffer? fp16B = null;
-            try
+            if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
             {
-                fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
-                fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
-                if (fp16A is not null && fp16B is not null)
-                {
-                    using var fp16Out = AllocateOutputBuffer(backend, left.Length);
-                    op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
-                    backend.ConvertToFp32(fp16Out.Buffer, bufferC.Buffer, left.Length);
-                }
-                else
-                {
-                    op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-                }
+                using var fp16A = AllocateReducedPrecisionInput(
+                    backend, bufferA.Buffer, left.Length, precisionPlan);
+                using var fp16B = AllocateReducedPrecisionInput(
+                    backend, bufferB.Buffer, right.Length, precisionPlan);
+                using var fp16Out = AllocateReducedPrecisionOutput(backend, left.Length, precisionPlan);
+                ExecuteFp16Binary(backend, precisionOperation, fp16A, fp16B, fp16Out, left.Length);
+                backend.ConvertToFp32(fp16Out, bufferC.Buffer, left.Length);
             }
-            finally
+            else
             {
-                fp16A?.Dispose();
-                fp16B?.Dispose();
+                op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
             }
-            return FinishGpuOp<T>(backend, bufferC, left.Length);
+            var result = FinishGpuOp<T>(backend, bufferC, left.Length);
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return result;
         }
         catch
         {
@@ -3786,6 +3827,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     internal T[]? TryRunBinaryChunked<T>(IDirectGpuBackend backend, Tensor<T> left, Tensor<T> right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op, AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException ex, out bool emittedEvent, string opName = "Binary")
     {
         emittedEvent = false;
+        var precisionOperation = PrecisionOperationForBinary(opName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, opName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
         long capBytes = ex.DeviceMaxAllocBytes;
         if (capBytes <= 0) return null;
         int totalElements = left.Length;
@@ -3830,34 +3878,22 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 using var bA = new OwnedBuffer(backend.AllocateBuffer(sliceL), ownsBuffer: true);
                 using var bB = new OwnedBuffer(backend.AllocateBuffer(sliceR), ownsBuffer: true);
                 using var bC = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                // Mirror the AutocastScope behaviour from TryRunBinaryGpu so the
-                // chunked fallback doesn't silently change numeric/perf behaviour
-                // when autocast is enabled.
-                IGpuBuffer? fp16A = null;
-                IGpuBuffer? fp16B = null;
-                try
+                if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
                 {
-                    fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bA.Buffer, len);
-                    fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bB.Buffer, len);
-                    if (fp16A is not null && fp16B is not null)
-                    {
-                        using var fp16Out = new OwnedBuffer(backend.AllocateBuffer(len), ownsBuffer: true);
-                        op(backend, fp16A, fp16B, fp16Out.Buffer, len);
-                        backend.ConvertToFp32(fp16Out.Buffer, bC.Buffer, len);
-                    }
-                    else
-                    {
-                        op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
-                    }
+                    using var fp16A = AllocateReducedPrecisionInput(backend, bA.Buffer, len, precisionPlan);
+                    using var fp16B = AllocateReducedPrecisionInput(backend, bB.Buffer, len, precisionPlan);
+                    using var fp16Out = AllocateReducedPrecisionOutput(backend, len, precisionPlan);
+                    ExecuteFp16Binary(backend, precisionOperation, fp16A, fp16B, fp16Out, len);
+                    backend.ConvertToFp32(fp16Out, bC.Buffer, len);
                 }
-                finally
+                else
                 {
-                    fp16A?.Dispose();
-                    fp16B?.Dispose();
+                    op(backend, bA.Buffer, bB.Buffer, bC.Buffer, len);
                 }
                 var chunkResult = backend.DownloadBuffer(bC.Buffer);
                 Array.Copy(chunkResult, 0, resultFloat, offset, len);
             }
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
             return (T[])(object)resultFloat;
         }
         catch (AiDotNet.Tensors.Engines.DirectGpu.GpuBufferTooLargeException)
@@ -3881,12 +3917,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private T[]? TryRunUnary<T>(T[] input, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        // A T[] is CPU memory by definition -- see the note on the binary array overload.
-        if (typeof(T) == typeof(double))
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return null;
 
         if (!TryGetBackend(out var backend))
             return null;
+
+        var precisionOperation = PrecisionOperationForUnary(callerName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, callerName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
 
         try
         {
@@ -3894,8 +3937,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var bufferB = AllocateOutputBuffer(backend, input.Length);
             try
             {
-                op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
-                return FinishGpuOpImmediate<T>(backend, bufferB, input.Length);
+                if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
+                {
+                    using var fp16Input = AllocateReducedPrecisionInput(
+                        backend, bufferA.Buffer, input.Length, precisionPlan);
+                    using var fp16Output = AllocateReducedPrecisionOutput(backend, input.Length, precisionPlan);
+                    ExecuteFp16Unary(backend, precisionOperation, fp16Input, fp16Output, input.Length);
+                    backend.ConvertToFp32(fp16Output, bufferB.Buffer, input.Length);
+                }
+                else
+                {
+                    op(backend, bufferA.Buffer, bufferB.Buffer, input.Length);
+                }
+                var result = FinishGpuOpImmediate<T>(backend, bufferB, input.Length);
+                Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+                return result;
             }
             catch
             {
@@ -3912,18 +3968,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private T[]? TryRunBinary<T>(T[] left, T[] right, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        // A T[] is CPU memory by definition, so uploading double data into a single-precision
-        // kernel here is ALWAYS a silent precision loss -- there is no device residency to respect.
-        // This is the overload the explicit IEngine.Add/Subtract/Multiply/Divide vector members
-        // call via GetDataArray(), which is how CPU-resident doubles were reaching a float kernel.
-        // See IsGpuPrecisionSafe; returning null falls through to base (CpuEngine).
-        if (typeof(T) == typeof(double))
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return null;
 
         if (!TryGetBackend(out var backend))
             return null;
         if (left.Length != right.Length)
             return null;
+
+        var precisionOperation = PrecisionOperationForBinary(callerName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, callerName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return null;
+        }
 
         try
         {
@@ -3932,8 +3991,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var bufferC = AllocateOutputBuffer(backend, left.Length);
             try
             {
-                op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
-                return FinishGpuOpImmediate<T>(backend, bufferC, left.Length);
+                if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
+                {
+                    using var fp16A = AllocateReducedPrecisionInput(
+                        backend, bufferA.Buffer, left.Length, precisionPlan);
+                    using var fp16B = AllocateReducedPrecisionInput(
+                        backend, bufferB.Buffer, right.Length, precisionPlan);
+                    using var fp16Out = AllocateReducedPrecisionOutput(backend, left.Length, precisionPlan);
+                    ExecuteFp16Binary(backend, precisionOperation, fp16A, fp16B, fp16Out, left.Length);
+                    backend.ConvertToFp32(fp16Out, bufferC.Buffer, left.Length);
+                }
+                else
+                {
+                    op(backend, bufferA.Buffer, bufferB.Buffer, bufferC.Buffer, left.Length);
+                }
+                var result = FinishGpuOpImmediate<T>(backend, bufferC, left.Length);
+                Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+                return result;
             }
             catch
             {
@@ -3950,10 +4024,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     private T[]? TryRunScalar<T>(T[] input, T scalar, Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, float, int> op,
         [System.Runtime.CompilerServices.CallerMemberName] string callerName = "")
     {
-        // A T[] is CPU memory by definition -- see the note on the binary array overload. Note this
-        // overload's kernel signature takes a `float` scalar, so a double scalar could never have
-        // survived the call in the first place.
-        if (typeof(T) == typeof(double))
+        if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return null;
 
         if (!TryGetBackend(out var backend))
@@ -4787,10 +4858,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return false;
 
+        var precisionOperation = PrecisionOperationForBinary(callerName);
+        var precisionPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(backend, precisionOperation, callerName);
+        if (precisionPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
+            return false;
+        }
+
         // GPU-RESIDENT compiled-step path: op directly into destination's stable buffer — no temp output
         // allocation and no DtoH download (both abort CUDA-graph capture + ping-pong host every op). Gated on
         // suspended eviction (the compiled step pins buffers) and no autocast fp16 remap.
-        if (ResidentStepActive && !Gpu.AutocastScope.IsEnabled)
+        if (ResidentStepActive && precisionPlan.InputStorage == Gpu.GpuScalarType.Float32)
         {
             try
             {
@@ -4826,30 +4905,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var output = AllocateOutputBuffer(backend, left.Length);
             try
             {
-                IGpuBuffer? fp16A = null;
-                IGpuBuffer? fp16B = null;
-                try
+                if (precisionPlan.InputStorage == Gpu.GpuScalarType.Float16)
                 {
-                    fp16A = Gpu.AutocastScope.MaybeConvertInput(backend, bufferA.Buffer, left.Length);
-                    fp16B = Gpu.AutocastScope.MaybeConvertInput(backend, bufferB.Buffer, left.Length);
-                    if (fp16A is not null && fp16B is not null)
-                    {
-                        using var fp16Out = AllocateOutputBuffer(backend, left.Length);
-                        op(backend, fp16A, fp16B, fp16Out.Buffer, left.Length);
-                        backend.ConvertToFp32(fp16Out.Buffer, output.Buffer, left.Length);
-                    }
-                    else
-                    {
-                        op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
-                    }
+                    using var fp16A = AllocateReducedPrecisionInput(
+                        backend, bufferA.Buffer, left.Length, precisionPlan);
+                    using var fp16B = AllocateReducedPrecisionInput(
+                        backend, bufferB.Buffer, right.Length, precisionPlan);
+                    using var fp16Out = AllocateReducedPrecisionOutput(backend, left.Length, precisionPlan);
+                    ExecuteFp16Binary(backend, precisionOperation, fp16A, fp16B, fp16Out, left.Length);
+                    backend.ConvertToFp32(fp16Out, output.Buffer, left.Length);
                 }
-                finally
+                else
                 {
-                    fp16A?.Dispose();
-                    fp16B?.Dispose();
+                    op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
                 }
 
                 DownloadGpuBufferInto(backend, output, destinationArray, left.Length);
+                Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
                 return true;
             }
             catch
@@ -5217,20 +5289,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 && backend is Engines.Gpu.IGpuHalfPrecisionBackend halfBackend
                 && halfBackend.SupportsHgemm)
             {
-                // Issue #560: FP16 tensor-core fast path. cublasGemmEx with
+                // Issue #560: FP16 vendor-library fast path. cublasGemmEx with
                 // FP16 inputs and an FP32 accumulator is the standard
                 // mixed-precision matmul (matches the AMP forward pass): the
-                // multiply runs on tensor cores, the FP32 accumulator preserves
+                // vendor library chooses the available FP16 execution units, and the FP32
+                // accumulator preserves
                 // long-chain precision, and the FP32 output flows back into
                 // the activation cache so downstream FP32 ops can consume it
                 // directly. The two FP32→FP16 conversions are O(MK+KN) —
                 // negligible against the O(MKN) GEMM.
                 //
-                // GemmFp16In32fOut requires tensor cores. Some CC>=5 GPUs
-                // (notably Turing TU116/TU117 — the GTX 16-series) advertise
-                // FP16 support but lack tensor cores, and cublasGemmEx returns
-                // CUBLAS_STATUS_NOT_SUPPORTED on those parts. Try the FP16 path
-                // first; on a clean failure fall through to SGEMM on the same
+                // A backend can support FP16 storage conversion without supporting this typed GEMM
+                // combination. Try the FP16 path first; on a clean capability/runtime failure fall
+                // through to SGEMM on the same
                 // (already-uploaded) FP32 inputs. This is the right behavior
                 // for "Half user on hardware that can't accelerate Half" —
                 // they get the FP32 speed of the GPU instead of dropping to
@@ -5246,7 +5317,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 }
                 catch (InvalidOperationException)
                 {
-                    // Tensor cores not available — SGEMM fallback below.
+                    // Typed FP16 GEMM unavailable at runtime — SGEMM fallback below.
                 }
                 catch (NotSupportedException)
                 {
@@ -18982,6 +19053,156 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // GPU-accelerated matrix operations (MatMul, Transpose, Permute)
     // ──────────────────────────────────────────────────────────────
 
+    private static IGpuBuffer AllocateReducedPrecisionInput(
+        IDirectGpuBackend backend,
+        IGpuBuffer fp32Input,
+        int elementCount,
+        Gpu.GpuComputePlan plan)
+    {
+        if (plan.InputStorage != Gpu.GpuScalarType.Float16)
+            throw new NotSupportedException($"No conversion implementation exists for {plan.InputStorage} input storage.");
+
+        var reduced = plan.ReducesStorageBytes
+            ? backend.AllocateByteBuffer(checked(elementCount * 2))
+            : backend.AllocateBuffer(elementCount);
+        try
+        {
+            backend.ConvertToFp16(fp32Input, reduced, elementCount);
+            return reduced;
+        }
+        catch
+        {
+            reduced.Dispose();
+            throw;
+        }
+    }
+
+    private static IGpuBuffer AllocateReducedPrecisionOutput(
+        IDirectGpuBackend backend,
+        int elementCount,
+        Gpu.GpuComputePlan plan)
+    {
+        if (plan.OutputStorage != Gpu.GpuScalarType.Float16)
+            throw new NotSupportedException($"No reduced output allocation exists for {plan.OutputStorage} storage.");
+
+        return plan.ReducesStorageBytes
+            ? backend.AllocateByteBuffer(checked(elementCount * 2))
+            : backend.AllocateBuffer(elementCount);
+    }
+
+    private Tensor<T> ExecutePlannedGemm<T>(
+        IDirectGpuBackend backend,
+        Tensor<T> a,
+        Tensor<T> b,
+        int m,
+        int n,
+        int k,
+        int[] outputShape,
+        Gpu.GpuComputePlan plan)
+    {
+        using var bufferA = GetOrAllocateBuffer(backend, a);
+        using var bufferB = GetOrAllocateBuffer(backend, b);
+        var bufferOut = AllocateOutputBuffer(backend, checked(m * n));
+        try
+        {
+            if (plan.InputStorage == Gpu.GpuScalarType.Float16)
+            {
+                if (backend is not IGpuHalfPrecisionBackend halfBackend || !halfBackend.SupportsHgemm)
+                    throw new NotSupportedException($"{backend.BackendName} advertised FP16 GEMM without an executable half GEMM route.");
+
+                using var fp16A = AllocateReducedPrecisionInput(backend, bufferA.Buffer, checked(m * k), plan);
+                using var fp16B = AllocateReducedPrecisionInput(backend, bufferB.Buffer, checked(k * n), plan);
+                halfBackend.GemmFp16In32fOut(fp16A, fp16B, bufferOut.Buffer, m, n, k);
+            }
+            else if (plan.InputStorage == Gpu.GpuScalarType.Float32)
+            {
+                backend.Gemm(bufferA.Buffer, bufferB.Buffer, bufferOut.Buffer, m, n, k);
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    $"The selected {plan.InputStorage} GEMM route has no backend dispatch implementation.");
+            }
+
+            var result = DeferTensorResult<T>(backend, bufferOut.Buffer, checked(m * n), outputShape);
+            Gpu.GpuPrecisionDiagnostics.Publish(plan);
+            return result;
+        }
+        catch
+        {
+            bufferOut.Dispose();
+            throw;
+        }
+    }
+
+    private Tensor<T> ExecutePlannedBatchedGemm<T>(
+        IDirectGpuBackend backend,
+        Tensor<T> a,
+        Tensor<T> b,
+        int batchCount,
+        int m,
+        int n,
+        int k,
+        int[] outputShape,
+        Gpu.GpuComputePlan plan)
+    {
+        // IDirectGpuBackend currently exposes only an FP32 BatchedGemm contract. Explicit FP16/BF16/FP8
+        // requests therefore resolve to FP32 before reaching this method rather than being misrepresented.
+        if (plan.InputStorage != Gpu.GpuScalarType.Float32)
+            throw new NotSupportedException($"No batched GEMM dispatch exists for {plan.InputStorage} storage.");
+
+        using var bufferA = GetOrAllocateBuffer(backend, a);
+        using var bufferB = GetOrAllocateBuffer(backend, b);
+        var outputLength = checked(batchCount * m * n);
+        var bufferOut = AllocateOutputBuffer(backend, outputLength);
+        try
+        {
+            backend.BatchedGemm(bufferA.Buffer, bufferB.Buffer, bufferOut.Buffer, m, n, k, batchCount);
+            var result = DeferTensorResult<T>(backend, bufferOut.Buffer, outputLength, outputShape);
+            Gpu.GpuPrecisionDiagnostics.Publish(plan);
+            return result;
+        }
+        catch
+        {
+            bufferOut.Dispose();
+            throw;
+        }
+    }
+
+    private static bool TryGetContiguousBatchedMatMulDimensions<T>(
+        Tensor<T> a,
+        Tensor<T> b,
+        out int batchCount,
+        out int m,
+        out int n,
+        out int k,
+        out int[] outputShape)
+    {
+        batchCount = 0;
+        m = n = k = 0;
+        outputShape = Array.Empty<int>();
+        if (a.Rank < 3 || b.Rank != a.Rank || !a.IsContiguous || !b.IsContiguous)
+            return false;
+
+        int rank = a.Rank;
+        m = a.Shape._dims[rank - 2];
+        k = a.Shape._dims[rank - 1];
+        if (b.Shape._dims[rank - 2] != k)
+            return false;
+        n = b.Shape._dims[rank - 1];
+        batchCount = 1;
+        for (int dimension = 0; dimension < rank - 2; dimension++)
+        {
+            if (a.Shape._dims[dimension] != b.Shape._dims[dimension])
+                return false;
+            batchCount = checked(batchCount * a.Shape._dims[dimension]);
+        }
+
+        outputShape = (int[])a.Shape._dims.Clone();
+        outputShape[rank - 1] = n;
+        return true;
+    }
+
     public override Tensor<T> TensorMatMul<T>(Tensor<T> a, Tensor<T> b)
     {
         DeviceDispatch.EnforceStrict(a, b); // no-op unless strict mode is enabled
@@ -18994,9 +19215,17 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // A is row-major [.., K], so collapsing all leading dims into a single M is a pure reshape (same
         // memory): do ONE GPU GEMM [M*, K]×[K, N] then reshape the result back to a.dims[:-1] + [N].
         // MatMulBackward already handles the ND×2D shapes (the base CpuEngine path recorded it identically).
-        if (typeof(T) == typeof(float) && a.Rank > 2 && b.Rank == 2
+        if (a.Rank > 2 && b.Rank == 2
             && a.Shape._dims[a.Rank - 1] == b.Shape._dims[0])
         {
+            var ndPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+                backend, Gpu.GpuPrecisionOperation.MatMul, "TensorMatMul.NDx2D");
+            if (ndPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+            {
+                Gpu.GpuPrecisionDiagnostics.Publish(ndPlan);
+                return base.TensorMatMul(a, b);
+            }
+
             try
             {
                 int Kc = a.Shape._dims[a.Rank - 1];
@@ -19005,44 +19234,41 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 for (int d = 0; d < a.Rank - 1; d++) Mc *= a.Shape._dims[d];
                 int[] outShapeRes = (int[])a.Shape._dims.Clone();
                 outShapeRes[a.Rank - 1] = Nc;
-                if (TryMatMulResident(a, b, Mc, Nc, Kc, outShapeRes) is { } rmm)
+                if (ndPlan.InputStorage == Gpu.GpuScalarType.Float32
+                    && TryMatMulResident(a, b, Mc, Nc, Kc, outShapeRes) is { } rmm)
                 {
+                    Gpu.GpuPrecisionDiagnostics.Publish(ndPlan);
                     Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", rmm, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
                     return rmm;
                 }
-                using var bufAc = GetOrAllocateBuffer(backend, a);
-                using var bufBc = GetOrAllocateBuffer(backend, b);
-                var bufOutc = AllocateOutputBuffer(backend, Mc * Nc);
-                backend.Gemm(bufAc.Buffer, bufBc.Buffer, bufOutc.Buffer, Mc, Nc, Kc);
-                int[] outShapec = (int[])a.Shape._dims.Clone();
-                outShapec[a.Rank - 1] = Nc;
-                var outputc = DeferTensorResult<T>(backend, bufOutc.Buffer, Mc * Nc, outShapec);
+                var outputc = ExecutePlannedGemm(backend, a, b, Mc, Nc, Kc, outShapeRes, ndPlan);
                 Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", outputc, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
                 return outputc;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
+                    backend, "TensorMatMul.NDx2D", ndPlan.RequestedPreference,
+                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
                 return base.TensorMatMul(a, b);
             }
         }
-        // PR #638 A1: resident-step CONTIGUOUS BATCHED matmul for ND×ND (the 4D attention score/output backward
-        // GEMMs: [B,H,M,K]×[B,H,K,N] → [B,H,M,N]). Collapse the leading dims into batchCount and run one resident
-        // BatchedGemm into a resident-bound output (capture-safe sequential cublasSgemm-per-batch loop) — no
-        // base CpuEngine download. Same contiguous batched semantics base.TensorMatMul records (MatMulBackward).
-        if (typeof(T) == typeof(float) && ResidentStepActive && !Gpu.AutocastScope.IsEnabled
-            && a.Rank >= 3 && b.Rank == a.Rank)
+        // Contiguous ND×ND matmul collapses every matching leading dimension into one batch count. This is the
+        // same shape contract for float, double, Half, and other generic T values; only the physical compute plan
+        // differs. The resident fast path remains available for its existing FP32 capture-safe case.
+        if (TryGetContiguousBatchedMatMulDimensions(
+            a, b, out int batch, out int Mb, out int Nb, out int Kb, out int[] batchedOutShape))
         {
-            int rk = a.Rank;
-            int Mb = a.Shape._dims[rk - 2], Kb = a.Shape._dims[rk - 1];
-            int Nb = b.Shape._dims[rk - 1];
-            bool leadingMatch = b.Shape._dims[rk - 2] == Kb;
-            int batch = 1;
-            for (int d = 0; d < rk - 2 && leadingMatch; d++)
+            var batchPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+                backend, Gpu.GpuPrecisionOperation.BatchMatMul, "TensorMatMul.NDxND");
+            if (batchPlan.Route == Gpu.GpuExecutionRoute.Cpu)
             {
-                if (a.Shape._dims[d] != b.Shape._dims[d]) { leadingMatch = false; break; }
-                batch *= a.Shape._dims[d];
+                Gpu.GpuPrecisionDiagnostics.Publish(batchPlan);
+                return base.TensorMatMul(a, b);
             }
-            if (leadingMatch && a.IsContiguous && b.IsContiguous)
+
+            if (typeof(T) == typeof(float) && ResidentStepActive && !Gpu.AutocastScope.IsEnabled
+                && batchPlan.InputStorage == Gpu.GpuScalarType.Float32)
             {
                 var aR = ResolveResidentBufferNoUpload(backend, a, batch * Mb * Kb);
                 var bR = ResolveResidentBufferNoUpload(backend, b, batch * Kb * Nb);
@@ -19050,15 +19276,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 {
                     try
                     {
-                        var outDims = (int[])a.Shape._dims.Clone();
-                        outDims[rk - 1] = Nb;
-                        var output = new Tensor<T>(new T[(long)batch * Mb * Nb], outDims);
+                        var output = new Tensor<T>(new T[(long)batch * Mb * Nb], batchedOutShape);
                         var outBuf = GetOrCreateResidentBuffer(backend, output, batch * Mb * Nb);
                         if (outBuf.Handle != System.IntPtr.Zero && outBuf.Size >= (long)batch * Mb * Nb)
                         {
                             backend.BatchedGemm(aR, bR, outBuf, Mb, Nb, Kb, batch, 1f, 0f);
                             ResidentSyncCheck("BatchedMatMulResident");
                             BindResidentBuffer(output, outBuf, backend);
+                            Gpu.GpuPrecisionDiagnostics.Publish(batchPlan);
                             Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", output, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
                             return output;
                         }
@@ -19068,14 +19293,38 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 else if (System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1")
                     AliasDiag($"BatchedMatMul bail aResident={aR is not null} bResident={bR is not null} aShape=[{string.Join(",", a._shape)}]");
             }
+
+            try
+            {
+                var output = ExecutePlannedBatchedGemm(
+                    backend, a, b, batch, Mb, Nb, Kb, batchedOutShape, batchPlan);
+                Autodiff.DifferentiableOps.RecordBinary(
+                    "TensorMatMul", output, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
+                return output;
+            }
+            catch (Exception ex)
+            {
+                Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
+                    backend, "TensorMatMul.NDxND", batchPlan.RequestedPreference,
+                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                return base.TensorMatMul(a, b);
+            }
         }
 
-        // Remaining non-2D shapes (ND × ND, K-mismatch, non-float) go through the base CpuEngine path,
-        // which correctly handles ND × ND (per-batch GEMM) and records on the tape.
+        // Remaining non-2D shapes (broadcasting, non-contiguous views, or shape mismatch) retain the CPU
+        // reference semantics until the backend contract can represent them without materializing incorrectly.
         if (a.Rank != 2 || b.Rank != 2)
         {
             if (ResidentStepActive && System.Environment.GetEnvironmentVariable("AIDOTNET_GRAPH_CAPTURE_DEBUG") == "1")
                 AliasDiag($"MatMul ND-base-fallthrough aShape=[{string.Join(",", a._shape)}] bShape=[{string.Join(",", b._shape)}]");
+            return base.TensorMatMul(a, b);
+        }
+
+        var rank2Plan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+            backend, Gpu.GpuPrecisionOperation.MatMul, "TensorMatMul.Rank2");
+        if (rank2Plan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(rank2Plan);
             return base.TensorMatMul(a, b);
         }
 
@@ -19096,8 +19345,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
             // PR #638 A1: resident-step GEMM into a resident-bound output (no temp/download) so the backward
             // matmul grads stay resident for capture.
-            if (TryMatMulResident(a, b, M, N, K, new[] { M, N }) is { } rmm2d)
+            if (rank2Plan.InputStorage == Gpu.GpuScalarType.Float32
+                && TryMatMulResident(a, b, M, N, K, new[] { M, N }) is { } rmm2d)
             {
+                Gpu.GpuPrecisionDiagnostics.Publish(rank2Plan);
                 Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", rmm2d, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
                 return rmm2d;
             }
@@ -19108,7 +19359,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Half-output GEMM (FP32 accumulate), and cache the Half output as an IsFp16 entry. Runs on ANY
             // backend that ships a half-output GEMM (IGpuHalfPrecisionBackend.Hgemm / SupportsHgemm) — the
             // half-resident matmul forward is no longer CUDA-only.
-            if (typeof(T) == typeof(Half) && s_fp16FwdStore
+            if (rank2Plan.InputStorage == Gpu.GpuScalarType.Float16
+                && typeof(T) == typeof(Half) && s_fp16FwdStore
                 && backend is IGpuHalfPrecisionBackend hpFwd && hpFwd.SupportsHgemm)
             {
                 IGpuBuffer? hAiOwned = null, hBiOwned = null, hOut = null;
@@ -19122,6 +19374,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     var resultH = FinishGpuOpHalfStore(backend, hOut, M * N, new[] { M, N }); // takes ownership of hOut
                     hOut = null;
                     var outputH = (Tensor<T>)(object)new Tensor<Half>(resultH, new[] { M, N });
+                    Gpu.GpuPrecisionDiagnostics.Publish(rank2Plan);
                     Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", outputH, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
                     storeOk = true;
                     return outputH;
@@ -19136,17 +19389,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 finally { hAiOwned?.Dispose(); hBiOwned?.Dispose(); if (!storeOk) hOut?.Dispose(); }
             }
 
-            using var bufA = GetOrAllocateBuffer(backend, a);
-            using var bufB = GetOrAllocateBuffer(backend, b);
-
-            var bufOut = AllocateOutputBuffer(backend, M * N);
-            backend.Gemm(bufA.Buffer, bufB.Buffer, bufOut.Buffer, M, N, K);
-            var output = DeferTensorResult<T>(backend, bufOut.Buffer, M * N, new[] { M, N });
+            var output = ExecutePlannedGemm(backend, a, b, M, N, K, new[] { M, N }, rank2Plan);
             Autodiff.DifferentiableOps.RecordBinary("TensorMatMul", output, a, b, Autodiff.BackwardFunctions<T>.MatMulBackward);
             return output;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
+                backend, "TensorMatMul.Rank2", rank2Plan.RequestedPreference,
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
             return base.TensorMatMul(a, b);
         }
     }
@@ -19154,12 +19405,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <inheritdoc/>
     public override Tensor<T> TensorMatMulTransposed<T>(Tensor<T> a, Tensor<T> b)
     {
-        // GPU path: float-only + 2D for now (matches the CPU fast-path
-        // contract). Other dtypes / higher rank fall through to the
-        // CpuEngine base implementation which correctly materializes
-        // the transpose for the generic case.
-        if (typeof(T) != typeof(float) || a.Rank != 2 || b.Rank != 2 || !TryGetBackend(out var backend))
+        if (a.Rank != 2 || b.Rank != 2 || !TryGetBackend(out var backend))
             return base.TensorMatMulTransposed(a, b);
+
+        var plan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+            backend, Gpu.GpuPrecisionOperation.MatMulTransposed, "TensorMatMulTransposed");
+        if (plan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(plan);
+            return base.TensorMatMulTransposed(a, b);
+        }
 
         try
         {
@@ -19179,14 +19434,18 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // no materialized transpose copy.
             backend.MatMulTransposed(bufA.Buffer, bufB.Buffer, bufOut.Buffer, M, N, K);
             var output = DeferTensorResult<T>(backend, bufOut.Buffer, M * N, new[] { M, N });
+            Gpu.GpuPrecisionDiagnostics.Publish(plan);
             // Use the dedicated MatMulTransposedBackward — see CpuEngine
             // override for why MatMulBackward is wrong here.
             Autodiff.DifferentiableOps.RecordBinary("TensorMatMulTransposed", output, a, b,
                 Autodiff.BackwardFunctions<T>.MatMulTransposedBackward);
             return output;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
+                backend, "TensorMatMulTransposed", plan.RequestedPreference,
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
             return base.TensorMatMulTransposed(a, b);
         }
     }
@@ -19276,24 +19535,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend) || a.Rank < 3 || b.Rank < 3)
             return base.BatchMatMul(a, b);
 
+        if (!TryGetContiguousBatchedMatMulDimensions(
+            a, b, out int batchCount, out int m, out int n, out int k, out int[] outputShape))
+            return base.BatchMatMul(a, b);
+
+        var plan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+            backend, Gpu.GpuPrecisionOperation.BatchMatMul, "BatchMatMul");
+        if (plan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(plan);
+            return base.BatchMatMul(a, b);
+        }
+
         try
         {
-            int batchSize = a.Shape._dims[0];
-            int M = a.Shape._dims[a.Rank - 2];
-            int K = a.Shape._dims[a.Rank - 1];
-            int N = b.Shape._dims[b.Rank - 1];
-            using var bufA = GetOrAllocateBuffer(backend, a);
-            using var bufB = GetOrAllocateBuffer(backend, b);
-            var bufOut = AllocateOutputBuffer(backend, batchSize * M * N);
-            backend.BatchedGemm(bufA.Buffer, bufB.Buffer, bufOut.Buffer, M, N, K, batchSize);
-            int[] outShape = (int[])a.Shape._dims.Clone();
-            outShape[a.Rank - 1] = N;
-            var output = DeferTensorResult<T>(backend, bufOut.Buffer, batchSize * M * N, outShape);
+            var output = ExecutePlannedBatchedGemm(
+                backend, a, b, batchCount, m, n, k, outputShape, plan);
             Autodiff.DifferentiableOps.RecordBinary("BatchMatMul", output, a, b, Autodiff.BackwardFunctions<T>.BatchMatMulBackward);
             return output;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
+                backend, "BatchMatMul", plan.RequestedPreference,
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
             return base.BatchMatMul(a, b);
         }
     }

--- a/src/AiDotNet.Tensors/Engines/Gpu/AutocastScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/AutocastScope.cs
@@ -43,8 +43,7 @@ public enum PrecisionMode
 /// </remarks>
 public sealed class AutocastScope : IDisposable
 {
-    [ThreadStatic]
-    private static AutocastScope? _current;
+    private static readonly System.Threading.AsyncLocal<AutocastScope?> s_current = new();
 
     private readonly AutocastScope? _previous;
     private bool _disposed;
@@ -52,7 +51,7 @@ public sealed class AutocastScope : IDisposable
     /// <summary>
     /// Gets the currently active autocast scope, or null if none.
     /// </summary>
-    public static AutocastScope? Current => _current;
+    public static AutocastScope? Current => s_current.Value;
 
     /// <summary>
     /// Gets the precision mode for this scope.
@@ -62,12 +61,12 @@ public sealed class AutocastScope : IDisposable
     /// <summary>
     /// Gets whether autocast is currently enabled (any scope is active).
     /// </summary>
-    public static bool IsEnabled => _current is not null;
+    public static bool IsEnabled => Current is not null;
 
     /// <summary>
     /// Gets the active precision mode, defaulting to Float32 when no scope is active.
     /// </summary>
-    public static PrecisionMode ActivePrecision => _current?.Precision ?? PrecisionMode.Float32;
+    public static PrecisionMode ActivePrecision => Current?.Precision ?? PrecisionMode.Float32;
 
     /// <summary>
     /// Optional per-layer precision policy. When non-null,
@@ -101,12 +100,10 @@ public sealed class AutocastScope : IDisposable
     /// <paramref name="precision"/> applies to every layer.</param>
     public AutocastScope(PrecisionMode precision, LayerPrecisionPolicy? policy)
     {
-        if (precision == PrecisionMode.BFloat16)
-            throw new NotSupportedException("BFloat16 autocast is not yet implemented. Use Float16 instead.");
         Precision = precision;
         Policy = policy;
-        _previous = _current;
-        _current = this;
+        _previous = Current;
+        s_current.Value = this;
     }
 
     /// <summary>
@@ -119,11 +116,9 @@ public sealed class AutocastScope : IDisposable
     /// // model forward / backward — runs in env-selected precision if set,
     /// // otherwise full FP32.
     /// </code>
-    /// Recognized values (case-insensitive): <c>fp16</c> / <c>float16</c> /
-    /// <c>half</c> → FP16; <c>fp8</c> / <c>float8</c> / <c>e5m2</c> →
-    /// Float8E5M2. Any other value (including unset / empty) yields a
-    /// no-op (returns null). <c>BFloat16</c> intentionally not auto-engaged
-    /// because the in-tree BFloat16 autocast is not yet implemented.
+    /// Recognized values (case-insensitive): FP16, BF16, FP8 E4M3, and FP8 E5M2 aliases.
+    /// Unsupported physical formats are resolved by <see cref="GpuPrecisionPlanner"/> at operation dispatch;
+    /// constructing a backend-agnostic scope never throws merely because one device lacks the requested format.
     /// </summary>
     /// <returns>An active <see cref="AutocastScope"/> when the env-var
     /// selects a supported precision, otherwise null.</returns>
@@ -131,22 +126,9 @@ public sealed class AutocastScope : IDisposable
     {
         var raw = Environment.GetEnvironmentVariable("AIDOTNET_AUTOCAST");
         if (string.IsNullOrWhiteSpace(raw)) return null;
-        var trimmed = raw.Trim();
-        if (string.Equals(trimmed, "fp16", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "float16", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "half", StringComparison.OrdinalIgnoreCase))
-        {
-            return new AutocastScope(PrecisionMode.Float16);
-        }
-        if (string.Equals(trimmed, "fp8", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "float8", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "e5m2", StringComparison.OrdinalIgnoreCase))
-        {
-            return new AutocastScope(PrecisionMode.Float8E5M2);
-        }
-        // Unknown / explicitly-fp32 / disabled — return null so the caller
-        // gets a no-op `using var x = null;` without throwing.
-        return null;
+        return TryParsePrecision(raw, out var precision) && precision != PrecisionMode.Float32
+            ? new AutocastScope(precision)
+            : null;
     }
 
     /// <summary>
@@ -160,16 +142,52 @@ public sealed class AutocastScope : IDisposable
     {
         var raw = Environment.GetEnvironmentVariable("AIDOTNET_AUTOCAST");
         if (string.IsNullOrWhiteSpace(raw)) return PrecisionMode.Float32;
-        var trimmed = raw.Trim();
-        if (string.Equals(trimmed, "fp16", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "float16", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "half", StringComparison.OrdinalIgnoreCase))
-            return PrecisionMode.Float16;
-        if (string.Equals(trimmed, "fp8", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "float8", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(trimmed, "e5m2", StringComparison.OrdinalIgnoreCase))
-            return PrecisionMode.Float8E5M2;
-        return PrecisionMode.Float32;
+        return TryParsePrecision(raw, out var precision) ? precision : PrecisionMode.Float32;
+    }
+
+    private static bool TryParsePrecision(string value, out PrecisionMode precision)
+    {
+        var normalized = value.Trim().Replace("-", string.Empty).Replace("_", string.Empty);
+        if (normalized.Equals("fp16", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("float16", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("half", StringComparison.OrdinalIgnoreCase))
+        {
+            precision = PrecisionMode.Float16;
+            return true;
+        }
+        if (normalized.Equals("bf16", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("bfloat16", StringComparison.OrdinalIgnoreCase))
+        {
+            precision = PrecisionMode.BFloat16;
+            return true;
+        }
+        if (normalized.Equals("e4m3", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("fp8e4m3", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("float8e4m3", StringComparison.OrdinalIgnoreCase))
+        {
+            precision = PrecisionMode.Float8E4M3;
+            return true;
+        }
+        if (normalized.Equals("fp8", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("float8", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("e5m2", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("fp8e5m2", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("float8e5m2", StringComparison.OrdinalIgnoreCase))
+        {
+            precision = PrecisionMode.Float8E5M2;
+            return true;
+        }
+        if (normalized.Equals("fp32", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("float32", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("off", StringComparison.OrdinalIgnoreCase)
+            || normalized.Equals("false", StringComparison.OrdinalIgnoreCase))
+        {
+            precision = PrecisionMode.Float32;
+            return true;
+        }
+
+        precision = PrecisionMode.Float32;
+        return false;
     }
 
     /// <summary>
@@ -317,17 +335,24 @@ public sealed class AutocastScope : IDisposable
     /// Converts a fp32 GPU buffer to the active precision for computation.
     /// Returns null if no conversion is needed. Caller MUST dispose the returned buffer.
     /// </summary>
-    public static IGpuBuffer? MaybeConvertInput(IDirectGpuBackend backend, IGpuBuffer fp32Buffer, int size)
+    public static IGpuBuffer? MaybeConvertInput(
+        IDirectGpuBackend backend,
+        IGpuBuffer fp32Buffer,
+        int size,
+        GpuPrecisionOperation operation = GpuPrecisionOperation.General)
     {
         if (!IsEnabled || ActivePrecision == PrecisionMode.Float32)
             return null;
 
-        // FP16 storage is 2 bytes/element. AllocateBuffer(size) reserves size FLOATS (size*4 bytes), so the
-        // fp16-compute inputs were stored float-sized and saved no memory (#558 layer-5 secondary finding).
-        // AllocateByteBuffer(size*2) reserves exactly the half-precision footprint — a contained ½-size win
-        // on the transient autocast GEMM inputs. IGpuBuffer.SizeInBytes then reflects the true 2-byte size,
-        // so the activation-cache byte accounting stays correct.
-        var fp16Buffer = backend.AllocateByteBuffer(size * 2);
+        var plan = GpuPrecisionPlanner.CreatePlan<float>(backend, operation, operation.ToString());
+        if (plan.Route != GpuExecutionRoute.Gpu || plan.InputStorage != GpuScalarType.Float16)
+            return null;
+
+        // Native/packed FP16 uses two bytes per element. An emulated backend (currently WebGPU without
+        // shader-f16) quantizes values but retains FP32 storage and must allocate accordingly.
+        var fp16Buffer = plan.ReducesStorageBytes
+            ? backend.AllocateByteBuffer(checked(size * 2))
+            : backend.AllocateBuffer(size);
         backend.ConvertToFp16(fp32Buffer, fp16Buffer, size);
         return fp16Buffer;
     }
@@ -335,9 +360,17 @@ public sealed class AutocastScope : IDisposable
     /// <summary>
     /// Converts a result buffer back to fp32 for gradient accumulation.
     /// </summary>
-    public static IGpuBuffer? MaybeConvertOutput(IDirectGpuBackend backend, IGpuBuffer resultBuffer, int size)
+    public static IGpuBuffer? MaybeConvertOutput(
+        IDirectGpuBackend backend,
+        IGpuBuffer resultBuffer,
+        int size,
+        GpuPrecisionOperation operation = GpuPrecisionOperation.General)
     {
         if (!IsEnabled || ActivePrecision == PrecisionMode.Float32)
+            return null;
+
+        var plan = GpuPrecisionPlanner.CreatePlan<float>(backend, operation, operation.ToString());
+        if (plan.Route != GpuExecutionRoute.Gpu || plan.OutputStorage != GpuScalarType.Float16)
             return null;
 
         var fp32Buffer = backend.AllocateBuffer(size);
@@ -349,7 +382,7 @@ public sealed class AutocastScope : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        _current = _previous;
+        s_current.Value = _previous;
         ClearTensors();
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Gpu/DirectGpuPrecisionCapabilities.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/DirectGpuPrecisionCapabilities.cs
@@ -1,0 +1,222 @@
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA
+{
+    /// <summary>Precision capabilities exposed by the CUDA backend.</summary>
+    public sealed partial class CudaBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                Fp16Implementation(operation),
+                fp16ReducesStorageBytes: true,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: IsFp16Elementwise(operation) ? GpuScalarType.Float32 : GpuScalarType.Float16,
+                fp32Implementation: IsGemm(operation)
+                    ? GpuPrecisionImplementation.VendorLibrary
+                    : GpuPrecisionImplementation.Native,
+                fp32MultiplyType: UsesTensorFloat32(operation)
+                    ? GpuScalarType.TensorFloat32
+                    : GpuScalarType.Float32,
+                supportsTensorFloat32: UsesTensorFloat32(operation));
+
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+
+        private static bool IsGemm(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.MatMul
+                or GpuPrecisionOperation.MatMulTransposed
+                or GpuPrecisionOperation.BatchMatMul;
+
+        private bool UsesTensorFloat32(GpuPrecisionOperation operation)
+            => IsGemm(operation)
+                && _ccMajor >= 8
+                && _fp32GemmComputeType == CuBlasNative.CUBLAS_COMPUTE_32F;
+
+        private static GpuPrecisionImplementation Fp16Implementation(GpuPrecisionOperation operation)
+            => operation switch
+            {
+                GpuPrecisionOperation.MatMul => GpuPrecisionImplementation.VendorLibrary,
+                GpuPrecisionOperation.Convolution => GpuPrecisionImplementation.Composite,
+                _ => GpuPrecisionImplementation.Native,
+            };
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP
+{
+    /// <summary>Precision capabilities exposed by the HIP backend.</summary>
+    public sealed partial class HipBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                Fp16Implementation(operation),
+                fp16ReducesStorageBytes: true,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: IsFp16Elementwise(operation) ? GpuScalarType.Float32 : GpuScalarType.Float16,
+                fp32Implementation: IsGemm(operation)
+                    ? GpuPrecisionImplementation.VendorLibrary
+                    : GpuPrecisionImplementation.Native);
+
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+
+        private static bool IsGemm(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.MatMul
+                or GpuPrecisionOperation.MatMulTransposed
+                or GpuPrecisionOperation.BatchMatMul;
+
+        private static GpuPrecisionImplementation Fp16Implementation(GpuPrecisionOperation operation)
+            => operation switch
+            {
+                GpuPrecisionOperation.MatMul => GpuPrecisionImplementation.VendorLibrary,
+                GpuPrecisionOperation.Convolution => GpuPrecisionImplementation.Composite,
+                _ => GpuPrecisionImplementation.Native,
+            };
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    /// <summary>Precision capabilities exposed by the Metal backend.</summary>
+    public sealed partial class MetalBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                GpuPrecisionImplementation.Native,
+                fp16ReducesStorageBytes: true,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: GpuScalarType.Float32);
+
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    /// <summary>Precision capabilities exposed by the OpenCL backend.</summary>
+    public sealed partial class OpenClBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                GpuPrecisionImplementation.Packed,
+                fp16ReducesStorageBytes: true,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: GpuScalarType.Float32);
+
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan
+{
+    /// <summary>Precision capabilities exposed by the Vulkan backend.</summary>
+    public sealed partial class VulkanBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                GpuPrecisionImplementation.Packed,
+                fp16ReducesStorageBytes: true,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: GpuScalarType.Float32);
+
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+    }
+}
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu
+{
+    /// <summary>Precision capabilities exposed by the WebGPU backend.</summary>
+#if NET7_0_OR_GREATER
+    public sealed partial class WebGpuBackend : IGpuPrecisionBackend, IGpuFp16ElementwiseBackend
+#else
+    public sealed partial class WebGpuBackend : IGpuPrecisionBackend
+#endif
+    {
+        /// <inheritdoc/>
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation)
+#if NET7_0_OR_GREATER
+            => GpuPrecisionCapabilityCatalog.Create(
+                SupportsFp16(operation),
+                GpuPrecisionImplementation.Emulated,
+                // The current WebGPU route truncates values to FP16 precision but stores them in FP32 buffers.
+                // It must not claim the memory or transfer benefit of native shader-f16.
+                fp16ReducesStorageBytes: false,
+                fp16OutputStorage: IsFp16Elementwise(operation) ? GpuScalarType.Float16 : GpuScalarType.Float32,
+                fp16MultiplyType: GpuScalarType.Float32);
+#else
+            => GpuPrecisionCapabilityCatalog.Float32Only;
+#endif
+
+#if NET7_0_OR_GREATER
+        private bool SupportsFp16(GpuPrecisionOperation operation) => operation switch
+        {
+            GpuPrecisionOperation.MatMul => SupportsHgemm,
+            GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu
+                => SupportsFp16NativeOps,
+            GpuPrecisionOperation.Convolution => Fp16Im2colAvailable,
+            _ => false,
+        };
+
+        private static bool IsFp16Elementwise(GpuPrecisionOperation operation)
+            => operation is GpuPrecisionOperation.Add or GpuPrecisionOperation.Relu or GpuPrecisionOperation.Gelu;
+#endif
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
@@ -1,0 +1,626 @@
+using System.Threading;
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>Controls whether GPU execution prioritizes throughput or the declared tensor type.</summary>
+public enum GpuAccuracyMode
+{
+    /// <summary>
+    /// Prefer GPU execution and permit conversion through a backend-supported floating-point format.
+    /// The returned tensor still has the caller's declared element type.
+    /// </summary>
+    SpeedFirst,
+
+    /// <summary>
+    /// Preserve the declared tensor type. A backend without a matching native route must use the CPU
+    /// implementation rather than silently narrowing the computation.
+    /// </summary>
+    PreserveInputType,
+}
+
+/// <summary>
+/// Preferred logical compute format for eligible GPU operations. The selected plan separately
+/// reports physical input storage, multiply, accumulation, and output formats.
+/// </summary>
+public enum GpuComputePreference
+{
+    /// <summary>Let the precision planner select from the backend's measured and advertised capabilities.</summary>
+    Auto,
+    /// <summary>64-bit IEEE floating point.</summary>
+    Float64,
+    /// <summary>32-bit IEEE floating point.</summary>
+    Float32,
+    /// <summary>NVIDIA/AMD tensor-float compute over FP32 storage.</summary>
+    TensorFloat32,
+    /// <summary>Brain floating point with FP32-range exponent.</summary>
+    BFloat16,
+    /// <summary>IEEE binary16.</summary>
+    Float16,
+    /// <summary>8-bit E4M3 floating point.</summary>
+    Float8E4M3,
+    /// <summary>8-bit E5M2 floating point.</summary>
+    Float8E5M2,
+}
+
+/// <summary>Behavior when an explicitly requested GPU format is unavailable.</summary>
+public enum GpuPrecisionFallbackBehavior
+{
+    /// <summary>Use a safe, supported higher-precision format and report the decision.</summary>
+    UseHigherPrecision,
+    /// <summary>Reject the operation before allocating or launching a kernel.</summary>
+    Throw,
+}
+
+/// <summary>Physical scalar formats understood by the GPU precision planner.</summary>
+public enum GpuScalarType
+{
+    /// <summary>A generic/non-floating public type without a matching physical GPU representation.</summary>
+    Generic,
+    /// <summary>64-bit IEEE floating point.</summary>
+    Float64,
+    /// <summary>32-bit IEEE floating point.</summary>
+    Float32,
+    /// <summary>TensorFloat-32 multiply over FP32 storage.</summary>
+    TensorFloat32,
+    /// <summary>Brain floating point.</summary>
+    BFloat16,
+    /// <summary>IEEE binary16.</summary>
+    Float16,
+    /// <summary>8-bit E4M3 floating point.</summary>
+    Float8E4M3,
+    /// <summary>8-bit E5M2 floating point.</summary>
+    Float8E5M2,
+}
+
+/// <summary>Operation families whose supported formats can differ on the same device.</summary>
+public enum GpuPrecisionOperation
+{
+    /// <summary>An operation without a specialized mixed-precision contract.</summary>
+    General,
+    /// <summary>Element-wise arithmetic or activation.</summary>
+    Elementwise,
+    /// <summary>Element-wise addition with a typed reduced-precision route.</summary>
+    Add,
+    /// <summary>Rectified linear activation with a typed reduced-precision route.</summary>
+    Relu,
+    /// <summary>Gaussian error linear activation with a typed reduced-precision route.</summary>
+    Gelu,
+    /// <summary>Matrix multiplication.</summary>
+    MatMul,
+    /// <summary>Matrix multiplication with a logically transposed right operand.</summary>
+    MatMulTransposed,
+    /// <summary>Batched matrix multiplication.</summary>
+    BatchMatMul,
+    /// <summary>Convolution.</summary>
+    Convolution,
+    /// <summary>Reduction or numerically-sensitive normalization.</summary>
+    Reduction,
+}
+
+/// <summary>How a backend realizes a reported precision capability.</summary>
+public enum GpuPrecisionImplementation
+{
+    /// <summary>Native device instructions and native-width storage.</summary>
+    Native,
+    /// <summary>A vendor math library such as cuBLAS, hipBLAS, or MPS.</summary>
+    VendorLibrary,
+    /// <summary>A composed route using both a backend-native kernel and a vendor math library.</summary>
+    Composite,
+    /// <summary>Reduced-width packed storage decoded by a shader with wider arithmetic.</summary>
+    Packed,
+    /// <summary>Values are quantized but retained in wider physical storage.</summary>
+    Emulated,
+}
+
+/// <summary>Whether a selected plan executes on the GPU or preserves semantics on the CPU.</summary>
+public enum GpuExecutionRoute
+{
+    /// <summary>Execute through the selected GPU backend.</summary>
+    Gpu,
+    /// <summary>Execute through the CPU engine.</summary>
+    Cpu,
+}
+
+/// <summary>Immutable user policy for generic GPU conversion and precision selection.</summary>
+public sealed class GpuExecutionPolicy
+{
+    /// <summary>The default speed-first policy with automatic format selection.</summary>
+    public static GpuExecutionPolicy Default { get; } = new(
+        GpuAccuracyMode.SpeedFirst,
+        GpuComputePreference.Auto,
+        GpuPrecisionFallbackBehavior.UseHigherPrecision);
+
+    /// <summary>A policy suitable for exactness-sensitive tests and numerical validation.</summary>
+    public static GpuExecutionPolicy Preserve { get; } = new(
+        GpuAccuracyMode.PreserveInputType,
+        GpuComputePreference.Auto,
+        GpuPrecisionFallbackBehavior.UseHigherPrecision);
+
+    /// <summary>Creates a precision policy.</summary>
+    public GpuExecutionPolicy(
+        GpuAccuracyMode accuracyMode = GpuAccuracyMode.SpeedFirst,
+        GpuComputePreference computePreference = GpuComputePreference.Auto,
+        GpuPrecisionFallbackBehavior fallbackBehavior = GpuPrecisionFallbackBehavior.UseHigherPrecision)
+    {
+        AccuracyMode = accuracyMode;
+        ComputePreference = computePreference;
+        FallbackBehavior = fallbackBehavior;
+    }
+
+    /// <summary>Gets the requested accuracy behavior.</summary>
+    public GpuAccuracyMode AccuracyMode { get; }
+
+    /// <summary>Gets the preferred compute format.</summary>
+    public GpuComputePreference ComputePreference { get; }
+
+    /// <summary>Gets the unsupported-format behavior.</summary>
+    public GpuPrecisionFallbackBehavior FallbackBehavior { get; }
+}
+
+/// <summary>
+/// Async-flowing execution-policy scope. Preservation is deliberately independent from autocast so tests can
+/// preserve <c>T</c> without pretending that preservation is another low-precision format.
+/// </summary>
+public sealed class GpuExecutionPolicyScope : IDisposable
+{
+    private static readonly AsyncLocal<GpuExecutionPolicyScope?> s_current = new();
+    private readonly GpuExecutionPolicyScope? _previous;
+    private bool _disposed;
+
+    /// <summary>Creates and activates a scope.</summary>
+    public GpuExecutionPolicyScope(GpuExecutionPolicy policy)
+    {
+        Policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _previous = s_current.Value;
+        s_current.Value = this;
+    }
+
+    /// <summary>Gets the current scope, or <see langword="null"/>.</summary>
+    public static GpuExecutionPolicyScope? Current => s_current.Value;
+
+    /// <summary>Gets the active policy, defaulting to speed-first automatic selection.</summary>
+    public static GpuExecutionPolicy CurrentPolicy => Current?.Policy ?? GpuExecutionPolicy.Default;
+
+    /// <summary>Gets this scope's policy.</summary>
+    public GpuExecutionPolicy Policy { get; }
+
+    /// <summary>Restores the containing scope.</summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        s_current.Value = _previous;
+    }
+}
+
+/// <summary>A physical precision combination supported for one operation family.</summary>
+public sealed class GpuPrecisionCapability
+{
+    /// <summary>Creates a backend precision capability.</summary>
+    public GpuPrecisionCapability(
+        GpuScalarType inputStorage,
+        GpuScalarType multiplyType,
+        GpuScalarType accumulatorType,
+        GpuScalarType outputStorage,
+        GpuPrecisionImplementation implementation,
+        bool reducesStorageBytes,
+        GpuScalarType? computeFormat = null)
+    {
+        InputStorage = inputStorage;
+        MultiplyType = multiplyType;
+        AccumulatorType = accumulatorType;
+        OutputStorage = outputStorage;
+        Implementation = implementation;
+        ReducesStorageBytes = reducesStorageBytes;
+        ComputeFormat = computeFormat ?? inputStorage;
+    }
+
+    /// <summary>Gets the logical format selected by Auto or explicit autocast.</summary>
+    public GpuScalarType ComputeFormat { get; }
+    /// <summary>Gets the physical input storage format.</summary>
+    public GpuScalarType InputStorage { get; }
+    /// <summary>Gets the multiply format used by the kernel.</summary>
+    public GpuScalarType MultiplyType { get; }
+    /// <summary>Gets the accumulator format.</summary>
+    public GpuScalarType AccumulatorType { get; }
+    /// <summary>Gets the physical result storage format.</summary>
+    public GpuScalarType OutputStorage { get; }
+    /// <summary>Gets how the backend realizes this capability.</summary>
+    public GpuPrecisionImplementation Implementation { get; }
+    /// <summary>Gets whether this route actually reduces device storage or transfer bytes.</summary>
+    public bool ReducesStorageBytes { get; }
+}
+
+/// <summary>Optional capability surface implemented by every in-tree DirectGPU backend.</summary>
+public interface IGpuPrecisionBackend
+{
+    /// <summary>Returns the physical precision combinations supported for <paramref name="operation"/>.</summary>
+    IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(GpuPrecisionOperation operation);
+}
+
+/// <summary>An immutable, observable precision decision for one operation.</summary>
+public sealed class GpuComputePlan
+{
+    internal GpuComputePlan(
+        GpuExecutionRoute route,
+        string backend,
+        string operation,
+        Type publicType,
+        GpuComputePreference requestedPreference,
+        GpuScalarType computeFormat,
+        GpuScalarType inputStorage,
+        GpuScalarType multiplyType,
+        GpuScalarType accumulatorType,
+        GpuScalarType outputStorage,
+        GpuPrecisionImplementation? implementation,
+        bool reducesStorageBytes,
+        string? fallbackReason)
+    {
+        Route = route;
+        Backend = backend;
+        Operation = operation;
+        PublicType = publicType;
+        RequestedPreference = requestedPreference;
+        ComputeFormat = computeFormat;
+        InputStorage = inputStorage;
+        MultiplyType = multiplyType;
+        AccumulatorType = accumulatorType;
+        OutputStorage = outputStorage;
+        Implementation = implementation;
+        ReducesStorageBytes = reducesStorageBytes;
+        FallbackReason = fallbackReason;
+    }
+
+    /// <summary>Gets the selected CPU/GPU route.</summary>
+    public GpuExecutionRoute Route { get; }
+    /// <summary>Gets the backend name considered by the planner.</summary>
+    public string Backend { get; }
+    /// <summary>Gets the operation name.</summary>
+    public string Operation { get; }
+    /// <summary>Gets the caller-visible tensor element type.</summary>
+    public Type PublicType { get; }
+    /// <summary>Gets the requested compute preference.</summary>
+    public GpuComputePreference RequestedPreference { get; }
+    /// <summary>Gets the selected logical autocast format.</summary>
+    public GpuScalarType ComputeFormat { get; }
+    /// <summary>Gets the selected physical input storage.</summary>
+    public GpuScalarType InputStorage { get; }
+    /// <summary>Gets the selected multiply type.</summary>
+    public GpuScalarType MultiplyType { get; }
+    /// <summary>Gets the selected accumulator type.</summary>
+    public GpuScalarType AccumulatorType { get; }
+    /// <summary>Gets the selected physical output storage.</summary>
+    public GpuScalarType OutputStorage { get; }
+    /// <summary>Gets how the backend implements the selected format.</summary>
+    public GpuPrecisionImplementation? Implementation { get; }
+    /// <summary>Gets whether the selected route actually reduces device storage bytes.</summary>
+    public bool ReducesStorageBytes { get; }
+    /// <summary>Gets why the requested format or route was not used.</summary>
+    public string? FallbackReason { get; }
+}
+
+/// <summary>Per-async-flow diagnostics for the precision route that actually executed.</summary>
+public static class GpuPrecisionDiagnostics
+{
+    private static readonly AsyncLocal<GpuComputePlan?> s_lastPlan = new();
+
+    /// <summary>Raised after an operation selects and commits to an execution route.</summary>
+    public static event Action<GpuComputePlan>? PlanExecuted;
+
+    /// <summary>Gets the most recently executed plan in the current async flow.</summary>
+    public static GpuComputePlan? LastPlan => s_lastPlan.Value;
+
+    /// <summary>Clears the current async flow's last plan.</summary>
+    public static void Clear() => s_lastPlan.Value = null;
+
+    internal static void Publish(GpuComputePlan plan)
+    {
+        s_lastPlan.Value = plan;
+        PlanExecuted?.Invoke(plan);
+    }
+}
+
+/// <summary>Central precision planner shared by generic conversion and autocast dispatch.</summary>
+public static class GpuPrecisionPlanner
+{
+    /// <summary>Creates a plan for a generic tensor operation without launching work.</summary>
+    public static GpuComputePlan CreatePlan<T>(
+        IDirectGpuBackend backend,
+        GpuPrecisionOperation operation,
+        string operationName)
+    {
+        if (backend is null) throw new ArgumentNullException(nameof(backend));
+        if (string.IsNullOrWhiteSpace(operationName)) throw new ArgumentException("Operation name required.", nameof(operationName));
+
+        var policy = GpuExecutionPolicyScope.CurrentPolicy;
+        var requested = AutocastScope.IsEnabled
+            ? FromPrecisionMode(AutocastScope.ActivePrecision)
+            : policy.ComputePreference;
+        var sourceType = ScalarTypeFor(typeof(T));
+        var capabilities = GetCapabilities(backend, operation);
+
+        if (policy.AccuracyMode == GpuAccuracyMode.PreserveInputType)
+        {
+            var exact = FindPreserving(capabilities, sourceType);
+            if (exact is not null)
+                return FromCapability(backend, operationName, typeof(T), requested, exact, null);
+
+            return CpuPlan(backend, operationName, typeof(T), requested,
+                $"{backend.BackendName} has no {sourceType} {operation} route required by PreserveInputType.");
+        }
+
+        var desired = requested == GpuComputePreference.Auto
+            ? AutomaticTypeFor(sourceType)
+            : ScalarTypeFor(requested);
+        var selected = Find(capabilities, desired);
+        if (selected is not null)
+        {
+            string? conversionReason = requested == GpuComputePreference.Auto && sourceType != desired
+                ? $"SpeedFirst Auto converts public {sourceType} through {desired}."
+                : null;
+            return FromCapability(backend, operationName, typeof(T), requested, selected, conversionReason);
+        }
+
+        if (policy.FallbackBehavior == GpuPrecisionFallbackBehavior.Throw)
+            throw new NotSupportedException(
+                $"{backend.BackendName} does not support requested {desired} for {operationName}.");
+
+        foreach (var fallback in SafeFallbacks(desired))
+        {
+            selected = Find(capabilities, fallback);
+            if (selected is not null)
+            {
+                return FromCapability(backend, operationName, typeof(T), requested, selected,
+                    $"Requested {desired} is unavailable for {operation}; using {selected.ComputeFormat}.");
+            }
+        }
+
+        return CpuPlan(backend, operationName, typeof(T), requested,
+            $"{backend.BackendName} exposes no eligible GPU precision for {operation}.");
+    }
+
+    internal static IReadOnlyList<GpuPrecisionCapability> GetCapabilities(
+        IDirectGpuBackend backend,
+        GpuPrecisionOperation operation)
+    {
+        if (backend is IGpuPrecisionBackend precisionBackend)
+            return precisionBackend.GetPrecisionCapabilities(operation);
+
+        // Compatibility adapter for third-party backends compiled before this capability surface existed.
+        // Their IDirectGpuBackend contract is FP32, so advertising more would be unsafe.
+        return GpuPrecisionCapabilityCatalog.Float32Only;
+    }
+
+    internal static GpuComputePlan CpuFallback<T>(
+        IDirectGpuBackend backend,
+        string operationName,
+        GpuComputePreference requested,
+        string reason)
+        => CpuPlan(backend, operationName, typeof(T), requested, reason);
+
+    private static GpuComputePlan FromCapability(
+        IDirectGpuBackend backend,
+        string operationName,
+        Type publicType,
+        GpuComputePreference requested,
+        GpuPrecisionCapability capability,
+        string? fallbackReason)
+        => new(
+            GpuExecutionRoute.Gpu,
+            backend.BackendName,
+            operationName,
+            publicType,
+            requested,
+            capability.ComputeFormat,
+            capability.InputStorage,
+            capability.MultiplyType,
+            capability.AccumulatorType,
+            capability.OutputStorage,
+            capability.Implementation,
+            capability.ReducesStorageBytes,
+            fallbackReason);
+
+    private static GpuComputePlan CpuPlan(
+        IDirectGpuBackend backend,
+        string operationName,
+        Type publicType,
+        GpuComputePreference requested,
+        string reason)
+        => new(
+            GpuExecutionRoute.Cpu,
+            backend.BackendName,
+            operationName,
+            publicType,
+            requested,
+            ScalarTypeFor(publicType),
+            ScalarTypeFor(publicType),
+            ScalarTypeFor(publicType),
+            ScalarTypeFor(publicType),
+            ScalarTypeFor(publicType),
+            null,
+            false,
+            reason);
+
+    private static GpuPrecisionCapability? Find(
+        IReadOnlyList<GpuPrecisionCapability> capabilities,
+        GpuScalarType computeFormat)
+    {
+        for (int i = 0; i < capabilities.Count; i++)
+        {
+            if (capabilities[i].ComputeFormat == computeFormat)
+                return capabilities[i];
+        }
+        return null;
+    }
+
+    private static GpuPrecisionCapability? FindPreserving(
+        IReadOnlyList<GpuPrecisionCapability> capabilities,
+        GpuScalarType sourceType)
+    {
+        for (int i = 0; i < capabilities.Count; i++)
+        {
+            var capability = capabilities[i];
+            if (capability.ComputeFormat == sourceType
+                && capability.InputStorage == sourceType
+                && DoesNotNarrow(sourceType, capability.MultiplyType)
+                && DoesNotNarrow(sourceType, capability.AccumulatorType)
+                && DoesNotNarrow(sourceType, capability.OutputStorage))
+            {
+                return capability;
+            }
+        }
+        return null;
+    }
+
+    private static bool DoesNotNarrow(GpuScalarType sourceType, GpuScalarType physicalType)
+        => sourceType switch
+        {
+            GpuScalarType.Float64 => physicalType == GpuScalarType.Float64,
+            GpuScalarType.Float32 => physicalType is GpuScalarType.Float32 or GpuScalarType.Float64,
+            GpuScalarType.BFloat16 => physicalType is GpuScalarType.BFloat16
+                or GpuScalarType.Float32 or GpuScalarType.Float64,
+            GpuScalarType.Float16 => physicalType is GpuScalarType.Float16
+                or GpuScalarType.Float32 or GpuScalarType.Float64,
+            GpuScalarType.Float8E4M3 => physicalType is GpuScalarType.Float8E4M3
+                or GpuScalarType.BFloat16 or GpuScalarType.Float16
+                or GpuScalarType.Float32 or GpuScalarType.Float64,
+            GpuScalarType.Float8E5M2 => physicalType is GpuScalarType.Float8E5M2
+                or GpuScalarType.BFloat16 or GpuScalarType.Float16
+                or GpuScalarType.Float32 or GpuScalarType.Float64,
+            GpuScalarType.TensorFloat32 => physicalType is GpuScalarType.TensorFloat32
+                or GpuScalarType.Float32 or GpuScalarType.Float64,
+            _ => physicalType == sourceType,
+        };
+
+    private static GpuScalarType AutomaticTypeFor(GpuScalarType sourceType)
+    {
+        // Preserve an explicitly reduced public format when the backend supports it. All other generic T values
+        // retain the package's established FP32 GPU boundary until a hardware-specific measured profile opts into
+        // a narrower automatic route. This avoids turning an unmeasured assumption into a global default.
+        return sourceType is GpuScalarType.Float16 or GpuScalarType.BFloat16
+            or GpuScalarType.Float8E4M3 or GpuScalarType.Float8E5M2
+            ? sourceType
+            : GpuScalarType.Float32;
+    }
+
+    private static IEnumerable<GpuScalarType> SafeFallbacks(GpuScalarType requested)
+    {
+        switch (requested)
+        {
+            case GpuScalarType.Float8E4M3:
+            case GpuScalarType.Float8E5M2:
+                yield return GpuScalarType.BFloat16;
+                yield return GpuScalarType.Float16;
+                yield return GpuScalarType.Float32;
+                break;
+            case GpuScalarType.BFloat16:
+            case GpuScalarType.Float16:
+            case GpuScalarType.TensorFloat32:
+            case GpuScalarType.Generic:
+                yield return GpuScalarType.Float32;
+                break;
+            case GpuScalarType.Float64:
+                // There is no higher-precision floating fallback. An explicit FP64 request must
+                // route to an exact CPU implementation when the device cannot execute it.
+                break;
+            case GpuScalarType.Float32:
+                break;
+        }
+    }
+
+    private static GpuComputePreference FromPrecisionMode(PrecisionMode mode) => mode switch
+    {
+        PrecisionMode.Float32 => GpuComputePreference.Float32,
+        PrecisionMode.Float16 => GpuComputePreference.Float16,
+        PrecisionMode.BFloat16 => GpuComputePreference.BFloat16,
+        PrecisionMode.Float8E4M3 => GpuComputePreference.Float8E4M3,
+        PrecisionMode.Float8E5M2 => GpuComputePreference.Float8E5M2,
+        _ => GpuComputePreference.Auto,
+    };
+
+    private static GpuScalarType ScalarTypeFor(GpuComputePreference preference) => preference switch
+    {
+        GpuComputePreference.Float64 => GpuScalarType.Float64,
+        GpuComputePreference.Float32 => GpuScalarType.Float32,
+        GpuComputePreference.TensorFloat32 => GpuScalarType.TensorFloat32,
+        GpuComputePreference.BFloat16 => GpuScalarType.BFloat16,
+        GpuComputePreference.Float16 => GpuScalarType.Float16,
+        GpuComputePreference.Float8E4M3 => GpuScalarType.Float8E4M3,
+        GpuComputePreference.Float8E5M2 => GpuScalarType.Float8E5M2,
+        _ => GpuScalarType.Float32,
+    };
+
+    private static GpuScalarType ScalarTypeFor(Type type)
+    {
+        if (type == typeof(double)) return GpuScalarType.Float64;
+        if (type == typeof(float)) return GpuScalarType.Float32;
+        if (type == typeof(Half)) return GpuScalarType.Float16;
+        if (type == typeof(NumericOperations.BFloat16)) return GpuScalarType.BFloat16;
+        if (type == typeof(NumericOperations.Float8E4M3)) return GpuScalarType.Float8E4M3;
+        if (type == typeof(NumericOperations.Float8E5M2)) return GpuScalarType.Float8E5M2;
+        return GpuScalarType.Generic;
+    }
+}
+
+/// <summary>Shared immutable capability sets used by backend implementations.</summary>
+internal static class GpuPrecisionCapabilityCatalog
+{
+    internal static readonly IReadOnlyList<GpuPrecisionCapability> Float32Only =
+        new[]
+        {
+            new GpuPrecisionCapability(
+                GpuScalarType.Float32,
+                GpuScalarType.Float32,
+                GpuScalarType.Float32,
+                GpuScalarType.Float32,
+                GpuPrecisionImplementation.Native,
+                false),
+        };
+
+    internal static IReadOnlyList<GpuPrecisionCapability> Create(
+        bool supportsFp16,
+        GpuPrecisionImplementation fp16Implementation,
+        bool fp16ReducesStorageBytes,
+        GpuScalarType fp16OutputStorage = GpuScalarType.Float32,
+        GpuScalarType fp16MultiplyType = GpuScalarType.Float16,
+        GpuPrecisionImplementation fp32Implementation = GpuPrecisionImplementation.Native,
+        GpuScalarType fp32MultiplyType = GpuScalarType.Float32,
+        bool supportsTensorFloat32 = false)
+    {
+        var capabilities = new List<GpuPrecisionCapability>(supportsFp16 && supportsTensorFloat32 ? 3 : 2)
+        {
+            new(
+                GpuScalarType.Float32,
+                fp32MultiplyType,
+                GpuScalarType.Float32,
+                GpuScalarType.Float32,
+                fp32Implementation,
+                false,
+                GpuScalarType.Float32),
+        };
+        if (supportsTensorFloat32)
+        {
+            capabilities.Add(new GpuPrecisionCapability(
+                GpuScalarType.Float32,
+                GpuScalarType.TensorFloat32,
+                GpuScalarType.Float32,
+                GpuScalarType.Float32,
+                fp32Implementation,
+                false,
+                GpuScalarType.TensorFloat32));
+        }
+        if (supportsFp16)
+        {
+            capabilities.Add(new GpuPrecisionCapability(
+                GpuScalarType.Float16,
+                fp16MultiplyType,
+                GpuScalarType.Float32,
+                fp16OutputStorage,
+                fp16Implementation,
+                fp16ReducesStorageBytes,
+                GpuScalarType.Float16));
+        }
+        return capabilities;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Gpu/IGpuFp16ElementwiseBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/IGpuFp16ElementwiseBackend.cs
@@ -1,0 +1,23 @@
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.Engines.Gpu;
+
+/// <summary>
+/// Optional typed dispatch surface for element-wise kernels that consume and produce FP16 storage.
+/// Keeping these methods separate from <see cref="IDirectGpuBackend"/>'s FP32 contract prevents a
+/// converted half buffer from being passed to a kernel that still interprets it as <see cref="float"/>.
+/// </summary>
+public interface IGpuFp16ElementwiseBackend
+{
+    /// <summary>Gets whether the backend can execute the typed operations in this interface.</summary>
+    bool SupportsFp16NativeOps { get; }
+
+    /// <summary>Computes GELU with FP16 input/output storage.</summary>
+    void Fp16Gelu(IGpuBuffer input, IGpuBuffer output, int size);
+
+    /// <summary>Computes ReLU with FP16 input/output storage.</summary>
+    void Fp16Relu(IGpuBuffer input, IGpuBuffer output, int size);
+
+    /// <summary>Adds two FP16 buffers into FP16 output storage.</summary>
+    void Fp16Add(IGpuBuffer left, IGpuBuffer right, IGpuBuffer output, int size);
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/GpuPrecisionEvidence.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/GpuPrecisionEvidence.cs
@@ -1,0 +1,311 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.NumericOperations;
+
+namespace AiDotNet.Tensors.Benchmarks;
+
+/// <summary>
+/// Hardware-profiled evidence harness for PR #971. It separates cold end-to-end conversion from
+/// warmed input-resident execution, forces every GPU result to materialize, and prints the actual
+/// precision plan selected by the backend. It intentionally does not impose timing thresholds in CI.
+/// </summary>
+internal static class GpuPrecisionEvidence
+{
+    internal static int Run(string[] args)
+    {
+        int size = ParsePositive(args, 1, 512);
+        int iterations = ParsePositive(args, 2, 15);
+        string? outputPath = args.Length > 3 ? args[3] : null;
+        var report = new StringBuilder();
+        void Line(string value = "")
+        {
+            Console.WriteLine(value);
+            report.AppendLine(value);
+        }
+
+        using var direct = new DirectGpuEngine();
+        if (!direct.IsAvailable || direct.Backend is null)
+        {
+            Line("# PR #971 GPU precision evidence");
+            Line();
+            Line("No DirectGPU backend is available on this host. No hardware timing was recorded.");
+            WriteReport(outputPath, report);
+            return 2;
+        }
+
+        using var gpu = new DirectGpuTensorEngine(direct);
+        var cpu = new CpuEngine();
+        var backend = direct.Backend;
+        Line("# PR #971 GPU precision evidence");
+        Line();
+        Line($"- UTC: {DateTime.UtcNow:O}");
+        Line($"- OS: {Environment.OSVersion}");
+        Line($"- Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+        Line($"- CPU logical processors: {Environment.ProcessorCount}");
+        Line($"- Backend: {direct.BackendName}");
+        Line($"- Device: {direct.DeviceName}");
+        Line($"- Vendor: {direct.DeviceVendor}");
+        Line($"- Compute units: {direct.ComputeUnits}");
+        Line($"- Global memory: {direct.GlobalMemoryBytes / (1024d * 1024 * 1024):F2} GiB");
+        Line($"- Matrix: {size} x {size}; warmups: 3; measured iterations: {iterations}");
+        Line();
+
+        PrintCapabilityMatrix(backend, Line);
+        PrintTypeMatrix(backend, Line);
+
+        var random = new Random(971);
+        int length = checked(size * size);
+        var doubleA = new double[length];
+        var doubleB = new double[length];
+        var floatA = new float[length];
+        var floatB = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            doubleA[i] = random.NextDouble() - 0.5;
+            doubleB[i] = random.NextDouble() - 0.5;
+            floatA[i] = (float)doubleA[i];
+            floatB[i] = (float)doubleB[i];
+        }
+
+        using var residentDoubleA = new Tensor<double>((double[])doubleA.Clone(), new[] { size, size });
+        using var residentDoubleB = new Tensor<double>((double[])doubleB.Clone(), new[] { size, size });
+        using var residentFloatA = new Tensor<float>((float[])floatA.Clone(), new[] { size, size });
+        using var residentFloatB = new Tensor<float>((float[])floatB.Clone(), new[] { size, size });
+
+        var cpuDouble = Measure(() =>
+        {
+            using var a = new Tensor<double>((double[])doubleA.Clone(), new[] { size, size });
+            using var b = new Tensor<double>((double[])doubleB.Clone(), new[] { size, size });
+            using var result = cpu.TensorMatMul(a, b);
+            return result.GetDataArray()[length - 1];
+        }, warmups: 1, iterations: Math.Max(3, Math.Min(iterations, 7)));
+
+        var gpuFloatCold = Measure(() =>
+        {
+            using var a = new Tensor<float>((float[])floatA.Clone(), new[] { size, size });
+            using var b = new Tensor<float>((float[])floatB.Clone(), new[] { size, size });
+            using var result = gpu.TensorMatMul(a, b);
+            return result.GetDataArray()[length - 1];
+        }, 3, iterations);
+        var gpuFloatColdPlan = GpuPrecisionDiagnostics.LastPlan;
+
+        var gpuDoubleCold = Measure(() =>
+        {
+            using var a = new Tensor<double>((double[])doubleA.Clone(), new[] { size, size });
+            using var b = new Tensor<double>((double[])doubleB.Clone(), new[] { size, size });
+            using var result = gpu.TensorMatMul(a, b);
+            return result.GetDataArray()[length - 1];
+        }, 3, iterations);
+        var gpuDoubleColdPlan = GpuPrecisionDiagnostics.LastPlan;
+
+        var gpuFloatResident = Measure(() =>
+        {
+            using var result = gpu.TensorMatMul(residentFloatA, residentFloatB);
+            return result.GetDataArray()[length - 1];
+        }, 3, iterations);
+        var gpuFloatResidentPlan = GpuPrecisionDiagnostics.LastPlan;
+
+        var gpuDoubleResident = Measure(() =>
+        {
+            using var result = gpu.TensorMatMul(residentDoubleA, residentDoubleB);
+            return result.GetDataArray()[length - 1];
+        }, 3, iterations);
+        var gpuDoubleResidentPlan = GpuPrecisionDiagnostics.LastPlan;
+
+        TimingResult? gpuFp16Cold = null;
+        TimingResult? gpuFp16Resident = null;
+        GpuComputePlan? gpuFp16ColdPlan = null;
+        GpuComputePlan? gpuFp16ResidentPlan = null;
+        using (var autocast = new AutocastScope(PrecisionMode.Float16))
+        {
+            var probe = GpuPrecisionPlanner.CreatePlan<float>(backend, GpuPrecisionOperation.MatMul, "evidence-probe");
+            if (probe.InputStorage == GpuScalarType.Float16)
+            {
+                gpuFp16Cold = Measure(() =>
+                {
+                    using var a = new Tensor<float>((float[])floatA.Clone(), new[] { size, size });
+                    using var b = new Tensor<float>((float[])floatB.Clone(), new[] { size, size });
+                    using var result = gpu.TensorMatMul(a, b);
+                    return result.GetDataArray()[length - 1];
+                }, 3, iterations);
+                gpuFp16ColdPlan = GpuPrecisionDiagnostics.LastPlan;
+                gpuFp16Resident = Measure(() =>
+                {
+                    using var result = gpu.TensorMatMul(residentFloatA, residentFloatB);
+                    return result.GetDataArray()[length - 1];
+                }, 3, iterations);
+                gpuFp16ResidentPlan = GpuPrecisionDiagnostics.LastPlan;
+            }
+        }
+
+        using var referenceA = new Tensor<double>((double[])doubleA.Clone(), new[] { size, size });
+        using var referenceB = new Tensor<double>((double[])doubleB.Clone(), new[] { size, size });
+        using var referenceTensor = cpu.TensorMatMul(referenceA, referenceB);
+        var reference = referenceTensor.GetDataArray();
+        using var autoTensor = gpu.TensorMatMul(residentDoubleA, residentDoubleB);
+        var autoValues = autoTensor.GetDataArray();
+        var autoError = RelativeMaxError(reference, autoValues);
+
+        double? fp16Error = null;
+        if (gpuFp16Resident is not null)
+        {
+            using var autocast = new AutocastScope(PrecisionMode.Float16);
+            using var fp16Tensor = gpu.TensorMatMul(residentFloatA, residentFloatB);
+            fp16Error = RelativeMaxError(reference, fp16Tensor.GetDataArray());
+        }
+
+        Line("## Timings");
+        Line();
+        Line("Every GPU sample includes output materialization/synchronization. Cold samples also include tensor creation, upload, and T↔compute-format conversion; resident samples reuse input tensors.");
+        Line();
+        Line("| Scenario | Median (ms) | P95 (ms) | Relative to native FP32 | Selected route |");
+        Line("|---|---:|---:|---:|---|");
+        WriteTiming("CPU declared double control", cpuDouble, gpuFloatCold.MedianMs, "CPU Float64", Line);
+        WriteTiming("GPU native FP32 cold", gpuFloatCold, gpuFloatCold.MedianMs, Describe(gpuFloatColdPlan), Line);
+        WriteTiming("GPU double→auto→double cold", gpuDoubleCold, gpuFloatCold.MedianMs, Describe(gpuDoubleColdPlan), Line);
+        WriteTiming("GPU native FP32 resident inputs", gpuFloatResident, gpuFloatResident.MedianMs, Describe(gpuFloatResidentPlan), Line);
+        WriteTiming("GPU double→auto→double resident inputs", gpuDoubleResident, gpuFloatResident.MedianMs, Describe(gpuDoubleResidentPlan), Line);
+        if (gpuFp16Cold is { } fp16Cold)
+            WriteTiming("GPU FP16 autocast cold", fp16Cold, gpuFloatCold.MedianMs, Describe(gpuFp16ColdPlan), Line);
+        if (gpuFp16Resident is { } fp16Resident)
+            WriteTiming("GPU FP16 autocast resident inputs", fp16Resident, gpuFloatResident.MedianMs, Describe(gpuFp16ResidentPlan), Line);
+        Line();
+        Line($"- End-to-end speedup, GPU converted double vs CPU declared double: {cpuDouble.MedianMs / gpuDoubleCold.MedianMs:F2}x");
+        Line($"- Cold conversion overhead vs native FP32 GPU control: {(gpuDoubleCold.MedianMs / gpuFloatCold.MedianMs - 1) * 100:F1}%");
+        Line($"- Resident-input conversion overhead vs native FP32 GPU control: {(gpuDoubleResident.MedianMs / gpuFloatResident.MedianMs - 1) * 100:F1}%");
+        Line();
+        Line("## Accuracy");
+        Line();
+        Line($"- GPU double→FP32→double relative max error vs CPU Float64: {autoError:E6}");
+        if (fp16Error is not null)
+            Line($"- GPU FP16 autocast relative max error vs CPU Float64: {fp16Error.Value:E6}");
+        Line();
+        Line("These measurements describe this named device and driver only. Packed/emulated formats and higher-precision fallbacks are labeled as such; they are not claimed as native hardware support.");
+
+        WriteReport(outputPath, report);
+        return 0;
+    }
+
+    private static void PrintCapabilityMatrix(IDirectGpuBackend backend, Action<string> line)
+    {
+        line("## Backend capability matrix");
+        line(string.Empty);
+        line("| Operation | Autocast format | Input | Multiply | Accumulator | Output | Implementation | Storage bytes reduced |");
+        line("|---|---|---|---|---|---|---|---|");
+        foreach (var operation in new[]
+                 {
+                     GpuPrecisionOperation.MatMul,
+                     GpuPrecisionOperation.BatchMatMul,
+                     GpuPrecisionOperation.MatMulTransposed,
+                     GpuPrecisionOperation.Add,
+                     GpuPrecisionOperation.Relu,
+                     GpuPrecisionOperation.Gelu,
+                     GpuPrecisionOperation.Convolution,
+                     GpuPrecisionOperation.Reduction,
+                 })
+        {
+            foreach (var capability in GpuPrecisionPlanner.GetCapabilities(backend, operation))
+            {
+                line($"| {operation} | {capability.ComputeFormat} | {capability.InputStorage} | {capability.MultiplyType} | {capability.AccumulatorType} | {capability.OutputStorage} | {capability.Implementation} | {capability.ReducesStorageBytes} |");
+            }
+        }
+        line(string.Empty);
+    }
+
+    private static void PrintTypeMatrix(IDirectGpuBackend backend, Action<string> line)
+    {
+        line("## Public type parity matrix (speed-first Auto, MatMul)");
+        line(string.Empty);
+        line("| Public T | Route | Format | Input | Multiply | Accumulator | Output | Fallback |");
+        line("|---|---|---|---|---|---|---|---|");
+        PrintType<float>(backend, line);
+        PrintType<double>(backend, line);
+        PrintType<Half>(backend, line);
+        PrintType<BFloat16>(backend, line);
+        PrintType<Float8E4M3>(backend, line);
+        PrintType<Float8E5M2>(backend, line);
+        PrintType<int>(backend, line);
+        PrintType<long>(backend, line);
+        PrintType<decimal>(backend, line);
+        line(string.Empty);
+    }
+
+    private static void PrintType<T>(IDirectGpuBackend backend, Action<string> line)
+    {
+        var plan = GpuPrecisionPlanner.CreatePlan<T>(backend, GpuPrecisionOperation.MatMul, "type-matrix");
+        line($"| {typeof(T).Name} | {plan.Route} | {plan.ComputeFormat} | {plan.InputStorage} | {plan.MultiplyType} | {plan.AccumulatorType} | {plan.OutputStorage} | {plan.FallbackReason ?? "—"} |");
+    }
+
+    private static TimingResult Measure(Func<double> action, int warmups, int iterations)
+    {
+        double checksum = 0;
+        for (int i = 0; i < warmups; i++) checksum += action();
+        var samples = new double[iterations];
+        for (int i = 0; i < iterations; i++)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            checksum += action();
+            stopwatch.Stop();
+            samples[i] = stopwatch.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(samples);
+        int p95Index = Math.Min(samples.Length - 1, (int)Math.Ceiling(samples.Length * 0.95) - 1);
+        return new TimingResult(samples[samples.Length / 2], samples[p95Index], checksum);
+    }
+
+    private static void WriteTiming(
+        string scenario,
+        TimingResult timing,
+        double controlMedian,
+        string route,
+        Action<string> line)
+        => line($"| {scenario} | {timing.MedianMs:F3} | {timing.P95Ms:F3} | {timing.MedianMs / controlMedian:F3}x | {route} |");
+
+    private static string Describe(GpuComputePlan? plan)
+        => plan is null
+            ? "No diagnostic"
+            : $"{plan.Route} format={plan.ComputeFormat} physical={plan.InputStorage}/{plan.MultiplyType}/{plan.AccumulatorType}/{plan.OutputStorage}"
+              + (plan.FallbackReason is null ? string.Empty : $" ({plan.FallbackReason})");
+
+    private static double RelativeMaxError(double[] expected, double[] actual)
+    {
+        double maxError = 0;
+        double maxReference = 0;
+        for (int i = 0; i < expected.Length; i++)
+        {
+            maxError = Math.Max(maxError, Math.Abs(expected[i] - actual[i]));
+            maxReference = Math.Max(maxReference, Math.Abs(expected[i]));
+        }
+        return maxError / Math.Max(maxReference, double.Epsilon);
+    }
+
+    private static double RelativeMaxError(double[] expected, float[] actual)
+    {
+        var widened = new double[actual.Length];
+        for (int i = 0; i < actual.Length; i++) widened[i] = actual[i];
+        return RelativeMaxError(expected, widened);
+    }
+
+    private static int ParsePositive(string[] args, int index, int fallback)
+        => args.Length > index
+           && int.TryParse(args[index], NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+           && value > 0
+            ? value
+            : fallback;
+
+    private static void WriteReport(string? path, StringBuilder report)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return;
+        string fullPath = Path.GetFullPath(path);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, report.ToString());
+        Console.WriteLine($"Evidence written to {fullPath}");
+    }
+
+    private readonly record struct TimingResult(double MedianMs, double P95Ms, double Checksum);
+}

--- a/tests/AiDotNet.Tensors.Benchmarks/Program.cs
+++ b/tests/AiDotNet.Tensors.Benchmarks/Program.cs
@@ -1151,6 +1151,12 @@ class Program
             return;
         }
 
+        if (args[0] == "--gpu-precision-evidence")
+        {
+            Environment.ExitCode = GpuPrecisionEvidence.Run(args);
+            return;
+        }
+
         // GPU activation benchmarks (ReLU, Sigmoid, Tanh, GELU, Softmax)
         if (args[0] == "--activation")
         {
@@ -1667,6 +1673,7 @@ class Program
         Console.WriteLine("  --cold-start             : Cold-start latency (AiDotNet vs PyTorch subprocess)");
         Console.WriteLine("  --cold-start-aidotnet    : Cold-start latency (AiDotNet only)");
         Console.WriteLine("  --determinism-bench      : Deterministic vs fast-mode reduction cost");
+        Console.WriteLine("  --gpu-precision-evidence [size] [iterations] [out.md]: PR #971 type/format/performance evidence");
         Console.WriteLine("  --layers                 : End-to-end layer (Linear/Conv/Norm) microbench");
         Console.WriteLine("  --unet                   : U-Net step microbench");
         Console.WriteLine("  --pr319-grain            : PR #319 grain-size migration regression harness");

--- a/tests/AiDotNet.Tensors.Tests/Engines/CpuResidentDoublePrecisionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/CpuResidentDoublePrecisionTests.cs
@@ -1,23 +1,24 @@
 using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
 /// <summary>
-/// A caller that asks for <c>double</c> and hands the engine CPU-resident data must get double
-/// answers, whatever the ambient engine happens to be.
+/// A caller that opts into input-type preservation must get exact <c>double</c> answers, whatever
+/// engine happens to be selected.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Narrowing double -&gt; float belongs at a real device boundary, for data that already lives on the
-/// device. It was also happening on the upload-compute-download paths: with
+/// Speed-first GPU execution intentionally permits a double -&gt; float32 -&gt; double boundary. These
+/// tests exercise the complementary preservation contract: with
 /// <c>AiDotNetEngine.Current</c> resolving to <see cref="DirectGpuTensorEngine"/>, a CPU-resident
 /// <c>Vector&lt;double&gt;</c> multiplied by a double came back with 3.974E-008 relative error --
-/// float32 epsilon (~1.19e-7), not double epsilon (~2.2e-16) -- because the operands were copied
-/// into a single-precision kernel. The same operations on an explicitly constructed
-/// <see cref="CpuEngine"/> were exact, so the kernels were never the problem; the dispatch was.
+/// float32 epsilon (~1.19e-7), not double epsilon (~2.2e-16), unless preservation was selected.
+/// The same operations on an explicitly constructed <see cref="CpuEngine"/> were exact, so the
+/// preservation policy must route to a computation that really retains double precision.
 /// </para>
 /// <para>
 /// The cost was not only accuracy: every such op paid a host-&gt;device-&gt;host round trip for data
@@ -88,6 +89,7 @@ public class CpuResidentDoublePrecisionTests : IDisposable
         // -- which is EVERY run on a CPU-only host, i.e. the common case.
         _owned.Add(gpu);
         Skip.If(!gpu.IsGpuAvailable, "needs a DirectGpu backend (CUDA/OpenCL/…).");
+        _owned.Add(new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve));
         return gpu;
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedConv2DDoublePerfTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedConv2DDoublePerfTests.cs
@@ -18,7 +18,10 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// </summary>
 public class FusedConv2DDoublePerfTests
 {
-    private readonly IEngine _engine = AiDotNetEngine.Current;
+    // These tests target the CPU SIMD implementations named above. Binding them to the ambient
+    // engine made their route depend on whether the test host happened to have a GPU, and mixed
+    // speed-first FP32 GPU references with exact-double CPU fused kernels.
+    private readonly IEngine _engine = new CpuEngine();
 
     // ─── FusedConv2D<double> bias fold ────────────────────────────────
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/AutocastFromEnvironmentTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/AutocastFromEnvironmentTests.cs
@@ -103,6 +103,23 @@ public class AutocastFromEnvironmentTests
         }
     }
 
+    [Theory]
+    [InlineData("bf16", PrecisionMode.BFloat16)]
+    [InlineData("fp8-e4m3", PrecisionMode.Float8E4M3)]
+    [InlineData("float8_e5m2", PrecisionMode.Float8E5M2)]
+    public void EnableFromEnvironment_ExplicitReducedFormatSelectsRequestedMode(
+        string value,
+        PrecisionMode expected)
+    {
+        using (SetEnv(value))
+        {
+            using var scope = AutocastScope.EnableFromEnvironment();
+            Assert.NotNull(scope);
+            Assert.Equal(expected, scope!.Precision);
+            Assert.Equal(expected, AutocastScope.ActivePrecision);
+        }
+    }
+
     [Fact]
     public void EnableFromEnvironment_UnrecognizedValue_ReturnsNull()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Fp16MatMulCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/Fp16MatMulCorrectnessTests.cs
@@ -52,18 +52,26 @@ public class Fp16MatMulCorrectnessTests
         var ref32 = cFp32.ToArray();
         var got = cFp16.ToArray();
 
-        // FP16 has ~3 decimal digits; for a K-deep accumulation, a relative tolerance that
-        // scales mildly with K (FP32 accumulate keeps this small) bounds the rounding.
-        float tol = 2e-2f + 1e-3f * k;
-        double maxRel = 0;
+        // A max-relative metric is not a stable GEMM oracle: values near zero make a tiny,
+        // expected FP16 quantization error look arbitrarily large. Use scale-invariant relative
+        // L2 plus a K-scaled absolute ceiling, while separately rejecting non-finite output.
+        double squaredError = 0;
+        double squaredReference = 0;
+        double maxAbsolute = 0;
         for (int i = 0; i < ref32.Length; i++)
         {
-            float denom = Math.Max(1e-3f, Math.Abs(ref32[i]));
-            double rel = Math.Abs(got[i] - ref32[i]) / denom;
-            if (rel > maxRel) maxRel = rel;
             Assert.False(float.IsNaN(got[i]) || float.IsInfinity(got[i]),
                 $"FP16 matmul produced non-finite at {i}");
+            double error = got[i] - ref32[i];
+            squaredError += error * error;
+            squaredReference += ref32[i] * ref32[i];
+            maxAbsolute = Math.Max(maxAbsolute, Math.Abs(error));
         }
-        Assert.True(maxRel < tol, $"FP16 matmul max relative error {maxRel:F4} exceeded tol {tol:F4} (m={m} k={k} n={n})");
+        double relativeL2 = Math.Sqrt(squaredError / Math.Max(squaredReference, double.Epsilon));
+        double maxAbsoluteTolerance = 3e-3 * Math.Sqrt(k);
+        Assert.True(relativeL2 < 2e-3,
+            $"FP16 matmul relative L2 error {relativeL2:E4} exceeded 2E-3 (m={m} k={k} n={n})");
+        Assert.True(maxAbsolute < maxAbsoluteTolerance,
+            $"FP16 matmul max absolute error {maxAbsolute:E4} exceeded {maxAbsoluteTolerance:E4} (m={m} k={k} n={n})");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionExecutionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionExecutionTests.cs
@@ -1,0 +1,477 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.NumericOperations;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+public sealed class GpuPrecisionExecutionTests
+{
+    [Fact]
+    public void SpeedFirst_DoubleMatMulExecutesThroughFp32AndReturnsDouble()
+    {
+        using var fixture = new Fixture();
+        var a = new Tensor<double>(new[] { 1d, 2d, 3d, 4d }, new[] { 2, 2 });
+        var b = new Tensor<double>(new[] { 5d, 6d, 7d, 8d }, new[] { 2, 2 });
+
+        var result = fixture.Engine.TensorMatMul(a, b);
+
+        Assert.Equal(new[] { 19d, 22d, 43d, 50d }, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.Fp32GemmCalls);
+        Assert.Equal(0, fixture.Backend.Fp16GemmCalls);
+        Assert.Equal(typeof(double), GpuPrecisionDiagnostics.LastPlan!.PublicType);
+        Assert.Equal(GpuScalarType.Float32, GpuPrecisionDiagnostics.LastPlan.MultiplyType);
+    }
+
+    [Fact]
+    public void SpeedFirst_IntegerMatMulConvertsBackToTheDeclaredType()
+    {
+        using var fixture = new Fixture();
+        var a = new Tensor<int>(new[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var b = new Tensor<int>(new[] { 5, 6, 7, 8 }, new[] { 2, 2 });
+
+        var result = fixture.Engine.TensorMatMul(a, b);
+
+        Assert.Equal(new[] { 19, 22, 43, 50 }, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.Fp32GemmCalls);
+        Assert.Equal(typeof(int), GpuPrecisionDiagnostics.LastPlan!.PublicType);
+    }
+
+    [Fact]
+    public void PreserveInputType_DoubleMatMulUsesExactCpuRoute()
+    {
+        using var fixture = new Fixture();
+        var a = new Tensor<double>(new[] { 0.1d, 0.2d, 0.3d, 0.4d }, new[] { 2, 2 });
+        var b = new Tensor<double>(new[] { 0.5d, 0.6d, 0.7d, 0.8d }, new[] { 2, 2 });
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        var result = fixture.Engine.TensorMatMul(a, b);
+
+        Assert.Equal(0, fixture.Backend.Fp32GemmCalls);
+        Assert.Equal(0, fixture.Backend.Fp16GemmCalls);
+        Assert.Equal(GpuExecutionRoute.Cpu, GpuPrecisionDiagnostics.LastPlan!.Route);
+        Assert.Equal(0.19d, result.GetDataArray()[0], 14);
+    }
+
+    [Fact]
+    public void Fp16Autocast_MatMulUsesTypedHalfInputsAndFp32Accumulation()
+    {
+        using var fixture = new Fixture();
+        var a = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        var b = new Tensor<float>(new[] { 5f, 6f, 7f, 8f }, new[] { 2, 2 });
+        using var autocast = new AutocastScope(PrecisionMode.Float16);
+
+        var result = fixture.Engine.TensorMatMul(a, b);
+
+        Assert.Equal(new[] { 19f, 22f, 43f, 50f }, result.GetDataArray());
+        Assert.Equal(0, fixture.Backend.Fp32GemmCalls);
+        Assert.Equal(1, fixture.Backend.Fp16GemmCalls);
+        Assert.True(fixture.Backend.Fp16Conversions >= 2);
+        Assert.Equal(GpuScalarType.Float16, GpuPrecisionDiagnostics.LastPlan!.InputStorage);
+        Assert.Equal(GpuScalarType.Float32, GpuPrecisionDiagnostics.LastPlan.AccumulatorType);
+        Assert.Equal(GpuScalarType.Float32, GpuPrecisionDiagnostics.LastPlan.OutputStorage);
+    }
+
+    [Fact]
+    public void Fp16Autocast_DoubleReluUsesTypedKernelAndReturnsDouble()
+    {
+        using var fixture = new Fixture();
+        var input = new Tensor<double>(new[] { -2d, -0d, 1.5d, 9d }, new[] { 4 });
+        using var autocast = new AutocastScope(PrecisionMode.Float16);
+
+        var result = fixture.Engine.TensorReLU(input);
+
+        Assert.Equal(new[] { 0d, 0d, 1.5d, 9d }, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.Fp16ReluCalls);
+        Assert.Equal(0, fixture.Backend.Fp32ReluCalls);
+        Assert.Equal(GpuScalarType.Float16, GpuPrecisionDiagnostics.LastPlan!.InputStorage);
+        Assert.Equal(GpuScalarType.Float16, GpuPrecisionDiagnostics.LastPlan.OutputStorage);
+    }
+
+    [Fact]
+    public void PreserveInputType_HalfReluUsesExactTypedGpuRoute()
+    {
+        using var fixture = new Fixture();
+        var input = new Tensor<Half>(new Half[] { (Half)(-2), (Half)1.5 }, new[] { 2 });
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        var result = fixture.Engine.TensorReLU(input);
+
+        Assert.Equal(new Half[] { (Half)0, (Half)1.5 }, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.Fp16ReluCalls);
+        Assert.Equal(0, fixture.Backend.Fp32ReluCalls);
+        Assert.Equal(GpuExecutionRoute.Gpu, GpuPrecisionDiagnostics.LastPlan!.Route);
+        Assert.Equal(GpuScalarType.Float16, GpuPrecisionDiagnostics.LastPlan.ComputeFormat);
+    }
+
+    [Fact]
+    public void Fp16Autocast_AddUsesTypedKernelInsteadOfFp32Delegate()
+    {
+        using var fixture = new Fixture();
+        var left = new Tensor<float>(new[] { 1f, 2f, 3f }, new[] { 3 });
+        var right = new Tensor<float>(new[] { 4f, 5f, 6f }, new[] { 3 });
+        using var autocast = new AutocastScope(PrecisionMode.Float16);
+
+        var result = fixture.Engine.TensorAdd(left, right);
+
+        Assert.Equal(new[] { 5f, 7f, 9f }, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.Fp16AddCalls);
+        Assert.Equal(0, fixture.Backend.Fp32AddCalls);
+    }
+
+    [Fact]
+    public void Rank4MatMulCollapsesEveryLeadingDimensionIntoTheBatchCount()
+    {
+        using var fixture = new Fixture();
+        var leftValues = Enumerable.Range(1, 24).Select(value => (double)value).ToArray();
+        var rightValues = new double[24];
+        for (int batch = 0; batch < 6; batch++)
+        {
+            rightValues[batch * 4] = 1;
+            rightValues[batch * 4 + 3] = 1;
+        }
+        var left = new Tensor<double>(leftValues, new[] { 2, 3, 2, 2 });
+        var right = new Tensor<double>(rightValues, new[] { 2, 3, 2, 2 });
+
+        var result = fixture.Engine.TensorMatMul(left, right);
+
+        Assert.Equal(leftValues, result.GetDataArray());
+        Assert.Equal(1, fixture.Backend.BatchedGemmCalls);
+        Assert.Equal(6, fixture.Backend.LastBatchCount);
+        Assert.Equal(new[] { 2, 3, 2, 2 }, result.Shape._dims);
+    }
+
+    [Fact]
+    public void SpeedFirst_LongAndDecimalMatMulReturnTheDeclaredTypes()
+    {
+        using var fixture = new Fixture();
+        var longLeft = new Tensor<long>(new long[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var longIdentity = new Tensor<long>(new long[] { 1, 0, 0, 1 }, new[] { 2, 2 });
+        Assert.Equal(longLeft.GetDataArray(), fixture.Engine.TensorMatMul(longLeft, longIdentity).GetDataArray());
+
+        var decimalLeft = new Tensor<decimal>(new decimal[] { 1, 2, 3, 4 }, new[] { 2, 2 });
+        var decimalIdentity = new Tensor<decimal>(new decimal[] { 1, 0, 0, 1 }, new[] { 2, 2 });
+        Assert.Equal(decimalLeft.GetDataArray(), fixture.Engine.TensorMatMul(decimalLeft, decimalIdentity).GetDataArray());
+    }
+
+    [Fact]
+    public void SpeedFirst_AllReducedPublicTypesExecuteAndConvertBack()
+    {
+        using var fixture = new Fixture();
+
+        AssertReducedRoundTrip(fixture.Engine, new Half[] { (Half)1, (Half)2, (Half)3, (Half)4 });
+        AssertReducedRoundTrip(fixture.Engine, new[]
+        {
+            BFloat16.FromFloat(1), BFloat16.FromFloat(2),
+            BFloat16.FromFloat(3), BFloat16.FromFloat(4),
+        });
+        AssertReducedRoundTrip(fixture.Engine, new[]
+        {
+            Float8E4M3.FromFloat(1), Float8E4M3.FromFloat(2),
+            Float8E4M3.FromFloat(3), Float8E4M3.FromFloat(4),
+        });
+        AssertReducedRoundTrip(fixture.Engine, new[]
+        {
+            Float8E5M2.FromFloat(1), Float8E5M2.FromFloat(2),
+            Float8E5M2.FromFloat(3), Float8E5M2.FromFloat(4),
+        });
+    }
+
+    private static void AssertReducedRoundTrip<T>(DirectGpuTensorEngine engine, T[] values)
+    {
+        var left = new Tensor<T>(values, new[] { 2, 2 });
+        var operations = AiDotNet.Tensors.Helpers.MathHelper.GetNumericOperations<T>();
+        var identityValues = new[]
+        {
+            operations.One, operations.Zero,
+            operations.Zero, operations.One,
+        };
+        var identity = new Tensor<T>(identityValues, new[] { 2, 2 });
+
+        var result = engine.TensorMatMul(left, identity).GetDataArray();
+
+        Assert.Equal(values, result);
+        Assert.Equal(typeof(T), GpuPrecisionDiagnostics.LastPlan!.PublicType);
+        Assert.Equal(GpuExecutionRoute.Gpu, GpuPrecisionDiagnostics.LastPlan.Route);
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly DirectGpuEngine _direct;
+
+        internal Fixture()
+        {
+            Backend = new ExecutablePrecisionBackend(
+                MockDirectGpuBackend.Create(new MockBackendState()));
+            _direct = new DirectGpuEngine(Backend);
+            Engine = new DirectGpuTensorEngine(_direct);
+            GpuPrecisionDiagnostics.Clear();
+        }
+
+        internal ExecutablePrecisionBackend Backend { get; }
+        internal DirectGpuTensorEngine Engine { get; }
+
+        public void Dispose()
+        {
+            Engine.Dispose();
+            _direct.Dispose();
+            GpuPrecisionDiagnostics.Clear();
+        }
+    }
+
+    private sealed class ExecutablePrecisionBackend : DelegatingGpuBackend,
+        IGpuPrecisionBackend,
+        IGpuHalfPrecisionBackend,
+        IGpuFp16ElementwiseBackend
+    {
+        internal ExecutablePrecisionBackend(IDirectGpuBackend inner) : base(inner) { }
+
+        internal int Fp32GemmCalls { get; private set; }
+        internal int Fp16GemmCalls { get; private set; }
+        internal int Fp16Conversions { get; private set; }
+        internal int Fp16ReluCalls { get; private set; }
+        internal int Fp32ReluCalls { get; private set; }
+        internal int Fp16AddCalls { get; private set; }
+        internal int Fp32AddCalls { get; private set; }
+        internal int BatchedGemmCalls { get; private set; }
+        internal int LastBatchCount { get; private set; }
+
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(
+            GpuPrecisionOperation operation)
+        {
+            var fp32 = new GpuPrecisionCapability(
+                GpuScalarType.Float32, GpuScalarType.Float32, GpuScalarType.Float32,
+                GpuScalarType.Float32, GpuPrecisionImplementation.Emulated, false);
+            if (operation is not (GpuPrecisionOperation.MatMul
+                or GpuPrecisionOperation.Add
+                or GpuPrecisionOperation.Relu
+                or GpuPrecisionOperation.Gelu))
+                return new[] { fp32 };
+
+            var outputStorage = operation == GpuPrecisionOperation.MatMul
+                ? GpuScalarType.Float32
+                : GpuScalarType.Float16;
+            return new[]
+            {
+                fp32,
+                new GpuPrecisionCapability(
+                    GpuScalarType.Float16, GpuScalarType.Float16, GpuScalarType.Float32,
+                    outputStorage, GpuPrecisionImplementation.Emulated, false),
+            };
+        }
+
+        public override IGpuBuffer AllocateBuffer(float[] data)
+            => new MockGpuBuffer((float[])data.Clone());
+
+        public override IGpuBuffer AllocateBuffer(int size)
+            => new MockGpuBuffer(new float[size]);
+
+        public override float[] DownloadBuffer(IGpuBuffer buffer)
+            => (float[])Buffer(buffer).Data.Clone();
+
+        public override void DownloadBuffer(IGpuBuffer buffer, float[] destination)
+            => Array.Copy(Buffer(buffer).Data, destination, destination.Length);
+
+        public override void ConvertToFp16(IGpuBuffer input, IGpuBuffer output, int size)
+        {
+            Fp16Conversions++;
+            var source = Buffer(input).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+                destination[i] = (float)(Half)source[i];
+        }
+
+        public override void ConvertToFp32(IGpuBuffer input, IGpuBuffer output, int size)
+            => Array.Copy(Buffer(input).Data, Buffer(output).Data, size);
+
+        public override void Gemm(
+            IGpuBuffer a,
+            IGpuBuffer b,
+            IGpuBuffer c,
+            int m,
+            int n,
+            int k,
+            float alpha = 1f,
+            float beta = 0f)
+        {
+            Fp32GemmCalls++;
+            GemmCore(a, b, c, m, n, k, alpha, beta);
+        }
+
+        public override void BatchedGemm(
+            IGpuBuffer a,
+            IGpuBuffer b,
+            IGpuBuffer c,
+            int m,
+            int n,
+            int k,
+            int batchCount,
+            float alpha = 1f,
+            float beta = 0f)
+        {
+            BatchedGemmCalls++;
+            LastBatchCount = batchCount;
+            int aStride = m * k;
+            int bStride = k * n;
+            int cStride = m * n;
+            var left = Buffer(a).Data;
+            var right = Buffer(b).Data;
+            var output = Buffer(c).Data;
+            for (int batch = 0; batch < batchCount; batch++)
+            {
+                for (int row = 0; row < m; row++)
+                {
+                    for (int column = 0; column < n; column++)
+                    {
+                        float sum = 0;
+                        for (int inner = 0; inner < k; inner++)
+                        {
+                            sum += left[batch * aStride + row * k + inner]
+                                * right[batch * bStride + inner * n + column];
+                        }
+                        int index = batch * cStride + row * n + column;
+                        output[index] = alpha * sum + beta * output[index];
+                    }
+                }
+            }
+        }
+
+        public override void Relu(IGpuBuffer input, IGpuBuffer output, int size)
+        {
+            Fp32ReluCalls++;
+            var source = Buffer(input).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+                destination[i] = MathF.Max(source[i], 0f);
+        }
+
+        public override void Add(IGpuBuffer left, IGpuBuffer right, IGpuBuffer output, int size)
+        {
+            Fp32AddCalls++;
+            var a = Buffer(left).Data;
+            var b = Buffer(right).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+                destination[i] = a[i] + b[i];
+        }
+
+        public bool SupportsHgemm => true;
+        public bool SupportsFp16FusedBackward => false;
+        public bool SupportsFp16NativeOps => true;
+        public bool Fp16Im2colAvailable => false;
+
+        public void Hgemm(IGpuBuffer a, IGpuBuffer b, IGpuBuffer c, int m, int n, int k)
+            => GemmCore(a, b, c, m, n, k, 1f, 0f);
+
+        public void GemmFp16In32fOut(IGpuBuffer a, IGpuBuffer b, IGpuBuffer c, int m, int n, int k)
+        {
+            Fp16GemmCalls++;
+            GemmCore(a, b, c, m, n, k, 1f, 0f);
+        }
+
+        public void MatMulBackwardFp16Fused(
+            IGpuBuffer gradC,
+            IGpuBuffer a,
+            IGpuBuffer b,
+            IGpuBuffer gradA,
+            IGpuBuffer gradB,
+            int m,
+            int n,
+            int k,
+            bool gradOutHalf)
+            => throw new NotSupportedException();
+
+        public void Fp16Gelu(IGpuBuffer input, IGpuBuffer output, int size)
+        {
+            var source = Buffer(input).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+            {
+                float x = source[i];
+                destination[i] = (float)(Half)(0.5f * x *
+                    (1f + MathF.Tanh(0.7978845608f * (x + 0.044715f * x * x * x))));
+            }
+        }
+
+        public void Fp16Relu(IGpuBuffer input, IGpuBuffer output, int size)
+        {
+            Fp16ReluCalls++;
+            var source = Buffer(input).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+                destination[i] = (float)(Half)MathF.Max(source[i], 0f);
+        }
+
+        public void Fp16Add(IGpuBuffer left, IGpuBuffer right, IGpuBuffer output, int size)
+        {
+            Fp16AddCalls++;
+            var a = Buffer(left).Data;
+            var b = Buffer(right).Data;
+            var destination = Buffer(output).Data;
+            for (int i = 0; i < size; i++)
+                destination[i] = (float)(Half)(a[i] + b[i]);
+        }
+
+        public void Fp16Softmax(IGpuBuffer input, IGpuBuffer output, int rows, int cols)
+            => throw new NotSupportedException();
+
+        public void Fp16LayerNorm(
+            IGpuBuffer input,
+            IGpuBuffer gamma,
+            IGpuBuffer beta,
+            IGpuBuffer output,
+            IGpuBuffer mean,
+            IGpuBuffer variance,
+            int rows,
+            int cols,
+            float epsilon)
+            => throw new NotSupportedException();
+
+        public void Im2colKNFp16(
+            IGpuBuffer input,
+            IGpuBuffer output,
+            int batch,
+            int channels,
+            int height,
+            int width,
+            int kernelH,
+            int kernelW,
+            int strideH,
+            int strideW,
+            int padH,
+            int padW,
+            int dilationH,
+            int dilationW)
+            => throw new NotSupportedException();
+
+        private static MockGpuBuffer Buffer(IGpuBuffer buffer) => Assert.IsType<MockGpuBuffer>(buffer);
+
+        private static void GemmCore(
+            IGpuBuffer a,
+            IGpuBuffer b,
+            IGpuBuffer c,
+            int m,
+            int n,
+            int k,
+            float alpha,
+            float beta)
+        {
+            var left = Buffer(a).Data;
+            var right = Buffer(b).Data;
+            var output = Buffer(c).Data;
+            for (int row = 0; row < m; row++)
+            {
+                for (int column = 0; column < n; column++)
+                {
+                    float sum = 0;
+                    for (int inner = 0; inner < k; inner++)
+                        sum += left[row * k + inner] * right[inner * n + column];
+                    output[row * n + column] = alpha * sum + beta * output[row * n + column];
+                }
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionPolicyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionPolicyTests.cs
@@ -1,0 +1,291 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.NumericOperations;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Gpu;
+
+public sealed class GpuPrecisionPolicyTests
+{
+    [Fact]
+    public void CublasDefaultAlgorithmMatchesTheNativeHeaderValue()
+        => Assert.Equal(-1, CuBlasNative.CUBLAS_GEMM_DEFAULT);
+
+    [Fact]
+    public void SpeedFirst_DefaultConvertsEveryOrdinaryPublicTypeThroughFp32()
+    {
+        var backend = CreateBackend(Fp32());
+
+        AssertGpuPlan<float>(backend, GpuScalarType.Float32);
+        AssertGpuPlan<double>(backend, GpuScalarType.Float32);
+        AssertGpuPlan<int>(backend, GpuScalarType.Float32);
+        AssertGpuPlan<long>(backend, GpuScalarType.Float32);
+        AssertGpuPlan<decimal>(backend, GpuScalarType.Float32);
+
+        Assert.Contains("Float64", Plan<double>(backend).FallbackReason);
+        Assert.Contains("Generic", Plan<int>(backend).FallbackReason);
+    }
+
+    [Fact]
+    public void SpeedFirst_AutoHonorsReducedPublicTypesWhenSupported()
+    {
+        var backend = CreateBackend(Fp32(), Fp16(), Bf16(), Fp8E4M3(), Fp8E5M2());
+
+        AssertGpuPlan<Half>(backend, GpuScalarType.Float16);
+        AssertGpuPlan<BFloat16>(backend, GpuScalarType.BFloat16);
+        AssertGpuPlan<Float8E4M3>(backend, GpuScalarType.Float8E4M3);
+        AssertGpuPlan<Float8E5M2>(backend, GpuScalarType.Float8E5M2);
+    }
+
+    [Fact]
+    public void PreserveInputType_UsesCpuWhenTheBackendCannotComputeTheDeclaredType()
+    {
+        var backend = CreateBackend(Fp32(), Fp16());
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        var doublePlan = Plan<double>(backend);
+        var integerPlan = Plan<int>(backend);
+
+        Assert.Equal(GpuExecutionRoute.Cpu, doublePlan.Route);
+        Assert.Equal(GpuScalarType.Float64, doublePlan.MultiplyType);
+        Assert.Contains("PreserveInputType", doublePlan.FallbackReason);
+        Assert.Equal(GpuExecutionRoute.Cpu, integerPlan.Route);
+        Assert.Equal(GpuScalarType.Generic, integerPlan.MultiplyType);
+    }
+
+    [Fact]
+    public void PreserveInputType_UsesNativeDeclaredTypeWhenAdvertised()
+    {
+        var backend = CreateBackend(Fp32(), Fp64());
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        AssertGpuPlan<double>(backend, GpuScalarType.Float64);
+    }
+
+    [Fact]
+    public void UnsupportedBFloat16FallsBackToFp32InsteadOfNarrowingToFp16()
+    {
+        var backend = CreateBackend(Fp32(), Fp16());
+        using var policy = new GpuExecutionPolicyScope(new GpuExecutionPolicy(
+            computePreference: GpuComputePreference.BFloat16));
+
+        var plan = Plan<float>(backend);
+
+        Assert.Equal(GpuScalarType.Float32, plan.MultiplyType);
+        Assert.Contains("BFloat16", plan.FallbackReason);
+    }
+
+    [Fact]
+    public void UnsupportedFp8UsesTheFirstSupportedHigherPrecisionFormat()
+    {
+        var backend = CreateBackend(Fp32(), Fp16(), Bf16());
+        using var policy = new GpuExecutionPolicyScope(new GpuExecutionPolicy(
+            computePreference: GpuComputePreference.Float8E4M3));
+
+        var plan = Plan<float>(backend);
+
+        Assert.Equal(GpuScalarType.BFloat16, plan.MultiplyType);
+        Assert.Contains("Float8E4M3", plan.FallbackReason);
+    }
+
+    [Fact]
+    public void ExplicitFp64NeverSilentlyFallsBackToLowerGpuPrecision()
+    {
+        var backend = CreateBackend(Fp32(), Fp16());
+        using var policy = new GpuExecutionPolicyScope(new GpuExecutionPolicy(
+            computePreference: GpuComputePreference.Float64));
+
+        var plan = Plan<double>(backend);
+
+        Assert.Equal(GpuExecutionRoute.Cpu, plan.Route);
+        Assert.Equal(GpuScalarType.Float64, plan.MultiplyType);
+        Assert.Contains("no eligible GPU precision", plan.FallbackReason);
+    }
+
+    [Fact]
+    public void StrictUnsupportedAutocastFailsBeforeDispatch()
+    {
+        var backend = CreateBackend(Fp32());
+        using var policy = new GpuExecutionPolicyScope(new GpuExecutionPolicy(
+            fallbackBehavior: GpuPrecisionFallbackBehavior.Throw));
+        using var autocast = new AutocastScope(PrecisionMode.Float8E5M2);
+
+        var error = Assert.Throws<NotSupportedException>(() => Plan<float>(backend));
+        Assert.Contains("Float8E5M2", error.Message);
+    }
+
+    [Fact]
+    public void ThirdPartyBackendWithoutPrecisionInterfaceRemainsFp32Compatible()
+    {
+        var backend = MockDirectGpuBackend.Create(new MockBackendState());
+
+        var plan = Plan<double>(backend);
+
+        Assert.Equal(GpuExecutionRoute.Gpu, plan.Route);
+        Assert.Equal(GpuScalarType.Float32, plan.InputStorage);
+        Assert.Equal(GpuScalarType.Float32, plan.AccumulatorType);
+    }
+
+    [Fact]
+    public void Fp16ElementwiseCapabilityKeepsFp32AccumulatorAndFp16Output()
+    {
+        var capabilities = GpuPrecisionCapabilityCatalog.Create(
+            supportsFp16: true,
+            GpuPrecisionImplementation.Native,
+            fp16ReducesStorageBytes: true,
+            fp16OutputStorage: GpuScalarType.Float16,
+            fp16MultiplyType: GpuScalarType.Float32);
+
+        var fp16 = Assert.Single(capabilities, capability =>
+            capability.InputStorage == GpuScalarType.Float16);
+        Assert.Equal(GpuScalarType.Float32, fp16.AccumulatorType);
+        Assert.Equal(GpuScalarType.Float16, fp16.OutputStorage);
+        Assert.Equal(GpuScalarType.Float16, fp16.ComputeFormat);
+        Assert.Equal(GpuScalarType.Float32, fp16.MultiplyType);
+    }
+
+    [Fact]
+    public void TensorFloat32CapabilitySeparatesLogicalSelectionFromPhysicalMultiply()
+    {
+        var capabilities = GpuPrecisionCapabilityCatalog.Create(
+            supportsFp16: false,
+            GpuPrecisionImplementation.Native,
+            fp16ReducesStorageBytes: false,
+            fp32Implementation: GpuPrecisionImplementation.VendorLibrary,
+            fp32MultiplyType: GpuScalarType.TensorFloat32,
+            supportsTensorFloat32: true);
+        var backend = CreateBackend(capabilities.ToArray());
+
+        var automatic = Plan<float>(backend);
+        Assert.Equal(GpuScalarType.Float32, automatic.ComputeFormat);
+        Assert.Equal(GpuScalarType.TensorFloat32, automatic.MultiplyType);
+        Assert.Equal(GpuScalarType.Float32, automatic.AccumulatorType);
+
+        using var explicitTf32 = new GpuExecutionPolicyScope(new GpuExecutionPolicy(
+            computePreference: GpuComputePreference.TensorFloat32));
+        var requested = Plan<float>(backend);
+        Assert.Equal(GpuScalarType.TensorFloat32, requested.ComputeFormat);
+        Assert.Equal(GpuScalarType.Float32, requested.InputStorage);
+        Assert.Equal(GpuScalarType.TensorFloat32, requested.MultiplyType);
+    }
+
+    [Fact]
+    public void PreserveInputType_RejectsTf32MultiplyForFloat()
+    {
+        var capabilities = GpuPrecisionCapabilityCatalog.Create(
+            supportsFp16: false,
+            GpuPrecisionImplementation.Native,
+            fp16ReducesStorageBytes: false,
+            fp32Implementation: GpuPrecisionImplementation.VendorLibrary,
+            fp32MultiplyType: GpuScalarType.TensorFloat32,
+            supportsTensorFloat32: true);
+        var backend = CreateBackend(capabilities.ToArray());
+        using var preserve = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        var plan = Plan<float>(backend);
+
+        Assert.Equal(GpuExecutionRoute.Cpu, plan.Route);
+        Assert.Equal(GpuScalarType.Float32, plan.MultiplyType);
+        Assert.Contains("PreserveInputType", plan.FallbackReason);
+    }
+
+    [Fact]
+    public async Task PolicyAndAutocastScopesFlowAcrossAwaitAndRestoreNestedValues()
+    {
+        Assert.Same(GpuExecutionPolicy.Default, GpuExecutionPolicyScope.CurrentPolicy);
+        Assert.False(AutocastScope.IsEnabled);
+
+        using (var preserve = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve))
+        using (var fp16 = new AutocastScope(PrecisionMode.Float16))
+        {
+            await Task.Yield();
+            Assert.Same(GpuExecutionPolicy.Preserve, GpuExecutionPolicyScope.CurrentPolicy);
+            Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+
+            using (var speed = new GpuExecutionPolicyScope(GpuExecutionPolicy.Default))
+            using (var bf16 = new AutocastScope(PrecisionMode.BFloat16))
+            {
+                await Task.Yield();
+                Assert.Same(GpuExecutionPolicy.Default, GpuExecutionPolicyScope.CurrentPolicy);
+                Assert.Equal(PrecisionMode.BFloat16, AutocastScope.ActivePrecision);
+            }
+
+            Assert.Same(GpuExecutionPolicy.Preserve, GpuExecutionPolicyScope.CurrentPolicy);
+            Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+        }
+
+        Assert.Same(GpuExecutionPolicy.Default, GpuExecutionPolicyScope.CurrentPolicy);
+        Assert.False(AutocastScope.IsEnabled);
+    }
+
+    [Theory]
+    [InlineData(PrecisionMode.BFloat16, GpuComputePreference.BFloat16)]
+    [InlineData(PrecisionMode.Float8E4M3, GpuComputePreference.Float8E4M3)]
+    [InlineData(PrecisionMode.Float8E5M2, GpuComputePreference.Float8E5M2)]
+    public void EveryAutocastModeIsAcceptedAndObservable(
+        PrecisionMode mode,
+        GpuComputePreference expected)
+    {
+        var backend = CreateBackend(Fp32());
+        using var autocast = new AutocastScope(mode);
+
+        var plan = Plan<float>(backend);
+
+        Assert.Equal(expected, plan.RequestedPreference);
+        Assert.Equal(GpuScalarType.Float32, plan.MultiplyType);
+        Assert.NotNull(plan.FallbackReason);
+    }
+
+    private static GpuComputePlan Plan<T>(IDirectGpuBackend backend)
+        => GpuPrecisionPlanner.CreatePlan<T>(backend, GpuPrecisionOperation.MatMul, "test-matmul");
+
+    private static void AssertGpuPlan<T>(IDirectGpuBackend backend, GpuScalarType expected)
+    {
+        var plan = Plan<T>(backend);
+        Assert.Equal(GpuExecutionRoute.Gpu, plan.Route);
+        Assert.Equal(typeof(T), plan.PublicType);
+        Assert.Equal(expected, plan.MultiplyType);
+    }
+
+    private static IDirectGpuBackend CreateBackend(params GpuPrecisionCapability[] capabilities)
+        => new PrecisionBackend(
+            MockDirectGpuBackend.Create(new MockBackendState()),
+            capabilities);
+
+    private static GpuPrecisionCapability Fp64() => Capability(GpuScalarType.Float64);
+    private static GpuPrecisionCapability Fp32() => Capability(GpuScalarType.Float32);
+    private static GpuPrecisionCapability Fp16() => Capability(GpuScalarType.Float16);
+    private static GpuPrecisionCapability Bf16() => Capability(GpuScalarType.BFloat16);
+    private static GpuPrecisionCapability Fp8E4M3() => Capability(GpuScalarType.Float8E4M3);
+    private static GpuPrecisionCapability Fp8E5M2() => Capability(GpuScalarType.Float8E5M2);
+
+    private static GpuPrecisionCapability Capability(GpuScalarType type) => new(
+        type,
+        type,
+        type is GpuScalarType.Float16 or GpuScalarType.BFloat16
+            or GpuScalarType.Float8E4M3 or GpuScalarType.Float8E5M2
+            ? GpuScalarType.Float32
+            : type,
+        type == GpuScalarType.Float64 ? GpuScalarType.Float64 : GpuScalarType.Float32,
+        GpuPrecisionImplementation.Native,
+        type is GpuScalarType.Float16 or GpuScalarType.BFloat16
+            or GpuScalarType.Float8E4M3 or GpuScalarType.Float8E5M2);
+
+    private sealed class PrecisionBackend : DelegatingGpuBackend, IGpuPrecisionBackend
+    {
+        private readonly IReadOnlyList<GpuPrecisionCapability> _capabilities;
+
+        internal PrecisionBackend(
+            IDirectGpuBackend inner,
+            IReadOnlyList<GpuPrecisionCapability> capabilities)
+            : base(inner)
+        {
+            _capabilities = capabilities;
+        }
+
+        public IReadOnlyList<GpuPrecisionCapability> GetPrecisionCapabilities(
+            GpuPrecisionOperation operation) => _capabilities;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/MixedPrecisionContextTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/MixedPrecisionContextTests.cs
@@ -28,17 +28,15 @@ public class MixedPrecisionContextTests
     }
 
     [Fact]
-    public void BeginAutocast_WithBFloat16_ThrowsNotSupported()
+    public void BeginAutocast_WithBFloat16_ReturnsActiveScope()
     {
-        // MixedPrecisionContext accepts BFloat16 at construction for
-        // policy/routing purposes, but the FP16 compute path in
-        // AutocastScope doesn't yet handle BFloat16 — BeginAutocast must
-        // throw rather than silently degrade. This test pins that
-        // contract so a future implementation change doesn't accidentally
-        // promote BFloat16 to an unsupported runtime path.
         using var ctx = new MixedPrecisionContext<float>(
             defaultPrecision: PrecisionMode.BFloat16);
-        Assert.Throws<NotSupportedException>(() => ctx.BeginAutocast());
+        using var scope = ctx.BeginAutocast();
+
+        Assert.True(AutocastScope.IsEnabled);
+        Assert.Equal(PrecisionMode.BFloat16, AutocastScope.ActivePrecision);
+        Assert.Same(ctx.Policy, scope.Policy);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This replaces the first iteration's float-only guards with a capability-aware GPU precision contract.

The default is now **speed-first**: eligible generic tensor operations execute on the GPU through a policy-selected route the backend can truthfully advertise, then convert the result back to the caller's declared `T`. Exact declared-type computation remains available through the scoped `PreserveInputType` policy and the legacy `AIDOTNET_DIRECTGPU_STRICT_FP64=1` compatibility switch.

This is API/output-type parity, not a claim of bitwise arithmetic parity: `Tensor<double>` still returns `Tensor<double>`, but under the default policy its GPU computation may use FP32 or TF32. Callers that require double arithmetic opt into preservation.

## What this adds

- `GpuExecutionPolicy` and async-flowing `GpuExecutionPolicyScope`:
  - `SpeedFirst` is the default.
  - `PreserveInputType` uses an exact matching GPU route when one exists and otherwise uses the CPU reference implementation.
- Explicit compute preferences for FP64, FP32, TF32, BF16, FP16, FP8 E4M3, and FP8 E5M2.
- Configurable unsupported-format behavior: deterministic higher-precision fallback or fail-fast `Throw`.
- Operation-specific backend capability discovery for CUDA, HIP, Metal, OpenCL, Vulkan, and WebGPU.
- Observable `GpuComputePlan` diagnostics that distinguish:
  - logical autocast format;
  - physical input storage;
  - multiply type;
  - accumulator type;
  - output storage;
  - native, vendor-library, composite, packed, or emulated implementation;
  - whether the route really reduces storage/transfer bytes.
- Async-safe autocast state. Nested policy/autocast scopes now survive `await` and restore their containing values.
- Full backend-agnostic autocast selection for FP16, BF16, FP8 E4M3, and FP8 E5M2. Creating a scope never fails merely because the current device lacks that physical format; the operation planner chooses an honest fallback.
- Typed FP16 dispatch for GEMM, Add, ReLU, and GELU, preventing reduced-width buffers from being passed to ordinary FP32 delegates.
- Generic rank-2, ND×2D, and contiguous ND×ND matmul execution with declared-type conversion on the GPU.
- A reproducible, synchronized hardware evidence harness with native-FP32 and exact-FP64 controls.

## What this fixes

The first PR iteration fixed silent double narrowing by sending every non-float matmul to the CPU. That restored exactness, but it also removed the GPU benefit and did not provide parity for `Half`, BF16, FP8, integers, or decimal. It also treated "tensor type," "storage type," and "compute type" as if they were the same property.

This revision fixes those limitations and several issues exposed while exercising the real routes:

- `double`, `int`, `long`, and `decimal` can use the default FP32/TF32 GPU boundary and still return the declared public type.
- `Half`, BF16, and both FP8 public types select their own format when supported and otherwise follow deterministic, reported fallback rules.
- BF16 never incorrectly narrows to FP16; its safe fallback is FP32.
- FP8 falls back in the order BF16 → FP16 → FP32.
- An explicit FP64 request never silently becomes lower-precision GPU arithmetic.
- Preservation no longer means "CPU unconditionally": exact Half elementwise work, for example, remains on a matching typed GPU route.
- Third-party `IDirectGpuBackend` implementations compiled before this capability API remain safely FP32-compatible.
- The old `ThreadStatic` autocast state no longer disappears across async continuations.
- BF16 and FP8 scopes are no longer inert or rejected at construction time.
- Generic FP16 elementwise execution no longer sends half buffers into FP32-only delegates.
- Rank-4 and higher contiguous batched matmul now multiplies every matching leading dimension into the batch count; `[2,3,...]` correctly dispatches six batches rather than two.
- The CUDA binding now uses the real `CUBLAS_GEMM_DEFAULT` value (`-1`, not `0`). On the test device the old value made the FP16-input/FP32-accumulate GEMM report `NotSupported` and silently fall back; the corrected value executes the vendor-library route.
- The FP16 GEMM correctness oracle now rejects non-finite output and uses relative-L2 plus K-scaled maximum-absolute error, avoiding unstable per-element relative error near zero.
- The historical `AIDOTNET_AUTOCAST=fp8` alias remains FP8 E5M2-compatible, while explicit E4M3/E5M2 aliases select the requested format.

## Type parity and fallback contract

| Public `T` | Speed-first `Auto` | Returned type | Preservation behavior |
|---|---|---|---|
| `float` | FP32 storage; TF32 multiply is allowed only when the CUDA device/config actually selects it | `float` | Exact FP32-multiply GPU route if advertised; otherwise CPU |
| `double` | FP32/TF32 GPU computation | `double` | Native FP64 GPU route if advertised; otherwise exact CPU |
| `Half` | FP16 when supported, otherwise FP32 | `Half` | Exact FP16 GPU route if advertised; otherwise CPU |
| `BFloat16` | BF16 when supported, otherwise FP32 | `BFloat16` | Exact BF16 GPU route if advertised; otherwise CPU |
| `Float8E4M3` | E4M3, then BF16 → FP16 → FP32 | `Float8E4M3` | Exact E4M3 route if advertised; otherwise CPU |
| `Float8E5M2` | E5M2, then BF16 → FP16 → FP32 | `Float8E5M2` | Exact E5M2 route if advertised; otherwise CPU |
| `int` | FP32 GPU computation | `int` | CPU unless an exact integer capability is introduced |
| `long` | FP32 GPU computation | `long` | CPU unless an exact integer capability is introduced |
| `decimal` | FP32 GPU computation | `decimal` | CPU unless an exact decimal capability is introduced |

The deterministic execution tests exercise and convert back all nine public types above. The capability tests separately cover native-format selection, every fallback order, strict rejection, FP32-vs-TF32 logical/physical separation, third-party backend compatibility, and nested async scopes.

## Backend/autocast truthfulness

"Supported" here means the autocast mode is accepted and produces a deterministic plan on every in-tree backend. It does **not** mean every device has a native kernel for every format.

- CUDA/HIP FP16 GEMM: vendor-library route with FP16 inputs/multiply and FP32 accumulation/output.
- CUDA FP32 GEMM on Ampere+: the plan reports TF32 multiply separately when TF32 is actually enabled; disabling TF32 reports FP32 multiply.
- CUDA/HIP FP16 Add/ReLU/GELU: reduced storage with FP32 shader arithmetic and FP16 output.
- Metal FP16 routes: native FP16 storage, with the current shaders' actual FP32 multiply/accumulation reported.
- OpenCL/Vulkan FP16 routes: packed FP16 storage with FP32 arithmetic, labeled `Packed` rather than native FP16 compute.
- WebGPU's current FP16 route: precision emulation in FP32 physical storage, labeled `Emulated`, with no storage-saving claim. The net471 compatibility target reports FP32-only WebGPU capability.
- BF16/FP8: no backend is labeled native unless it advertises a real operation-specific implementation. Otherwise the selected higher-precision fallback is visible in diagnostics.
- Operations without a typed reduced-precision contract remain on a truthful FP32 route rather than reinterpreting buffer bytes unsafely.

This matches the separation used by vendor APIs: storage, multiply, accumulator, and output types are distinct choices in [NVIDIA cuBLAS](https://docs.nvidia.com/cuda/cublas/index.html) and [AMD rocWMMA](https://rocm.docs.amd.com/_/downloads/rocWMMA/en/docs-6.3.0/pdf/), while WGSL requires the optional [`shader-f16` extension](https://gpuweb.github.io/gpuweb/wgsl/#enable-extensions) before native f16 can be claimed.

## Hardware evidence

Measured locally on:

- Windows 11 `10.0.26200`
- .NET `10.0.11`
- AMD Ryzen 7 4800H, 16 logical processors
- NVIDIA GeForce GTX 1660 Ti, driver `610.88`, compute capability `7.5`, 6 GiB
- CUDA DirectGPU backend

Every GPU timing materializes the output, so asynchronous launches cannot make an incomplete operation look fast. "Cold" includes tensor creation, upload, compute-format conversion, execution, conversion back to `T`, download, and synchronization. "Resident inputs" reuses input tensors. Native FP32 GPU and declared-double CPU runs are controls. Values below are medians; the harness also emits P95.

| Matrix | CPU FP64 control | GPU FP32 cold | GPU `double→Auto→double` cold | GPU FP16 cold | Converted-double vs CPU | Conversion overhead vs FP32, cold/resident | Double-route max relative error | FP16 max relative error |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 256² | 0.932 ms | 0.641 ms | 1.338 ms | 0.756 ms | **0.70×** | 108.7% / 101.3% | 1.791519E-7 | 2.371950E-4 |
| 1024² | 27.232 ms | 7.680 ms | 16.495 ms | 11.956 ms | **1.65×** | 114.8% / 180.1% | 1.304817E-6 | 2.615586E-4 |
| 2048² | 125.982 ms | 30.556 ms | 65.843 ms | 59.538 ms | **1.91×** | 115.5% / 135.0% | 1.813151E-6 | 2.469055E-4 |

The result is intentionally not summarized as "conversion is always faster": at 256² the conversion/transfer boundary outweighs GPU compute, while 1024² and 2048² recover a net win over exact CPU double. Conversion remains expensive relative to a native FP32 caller, which is why the benchmark reports it explicitly.

FP16 is also slower than FP32 on this GTX 1660 Ti at the larger sizes (11.956 vs 7.680 ms at 1024²; 59.538 vs 30.556 ms at 2048²). That is evidence against assuming FP16 is universally the fastest GPU format and supports capability/device-dependent selection. These measurements are not generalized to untested hardware.

Reproduce with:

```text
dotnet run --project tests/AiDotNet.Tensors.Benchmarks/AiDotNet.Tensors.Benchmarks.csproj -c Release -- --gpu-precision-evidence <size> <iterations> <report.md>
```

The generated report includes the backend capability matrix, all-public-type plan matrix, cold/resident medians and P95, actual executed plans, and accuracy results. Timing thresholds are intentionally not placed in xUnit/CI.

## Validation

- `AiDotNet.Tensors` net10.0 build: 0 warnings, 0 errors.
- `AiDotNet.Tensors` net471 build: 0 warnings, 0 errors.
- Precision/autocast/type-parity/CUDA-FP16/convolution-contract focused set on net10.0: 77/77 passed.
- Precision/autocast/type-parity/convolution-contract focused set on net471: 75/75 passed.
- Real CUDA FP16-input/FP32-accumulate correctness cases pass with finite-output, relative-L2, and K-scaled max-absolute checks.
- `git diff --check` passes.

An initial unfiltered local audit reached 7,761 passed and 295 skipped before an existing CUDA offload-context access violation aborted the host. The crash test passes in isolation. Two unrelated managed-CPU stress defects also reproduce in isolation in untouched code (`PaddedBufferConcurrencyStressTests` and one `GemmBeta0BitExactTests` case); no assertions or CPU GEMM code were weakened in this PR.

## Compatibility notes

- Default generic GPU behavior changes from strict-double CPU fallback to speed-first approximate GPU execution.
- Exactness-sensitive callers and AiDotNet numerical tests should wrap the operation in `new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve)`.
- Existing process-wide strict behavior remains available through `AIDOTNET_DIRECTGPU_STRICT_FP64=1`.
- Existing third-party DirectGPU backends require no source change and are conservatively treated as FP32-only until they implement `IGpuPrecisionBackend`.
