### PR TITLE
fix(compilation): skip a fused optimizer step whose gradients are not finite

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -6679,14 +6679,44 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     else { var r = eng.TensorAdd(a, b); r.AsSpan().CopyTo(o.AsWritableSpan()); }
                 };
             }
-            // Broadcast path: copy a into output, then in-place add b (b is the
-            // smaller operand and broadcasts up to a's shape).
-            return eng =>
+            // Broadcast path: seed the output with whichever operand ALREADY CARRIES THE OUTPUT
+            // SHAPE, then broadcast the other one up into it.
+            //
+            // WHICH OPERAND IS THE LARGER ONE IS NOT KNOWN IN ADVANCE, and this path used to assume
+            // it was always `a`. Seeding from `a` when `a` is the SMALLER operand copies only a's
+            // elements into the full-size buffer and leaves the remainder holding whatever was
+            // there before -- zeros from a fresh allocation, or a previous step's bytes from a
+            // recycled one. Addition is commutative, so seeding from the full-shape operand
+            // instead is the same arithmetic with every element actually written.
+            //
+            // This is reached constantly: TensorBroadcastTo expresses a genuine expansion as
+            // TensorBroadcastAdd(input, zeros(targetShape)), whose FIRST operand is by construction
+            // the small one, so every such broadcast replayed through a compiled plan was wrong.
+            // MEASURED on [4,1] -> [4,3]: a correctly SHAPED 12-element output holding the 4 source
+            // values contiguously and 8 stale slots -- a silent wrong answer at exactly 1/3 of the
+            // true sum when the buffer was fresh, and NaN/1e35 when it was recycled, which then
+            // poisons every parameter through the gradient.
+            bool aIsFullShape = ShapeMatchesBuffer(a._shape, o._shape);
+            bool bIsFullShape = ShapeMatchesBuffer(b._shape, o._shape);
+            if (aIsFullShape || bIsFullShape)
             {
-                a.AsSpan().CopyTo(o.AsWritableSpan());
-                if (eng is CpuEngine cpuEng) cpuEng.TensorBroadcastAddInPlace(o, b);
-                else { var r = eng.TensorAdd(a, b); r.AsSpan().CopyTo(o.AsWritableSpan()); }
-            };
+                var full = aIsFullShape ? a : b;
+                var addend = aIsFullShape ? b : a;
+                return eng =>
+                {
+                    full.AsSpan().CopyTo(o.AsWritableSpan());
+                    if (eng is CpuEngine cpuEng) cpuEng.TensorBroadcastAddInPlace(o, addend);
+                    else
+                    {
+                        var r = eng.TensorAdd(a, b);
+                        if (!r.IsContiguous) r = r.Contiguous();
+                        r.AsSpan().CopyTo(o.AsWritableSpan());
+                    }
+                };
+            }
+            // Neither operand carries the output shape -- a MUTUAL broadcast such as
+            // [4,1] + [1,3] -> [4,3], where each side expands along a different axis. There is no
+            // operand to seed from, so fall through to the generic path rather than guess.
         }
 
         // ConvTranspose2D forward: route compiled-plan replay through
@@ -7293,6 +7323,21 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// reads the now-clipped grads. Returns false if any gradient is not CUDA-resident (caller uses the CPU
     /// clip instead); the global norm requires ALL grads present, so a mixed CPU/GPU set is not handled here.
     /// </summary>
+    /// <summary>
+    /// True when <paramref name="shape"/> is exactly the plan buffer's shape, i.e. this operand
+    /// already spans the whole output and nothing about it needs broadcasting.
+    /// </summary>
+    private static bool ShapeMatchesBuffer(int[] shape, int[] bufferShape)
+    {
+        if (shape is null || bufferShape is null) return false;
+        if (shape.Length != bufferShape.Length) return false;
+        for (int i = 0; i < shape.Length; i++)
+        {
+            if (shape[i] != bufferShape[i]) return false;
+        }
+        return true;
+    }
+
     private static bool TryClipGradientsGlobalL2Gpu(Tensor<T>[] gradients, double maxNorm)
     {
         // The CUDA reduction/scale path is float-typed. For a Tensor<double> (or any

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -744,6 +744,26 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private int _optimizerStep;
     private FusedOptimizerRuntimeState? _optimizerRuntimeState;
 
+    private int _nonFiniteStepsSkipped;
+
+    /// <summary>
+    /// How many fused optimizer steps have been skipped because the gradients for that step were
+    /// not finite. Zero on a healthy run.
+    /// </summary>
+    /// <remarks>
+    /// A skipped step leaves every parameter exactly as it was, so training continues from the last
+    /// good state instead of propagating a NaN forward. Surfaced so a caller can tell "the model is
+    /// not learning" apart from "the model is diverging and its steps are being discarded" -- those
+    /// look identical from the loss alone once the weights are already poisoned.
+    /// </remarks>
+    public int NonFiniteStepsSkipped => _nonFiniteStepsSkipped;
+
+    /// <summary>
+    /// True when the most recent <see cref="Step"/> discarded its optimizer update because the
+    /// gradients were not finite.
+    /// </summary>
+    public bool LastStepSkippedNonFiniteGradients { get; private set; }
+
     private sealed class FusedOptimizerRuntimeScalars
     {
         public float HypergradientAdjustment;
@@ -2900,6 +2920,50 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     return;
                 }
             }
+
+            // GRADIENT GATE: VALIDATE EVERY GRADIENT BEFORE WRITING ANY PARAMETER.
+            //
+            // The kernels below fuse backward and update into one pass -- each reads grad and writes
+            // param in place. That makes a non-finite gradient unrecoverable rather than merely bad:
+            // the NaN lands in the weights, every later step reads it back, and the loss is NaN from
+            // then on with nothing to say which step caused it. The eager tape does not have this
+            // property, which is why a model can show perfectly finite gradients from
+            // ComputeGradients while Train destroys it.
+            //
+            // torch.amp.GradScaler is the reference behaviour: inspect the gradients each iteration
+            // and SKIP the optimizer step when any are inf or NaN, leaving the parameters untouched
+            // so the run continues from the last good state. Fusing backward with the update removed
+            // the point where that check naturally sits, so it is reinstated here.
+            //
+            // The scan must cover ALL parameters before ANY is written -- a per-parameter check
+            // would still apply the tensors it had already reached before hitting the bad one,
+            // leaving the model half-updated, which is worse than either clean outcome.
+            //
+            // Scope: this gates the CPU path. The multi-tensor GPU path returns above with its
+            // gradients in device buffers, so it needs an equivalent device-side reduction rather
+            // than this host scan.
+            bool gradientsFinite = true;
+            for (int p = 0; p < paramCount && gradientsFinite; p++)
+            {
+                if (gradArrays[p].Length == 0) continue;
+                fixed (float* pGradCheck = &gradArrays[p][gradOffsets[p]])
+                {
+                    gradientsFinite = FusedOptimizer.AllFiniteSimd(pGradCheck, lengths[p]);
+                }
+            }
+
+            if (!gradientsFinite)
+            {
+                // Discard the step. Parameters, optimizer moments and the step counter that drives
+                // bias correction all stay as they were, so the next step behaves as though this one
+                // never happened -- the same contract GradScaler gives on an overflow.
+                _optimizerStep--;
+                _nonFiniteStepsSkipped++;
+                LastStepSkippedNonFiniteGradients = true;
+                return;
+            }
+
+            LastStepSkippedNonFiniteGradients = false;
 
             for (int p = 0; p < paramCount; p++)
             {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -765,27 +765,120 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     public bool LastStepSkippedNonFiniteGradients { get; private set; }
 
     /// <summary>
-    /// Checks every materialized CPU gradient before any optimizer state or parameter is written.
-    /// GPU-resident entries intentionally have no host array and remain in the existing device-path
-    /// scope; unmaterialized parameters are also skipped because their pooled gradient storage was
-    /// not written by this step.
+    /// Resolves the authoritative gradient for every GPU-resident parameter before the optimizer
+    /// writes anything. A resident gradient is usable only when its device version is current;
+    /// otherwise the backward pass wrote the host backing and that backing remains authoritative.
+    /// </summary>
+    private void ResolveAuthoritativeGpuGradients(
+        Engines.DirectGpu.IGpuBuffer?[] gpuParameters,
+        Engines.DirectGpu.IDirectGpuBackend?[] gpuBackends,
+        Engines.DirectGpu.IGpuBuffer?[] gpuGradients,
+        float[][] gradArrays,
+        int[] gradOffsets,
+        bool[] stagedGrads)
+    {
+        for (int p = 0; p < gpuGradients.Length; p++)
+        {
+            gpuGradients[p] = null;
+            if (gpuParameters[p] is null || gpuBackends[p] is not { } backend)
+                continue;
+
+            var gradient = _gradients[p];
+            if (gradient is null)
+                continue;
+
+            var resident = gradient.TryGetGpuBuffer();
+            bool streamCapturing =
+                backend is Engines.DirectGpu.CUDA.CudaBackend cuda && cuda.IsStreamCapturing();
+            if (resident is not null &&
+                (streamCapturing || gradient._gpuBufferVersion == gradient.Version))
+            {
+                gpuGradients[p] = resident;
+                continue;
+            }
+
+            // A lazy gradient can materialize after ConfigureOptimizer. Bind it before the
+            // finiteness preflight; otherwise the update loop could upload and consume a gradient
+            // that the preflight never inspected.
+            if (gradArrays[p] is null || gradArrays[p].Length == 0)
+            {
+                var rebound = BindCpuOptimizerTensor(
+                    gradient, out gradOffsets[p], out stagedGrads[p]);
+                gradArrays[p] = (float[])(object)rebound;
+                if (stagedGrads[p] && gradArrays[p].Length != 0)
+                    gradient.CopyLogicalTo((T[])(object)gradArrays[p]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Allocates one reusable classification buffer per distinct GPU backend, sized for that
+    /// backend's largest parameter. Sharing keeps the guard's persistent memory bounded by the
+    /// largest tensor rather than the sum of every gradient tensor.
+    /// </summary>
+    private void AllocateGpuFinitenessScratch(
+        Engines.DirectGpu.IDirectGpuBackend?[] gpuBackends,
+        int[] lengths,
+        Engines.DirectGpu.IGpuBuffer?[] scratchByParameter)
+    {
+        for (int p = 0; p < gpuBackends.Length; p++)
+        {
+            if (gpuBackends[p] is not { } backend || scratchByParameter[p] is not null)
+                continue;
+
+            int maximumLength = lengths[p];
+            for (int q = p + 1; q < gpuBackends.Length; q++)
+                if (ReferenceEquals(gpuBackends[q], backend))
+                    maximumLength = Math.Max(maximumLength, lengths[q]);
+
+            var sharedScratch = backend.AllocateBuffer(maximumLength);
+            _gpuOptimizerBuffers.Add(sharedScratch);
+            for (int q = p; q < gpuBackends.Length; q++)
+                if (ReferenceEquals(gpuBackends[q], backend))
+                    scratchByParameter[q] = sharedScratch;
+        }
+    }
+
+    /// <summary>
+    /// Checks every authoritative CPU or GPU gradient before any optimizer state or parameter is
+    /// written. GPU gradients are classified on-device using the backend's IEEE-bitwise
+    /// <c>ClassifyFloat</c> kernel and reduced to one scalar; the full gradient is never downloaded.
     /// </summary>
     private unsafe bool TryDiscardNonFiniteOptimizerStep(
         float[][] gradArrays,
         int[] gradOffsets,
-        float[][] paramArrays,
+        Engines.DirectGpu.IGpuBuffer?[] gpuGradients,
+        Engines.DirectGpu.IDirectGpuBackend?[] gpuBackends,
+        Engines.DirectGpu.IGpuBuffer?[] gpuFinitenessScratch,
         int[] paramOffsets,
         int[] lengths,
         OptimizerType optimizerType,
+        float[][] paramArrays,
         float[][] scheduleFreeEvalCopies)
     {
         bool gradientsFinite = true;
         for (int p = 0; p < gradArrays.Length && gradientsFinite; p++)
         {
+            if (gpuGradients[p] is { } gpuGradient)
+            {
+                var backend = gpuBackends[p]
+                    ?? throw new InvalidOperationException("A GPU gradient has no owning backend.");
+                var scratch = gpuFinitenessScratch[p]
+                    ?? throw new InvalidOperationException("GPU gradient finiteness scratch was not allocated.");
+                int length = lengths[p];
+                if (length <= 0)
+                    continue;
+
+                // mode 2 = isfinite. Min(mask) is exactly 1 only when every element is finite;
+                // unlike summing a 0/1 mask, this cannot lose a single zero to float rounding for
+                // tensors larger than 2^24 elements.
+                backend.ClassifyFloat(gpuGradient, scratch, mode: 2, size: length);
+                gradientsFinite = backend.Min(scratch, length) == 1.0f;
+                continue;
+            }
+
             var gradients = gradArrays[p];
-            var parameters = paramArrays[p];
-            if (gradients is null || gradients.Length == 0 ||
-                parameters is null || parameters.Length == 0)
+            if (gradients is null || gradients.Length == 0)
             {
                 continue;
             }
@@ -2309,6 +2402,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
         var gpuGradUploadScratch = new float[paramCount][];
+        var gpuFinitenessScratch = new Engines.DirectGpu.IGpuBuffer?[paramCount];
 
         // Issue #350: GetDataArray() returns a COPY when the parameter tensor's
         // backing storage is pool-padded (e.g. logical length 6 on a 16-slot
@@ -2510,6 +2604,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
+        AllocateGpuFinitenessScratch(gpuBackends, lengths, gpuFinitenessScratch);
+
         _optimizerStep = 0;
         var b1 = beta1;
         var b2 = beta2;
@@ -2631,8 +2727,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            ResolveAuthoritativeGpuGradients(
+                gpuParam, gpuBackends, gpuGrad, gradArrays, gradOffsets, stagedGrads);
             if (TryDiscardNonFiniteOptimizerStep(
-                gradArrays, gradOffsets, paramArrays, paramOffsets, lengths, optimizerType, v))
+                gradArrays, gradOffsets, gpuGrad, gpuBackends, gpuFinitenessScratch,
+                paramOffsets, lengths, optimizerType, paramArrays, v))
             {
                 return;
             }
@@ -3003,9 +3102,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     if (gpuM[p] is not { } gm || gpuV[p] is not { } gv) { eligible = false; break; }
                     int lp = lengths[p];
                     if (lp <= 0) { eligible = false; break; }
-                    var gt = _gradients[p];
-                    var gradResident = gt?.TryGetGpuBuffer();
-                    if (gt is null || gradResident is null || gt._gpuBufferVersion != gt.Version) { eligible = false; break; }
+                    var gradResident = gpuGrad[p];
+                    if (gradResident is null) { eligible = false; break; }
                     mtParams.Add(gp); mtGrads.Add(gradResident); mtM.Add(gm); mtV.Add(gv); mtSizes.Add(lp);
                 }
                 if (eligible && mtParams.Count == paramCount)
@@ -3057,37 +3155,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // (uploaded transiently) or GPU (passed through directly).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
                 {
-                    // CAPTURE-FREEZE FIX (#638): re-resolve the gradient's resident buffer EACH STEP. gpuGrad[p]
-                    // was bound ONCE at ConfigureOptimizer time — but under CUDA-graph capture the backward writes
-                    // grads into a buffer made GPU-resident by the capture pre-pass (EnsureResidentBuffer on
-                    // _preAllocatedGrads), which runs AFTER ConfigureOptimizer. So at config time the param-grad
-                    // tensor was NOT yet resident → gpuGrad[p] was null → the optimizer fell back to uploading the
-                    // stale host backing (gradArrays[p], all zeros after the captured resident backward bypassed
-                    // it) → AdamUpdate ran on ~zero grads → weights never changed → FLAT loss / frozen pL1 across
-                    // epochs (the capture-doesn't-learn bug; only visible at a learning scale, not the smoke run).
-                    // Reading the tensor's CURRENT resident buffer each step makes the optimizer consume the grads
-                    // the captured backward actually produced. Mirrors the param-side pin near the GPU fast path.
-                    // Eager paths are unaffected: a non-resident grad still yields null here → gpuGrad/host fallback.
-                    // The #638 line trusts the grad tensor's resident GPU buffer as authoritative. That is correct
-                    // ONLY when that buffer actually holds the gradient the backward produced THIS step. Two backward
-                    // paths write it and keep its version in sync with the tensor Version: (a) CUDA-graph capture —
-                    // the captured backward writes it in place; (b) the FP16-hetero resident backward. But the plain
-                    // eager backward instead accumulates into the grad's HOST backing (gradArrays[p]) and leaves the
-                    // resident buffer at its memset-zero: Version bumps, _gpuBufferVersion does NOT. Consuming that
-                    // stale-zero buffer makes the fused optimizer apply ~ZERO grads, so the weights barely move and
-                    // the loss goes FLAT — the GPU-resident-param mistrain (7.70->7.70 resident vs 7.70->1.31
-                    // non-resident on the same graph; the TimeSeries family runs this path by default). So trust the
-                    // resident grad buffer only when it is version-FRESH (or we are mid stream-capture, where a host
-                    // download is impossible anyway); otherwise upload the authoritative HOST gradient the backward
-                    // produced. This keeps the #638 capture path AND the FP16 resident backward intact.
-                    bool gradStreamCapturing =
-                        gpuBe is Engines.DirectGpu.CUDA.CudaBackend _cbGrad && _cbGrad.IsStreamCapturing();
-                    var _gradT = _gradients[p];
-                    bool residentGradAuthoritative = _gradT is not null && _gradT.TryGetGpuBuffer() is not null
-                        && (gradStreamCapturing || _gradT._gpuBufferVersion == _gradT.Version);
-                    Engines.DirectGpu.IGpuBuffer? gradBuf = residentGradAuthoritative
-                        ? _gradT!.TryGetGpuBuffer()
-                        : null;
+                    // The preflight resolved this step's authoritative gradient before checking
+                    // every gradient for finiteness. Reuse that exact buffer here so the update
+                    // cannot consume a different, unchecked source.
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
                     bool gradTransient = false;
                     if (gradBuf is null)
                     {
@@ -3502,6 +3573,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuBackends = new Engines.DirectGpu.IDirectGpuBackend?[paramCount];
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
         var gpuGradUploadScratch = new float[paramCount][];
+        var gpuFinitenessScratch = new Engines.DirectGpu.IGpuBuffer?[paramCount];
 
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
@@ -3675,6 +3747,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
+        AllocateGpuFinitenessScratch(gpuBackends, lengths, gpuFinitenessScratch);
+
         _optimizerStep = 0;
         var b1 = beta1;
         var b2 = beta2;
@@ -3729,8 +3803,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            ResolveAuthoritativeGpuGradients(
+                gpuParam, gpuBackends, gpuGrad, gradArrays, gradOffsets, stagedGrads);
             if (TryDiscardNonFiniteOptimizerStep(
-                gradArrays, gradOffsets, paramArrays, paramOffsets, lengths, optimizerType, v))
+                gradArrays, gradOffsets, gpuGrad, gpuBackends, gpuFinitenessScratch,
+                paramOffsets, lengths, optimizerType, paramArrays, v))
             {
                 return;
             }
@@ -3759,18 +3836,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // GPU path (mirrors ConfigureOptimizerFloat).
                 if (gpuParam[p] is { } gpuP && gpuBackends[p] is { } gpuBe)
                 {
-                    // CAPTURE-FREEZE FIX (#638): re-resolve the gradient's resident buffer EACH STEP. gpuGrad[p]
-                    // was bound ONCE at ConfigureOptimizer time — but under CUDA-graph capture the backward writes
-                    // grads into a buffer made GPU-resident by the capture pre-pass (EnsureResidentBuffer on
-                    // _preAllocatedGrads), which runs AFTER ConfigureOptimizer. So at config time the param-grad
-                    // tensor was NOT yet resident → gpuGrad[p] was null → the optimizer fell back to uploading the
-                    // stale host backing (gradArrays[p], all zeros after the captured resident backward bypassed
-                    // it) → AdamUpdate ran on ~zero grads → weights never changed → FLAT loss / frozen pL1 across
-                    // epochs (the capture-doesn't-learn bug; only visible at a learning scale, not the smoke run).
-                    // Reading the tensor's CURRENT resident buffer each step makes the optimizer consume the grads
-                    // the captured backward actually produced. Mirrors the param-side pin near the GPU fast path.
-                    // Eager paths are unaffected: a non-resident grad still yields null here → gpuGrad/host fallback.
-                    Engines.DirectGpu.IGpuBuffer? gradBuf = (_gradients[p]?.TryGetGpuBuffer()) ?? gpuGrad[p];
+                    // Use the source selected and checked by the all-gradient preflight. This also
+                    // fixes the grouped path's former unconditional trust of a stale resident
+                    // gradient when the current backward had written the host backing instead.
+                    Engines.DirectGpu.IGpuBuffer? gradBuf = gpuGrad[p];
                     bool gradTransient = false;
                     if (gradBuf is null)
                     {

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1152,6 +1152,80 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     public static System.Action<int, string, Tensor<T>>? ForwardStepObserver { get; set; }
 
     /// <summary>
+    /// Fills every forward step's output buffer with a sentinel before that step runs, then reports
+    /// any step that left the sentinel behind — a step that did not write its whole output.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Forward outputs come from <c>TensorAllocator.RentUninitialized</c>, so the standing contract
+    /// is that a kernel writes ALL of its output; whatever it skips keeps the previous tenant's
+    /// bytes. A kernel that breaks that contract does not fail predictably. It fails when the
+    /// recycled block happens to hold something harmful, which makes it intermittent, and it stops
+    /// failing the moment anything perturbs the heap — including the diagnostics used to look at
+    /// it. That is not a debuggable state.
+    /// </para>
+    /// <para>
+    /// Poisoning the buffer first removes the luck: a partial write leaves sentinels that are
+    /// counted immediately, in the op that produced them, on every run rather than some runs.
+    /// </para>
+    /// <para>
+    /// Off by default. Enabling it costs a fill per step and changes what a non-conforming kernel
+    /// leaves behind, so it is a diagnostic, not a hardening measure.
+    /// </para>
+    /// </remarks>
+    public static bool SanitizeForwardBuffers { get; set; }
+
+    /// <summary>
+    /// Called for each forward step that left sentinel values behind under
+    /// <see cref="SanitizeForwardBuffers"/>: the action index, the op name, and how many of the
+    /// step's output elements it never wrote.
+    /// </summary>
+    public static System.Action<int, string, int>? ForwardBufferLeak { get; set; }
+
+    /// <summary>
+    /// Called for each forward step that CONSUMED sentinel values under
+    /// <see cref="SanitizeForwardBuffers"/>: the action index, the op name, and how many of the
+    /// elements it read had not been written by any earlier step.
+    /// </summary>
+    /// <remarks>
+    /// A step reading unwritten memory is the mirror image of one leaving its own output unwritten,
+    /// and it fails the same way: the value is whatever the pool handed back. The two need separate
+    /// reporting because the culprit is a different op — the reader is wrong about ordering or
+    /// aliasing, not about how much it writes.
+    /// </remarks>
+    public static System.Action<int, string, int>? ForwardBufferReadBeforeWrite { get; set; }
+
+    /// <summary>
+    /// The sentinel written into forward outputs under <see cref="SanitizeForwardBuffers"/>. A
+    /// magnitude no real activation reaches, so a survivor is unambiguous — unlike NaN, which a
+    /// kernel could legitimately produce.
+    /// </summary>
+    private const double ForwardSanitizerSentinel = -8.5070591e37;
+
+    /// <summary>Writes the sentinel across a step's output buffer.</summary>
+    private static void PoisonForwardBuffer(Tensor<T> buffer)
+    {
+        if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return;
+        var sentinel = MathHelper.GetNumericOperations<T>().FromDouble(ForwardSanitizerSentinel);
+        var span = buffer.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++) span[i] = sentinel;
+    }
+
+    /// <summary>Counts sentinel values a step failed to overwrite.</summary>
+    private static int CountForwardBufferLeaks(Tensor<T> buffer)
+    {
+        if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return 0;
+        var sentinel = MathHelper.GetNumericOperations<T>().FromDouble(ForwardSanitizerSentinel);
+        var span = buffer.AsSpan();
+        int leaked = 0;
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (EqualityComparer<T>.Default.Equals(span[i], sentinel)) leaked++;
+        }
+        return leaked;
+    }
+
+    /// <summary>
     /// Maps a forward ACTION index to the step that emitted it. Actions and steps are not 1:1 --
     /// a skipped step emits none and a fused group emits one for several -- so indexing the step
     /// list by action position mislabels everything after the first skip.
@@ -1554,13 +1628,51 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             var fwd = _forwardActions;
             var probe = StepProbe;
             var observer = ForwardStepObserver;
-            if (probe != null || observer != null)
+            bool sanitize = SanitizeForwardBuffers;
+            if (probe != null || observer != null || sanitize)
             {
                 var actionToStep = ActionToStepIndex;
+
+                // Poison EVERY forward output before anything runs. Per-step poisoning would only
+                // expose a step that under-writes its own buffer; filling them all up front also
+                // exposes a step that READS one before its producer has run, because the sentinel
+                // is still sitting there when it is read.
+                if (sanitize && _forwardSteps is not null)
+                {
+                    for (int st = 0; st < _forwardSteps.Length; st++)
+                        PoisonForwardBuffer(_forwardSteps[st].OutputBuffer);
+                }
+
                 probe?.Invoke("BEGIN-FWD");
                 for (int i = 0; i < fwd.Length; i++)
                 {
+                    // Resolve the step BEFORE running, so its inputs can be checked first.
+                    CompiledStep<T>? sanitizeTarget = null;
+                    if (sanitize && _forwardSteps is not null)
+                    {
+                        int idx = actionToStep is not null && i < actionToStep.Length ? actionToStep[i] : i;
+                        if (idx < _forwardSteps.Length) sanitizeTarget = _forwardSteps[idx];
+
+                        if (sanitizeTarget is not null && ForwardBufferReadBeforeWrite is not null)
+                        {
+                            int unwritten = 0;
+                            foreach (var operand in sanitizeTarget.Inputs)
+                            {
+                                if (operand is not null) unwritten += CountForwardBufferLeaks(operand);
+                            }
+                            if (unwritten > 0)
+                                ForwardBufferReadBeforeWrite(i, sanitizeTarget.OpName, unwritten);
+                        }
+                    }
+
                     fwd[i](engine);
+
+                    if (sanitizeTarget is not null)
+                    {
+                        int leaked = CountForwardBufferLeaks(sanitizeTarget.OutputBuffer);
+                        if (leaked > 0)
+                            ForwardBufferLeak?.Invoke(i, sanitizeTarget.OpName, leaked);
+                    }
 
                     // Resolve the STEP this action came from. Indexing _forwardSteps by the action
                     // position is wrong as soon as any step is skipped or folded into a fused group.
@@ -5635,6 +5747,36 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         Tensor<T>? graphRefreshTensor = firstIsEmbedding
             ? forwardSteps[0].OutputBuffer
             : compiledInputTensor;
+
+        // BIND EVERY FORWARD OUTPUT'S LIVE BACKING BEFORE THE PLAN RUNS.
+        //
+        // These buffers come from TensorAllocator.RentUninitialized, and a pooled tensor whose
+        // storage is larger than its logical length does not settle which array IS the tensor until
+        // something asks for writable storage. Until then a writer that reaches for the data array
+        // can be handed a pool-padded COPY while the plan goes on reading the live backing, so the
+        // values written are simply not the values read back. The same hazard is already documented
+        // and fixed for the gradient buffers via BindInternalStepBuffer.
+        //
+        // It presents as a first-step loss that is intermittently enormous (1e10..1e35) or NaN,
+        // because what the plan reads is whatever the recycled block held. MEASURED on a span-scorer
+        // forward: roughly 60% of freshly built plans, and it disappears the instant anything
+        // touches those buffers first -- including the diagnostics used to look at it, which is what
+        // made it read as a heisenbug rather than a defect.
+        //
+        // One AsWritableSpan per buffer at COMPILE time settles the backing once, before any kernel
+        // binds it. Nothing is written and nothing is read; the cost is a single call per buffer,
+        // not per step.
+        for (int i = 0; i < forwardSteps.Count; i++)
+        {
+            var outputBuffer = forwardSteps[i].OutputBuffer;
+
+            // Only a CONTIGUOUS buffer owns storage that could be served as a padded copy. A
+            // non-contiguous output is a view onto another tensor's storage -- an Expand's output
+            // carries stride 0 on its broadcast axes -- and has no writable span of its own to bind.
+            if (outputBuffer is null || outputBuffer.Length == 0 || !outputBuffer.IsContiguous) continue;
+
+            outputBuffer.AsWritableSpan();
+        }
 
         return new CompiledTrainingPlan<T>(
             forwardActions,

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -3159,7 +3159,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool gradientsFinite = true;
             for (int p = 0; p < paramCount && gradientsFinite; p++)
             {
-                if (gradArrays[p].Length == 0) continue;
+                // A parameter whose gradient is not a host float array has no entry here -- a
+                // heterogeneous FP16 plan keeps some gradients in Half or in device buffers, which
+                // is the same case the scope note above calls out for the multi-tensor GPU path.
+                // Those need a scan in their own storage; skipping them keeps this one from
+                // dereferencing a slot it was never given (an FP16 plan threw NullReference here on
+                // its first step).
+                if (gradArrays[p] is null || gradArrays[p].Length == 0) continue;
                 fixed (float* pGradCheck = &gradArrays[p][gradOffsets[p]])
                 {
                     gradientsFinite = FusedOptimizer.AllFiniteSimd(pGradCheck, lengths[p]);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -6643,80 +6643,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
-        // Legacy TensorBroadcastAdd forward: route compiled-plan replay through
-        // a copy-into-output + TensorBroadcastAddInPlace pair instead of the
-        // generic "allocate fresh result + memcpy into plan output" closure.
-        // Used in every SD UNet ResBlock for the time-embedding conditioning
-        // (15+ calls per UNet forward × 10 sampling steps per Predict).
-        //
-        // Save: 1 tensor allocation per Execute. Still pays one memcpy (to copy
-        // `a` into the plan's output buffer before the in-place add), but that
-        // memcpy is one fewer than the generic path which copies the eager
-        // result back into the output buffer.
-        if (step.OpType == OpType.TensorBroadcastAdd && step.Inputs.Length == 2
-            && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous)
+        // Broadcasting binary forward (add / subtract / multiply). ONE builder owns every one of
+        // these, so the question "which operand spans the output" is answered in a single place.
         {
-            var a = step.Inputs[0];
-            var b = step.Inputs[1];
-            var o = step.OutputBuffer;
-            // Same-shape fast path: just call TensorAddInPlace (no broadcast needed).
-            // Many SD ResBlock residual adds hit this — both operands are
-            // [batch, channels, h, w].
-            bool sameShape = a._shape.Length == b._shape.Length;
-            if (sameShape)
-            {
-                for (int d = 0; d < a._shape.Length; d++)
-                {
-                    if (a._shape[d] != b._shape[d]) { sameShape = false; break; }
-                }
-            }
-            if (sameShape)
-            {
-                return eng =>
-                {
-                    a.AsSpan().CopyTo(o.AsWritableSpan());
-                    if (eng is CpuEngine cpuEng) cpuEng.TensorAddInPlace(o, b);
-                    else { var r = eng.TensorAdd(a, b); r.AsSpan().CopyTo(o.AsWritableSpan()); }
-                };
-            }
-            // Broadcast path: seed the output with whichever operand ALREADY CARRIES THE OUTPUT
-            // SHAPE, then broadcast the other one up into it.
-            //
-            // WHICH OPERAND IS THE LARGER ONE IS NOT KNOWN IN ADVANCE, and this path used to assume
-            // it was always `a`. Seeding from `a` when `a` is the SMALLER operand copies only a's
-            // elements into the full-size buffer and leaves the remainder holding whatever was
-            // there before -- zeros from a fresh allocation, or a previous step's bytes from a
-            // recycled one. Addition is commutative, so seeding from the full-shape operand
-            // instead is the same arithmetic with every element actually written.
-            //
-            // This is reached constantly: TensorBroadcastTo expresses a genuine expansion as
-            // TensorBroadcastAdd(input, zeros(targetShape)), whose FIRST operand is by construction
-            // the small one, so every such broadcast replayed through a compiled plan was wrong.
-            // MEASURED on [4,1] -> [4,3]: a correctly SHAPED 12-element output holding the 4 source
-            // values contiguously and 8 stale slots -- a silent wrong answer at exactly 1/3 of the
-            // true sum when the buffer was fresh, and NaN/1e35 when it was recycled, which then
-            // poisons every parameter through the gradient.
-            bool aIsFullShape = ShapeMatchesBuffer(a._shape, o._shape);
-            bool bIsFullShape = ShapeMatchesBuffer(b._shape, o._shape);
-            if (aIsFullShape || bIsFullShape)
-            {
-                var full = aIsFullShape ? a : b;
-                var addend = aIsFullShape ? b : a;
-                return eng =>
-                {
-                    full.AsSpan().CopyTo(o.AsWritableSpan());
-                    if (eng is CpuEngine cpuEng) cpuEng.TensorBroadcastAddInPlace(o, addend);
-                    else
-                    {
-                        var r = eng.TensorAdd(a, b);
-                        if (!r.IsContiguous) r = r.Contiguous();
-                        r.AsSpan().CopyTo(o.AsWritableSpan());
-                    }
-                };
-            }
-            // Neither operand carries the output shape -- a MUTUAL broadcast such as
-            // [4,1] + [1,3] -> [4,3], where each side expands along a different axis. There is no
-            // operand to seed from, so fall through to the generic path rather than guess.
+            var broadcastReplay = TryBuildBroadcastBinaryForward(step);
+            if (broadcastReplay is not null) return broadcastReplay;
         }
 
         // ConvTranspose2D forward: route compiled-plan replay through
@@ -7074,28 +7005,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             };
         }
 
-        // BroadcastAdd/Sub/Mul forward: direct array loop for [N,M] op [M] pattern
-        if ((step.OpType == OpType.TensorBroadcastAdd || step.OpType == OpType.TensorBroadcastSubtract || step.OpType == OpType.TensorBroadcastMultiply)
-            && step.Inputs.Length == 2 && typeof(T) == typeof(float)
-            && step.Inputs[0].Rank == 2 && (step.Inputs[1].Rank == 1 || (step.Inputs[1].Rank == 2 && step.Inputs[1]._shape[0] == 1)))
-        {
-            var a = step.Inputs[0]; var b = step.Inputs[1]; var o = step.OutputBuffer;
-            int rows = a._shape[0], cols = a._shape[1];
-            int bCols = b.Rank == 1 ? b._shape[0] : b._shape[1];
-            if (cols == bCols)
-            {
-                var aArr = TryGetLiveFloatBacking(a)!;
-                var bArr = TryGetLiveFloatBacking(b)!;
-                var oArr = TryGetLiveFloatBacking(o)!;
-                if (step.OpType == OpType.TensorBroadcastAdd)
-                    return eng => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) oArr[off + c] = aArr[off + c] + bArr[c]; } };
-                else if (step.OpType == OpType.TensorBroadcastSubtract)
-                    return eng => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) oArr[off + c] = aArr[off + c] - bArr[c]; } };
-                else
-                    return eng => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) oArr[off + c] = aArr[off + c] * bArr[c]; } };
-            }
-        }
-
         // MSELoss forward: fused single-pass diff^2 sum
         if (step.OpType == OpType.MSELoss && step.Inputs.Length == 2
             && step.Inputs[0].IsContiguous && step.Inputs[1].IsContiguous
@@ -7323,6 +7232,135 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// reads the now-clipped grads. Returns false if any gradient is not CUDA-resident (caller uses the CPU
     /// clip instead); the global norm requires ALL grads present, so a mixed CPU/GPU set is not handled here.
     /// </summary>
+    /// <summary>
+    /// Builds the compiled replay for a broadcasting binary op — add, subtract or multiply —
+    /// writing <c>left OP right</c> into the plan's output buffer. Returns <see langword="null"/>
+    /// for the shapes it deliberately leaves to the generic engine path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// THIS IS THE ONLY PLACE THAT DECIDES HOW A BROADCASTING BINARY IS REPLAYED. There used to be
+    /// two independent branches — a zero-alloc add and a float <c>[N,M] op [M]</c> loop — and each
+    /// re-derived which operand was the larger one. One of them assumed the FIRST operand always
+    /// was, which holds for <c>big + small</c> and fails for <c>small + big</c>: it copied the small
+    /// operand's elements into the full-size buffer and left the remainder holding whatever was
+    /// there before. That is not an exotic shape — <c>TensorBroadcastTo</c> expresses an expansion
+    /// as <c>input + zeros(target)</c>, whose first operand is by construction the small one.
+    /// </para>
+    /// <para>
+    /// The seed operand is chosen once, from shapes, and the output is filled in full either way,
+    /// so no caller has to know the convention and no second branch can disagree about it.
+    /// </para>
+    /// <para>
+    /// Order is preserved rather than normalized, because subtract and multiply are not both
+    /// commutative and <c>small - big</c> must stay <c>small - big</c>.
+    /// </para>
+    /// </remarks>
+    private static Action<IEngine>? TryBuildBroadcastBinaryForward(CompiledStep<T> step)
+    {
+        if (step.Inputs.Length != 2) return null;
+
+        bool isAdd = step.OpType == OpType.TensorBroadcastAdd;
+        bool isSubtract = step.OpType == OpType.TensorBroadcastSubtract;
+        bool isMultiply = step.OpType == OpType.TensorBroadcastMultiply;
+        if (!isAdd && !isSubtract && !isMultiply) return null;
+
+        var left = step.Inputs[0];
+        var right = step.Inputs[1];
+        var output = step.OutputBuffer;
+        if (!left.IsContiguous || !right.IsContiguous || !output.IsContiguous) return null;
+
+        // The single orientation decision.
+        bool leftSpansOutput = ShapeMatchesBuffer(left._shape, output._shape);
+        bool rightSpansOutput = ShapeMatchesBuffer(right._shape, output._shape);
+
+        // A MUTUAL broadcast such as [4,1] op [1,3] -> [4,3] has no operand to seed from, and
+        // guessing one is the defect this method exists to prevent. The generic engine path
+        // computes it correctly.
+        if (!leftSpansOutput && !rightSpansOutput) return null;
+
+        // Dense float [N,M] op [M] (row-vector / bias shape): a tight indexed loop, kept as a fast
+        // sub-case of the one path rather than as a branch that re-decides orientation.
+        if (typeof(T) == typeof(float) && leftSpansOutput && !rightSpansOutput
+            && left.Rank == 2
+            && (right.Rank == 1 || (right.Rank == 2 && right._shape[0] == 1))
+            && left._shape[1] == (right.Rank == 1 ? right._shape[0] : right._shape[1]))
+        {
+            var leftArray = TryGetLiveFloatBacking(left);
+            var rightArray = TryGetLiveFloatBacking(right);
+            var outputArray = TryGetLiveFloatBacking(output);
+            if (leftArray is not null && rightArray is not null && outputArray is not null)
+            {
+                int rows = left._shape[0];
+                int cols = left._shape[1];
+                if (isAdd)
+                    return _ => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) outputArray[off + c] = leftArray[off + c] + rightArray[c]; } };
+                if (isSubtract)
+                    return _ => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) outputArray[off + c] = leftArray[off + c] - rightArray[c]; } };
+                return _ => { for (int r = 0; r < rows; r++) { int off = r * cols; for (int c = 0; c < cols; c++) outputArray[off + c] = leftArray[off + c] * rightArray[c]; } };
+            }
+        }
+
+        // Subtract and multiply have no in-place broadcasting kernel for a smaller RIGHT operand,
+        // and the row-vector case above did not apply. Leave it to the generic path rather than
+        // open-code a second expansion here.
+        if ((isSubtract || isMultiply) && !rightSpansOutput) return null;
+
+        return engine =>
+        {
+            if (engine is not CpuEngine cpu)
+            {
+                ReplayBroadcastBinaryEagerly(engine, step.OpType, left, right, output);
+                return;
+            }
+
+            // 1. Fill the output from the LEFT operand, expanding it when it is the smaller side.
+            //    Every element is written, so nothing downstream can read a stale slot.
+            if (leftSpansOutput)
+            {
+                left.AsSpan().CopyTo(output.AsWritableSpan());
+            }
+            else
+            {
+                output.AsWritableSpan().Clear();
+                cpu.TensorBroadcastAddInPlace(output, left);
+            }
+
+            // 2. Apply the RIGHT operand in place, broadcasting it if it is the smaller side.
+            if (rightSpansOutput)
+            {
+                if (isAdd) cpu.TensorAddInPlace(output, right);
+                else if (isSubtract) cpu.TensorSubtractInPlace(output, right);
+                else cpu.TensorMultiplyInPlace(output, right);
+            }
+            else
+            {
+                cpu.TensorBroadcastAddInPlace(output, right);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Generic replay for engines without the in-place CPU kernels: recompute eagerly, materialize
+    /// any strided result, and copy it into the plan's buffer.
+    /// </summary>
+    private static void ReplayBroadcastBinaryEagerly(
+        IEngine engine, OpType opType, Tensor<T> left, Tensor<T> right, Tensor<T> output)
+    {
+        var result = opType switch
+        {
+            OpType.TensorBroadcastSubtract => engine.TensorSubtract(left, right),
+            OpType.TensorBroadcastMultiply => engine.TensorMultiply(left, right),
+            _ => engine.TensorAdd(left, right),
+        };
+
+        // A broadcast result can be a stride-0 VIEW whose backing storage is smaller than its
+        // logical shape; AsSpan() would then copy only that backing and leave the rest of output
+        // untouched.
+        if (!result.IsContiguous) result = result.Contiguous();
+        result.AsSpan().CopyTo(output.AsWritableSpan());
+    }
+
     /// <summary>
     /// True when <paramref name="shape"/> is exactly the plan buffer's shape, i.e. this operand
     /// already spans the whole output and nothing about it needs broadcasting.

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -812,14 +812,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     }
 
     /// <summary>
-    /// Allocates one reusable classification buffer per distinct GPU backend, sized for that
-    /// backend's largest parameter. Sharing keeps the guard's persistent memory bounded by the
-    /// largest tensor rather than the sum of every gradient tensor.
+    /// Allocates a reusable classification buffer and aggregate mask per distinct GPU backend,
+    /// sized for that backend's largest parameter. Sharing keeps the guard's persistent memory
+    /// bounded by twice the largest tensor rather than the sum of every gradient tensor.
     /// </summary>
     private void AllocateGpuFinitenessScratch(
         Engines.DirectGpu.IDirectGpuBackend?[] gpuBackends,
         int[] lengths,
-        Engines.DirectGpu.IGpuBuffer?[] scratchByParameter)
+        Engines.DirectGpu.IGpuBuffer?[] scratchByParameter,
+        Engines.DirectGpu.IGpuBuffer?[] aggregateByParameter,
+        int[] reductionLengths)
     {
         for (int p = 0; p < gpuBackends.Length; p++)
         {
@@ -832,17 +834,24 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     maximumLength = Math.Max(maximumLength, lengths[q]);
 
             var sharedScratch = backend.AllocateBuffer(maximumLength);
+            var sharedAggregate = backend.AllocateBuffer(maximumLength);
             _gpuOptimizerBuffers.Add(sharedScratch);
+            _gpuOptimizerBuffers.Add(sharedAggregate);
+            reductionLengths[p] = maximumLength;
             for (int q = p; q < gpuBackends.Length; q++)
                 if (ReferenceEquals(gpuBackends[q], backend))
+                {
                     scratchByParameter[q] = sharedScratch;
+                    aggregateByParameter[q] = sharedAggregate;
+                }
         }
     }
 
     /// <summary>
     /// Checks every authoritative CPU or GPU gradient before any optimizer state or parameter is
     /// written. GPU gradients are classified on-device using the backend's IEEE-bitwise
-    /// <c>ClassifyFloat</c> kernel and reduced to one scalar; the full gradient is never downloaded.
+    /// <c>ClassifyFloat</c> kernel, aggregated on-device, and reduced to one scalar per backend; the
+    /// full gradient is never downloaded.
     /// </summary>
     private unsafe bool TryDiscardNonFiniteOptimizerStep(
         float[][] gradArrays,
@@ -850,6 +859,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         Engines.DirectGpu.IGpuBuffer?[] gpuGradients,
         Engines.DirectGpu.IDirectGpuBackend?[] gpuBackends,
         Engines.DirectGpu.IGpuBuffer?[] gpuFinitenessScratch,
+        Engines.DirectGpu.IGpuBuffer?[] gpuFinitenessAggregate,
+        int[] gpuFinitenessReductionLengths,
         int[] paramOffsets,
         int[] lengths,
         OptimizerType optimizerType,
@@ -857,25 +868,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         float[][] scheduleFreeEvalCopies)
     {
         bool gradientsFinite = true;
+        // Inspect host-authoritative gradients first. If one is already bad, avoid launching any
+        // device work; no optimizer state or parameter has been touched at this point.
         for (int p = 0; p < gradArrays.Length && gradientsFinite; p++)
         {
-            if (gpuGradients[p] is { } gpuGradient)
-            {
-                var backend = gpuBackends[p]
-                    ?? throw new InvalidOperationException("A GPU gradient has no owning backend.");
-                var scratch = gpuFinitenessScratch[p]
-                    ?? throw new InvalidOperationException("GPU gradient finiteness scratch was not allocated.");
-                int length = lengths[p];
-                if (length <= 0)
-                    continue;
-
-                // mode 2 = isfinite. Min(mask) is exactly 1 only when every element is finite;
-                // unlike summing a 0/1 mask, this cannot lose a single zero to float rounding for
-                // tensors larger than 2^24 elements.
-                backend.ClassifyFloat(gpuGradient, scratch, mode: 2, size: length);
-                gradientsFinite = backend.Min(scratch, length) == 1.0f;
+            if (gpuGradients[p] is not null)
                 continue;
-            }
 
             var gradients = gradArrays[p];
             if (gradients is null || gradients.Length == 0)
@@ -886,6 +884,69 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             fixed (float* pGrad = &gradients[gradOffsets[p]])
             {
                 gradientsFinite = FusedOptimizer.AllFiniteSimd(pGrad, lengths[p]);
+            }
+        }
+
+        if (gradientsFinite)
+        {
+            // Aggregate every gradient mask on-device and synchronize only once per backend. The
+            // accumulator begins as all ones; multiplying a 0/1 mask into its prefix preserves a
+            // zero from any tensor while unused tail entries remain one.
+            for (int p = 0; p < gpuFinitenessReductionLengths.Length; p++)
+            {
+                int reductionLength = gpuFinitenessReductionLengths[p];
+                if (reductionLength <= 0)
+                    continue;
+
+                var backend = gpuBackends[p]
+                    ?? throw new InvalidOperationException("GPU finiteness reduction has no owning backend.");
+                bool hasDeviceGradient = false;
+                for (int q = 0; q < gpuGradients.Length && !hasDeviceGradient; q++)
+                    hasDeviceGradient = gpuGradients[q] is not null &&
+                        ReferenceEquals(gpuBackends[q], backend);
+                if (!hasDeviceGradient)
+                    continue;
+
+                var aggregate = gpuFinitenessAggregate[p]
+                    ?? throw new InvalidOperationException("GPU gradient finiteness aggregate was not allocated.");
+                backend.Fill(aggregate, 1.0f, reductionLength);
+            }
+
+            for (int p = 0; p < gpuGradients.Length; p++)
+            {
+                if (gpuGradients[p] is not { } gpuGradient || lengths[p] <= 0)
+                    continue;
+
+                var backend = gpuBackends[p]
+                    ?? throw new InvalidOperationException("A GPU gradient has no owning backend.");
+                var scratch = gpuFinitenessScratch[p]
+                    ?? throw new InvalidOperationException("GPU gradient finiteness scratch was not allocated.");
+                var aggregate = gpuFinitenessAggregate[p]
+                    ?? throw new InvalidOperationException("GPU gradient finiteness aggregate was not allocated.");
+
+                // mode 2 = isfinite. Multiplication acts as exact logical AND for the 0/1 masks.
+                backend.ClassifyFloat(gpuGradient, scratch, mode: 2, size: lengths[p]);
+                backend.Multiply(scratch, aggregate, aggregate, lengths[p]);
+            }
+
+            for (int p = 0; p < gpuFinitenessReductionLengths.Length && gradientsFinite; p++)
+            {
+                int reductionLength = gpuFinitenessReductionLengths[p];
+                if (reductionLength <= 0)
+                    continue;
+
+                var backend = gpuBackends[p]!;
+                bool hasDeviceGradient = false;
+                for (int q = 0; q < gpuGradients.Length && !hasDeviceGradient; q++)
+                    hasDeviceGradient = gpuGradients[q] is not null &&
+                        ReferenceEquals(gpuBackends[q], backend);
+                if (!hasDeviceGradient)
+                    continue;
+
+                var aggregate = gpuFinitenessAggregate[p]!;
+                // Min(mask) is exactly 1 only when every value is finite; unlike summing a 0/1
+                // mask, this cannot lose one zero to float rounding beyond 2^24 elements.
+                gradientsFinite = backend.Min(aggregate, reductionLength) == 1.0f;
             }
         }
 
@@ -2403,6 +2464,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
         var gpuGradUploadScratch = new float[paramCount][];
         var gpuFinitenessScratch = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuFinitenessAggregate = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuFinitenessReductionLengths = new int[paramCount];
 
         // Issue #350: GetDataArray() returns a COPY when the parameter tensor's
         // backing storage is pool-padded (e.g. logical length 6 on a 16-slot
@@ -2604,7 +2667,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
-        AllocateGpuFinitenessScratch(gpuBackends, lengths, gpuFinitenessScratch);
+        AllocateGpuFinitenessScratch(
+            gpuBackends, lengths, gpuFinitenessScratch,
+            gpuFinitenessAggregate, gpuFinitenessReductionLengths);
 
         _optimizerStep = 0;
         var b1 = beta1;
@@ -2731,6 +2796,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 gpuParam, gpuBackends, gpuGrad, gradArrays, gradOffsets, stagedGrads);
             if (TryDiscardNonFiniteOptimizerStep(
                 gradArrays, gradOffsets, gpuGrad, gpuBackends, gpuFinitenessScratch,
+                gpuFinitenessAggregate, gpuFinitenessReductionLengths,
                 paramOffsets, lengths, optimizerType, paramArrays, v))
             {
                 return;
@@ -3574,6 +3640,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var gpuMomentStorage = new FusedMomentStorageMode[paramCount];
         var gpuGradUploadScratch = new float[paramCount][];
         var gpuFinitenessScratch = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuFinitenessAggregate = new Engines.DirectGpu.IGpuBuffer?[paramCount];
+        var gpuFinitenessReductionLengths = new int[paramCount];
 
         // Issue #350: live-backing binding (see ConfigureOptimizerFloat).
         for (int p = 0; p < paramCount; p++)
@@ -3747,7 +3815,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             vMax[p] = optimizerType is OptimizerType.AMSGrad or OptimizerType.AdaDelta or OptimizerType.FTRL ? TensorArena.RentPersistentZeroed<float>(lengths[p]) : Array.Empty<float>();
         }
 
-        AllocateGpuFinitenessScratch(gpuBackends, lengths, gpuFinitenessScratch);
+        AllocateGpuFinitenessScratch(
+            gpuBackends, lengths, gpuFinitenessScratch,
+            gpuFinitenessAggregate, gpuFinitenessReductionLengths);
 
         _optimizerStep = 0;
         var b1 = beta1;
@@ -3807,6 +3877,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 gpuParam, gpuBackends, gpuGrad, gradArrays, gradOffsets, stagedGrads);
             if (TryDiscardNonFiniteOptimizerStep(
                 gradArrays, gradOffsets, gpuGrad, gpuBackends, gpuFinitenessScratch,
+                gpuFinitenessAggregate, gpuFinitenessReductionLengths,
                 paramOffsets, lengths, optimizerType, paramArrays, v))
             {
                 return;

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -115,6 +115,36 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // Phase G.4: rebuild state captured at compile time so
     // EnableFrozenWeightOptimizations() can preserve fused-group action
     // identity while replacing non-fused MatMul forward specializations.
+    /// <summary>
+    /// What the compile-time forward walk decided to emit for one step.
+    /// </summary>
+    /// <remarks>
+    /// The walk that builds the forward actions weighs SEVEN cases -- analytic MatMul-into-loss
+    /// forwards, skippable ReduceSums, slice-prefix fusion, slice steps consumed by that fusion,
+    /// fused groups, per-op specializations, and the generic engine dispatch. Anything that needs
+    /// to rebuild those actions later must reach the same verdict on every step, and the rebuild
+    /// used to re-derive them from scratch while knowing only three of the seven -- so it silently
+    /// re-executed slice steps that a fused MatMul had already consumed and dropped the analytic
+    /// forwards entirely. Recording the verdict once removes the second opinion.
+    /// </remarks>
+    private enum ForwardEmit : byte
+    {
+        /// <summary>Emit nothing: another step's action already covers this one.</summary>
+        Skip = 0,
+
+        /// <summary>Emit the exact action decided at compile time; it cannot be re-derived.</summary>
+        Fixed = 1,
+
+        /// <summary>Emit a per-op specialization, or the generic dispatch when there is none.</summary>
+        Rebuildable = 2,
+    }
+
+    /// <summary>The compile-time verdict for each forward step, indexed by step.</summary>
+    private readonly ForwardEmit[]? _forwardEmitKinds;
+
+    /// <summary>The action to re-emit for each <see cref="ForwardEmit.Fixed"/> step.</summary>
+    private readonly Action<IEngine>?[]? _forwardFixedActions;
+
     private readonly int[]? _fusedStepIndices;
     private readonly Action<IEngine>[]? _fusedForwardActions;
     private bool _isFrozenWeights;
@@ -167,7 +197,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         Action<IEngine>[]? fusedForwardActions = null,
         bool graphStepEligible = false,
         ILazyNode[]? fp16HeteroOrder = null,
-        int[][]? gradPoolReZeroByStep = null)
+        int[][]? gradPoolReZeroByStep = null,
+        ForwardEmit[]? forwardEmitKinds = null,
+        Action<IEngine>?[]? forwardFixedActions = null)
     {
         _gradPoolReZeroByStep = gradPoolReZeroByStep;
         _forwardActions = forwardActions;
@@ -195,6 +227,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _compiledInputTensor = compiledInputTensor;
         // Fall back to the compiled input when no distinct refresh tensor was supplied (non-graph / non-embedding).
         _graphRefreshTensor = graphRefreshTensor ?? compiledInputTensor;
+        _forwardEmitKinds = forwardEmitKinds;
+        _forwardFixedActions = forwardFixedActions;
         _fusedStepIndices = fusedStepIndices;
         _fusedForwardActions = fusedForwardActions;
         _lossGradDest = lossGradDest;
@@ -602,35 +636,37 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 "EnableFrozenWeightOptimizations requires a compiled plan with retained forward steps. " +
                 "Plans loaded from serialization don't currently carry the step metadata.");
 
-        // Rebuild forward actions with allowCachedB=true. Walks the original
-        // step list, preserves fused-group action identity, replaces non-
-        // fused step specializations with the cached-B variant.
-        var fusedSet = _fusedStepIndices is null
-            ? null
-            : new HashSet<int>(_fusedStepIndices);
+        // Rebuild the forward actions, replaying the verdict the compile-time walk already
+        // reached for each step instead of re-deriving it. Only a Rebuildable step is
+        // re-specialized; a Fixed one keeps the exact action it was given (analytic forward,
+        // slice-prefix MatMul, fused group) and a Skip stays skipped.
+        //
+        // Re-deriving here is what made this wrong: the walk that built these actions weighs seven
+        // cases and this one knew three, so a slice step already consumed by a fused MatMul was
+        // re-executed as a standalone action and the analytic forwards were dropped.
+        if (_forwardEmitKinds is null || _forwardFixedActions is null)
+            throw new InvalidOperationException(
+                "EnableFrozenWeightOptimizations requires the compile-time forward decisions. " +
+                "Plans loaded from serialization don't currently carry them.");
+
         var rebuiltForward = new List<Action<IEngine>>(_forwardSteps.Length);
         bool installedSpecialization = false;
-        int nextFusedGroupIdx = 0;
         for (int i = 0; i < _forwardSteps.Length; i++)
         {
-            if (fusedSet is not null && fusedSet.Contains(i))
+            switch (_forwardEmitKinds[i])
             {
-                bool isFirstInGroup = i == 0 || !fusedSet.Contains(i - 1);
-                if (isFirstInGroup && _fusedForwardActions is not null
-                    && nextFusedGroupIdx < _fusedForwardActions.Length)
-                {
-                    rebuiltForward.Add(_fusedForwardActions[nextFusedGroupIdx]);
-                    nextFusedGroupIdx++;
-                }
-                continue;
+                case ForwardEmit.Skip:
+                    continue;
+
+                case ForwardEmit.Fixed:
+                    var fixedAction = _forwardFixedActions[i];
+                    if (fixedAction is not null) rebuiltForward.Add(fixedAction);
+                    continue;
             }
 
             var step = _forwardSteps[i];
             // Training plans mutate parameters in-place between Step() calls, so the
-            // identity-keyed pre-pack cache would serve stale weights — same policy as
-            // the initial build below. (This site used to pass true, which was
-            // harmlessly ignored while the FusedLinear branch hardcoded false; now that
-            // the branch respects the caller's policy, training must say false here.)
+            // identity-keyed pre-pack cache would serve stale weights.
             var specialized = TryBuildSpecializedForward(step, _pinnedHandles, allowCachedB: false);
             if (specialized != null)
             {
@@ -641,9 +677,16 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             {
                 var output = step.OutputBuffer;
                 var exec = step.Execute;
-                rebuiltForward.Add(eng => exec(eng, output));
+                var opName = step.OpName;
+                rebuiltForward.Add(eng =>
+                {
+                    Engines.DirectGpuTensorEngine.s_currentForwardOp = opName;
+                    exec(eng, output);
+                    Engines.DirectGpuTensorEngine.TagProducer(output, opName);
+                });
             }
         }
+
         _forwardActions = rebuiltForward.ToArray();
         _isFrozenWeights = true;
         // Installing host-only forward specializations makes the action set unsafe for
@@ -5169,6 +5212,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var allForwardActions = new List<Action<IEngine>>();
         int genericForwardCount = 0; // engine-dispatched forward actions (for CUDA-graph eligibility)
         int nextFusedGroupIdx = 0; // index into fusedForwardActions
+        // The verdict for each step, recorded as it is reached, so a later rebuild replays this
+        // walk instead of re-deriving it from a subset of the inputs.
+        var forwardEmitKinds = new ForwardEmit[forwardSteps.Count];
+        var forwardFixedActions = new Action<IEngine>?[forwardSteps.Count];
         for (int i = 0; i < forwardSteps.Count; i++)
         {
             // Phase G.8: analytic forward for MatMul→ReduceSum-loss replaces
@@ -5176,6 +5223,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (analyticForwardSpecs.TryGetValue(i, out var analyticFwdAction))
             {
                 allForwardActions.Add(analyticFwdAction);
+                forwardEmitKinds[i] = ForwardEmit.Fixed;
+                forwardFixedActions[i] = analyticFwdAction;
                 continue;
             }
             // Skip the ReduceSum's forward action when paired with an
@@ -5183,6 +5232,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // the loss into the ReduceSum's output buffer.
             if (skippableReduceSumForwardIndices.Contains(i))
             {
+                forwardEmitKinds[i] = ForwardEmit.Skip;
                 continue;
             }
             // Phase G.9: slice-prefix MatMul fusion — MatMul step uses
@@ -5190,10 +5240,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             if (slicePrefixForwardSpecs.TryGetValue(i, out var slicePrefixFwd))
             {
                 allForwardActions.Add(slicePrefixFwd);
+                forwardEmitKinds[i] = ForwardEmit.Fixed;
+                forwardFixedActions[i] = slicePrefixFwd;
                 continue;
             }
             if (consumedBySlicePrefix.Contains(i))
             {
+                forwardEmitKinds[i] = ForwardEmit.Skip;
                 continue;  // Slice step — already handled by the fused MatMul above
             }
             if (fusedStepIndices.Contains(i))
@@ -5201,9 +5254,13 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                 // A fused step starts a new group when its predecessor is NOT fused.
                 // This correctly handles consecutive groups (e.g., {0,1,2, 3,4,5}).
                 bool isFirstInGroup = i == 0 || !fusedStepIndices.Contains(i - 1);
+                forwardEmitKinds[i] = ForwardEmit.Skip;
                 if (isFirstInGroup && nextFusedGroupIdx < fusedForwardActions.Count)
                 {
-                    allForwardActions.Add(fusedForwardActions[nextFusedGroupIdx]);
+                    var fusedGroupAction = fusedForwardActions[nextFusedGroupIdx];
+                    allForwardActions.Add(fusedGroupAction);
+                    forwardEmitKinds[i] = ForwardEmit.Fixed;
+                    forwardFixedActions[i] = fusedGroupAction;
                     nextFusedGroupIdx++;
                 }
                 continue;
@@ -5215,6 +5272,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             // for training specialization; correctness over cache-hit speed.
             // On a GPU engine, skip the host CPU-SIMD specialization entirely (preferGenericForGpu) so the
             // op runs on the GPU and stays CUDA-graph-capturable.
+            forwardEmitKinds[i] = ForwardEmit.Rebuildable;
             var specialized = preferGenericForGpu ? null : TryBuildSpecializedForward(step, pinnedHandles, allowCachedB: false);
             if (specialized != null)
             {
@@ -5540,7 +5598,9 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             fusedForwardActions.Count > 0 ? fusedForwardActions.ToArray() : null,
             graphStepEligible,
             fp16HeteroOrder,
-            gradPoolReZeroByStep);
+            gradPoolReZeroByStep,
+            forwardEmitKinds,
+            forwardFixedActions);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -1131,6 +1131,50 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// </summary>
     public static System.Action<string>? StepProbe { get; set; }
 
+    /// <summary>
+    /// Called after each forward action during replay with the step it came from and the buffer it
+    /// just wrote, so a caller can compare a compiled plan against an eager run op by op.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A compiled plan otherwise reports one number -- the loss -- which says a replay went wrong
+    /// but not where. Reconstructing the intermediate values from outside is not possible: the
+    /// tensors handed back while tracing are placeholders, and reading one after a Step shows
+    /// whatever the buffer holds now, not what this step produced. Both of those look like real
+    /// measurements and are not, which is exactly how a wrong answer gets built on one.
+    /// </para>
+    /// <para>
+    /// The buffer is passed live rather than copied, so an observer that wants to keep values must
+    /// copy them itself. Null by default and checked once per action, so replay is unaffected when
+    /// nothing is watching.
+    /// </para>
+    /// </remarks>
+    public static System.Action<int, string, Tensor<T>>? ForwardStepObserver { get; set; }
+
+    /// <summary>
+    /// Maps a forward ACTION index to the step that emitted it. Actions and steps are not 1:1 --
+    /// a skipped step emits none and a fused group emits one for several -- so indexing the step
+    /// list by action position mislabels everything after the first skip.
+    /// </summary>
+    private int[]? ActionToStepIndex
+    {
+        get
+        {
+            if (_actionToStepIndex is not null) return _actionToStepIndex;
+            if (_forwardEmitKinds is null) return null;
+
+            var map = new List<int>(_forwardEmitKinds.Length);
+            for (int step = 0; step < _forwardEmitKinds.Length; step++)
+            {
+                if (_forwardEmitKinds[step] != ForwardEmit.Skip) map.Add(step);
+            }
+            _actionToStepIndex = map.ToArray();
+            return _actionToStepIndex;
+        }
+    }
+
+    private int[]? _actionToStepIndex;
+
     /// <summary>Diagnostic capture: TensorSubtract specialized forward writes
     /// here when AIDOTNET_DEBUG_SUB=1. Used by Pinpoint tests to inspect
     /// what the kernel sees vs writes.</summary>
@@ -1509,14 +1553,29 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         {
             var fwd = _forwardActions;
             var probe = StepProbe;
-            if (probe != null)
+            var observer = ForwardStepObserver;
+            if (probe != null || observer != null)
             {
-                probe("BEGIN-FWD");
+                var actionToStep = ActionToStepIndex;
+                probe?.Invoke("BEGIN-FWD");
                 for (int i = 0; i < fwd.Length; i++)
                 {
                     fwd[i](engine);
-                    var name = i < (_forwardSteps?.Length ?? 0) ? _forwardSteps![i].OpName : $"#{i}";
-                    probe($"AFTER-FWD-{i}:{name}");
+
+                    // Resolve the STEP this action came from. Indexing _forwardSteps by the action
+                    // position is wrong as soon as any step is skipped or folded into a fused group.
+                    CompiledStep<T>? step = null;
+                    if (_forwardSteps is not null)
+                    {
+                        int stepIndex = actionToStep is not null && i < actionToStep.Length
+                            ? actionToStep[i]
+                            : i;
+                        if (stepIndex < _forwardSteps.Length) step = _forwardSteps[stepIndex];
+                    }
+
+                    var name = step?.OpName ?? $"#{i}";
+                    probe?.Invoke($"AFTER-FWD-{i}:{name}");
+                    if (observer is not null && step is not null) observer(i, name, step.OutputBuffer);
                 }
             }
             else

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -764,6 +764,106 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     /// </summary>
     public bool LastStepSkippedNonFiniteGradients { get; private set; }
 
+    /// <summary>
+    /// Checks every materialized CPU gradient before any optimizer state or parameter is written.
+    /// GPU-resident entries intentionally have no host array and remain in the existing device-path
+    /// scope; unmaterialized parameters are also skipped because their pooled gradient storage was
+    /// not written by this step.
+    /// </summary>
+    private unsafe bool TryDiscardNonFiniteOptimizerStep(
+        float[][] gradArrays,
+        int[] gradOffsets,
+        float[][] paramArrays,
+        int[] paramOffsets,
+        int[] lengths,
+        OptimizerType optimizerType,
+        float[][] scheduleFreeEvalCopies)
+    {
+        bool gradientsFinite = true;
+        for (int p = 0; p < gradArrays.Length && gradientsFinite; p++)
+        {
+            var gradients = gradArrays[p];
+            var parameters = paramArrays[p];
+            if (gradients is null || gradients.Length == 0 ||
+                parameters is null || parameters.Length == 0)
+            {
+                continue;
+            }
+
+            fixed (float* pGrad = &gradients[gradOffsets[p]])
+            {
+                gradientsFinite = FusedOptimizer.AllFiniteSimd(pGrad, lengths[p]);
+            }
+        }
+
+        if (gradientsFinite)
+        {
+            LastStepSkippedNonFiniteGradients = false;
+            return false;
+        }
+
+        // Schedule-Free evaluates at y, written by _preForwardParamTransform before backward.
+        // A discarded step must restore the externally-visible x copy or it would still mutate
+        // the model despite skipping all optimizer-state updates.
+        if (optimizerType == OptimizerType.ScheduleFreeSGD)
+        {
+            for (int p = 0; p < paramArrays.Length; p++)
+            {
+                var parameters = paramArrays[p];
+                if (parameters is null || parameters.Length == 0) continue;
+                Array.Copy(scheduleFreeEvalCopies[p], 0, parameters, paramOffsets[p], lengths[p]);
+                MarkHostWeightMutated(p);
+            }
+        }
+
+        MarkOptimizerStepDiscarded();
+        return true;
+    }
+
+    /// <summary>Double-precision CPU counterpart to the float finiteness gate.</summary>
+    private unsafe bool TryDiscardNonFiniteOptimizerStep(
+        double[][] gradArrays,
+        int[] gradOffsets,
+        double[][] paramArrays,
+        int[] lengths)
+    {
+        bool gradientsFinite = true;
+        for (int p = 0; p < gradArrays.Length && gradientsFinite; p++)
+        {
+            var gradients = gradArrays[p];
+            var parameters = paramArrays[p];
+            if (gradients is null || gradients.Length == 0 ||
+                parameters is null || parameters.Length == 0)
+            {
+                continue;
+            }
+
+            fixed (double* pGrad = &gradients[gradOffsets[p]])
+            {
+                gradientsFinite = FusedOptimizer.AllFiniteSimd(pGrad, lengths[p]);
+            }
+        }
+
+        if (gradientsFinite)
+        {
+            LastStepSkippedNonFiniteGradients = false;
+            return false;
+        }
+
+        MarkOptimizerStepDiscarded();
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void MarkOptimizerStepDiscarded()
+    {
+        // The step counter drives schedules and bias correction. A discarded update must be
+        // invisible to both, matching GradScaler's contract.
+        _optimizerStep--;
+        _nonFiniteStepsSkipped++;
+        LastStepSkippedNonFiniteGradients = true;
+    }
+
     private sealed class FusedOptimizerRuntimeScalars
     {
         public float HypergradientAdjustment;
@@ -2531,6 +2631,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            if (TryDiscardNonFiniteOptimizerStep(
+                gradArrays, gradOffsets, paramArrays, paramOffsets, lengths, optimizerType, v))
+            {
+                return;
+            }
             float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
             float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
             // #739 review: retire any captured on-device step graph before the CPU fused optimizer
@@ -2920,50 +3025,6 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     return;
                 }
             }
-
-            // GRADIENT GATE: VALIDATE EVERY GRADIENT BEFORE WRITING ANY PARAMETER.
-            //
-            // The kernels below fuse backward and update into one pass -- each reads grad and writes
-            // param in place. That makes a non-finite gradient unrecoverable rather than merely bad:
-            // the NaN lands in the weights, every later step reads it back, and the loss is NaN from
-            // then on with nothing to say which step caused it. The eager tape does not have this
-            // property, which is why a model can show perfectly finite gradients from
-            // ComputeGradients while Train destroys it.
-            //
-            // torch.amp.GradScaler is the reference behaviour: inspect the gradients each iteration
-            // and SKIP the optimizer step when any are inf or NaN, leaving the parameters untouched
-            // so the run continues from the last good state. Fusing backward with the update removed
-            // the point where that check naturally sits, so it is reinstated here.
-            //
-            // The scan must cover ALL parameters before ANY is written -- a per-parameter check
-            // would still apply the tensors it had already reached before hitting the bad one,
-            // leaving the model half-updated, which is worse than either clean outcome.
-            //
-            // Scope: this gates the CPU path. The multi-tensor GPU path returns above with its
-            // gradients in device buffers, so it needs an equivalent device-side reduction rather
-            // than this host scan.
-            bool gradientsFinite = true;
-            for (int p = 0; p < paramCount && gradientsFinite; p++)
-            {
-                if (gradArrays[p].Length == 0) continue;
-                fixed (float* pGradCheck = &gradArrays[p][gradOffsets[p]])
-                {
-                    gradientsFinite = FusedOptimizer.AllFiniteSimd(pGradCheck, lengths[p]);
-                }
-            }
-
-            if (!gradientsFinite)
-            {
-                // Discard the step. Parameters, optimizer moments and the step counter that drives
-                // bias correction all stay as they were, so the next step behaves as though this one
-                // never happened -- the same contract GradScaler gives on an overflow.
-                _optimizerStep--;
-                _nonFiniteStepsSkipped++;
-                LastStepSkippedNonFiniteGradients = true;
-                return;
-            }
-
-            LastStepSkippedNonFiniteGradients = false;
 
             for (int p = 0; p < paramCount; p++)
             {
@@ -3668,6 +3729,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            if (TryDiscardNonFiniteOptimizerStep(
+                gradArrays, gradOffsets, paramArrays, paramOffsets, lengths, optimizerType, v))
+            {
+                return;
+            }
             float stepBc1 = 1f - MathF.Pow(b1, _optimizerStep);
             float stepBc2 = 1f - MathF.Pow(b2, _optimizerStep);
             // #739 review: retire any captured on-device step graph before this CPU fused optimizer
@@ -4100,6 +4166,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            if (TryDiscardNonFiniteOptimizerStep(gradArrays, gradOffsets, paramArrays, lengths))
+            {
+                return;
+            }
             // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
             // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
             // (bit-identical — a deep model with many small tensors paid ~2x(param count) Pow/step).
@@ -4290,6 +4360,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             try
             {
             _optimizerStep++;
+            if (TryDiscardNonFiniteOptimizerStep(gradArrays, gradOffsets, paramArrays, lengths))
+            {
+                return;
+            }
             // Bias corrections stepBc1=1-b1^step, stepBc2=1-b2^step are STEP-GLOBAL; compute the
             // two Math.Pow ONCE here instead of once per parameter inside the Adam/AdamW kernels
             // (bit-identical — a deep model with many small tensors paid ~2x(param count) Pow/step).

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -71,6 +71,59 @@ internal static class FusedOptimizer
         return (length + chunk - 1) / chunk;
     }
 
+    /// <summary>
+    /// Returns <c>false</c> as soon as any element is NaN or infinite. Used to gate a fused
+    /// optimizer step on the gradients being usable BEFORE any parameter is written.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every update kernel below reads <c>grad</c> and writes <c>param</c> in a single pass, so a
+    /// non-finite gradient is not merely a bad step -- it is written into the weights and every
+    /// later step inherits it. The damage is permanent and silent: the loss reports NaN from then
+    /// on, with nothing to indicate which step poisoned it.
+    /// </para>
+    /// <para>
+    /// PyTorch handles this with <c>torch.amp.GradScaler</c>, which inspects the gradients for inf
+    /// and NaN each iteration and SKIPS the optimizer step when it finds any, leaving the
+    /// parameters untouched so training can continue from the last good state. The skip is free
+    /// there because backward and the update are separate phases. Fusing them removes that natural
+    /// checkpoint, so the check has to be reinstated explicitly -- which is what this provides.
+    /// </para>
+    /// <para>
+    /// The test is <c>x - x == 0</c>: finite values give exactly zero, NaN gives NaN (which fails
+    /// every comparison) and both infinities give NaN as well. That catches all three cases in one
+    /// vector op, without the mask-and-compare an <c>Abs(x) &lt;= MaxValue</c> formulation needs.
+    /// Cost is one streaming pass over the gradients with an early exit, against a backward pass
+    /// that is orders of magnitude more expensive.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe bool AllFiniteSimd(float* values, int length)
+    {
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && length >= 8)
+        {
+            for (; i <= length - 8; i += 8)
+            {
+                var v = Avx.LoadVector256(values + i);
+                var diff = Avx.Subtract(v, v);
+                // OrderedNonSignaling equality: NaN operands compare false, so a zero mask bit
+                // marks a non-finite lane.
+                var cmp = Avx.Compare(diff, Vector256<float>.Zero, FloatComparisonMode.OrderedEqualNonSignaling);
+                if (Avx.MoveMask(cmp) != 0xFF) return false;
+            }
+        }
+#endif
+        for (; i < length; i++)
+        {
+            float x = values[i];
+            if (float.IsNaN(x) || float.IsInfinity(x)) return false;
+        }
+
+        return true;
+    }
+
     /// <summary>AVX2 SGD: param -= lr * grad</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static unsafe void SgdUpdateSimd(float* param, float* grad, int length, float lr)

--- a/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/FusedOptimizer.cs
@@ -124,6 +124,34 @@ internal static class FusedOptimizer
         return true;
     }
 
+    /// <summary>
+    /// Double-precision counterpart to <see cref="AllFiniteSimd(float*, int)"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe bool AllFiniteSimd(double* values, int length)
+    {
+        int i = 0;
+#if NET5_0_OR_GREATER
+        if (Avx.IsSupported && length >= 4)
+        {
+            for (; i <= length - 4; i += 4)
+            {
+                var v = Avx.LoadVector256(values + i);
+                var diff = Avx.Subtract(v, v);
+                var cmp = Avx.Compare(diff, Vector256<double>.Zero, FloatComparisonMode.OrderedEqualNonSignaling);
+                if (Avx.MoveMask(cmp) != 0xF) return false;
+            }
+        }
+#endif
+        for (; i < length; i++)
+        {
+            double x = values[i];
+            if (double.IsNaN(x) || double.IsInfinity(x)) return false;
+        }
+
+        return true;
+    }
+
     /// <summary>AVX2 SGD: param -= lr * grad</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static unsafe void SgdUpdateSimd(float* param, float* grad, int length, float lr)

--- a/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ICompiledPlan.cs
@@ -368,6 +368,28 @@ public interface ICompiledTrainingPlan<T> : IDisposable
     Tensor<T> Step();
 
     /// <summary>
+    /// How many optimizer updates have been discarded because that step's gradients were not
+    /// finite. Zero on a healthy run.
+    /// </summary>
+    /// <remarks>
+    /// The fused kernels read a gradient and write its parameter in the same pass, so applying a
+    /// non-finite gradient is unrecoverable — it lands in the weights and every later step reads it
+    /// back. Steps whose gradients fail the finiteness check are therefore skipped outright,
+    /// matching <c>torch.amp.GradScaler</c>, which does the same on an inf/NaN overflow.
+    /// </remarks>
+    int NonFiniteStepsSkipped { get; }
+
+    /// <summary>
+    /// True when the most recent <see cref="Step"/> discarded its optimizer update because the
+    /// gradients were not finite. The parameters are unchanged in that case.
+    /// </summary>
+    /// <remarks>
+    /// Worth surfacing rather than silently skipping: from the loss alone, "the model is not
+    /// learning" and "the model is diverging and its updates are being discarded" look identical.
+    /// </remarks>
+    bool LastStepSkippedNonFiniteGradients { get; }
+
+    /// <summary>
     /// CUDA-Graph-capture-safe counterpart to <see cref="Step"/>: runs forward +
     /// backward, writes the final loss into <paramref name="lossOutput"/>, and
     /// leaves gradients in <see cref="Gradients"/>. No per-call allocation of the

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -4299,21 +4299,30 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
         int maximumPartials = (size + blockSize - 1) / blockSize;
         using var temporaryA = AllocateBuffer(maximumPartials);
         using var temporaryB = AllocateBuffer(maximumPartials);
+        using var scalarResult = AllocateBuffer(1);
         IGpuBuffer current = input;
         int currentSize = size;
         bool writeA = true;
         while (currentSize > 1)
         {
             int partialCount = (currentSize + blockSize - 1) / blockSize;
-            IGpuBuffer next = writeA ? temporaryA : temporaryB;
+            IGpuBuffer next = partialCount == 1
+                ? scalarResult
+                : writeA ? temporaryA : temporaryB;
             LaunchReductionKernel(kernelName, current, next, currentSize, blockSize);
             current = next;
             currentSize = partialCount;
             writeA = !writeA;
         }
 
+        // DownloadBuffer intentionally requires a destination large enough for the buffer's physical
+        // capacity. A reduction's logical size can be one while its scratch buffer is larger, so make
+        // the final device value live in an exact one-element allocation before reading it back.
+        if (current.Handle != scalarResult.Handle)
+            Copy(current, scalarResult, 1);
+
         var result = new float[1];
-        DownloadBuffer(current, result);
+        DownloadBuffer(scalarResult, result);
         return result[0];
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaActivationKernels.cs
@@ -921,15 +921,17 @@ extern ""C"" __global__ __launch_bounds__(256) void reduce_sum(const float* __re
         scratch[warpId] = val;
     __syncthreads();
 
-    // Final reduction across warps (only first warp)
+    // Final reduction across warps. Every lane in the first warp participates and
+    // lanes beyond numWarps contribute the identity. Using a partial active mask with
+    // offsets larger than numWarps makes __shfl_down_sync read an inactive source lane;
+    // CUDA leaves that value undefined (observed as zero for 4-element reductions).
     unsigned int numWarps = (blockDim.x + 31) >> 5;
-    if (tid < numWarps)
+    if (warpId == 0)
     {
-        val = scratch[tid];
-        unsigned int warp_mask = (numWarps >= 32) ? 0xFFFFFFFF : ((1u << numWarps) - 1);
+        val = lane < numWarps ? scratch[lane] : 0.0f;
         #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1)
-            val += __shfl_down_sync(warp_mask, val, offset);
+            val += __shfl_down_sync(0xFFFFFFFF, val, offset);
 
         if (tid == 0)
             output[blockIdx.x] = val;
@@ -959,16 +961,15 @@ extern ""C"" __global__ __launch_bounds__(256) void reduce_max(const float* __re
         scratch[warpId] = val;
     __syncthreads();
 
-    // Final reduction across warps (only first warp)
+    // Final reduction across warps; inactive logical lanes contribute -infinity.
     unsigned int numWarps = (blockDim.x + 31) >> 5;
-    if (tid < numWarps)
+    if (warpId == 0)
     {
-        val = scratch[tid];
-        unsigned int warp_mask = (numWarps >= 32) ? 0xFFFFFFFF : ((1u << numWarps) - 1);
+        val = lane < numWarps ? scratch[lane] : -INFINITY;
         #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1)
         {
-            float other = __shfl_down_sync(warp_mask, val, offset);
+            float other = __shfl_down_sync(0xFFFFFFFF, val, offset);
             val = fmaxf(val, other);
         }
 
@@ -1000,16 +1001,15 @@ extern ""C"" __global__ __launch_bounds__(256) void reduce_min(const float* __re
         scratch[warpId] = val;
     __syncthreads();
 
-    // Final reduction across warps (only first warp)
+    // Final reduction across warps; inactive logical lanes contribute +infinity.
     unsigned int numWarps = (blockDim.x + 31) >> 5;
-    if (tid < numWarps)
+    if (warpId == 0)
     {
-        val = scratch[tid];
-        unsigned int warp_mask = (numWarps >= 32) ? 0xFFFFFFFF : ((1u << numWarps) - 1);
+        val = lane < numWarps ? scratch[lane] : INFINITY;
         #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1)
         {
-            float other = __shfl_down_sync(warp_mask, val, offset);
+            float other = __shfl_down_sync(0xFFFFFFFF, val, offset);
             val = fminf(val, other);
         }
 
@@ -1477,4 +1477,3 @@ extern ""C"" __global__ __launch_bounds__(256) void max_vectors_vec4(const float
         }
     }
 }
-

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBroadcastOperandOrderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBroadcastOperandOrderTests.cs
@@ -132,6 +132,59 @@ public class CompiledBroadcastOperandOrderTests
         });
     }
 
+    /// <summary>
+    /// Subtract and multiply go through the same single builder, and subtract is NOT commutative:
+    /// seeding the buffer from the wrong operand would silently compute <c>big - small</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(4, 3)]
+    [InlineData(8, 9)]
+    public void BroadcastSubtractAndMultiply_PreserveOperandOrder(int rows, int cols)
+    {
+        AssertAgrees("small - big", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorSubtract(small, big), new[] { small, big });
+        });
+
+        AssertAgrees("big - small", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorSubtract(big, small), new[] { small, big });
+        });
+
+        AssertAgrees("small * big", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorMultiply(small, big), new[] { small, big });
+        });
+
+        AssertAgrees("big * small", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorMultiply(big, small), new[] { small, big });
+        });
+    }
+
+    /// <summary>
+    /// A MUTUAL broadcast has no operand spanning the output; the single builder declines it and
+    /// the generic path must still produce the eager answer.
+    /// </summary>
+    [Fact]
+    public void MutualBroadcast_FallsBackAndStillAgrees()
+    {
+        AssertAgrees("[4,1] + [1,3]", e =>
+        {
+            var rowsOnly = Filled(new[] { 4, 1 }, 0.3f, 2);
+            var colsOnly = Filled(new[] { 1, 3 }, 0.1f, 9);
+            return (e.TensorAdd(rowsOnly, colsOnly), new[] { rowsOnly, colsOnly });
+        });
+    }
+
     [Fact]
     public void BiasAddPattern_StillAgrees()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBroadcastOperandOrderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBroadcastOperandOrderTests.cs
@@ -1,0 +1,182 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// A broadcasting binary op must produce the same values through a compiled plan as it does
+/// eagerly, WHICHEVER operand is the one that expands.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The compiled replay seeds the output buffer from one operand and then broadcasts the other up
+/// into it. It used to seed unconditionally from the FIRST operand, which is only the larger one
+/// by convention: <c>big + small</c> filled the buffer and was correct, while <c>small + big</c>
+/// wrote just the small operand's elements and left the rest of the buffer holding whatever was
+/// there before.
+/// </para>
+/// <para>
+/// That is not a rare shape. <see cref="IEngine.TensorBroadcastTo"/> expresses a genuine expansion
+/// as <c>input + zeros(targetShape)</c>, whose first operand is by construction the SMALL one, so
+/// every such broadcast replayed through a compiled plan was affected. The stale remainder read as
+/// zeros from a fresh buffer -- a silent wrong answer, the sum landing at exactly 1/N of the true
+/// value -- and as a previous step's bytes from a recycled one, which surfaced as NaN or ~1e35 and
+/// then poisoned every parameter through the gradient.
+/// </para>
+/// <para>
+/// These compare against the eager result rather than a hardcoded constant, so they pin the
+/// invariant that actually matters: compiled and eager agree.
+/// </para>
+/// </remarks>
+public class CompiledBroadcastOperandOrderTests
+{
+    private static Tensor<float> Filled(int[] shape, float scale, int salt)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = scale * (float)Math.Sin((i + salt) * 0.37);
+        return t;
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="build"/> into a training plan and returns the loss its replay
+    /// produces, alongside the eager value of the same graph.
+    /// </summary>
+    private static (double compiled, double eager) CompiledVsEager(
+        Func<CpuEngine, (Tensor<float> output, Tensor<float>[] parameters)> build)
+    {
+        var engine = new CpuEngine();
+
+        var (eagerOutput, _) = build(engine);
+        double eager = engine.ReduceSum(eagerOutput, null)[0];
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var (output, parameters) = build(engine);
+            engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(parameters);
+        }
+
+        using (plan)
+        {
+            // Zero learning rate: this pins the FORWARD replay, so nothing moves underneath it.
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            var loss = new Tensor<float>(new[] { 1 });
+            plan.StepInto(loss);
+            return (loss[0], eager);
+        }
+    }
+
+    private static void AssertAgrees(string what,
+        Func<CpuEngine, (Tensor<float>, Tensor<float>[])> build)
+    {
+        var (compiled, eager) = CompiledVsEager(build);
+        Assert.False(double.IsNaN(compiled) || double.IsInfinity(compiled),
+            $"{what}: compiled replay produced {compiled}, eager was {eager:G8}.");
+        Assert.True(Math.Abs(compiled - eager) <= 1e-3 * Math.Max(1.0, Math.Abs(eager)),
+            $"{what}: compiled {compiled:G8} != eager {eager:G8}.");
+    }
+
+    [Theory]
+    [InlineData(4, 3)]
+    [InlineData(8, 9)]
+    public void BroadcastAdd_AgreesWithEager_WithEitherOperandFirst(int rows, int cols)
+    {
+        AssertAgrees("small + big", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorAdd(small, big), new[] { small, big });
+        });
+
+        AssertAgrees("big + small", e =>
+        {
+            var small = Filled(new[] { rows, 1 }, 0.3f, 2);
+            var big = Filled(new[] { rows, cols }, 0.1f, 9);
+            return (e.TensorAdd(big, small), new[] { small, big });
+        });
+    }
+
+    [Theory]
+    [InlineData(4, 3)]
+    [InlineData(8, 9)]
+    public void BroadcastTo_ExpandsEveryElement_UnderACompiledPlan(int rows, int cols)
+    {
+        // TensorBroadcastTo is the small-operand-first case by construction.
+        AssertAgrees($"broadcastTo [{rows},1] -> [{rows},{cols}]", e =>
+        {
+            var source = Filled(new[] { rows, 1 }, 0.3f, 2);
+            return (e.TensorBroadcastTo(source, new[] { rows, cols }), new[] { source });
+        });
+    }
+
+    [Fact]
+    public void BroadcastTo_HigherRanks_AgreeWithEager()
+    {
+        const int S = 4, C = 3;
+
+        AssertAgrees("rank 3 [1,S,1] -> [1,S,S]", e =>
+        {
+            var source = Filled(new[] { 1, S, 1 }, 0.3f, 2);
+            return (e.TensorBroadcastTo(source, new[] { 1, S, S }), new[] { source });
+        });
+
+        AssertAgrees("rank 4 [1,S,1,C] -> [1,S,S,C]", e =>
+        {
+            var source = Filled(new[] { 1, S, 1, C }, 0.3f, 2);
+            return (e.TensorBroadcastTo(source, new[] { 1, S, S, C }), new[] { source });
+        });
+    }
+
+    [Fact]
+    public void BiasAddPattern_StillAgrees()
+    {
+        // The big-operand-first shape that always worked — it must keep working.
+        const int S = 8, C = 9;
+        AssertAgrees("[S,C] + [C] bias add", e =>
+        {
+            var activations = Filled(new[] { S, C }, 0.3f, 2);
+            var bias = Filled(new[] { C }, 0.1f, 9);
+            return (e.TensorAdd(activations, bias), new[] { activations, bias });
+        });
+    }
+
+    /// <summary>
+    /// Every element of the expanded output must be written — the defect left most of the buffer
+    /// untouched while still reporting the correct SHAPE, so a shape assertion would have passed.
+    /// </summary>
+    [Fact]
+    public void BroadcastTo_WritesEveryElement_NotJustTheSourceLength()
+    {
+        const int rows = 4, cols = 3;
+        var engine = new CpuEngine();
+        var source = Filled(new[] { rows, 1 }, 0.3f, 2);
+        var expected = engine.TensorBroadcastTo(source, new[] { rows, cols });
+
+        Tensor<float> replayed;
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            replayed = engine.TensorBroadcastTo(source, new[] { rows, cols });
+            engine.ReduceSum(replayed, null);
+            plan = scope.CompileTraining(new[] { source });
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+            plan.StepInto(new Tensor<float>(new[] { 1 }));
+        }
+
+        Assert.Equal(expected.Length, replayed.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.True(Math.Abs(expected[i] - replayed[i]) < 1e-5f,
+                $"element {i}: expected {expected[i]:G8}, compiled replay left {replayed[i]:G8}.");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardBufferBindingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardBufferBindingTests.cs
@@ -1,0 +1,86 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Every forward output buffer must expose its live backing once the plan is compiled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Forward outputs come from <c>TensorAllocator.RentUninitialized</c>, and a pooled tensor whose
+/// storage is larger than its logical length does not settle which array IS the tensor until
+/// something asks for writable storage. Until then a writer reaching for the data array can be
+/// handed a pool-padded COPY while the plan reads the live backing, so what was written is not
+/// what is read back.
+/// </para>
+/// <para>
+/// It presented as a first-step loss that was intermittently enormous (1e10..1e35) or NaN on
+/// roughly 60% of freshly built plans, and it vanished whenever anything touched those buffers
+/// first — including the diagnostics used to look at it, which is what made it read as a
+/// heisenbug rather than a defect. Binding at compile time settles the backing before any kernel
+/// can bind it.
+/// </para>
+/// </remarks>
+public class CompiledForwardBufferBindingTests
+{
+    private static Tensor<float> Filled(int[] shape, float scale, int salt)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = scale * (float)Math.Sin((i + salt) * 0.37);
+        return t;
+    }
+
+    /// <summary>
+    /// Compiling the same graph repeatedly must give the same loss every time. The defect this
+    /// pins was intermittent, so a single comparison could pass on a lucky pool block.
+    /// </summary>
+    [Fact]
+    public void RepeatedlyCompiledPlans_AgreeWithEachOtherAndWithEager()
+    {
+        const int S = 8, D = 8, C = 9;
+        var engine = new CpuEngine();
+
+        static (Tensor<float> output, Tensor<float>[] parameters) Build(CpuEngine e)
+        {
+            var hs = Filled(new[] { 1, S, D }, 0.5f, 1);
+            var he = Filled(new[] { 1, S, D }, 0.5f, 7);
+            var bias = Filled(new[] { C }, 0.01f, 5);
+            var heT = e.TensorPermute(he, new[] { 0, 2, 1 });
+            var scores = e.TensorBatchMatMul<float>(hs, heT);                       // [1, S, S]
+            var grid = e.TensorBroadcastTo(e.Reshape(scores, new[] { 1, S, S, 1 }), new[] { 1, S, S, C });
+            var biasGrid = e.TensorBroadcastTo(e.Reshape(bias, new[] { 1, 1, 1, C }), new[] { 1, S, S, C });
+            return (e.TensorAdd(grid, biasGrid), new[] { hs, he, bias });
+        }
+
+        var (eagerOutput, _) = Build(engine);
+        double eager = engine.ReduceSum(eagerOutput, null)[0];
+
+        for (int attempt = 0; attempt < 12; attempt++)
+        {
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                var (output, parameters) = Build(engine);
+                engine.ReduceSum(output, null);
+                plan = scope.CompileTraining(parameters);
+            }
+
+            using (plan)
+            {
+                plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+                var loss = new Tensor<float>(new[] { 1 });
+                plan.StepInto(loss);
+
+                Assert.False(float.IsNaN(loss[0]) || float.IsInfinity(loss[0]),
+                    $"attempt {attempt}: compiled replay produced {loss[0]}; eager was {eager:G8}.");
+                Assert.True(Math.Abs(loss[0] - eager) <= 1e-3 * Math.Max(1.0, Math.Abs(eager)),
+                    $"attempt {attempt}: compiled {loss[0]:G8} != eager {eager:G8}.");
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardObserverTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardObserverTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// The forward observer must report each replayed step with the op that produced it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A compiled plan otherwise reports one number — the loss — which says a replay went wrong but not
+/// where, and the intermediate values cannot be recovered from outside: the tensors handed back
+/// while tracing are placeholders, and reading one after a Step shows whatever the buffer holds
+/// now rather than what that step produced. Both look like measurements and neither is one, which
+/// is how a wrong conclusion gets built on them.
+/// </para>
+/// <para>
+/// The step label matters as much as the values. Actions and steps are not 1:1 — a skipped step
+/// emits none and a fused group emits one for several — so indexing the step list by action
+/// position mislabels every op after the first skip, which is what the old probe did.
+/// </para>
+/// </remarks>
+public class CompiledForwardObserverTests
+{
+    private static Tensor<float> Filled(int[] shape, float scale, int salt)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = scale * (float)Math.Sin((i + salt) * 0.37);
+        return t;
+    }
+
+    [Fact]
+    public void Observer_ReportsEveryReplayedStep_WithItsOpNameAndValues()
+    {
+        var engine = new CpuEngine();
+        var a = Filled(new[] { 8, 8 }, 0.3f, 1);
+        var b = Filled(new[] { 8, 8 }, 0.2f, 5);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var scaled = engine.TensorMultiply(a, b);
+            engine.ReduceSum(engine.TensorAdd(scaled, a), null);
+            plan = scope.CompileTraining(new[] { a, b });
+        }
+
+        var seen = new List<(int Index, string Op, int Length, bool AllFinite)>();
+        try
+        {
+            CompiledTrainingPlan<float>.ForwardStepObserver = (index, op, buffer) =>
+            {
+                bool finite = true;
+                for (int i = 0; i < buffer.Length; i++)
+                    if (float.IsNaN(buffer[i]) || float.IsInfinity(buffer[i])) { finite = false; break; }
+                seen.Add((index, op, buffer.Length, finite));
+            };
+
+            using (plan)
+            {
+                plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+                plan.StepInto(new Tensor<float>(new[] { 1 }));
+            }
+        }
+        finally { CompiledTrainingPlan<float>.ForwardStepObserver = null; }
+
+        Assert.NotEmpty(seen);
+
+        // Indices are dense and ascending: one report per emitted action, none skipped or repeated.
+        for (int i = 0; i < seen.Count; i++)
+            Assert.Equal(i, seen[i].Index);
+
+        // Every step is named and carries real values.
+        foreach (var (index, op, length, allFinite) in seen)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(op), $"step {index} was reported without an op name.");
+            Assert.True(length > 0, $"step {index} ({op}) reported an empty buffer.");
+            Assert.True(allFinite, $"step {index} ({op}) reported a non-finite value.");
+        }
+
+        // The ops actually traced must be the ops reported.
+        Assert.Contains(seen, s => s.Op.Contains("Multiply", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(seen, s => s.Op.Contains("Add", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Observer_IsOffByDefault_AndReplayIsUnaffected()
+    {
+        var engine = new CpuEngine();
+
+        static (Tensor<float> a, Tensor<float> b) Operands()
+            => (Filled(new[] { 8, 8 }, 0.3f, 1), Filled(new[] { 8, 8 }, 0.2f, 5));
+
+        float Run(bool observe)
+        {
+            var (a, b) = Operands();
+            ICompiledTrainingPlan<float> plan;
+            using (var scope = GraphMode.Enable())
+            {
+                engine.ReduceSum(engine.TensorAdd(engine.TensorMultiply(a, b), a), null);
+                plan = scope.CompileTraining(new[] { a, b });
+            }
+
+            int reports = 0;
+            if (observe) CompiledTrainingPlan<float>.ForwardStepObserver = (_, _, _) => reports++;
+            try
+            {
+                using (plan)
+                {
+                    plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+                    var loss = new Tensor<float>(new[] { 1 });
+                    plan.StepInto(loss);
+                    if (observe) Assert.True(reports > 0, "observer was set but never called.");
+                    else Assert.Equal(0, reports);
+                    return loss[0];
+                }
+            }
+            finally { CompiledTrainingPlan<float>.ForwardStepObserver = null; }
+        }
+
+        float unobserved = Run(observe: false);
+        float observed = Run(observe: true);
+
+        Assert.Equal(unobserved, observed, 4);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardObserverTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardObserverTests.cs
@@ -25,6 +25,12 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// position mislabels every op after the first skip, which is what the old probe did.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// Serialized against the other global-state suites: <c>ForwardStepObserver</c> is static, matching
+/// the existing <c>StepProbe</c>, so any plan replayed on another thread reports into whatever
+/// observer is installed. Run in parallel these assertions see a neighbouring test's steps.
+/// </remarks>
+[Collection("EngineCurrentGlobalState")]
 public class CompiledForwardObserverTests
 {
     private static Tensor<float> Filled(int[] shape, float scale, int salt)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardRebuildTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledForwardRebuildTests.cs
@@ -1,0 +1,119 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Rebuilding a plan's forward actions must not change what the forward computes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ICompiledPlan{T}.EnableFrozenWeightOptimizations"/> rebuilds the forward action list.
+/// It used to re-derive each step's verdict from scratch while knowing only three of the seven
+/// cases the compile-time walk weighs, so a slice step already consumed by a fused MatMul was
+/// re-executed as a standalone action and analytic MatMul-into-loss forwards were dropped
+/// entirely. Nothing in either repository calls the method, so no test covered the drift.
+/// </para>
+/// <para>
+/// These compare the loss across the rebuild rather than against a constant: whatever the plan
+/// computed before must be exactly what it computes after.
+/// </para>
+/// </remarks>
+public class CompiledForwardRebuildTests
+{
+    private static Tensor<float> Filled(int[] shape, float scale, int salt)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = scale * (float)Math.Sin((i + salt) * 0.37);
+        return t;
+    }
+
+    private static void AssertRebuildPreservesForward(
+        string what, Func<CpuEngine, (Tensor<float> output, Tensor<float>[] parameters)> build)
+    {
+        var engine = new CpuEngine();
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var (output, parameters) = build(engine);
+            engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(parameters);
+        }
+
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.0f);
+
+            var before = new Tensor<float>(new[] { 1 });
+            plan.StepInto(before);
+
+            plan.EnableFrozenWeightOptimizations();
+
+            var after = new Tensor<float>(new[] { 1 });
+            plan.StepInto(after);
+
+            Assert.False(float.IsNaN(after[0]) || float.IsInfinity(after[0]),
+                $"{what}: forward returned {after[0]} after the rebuild (was {before[0]:G8}).");
+            Assert.True(Math.Abs(before[0] - after[0]) <= 1e-4f * Math.Max(1f, Math.Abs(before[0])),
+                $"{what}: rebuild changed the forward — {before[0]:G8} became {after[0]:G8}.");
+        }
+    }
+
+    [Fact]
+    public void Rebuild_PreservesForward_ForAPointwiseChain()
+    {
+        AssertRebuildPreservesForward("pointwise chain", e =>
+        {
+            var a = Filled(new[] { 8, 8 }, 0.3f, 1);
+            var b = Filled(new[] { 8, 8 }, 0.2f, 5);
+            var scaled = e.TensorMultiply(a, b);
+            return (e.TensorAdd(scaled, a), new[] { a, b });
+        });
+    }
+
+    [Fact]
+    public void Rebuild_PreservesForward_ForAMatMulIntoLoss()
+    {
+        AssertRebuildPreservesForward("matmul into loss", e =>
+        {
+            var x = Filled(new[] { 1, 8, 8 }, 0.3f, 1);
+            var w = Filled(new[] { 1, 8, 8 }, 0.1f, 5);
+            return (e.TensorBatchMatMul<float>(x, w), new[] { x, w });
+        });
+    }
+
+    /// <summary>
+    /// A MatMul whose output is sliced to a prefix is fused: the MatMul step gets a specialized
+    /// action and the Slice step is CONSUMED, emitting nothing. The rebuild knew nothing about
+    /// that pairing, so it re-emitted the consumed Slice as a standalone action.
+    /// </summary>
+    [Fact]
+    public void Rebuild_PreservesForward_WhenASliceIsConsumedByAFusedMatMul()
+    {
+        AssertRebuildPreservesForward("matmul + prefix slice", e =>
+        {
+            var a = Filled(new[] { 8, 16 }, 0.3f, 1);
+            var w = Filled(new[] { 16, 32 }, 0.1f, 5);
+            var product = e.TensorMatMul<float>(a, w);                       // [8, 32]
+            var prefix = e.TensorSlice(product, new[] { 0, 0 }, new[] { 8, 16 });
+            return (prefix, new[] { a, w });
+        });
+    }
+
+    [Fact]
+    public void Rebuild_PreservesForward_ForABroadcastExpansion()
+    {
+        AssertRebuildPreservesForward("broadcast expansion", e =>
+        {
+            var rowVector = Filled(new[] { 8, 1 }, 0.3f, 2);
+            var full = Filled(new[] { 8, 9 }, 0.1f, 7);
+            return (e.TensorAdd(e.TensorBroadcastTo(rowVector, new[] { 8, 9 }), full),
+                    new[] { rowVector, full });
+        });
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Reflection;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -73,6 +76,67 @@ public class FusedOptimizerNonFiniteGradientTests
         }
 
         return (plan, param);
+    }
+
+    private static (ICompiledTrainingPlan<float> plan, Tensor<float>[] parameters) BuildTwoParameterPlan()
+    {
+        var first = new Tensor<float>(new[] { 16 });
+        var second = new Tensor<float>(new[] { 16 });
+        var input = new Tensor<float>(new[] { 16 });
+        for (int i = 0; i < input.Length; i++)
+        {
+            first[i] = 1f;
+            second[i] = 2f;
+            input[i] = 1f;
+        }
+
+        var engine = new CpuEngine();
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var firstProduct = engine.TensorMultiply(first, input);
+            var secondProduct = engine.TensorMultiply(second, input);
+            var combined = engine.TensorAdd(firstProduct, secondProduct);
+            engine.ReduceSum(combined, null);
+            plan = scope.CompileTraining(new[] { first, second });
+        }
+
+        return (plan, new[] { first, second });
+    }
+
+    private static void AttachGpuBuffer(
+        Tensor<float> tensor,
+        AiDotNet.Tensors.Engines.DirectGpu.IDirectGpuBackend backend,
+        float value)
+    {
+        var data = new float[tensor.Length];
+        for (int i = 0; i < data.Length; i++) data[i] = value;
+        tensor._gpuBuffer = new MockGpuBuffer(data);
+        tensor._gpuBackend = backend;
+        tensor._gpuBufferVersion = tensor.Version;
+    }
+
+    private static Tensor<float>[] GetPlanGradients(ICompiledTrainingPlan<float> plan)
+    {
+        var field = plan.GetType().GetField("_gradients", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Compiled plan gradient field was not found.");
+        return (Tensor<float>[])field.GetValue(plan)!;
+    }
+
+    private static void InvokeOptimizerUpdate(ICompiledTrainingPlan<float> plan)
+    {
+        var field = plan.GetType().GetField("_optimizerUpdate", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Compiled plan optimizer closure was not found.");
+        var update = (Action?)field.GetValue(plan)
+            ?? throw new InvalidOperationException("Compiled plan optimizer was not configured.");
+        update();
+    }
+
+    private static int GetOptimizerStep(ICompiledTrainingPlan<float> plan)
+    {
+        var field = plan.GetType().GetField("_optimizerStep", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Compiled plan optimizer step field was not found.");
+        return (int)field.GetValue(plan)!;
     }
 
     private static float[] Snapshot(Tensor<float> t)
@@ -179,6 +243,192 @@ public class FusedOptimizerNonFiniteGradientTests
                 Assert.True(before[i].Equals(param[i]), $"grouped parameter[{i}] changed");
         }
     }
+
+    [Theory]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void GpuResidentGradient_NonFiniteValue_SkipsBeforeAnyGpuUpdate(float badGradient)
+    {
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.Create(state);
+        var (plan, parameters) = BuildTwoParameterPlan();
+        using (plan)
+        {
+            foreach (var parameter in parameters) AttachGpuBuffer(parameter, backend, 1f);
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+
+            var gradients = GetPlanGradients(plan);
+            AttachGpuBuffer(gradients[0], backend, 1f);
+            AttachGpuBuffer(gradients[1], backend, badGradient);
+
+            InvokeOptimizerUpdate(plan);
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            Assert.Equal(2, state.ClassifyFloatCalls);
+            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Empty(state.OptimizerCalls);
+            Assert.Equal(0, state.DownloadBufferCalls);
+            Assert.Equal(new[] { 16 }, state.AllocationSizes);
+            Assert.Equal(0, GetOptimizerStep(plan));
+
+            foreach (var gradient in gradients) AttachGpuBuffer(gradient, backend, 1f);
+            InvokeOptimizerUpdate(plan);
+
+            Assert.False(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            Assert.Equal(1, GetOptimizerStep(plan));
+            Assert.Equal(new[] { "SgdUpdate", "SgdUpdate" }, state.OptimizerCalls);
+        }
+    }
+
+    [Fact]
+    public void GpuResidentFiniteGradients_RunEveryGpuUpdate()
+    {
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.Create(state);
+        var (plan, parameters) = BuildTwoParameterPlan();
+        using (plan)
+        {
+            foreach (var parameter in parameters) AttachGpuBuffer(parameter, backend, 1f);
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+
+            foreach (var gradient in GetPlanGradients(plan))
+                AttachGpuBuffer(gradient, backend, 1f);
+
+            InvokeOptimizerUpdate(plan);
+
+            Assert.False(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(0, plan.NonFiniteStepsSkipped);
+            Assert.Equal(2, state.ClassifyFloatCalls);
+            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(new[] { "SgdUpdate", "SgdUpdate" }, state.OptimizerCalls);
+            Assert.Equal(0, state.DownloadBufferCalls);
+            Assert.Equal(new[] { 16 }, state.AllocationSizes);
+        }
+    }
+
+    [Fact]
+    public void MultiTensorGpuRoute_NonFiniteGradient_SkipsBeforeBatchedUpdate()
+    {
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.CreateMultiTensor(state);
+        var (plan, parameters) = BuildTwoParameterPlan();
+        using (plan)
+        {
+            foreach (var parameter in parameters) AttachGpuBuffer(parameter, backend, 1f);
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.001f);
+
+            var gradients = GetPlanGradients(plan);
+            AttachGpuBuffer(gradients[0], backend, 1f);
+            AttachGpuBuffer(gradients[1], backend, float.NaN);
+
+            InvokeOptimizerUpdate(plan);
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            Assert.Empty(state.OptimizerCalls);
+            Assert.Equal(2, state.ClassifyFloatCalls);
+            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(0, state.DownloadBufferCalls);
+        }
+    }
+
+    [Fact]
+    public void MultiTensorGpuRoute_FiniteGradients_UsesOneBatchedUpdate()
+    {
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.CreateMultiTensor(state);
+        var (plan, parameters) = BuildTwoParameterPlan();
+        using (plan)
+        {
+            foreach (var parameter in parameters) AttachGpuBuffer(parameter, backend, 1f);
+            plan.ConfigureOptimizer(OptimizerType.Adam, learningRate: 0.001f);
+
+            foreach (var gradient in GetPlanGradients(plan))
+                AttachGpuBuffer(gradient, backend, 1f);
+
+            InvokeOptimizerUpdate(plan);
+
+            Assert.False(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(0, plan.NonFiniteStepsSkipped);
+            Assert.Equal(new[] { "AdamMultiTensorUpdate" }, state.OptimizerCalls);
+            Assert.Equal(2, state.ClassifyFloatCalls);
+            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(0, state.DownloadBufferCalls);
+        }
+    }
+
+    [Fact]
+    public void GroupedGpuPlan_StaleResidentGradientChecksAuthoritativeHostValues()
+    {
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.Create(state);
+        var (plan, parameters) = BuildTwoParameterPlan();
+        using (plan)
+        {
+            foreach (var parameter in parameters) AttachGpuBuffer(parameter, backend, 1f);
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.1) },
+                new[] { 0, 0 });
+
+            var gradients = GetPlanGradients(plan);
+            AttachGpuBuffer(gradients[0], backend, 1f);
+            AttachGpuBuffer(gradients[1], backend, 1f);
+            for (int i = 0; i < gradients[1].Length; i++) gradients[1][i] = float.NaN;
+
+            InvokeOptimizerUpdate(plan);
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            Assert.Empty(state.OptimizerCalls);
+            Assert.Equal(1, state.ClassifyFloatCalls);
+            Assert.Equal(1, state.ScalarMinCalls);
+            Assert.Equal(0, state.DownloadBufferCalls);
+        }
+    }
+
+#if !NETFRAMEWORK
+    [SkippableFact]
+    public void ActiveGpuBackend_ClassifyAndReduceDetectsEveryNonFiniteKind()
+    {
+        AiDotNet.Tensors.Engines.DirectGpuTensorEngine? engine = null;
+        try
+        {
+            engine = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine();
+        }
+        catch
+        {
+            Skip.If(true, "No direct GPU backend is available on this host.");
+        }
+
+        using (engine)
+        {
+            Skip.If(engine is null || !engine.IsGpuAvailable, "No direct GPU backend is available on this host.");
+            var backend = engine!.GetBackend();
+            Skip.If(backend is null, "No direct GPU backend is available on this host.");
+
+            foreach (int length in new[] { 1, 4, 31, 32, 33, 255, 256, 257, 1025 })
+            {
+                foreach (float badValue in new[]
+                         { 0f, float.NaN, float.PositiveInfinity, float.NegativeInfinity })
+                {
+                    var values = new float[length];
+                    for (int i = 0; i < length; i++) values[i] = 1f;
+                    bool allFinite = badValue == 0f;
+                    if (!allFinite) values[length - 1] = badValue;
+
+                    using var gradient = backend!.AllocateBuffer(values);
+                    using var scratch = backend.AllocateBuffer(length);
+                    backend.ClassifyFloat(gradient, scratch, mode: 2, size: length);
+                    Assert.Equal(allFinite ? 1f : 0f, backend.Min(scratch, length));
+                }
+            }
+        }
+    }
+#endif
 
     [Theory]
     [InlineData(double.NaN)]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -31,7 +31,7 @@ public class FusedOptimizerNonFiniteGradientTests
     /// <c>x</c>. Feeding a non-finite <c>x</c> therefore produces a non-finite gradient by
     /// construction, with no reliance on a model diverging.
     /// </summary>
-    private static (ICompiledTrainingPlan<float> plan, Tensor<float> param) BuildPlan(float xValue)
+    private static (ICompiledTrainingPlan<float> plan, Tensor<float> param, Tensor<float> input) BuildPlan(float xValue)
     {
         var param = new Tensor<float>(new[] { 16 });
         var x = new Tensor<float>(new[] { 16 });
@@ -50,6 +50,28 @@ public class FusedOptimizerNonFiniteGradientTests
             plan = scope.CompileTraining(new[] { param });
         }
 
+        return (plan, param, x);
+    }
+
+    private static (ICompiledTrainingPlan<double> plan, Tensor<double> param) BuildDoublePlan(double xValue)
+    {
+        var param = new Tensor<double>(new[] { 16 });
+        var x = new Tensor<double>(new[] { 16 });
+        for (int i = 0; i < param.Length; i++)
+        {
+            param[i] = 1.0 + (0.1 * i);
+            x[i] = xValue;
+        }
+
+        var engine = new CpuEngine();
+        ICompiledTrainingPlan<double> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var product = engine.TensorMultiply(param, x);
+            engine.ReduceSum(product, null);
+            plan = scope.CompileTraining(new[] { param });
+        }
+
         return (plan, param);
     }
 
@@ -60,13 +82,20 @@ public class FusedOptimizerNonFiniteGradientTests
         return copy;
     }
 
+    private static double[] Snapshot(Tensor<double> t)
+    {
+        var copy = new double[t.Length];
+        for (int i = 0; i < t.Length; i++) copy[i] = t[i];
+        return copy;
+    }
+
     [Theory]
     [InlineData(float.NaN)]
     [InlineData(float.PositiveInfinity)]
     [InlineData(float.NegativeInfinity)]
     public void NonFiniteGradient_LeavesEveryParameterUntouched(float badGradient)
     {
-        var (plan, param) = BuildPlan(badGradient);
+        var (plan, param, _) = BuildPlan(badGradient);
         using (plan)
         {
             plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
@@ -90,7 +119,7 @@ public class FusedOptimizerNonFiniteGradientTests
     public void FiniteGradient_StillUpdates_AndReportsNoSkip()
     {
         // The gate must not become a blanket refusal: an ordinary step still has to train.
-        var (plan, param) = BuildPlan(2.0f);
+        var (plan, param, _) = BuildPlan(2.0f);
         using (plan)
         {
             plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
@@ -115,7 +144,7 @@ public class FusedOptimizerNonFiniteGradientTests
     {
         // The point of skipping rather than clamping: the model is still trainable afterwards.
         // A single poisoned step used to make every later step NaN forever.
-        var (badPlan, param) = BuildPlan(float.NaN);
+        var (badPlan, param, _) = BuildPlan(float.NaN);
         using (badPlan)
         {
             badPlan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
@@ -127,6 +156,104 @@ public class FusedOptimizerNonFiniteGradientTests
         {
             Assert.False(float.IsNaN(param[i]), $"parameter[{i}] is NaN after a step that was skipped");
             Assert.False(float.IsInfinity(param[i]), $"parameter[{i}] is Infinity after a skipped step");
+        }
+    }
+
+    [Fact]
+    public void GroupedSchedule_NonFiniteGradient_SkipsTheWholeStep()
+    {
+        var (plan, param, _) = BuildPlan(float.NaN);
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.1) },
+                new[] { 0 });
+            var before = Snapshot(param);
+
+            plan.Step();
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            for (int i = 0; i < param.Length; i++)
+                Assert.True(before[i].Equals(param[i]), $"grouped parameter[{i}] changed");
+        }
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void DoublePlan_NonFiniteGradient_SkipsTheWholeStep(double badGradient)
+    {
+        var (plan, param) = BuildDoublePlan(badGradient);
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+            var before = Snapshot(param);
+
+            plan.Step();
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            for (int i = 0; i < param.Length; i++)
+                Assert.True(before[i].Equals(param[i]), $"double parameter[{i}] changed");
+        }
+    }
+
+    [Fact]
+    public void DoubleGroupedSchedule_NonFiniteGradient_SkipsTheWholeStep()
+    {
+        var (plan, param) = BuildDoublePlan(double.NaN);
+        using (plan)
+        {
+            plan.ConfigureOptimizerGrouped(
+                OptimizerType.SGD,
+                new[] { LrSchedule.Constant(0.1) },
+                new[] { 0 });
+            var before = Snapshot(param);
+
+            plan.Step();
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+            for (int i = 0; i < param.Length; i++)
+                Assert.True(before[i].Equals(param[i]), $"double grouped parameter[{i}] changed");
+        }
+    }
+
+    [Theory]
+    [InlineData(OptimizerType.LBFGS)]
+    [InlineData(OptimizerType.TrustRegion)]
+    [InlineData(OptimizerType.ConjugateGradient)]
+    [InlineData(OptimizerType.HypergradientSGD)]
+    [InlineData(OptimizerType.DAdaptationSGD)]
+    [InlineData(OptimizerType.ScheduleFreeSGD)]
+    public void GlobalStateOptimizer_NonFiniteGradient_SkipsWithoutChangingParameters(
+        OptimizerType optimizerType)
+    {
+        var (plan, param, input) = BuildPlan(2.0f);
+        using (plan)
+        {
+            plan.ConfigureOptimizer(optimizerType, learningRate: 0.1f);
+
+            // Establish non-trivial optimizer state first. In particular, Schedule-Free's z and x
+            // copies now differ, so the bad step's pre-forward y write must be rolled back to x.
+            plan.Step();
+            for (int i = 0; i < input.Length; i++) input[i] = float.NaN;
+            var before = Snapshot(param);
+            int skippedBefore = plan.NonFiniteStepsSkipped;
+
+            plan.Step();
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(skippedBefore + 1, plan.NonFiniteStepsSkipped);
+            for (int i = 0; i < param.Length; i++)
+            {
+                Assert.True(before[i].Equals(param[i]),
+                    $"{optimizerType} changed parameter[{i}] on a discarded step: " +
+                    $"{before[i]:G9} -> {param[i]:G9}");
+            }
         }
     }
 
@@ -155,6 +282,31 @@ public class FusedOptimizerNonFiniteGradientTests
 
                 Assert.True(expected == actual,
                     $"length={length} bad-index={bad}: scan returned {actual}");
+            }
+        }
+    }
+
+    [Fact]
+    public void DoubleAllFiniteScan_AgreesWithElementwiseChecks_AcrossVectorBoundaries()
+    {
+        for (int length = 1; length <= 24; length++)
+        {
+            for (int bad = 0; bad < length; bad++)
+            {
+                var values = new double[length];
+                for (int i = 0; i < length; i++) values[i] = 1.0;
+                values[bad] = double.PositiveInfinity;
+
+                bool actual;
+                unsafe
+                {
+                    fixed (double* p = values)
+                    {
+                        actual = AiDotNet.Tensors.Engines.Compilation.FusedOptimizer.AllFiniteSimd(p, length);
+                    }
+                }
+
+                Assert.False(actual, $"length={length} bad-index={bad}: scan missed infinity");
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -1,0 +1,161 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// The fused optimizer must DISCARD a step whose gradients are not finite, leaving every parameter
+/// exactly as it was.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The fused kernels read a gradient and write its parameter in one pass, so a NaN or infinite
+/// gradient is not just a wasted step — it is written into the weights, and every subsequent step
+/// reads it back. The loss reports NaN from then on with nothing to indicate which step poisoned it,
+/// and because the eager autograd tape has no such fusion, the same model can show perfectly finite
+/// gradients from a direct gradient call while training destroys it.
+/// </para>
+/// <para>
+/// <c>torch.amp.GradScaler</c> is the reference behaviour: check the gradients each iteration, skip
+/// the optimizer step when any are inf or NaN, and leave the parameters untouched so the run
+/// continues from the last good state. These pin that contract.
+/// </para>
+/// </remarks>
+public class FusedOptimizerNonFiniteGradientTests
+{
+    /// <summary>
+    /// Builds <c>loss = sum(param * x)</c>, whose gradient with respect to <c>param</c> is exactly
+    /// <c>x</c>. Feeding a non-finite <c>x</c> therefore produces a non-finite gradient by
+    /// construction, with no reliance on a model diverging.
+    /// </summary>
+    private static (ICompiledTrainingPlan<float> plan, Tensor<float> param) BuildPlan(float xValue)
+    {
+        var param = new Tensor<float>(new[] { 16 });
+        var x = new Tensor<float>(new[] { 16 });
+        for (int i = 0; i < param.Length; i++)
+        {
+            param[i] = 1.0f + (0.1f * i);
+            x[i] = xValue;
+        }
+
+        var engine = new CpuEngine();
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.Enable())
+        {
+            var product = engine.TensorMultiply(param, x);
+            engine.ReduceSum(product, null);
+            plan = scope.CompileTraining(new[] { param });
+        }
+
+        return (plan, param);
+    }
+
+    private static float[] Snapshot(Tensor<float> t)
+    {
+        var copy = new float[t.Length];
+        for (int i = 0; i < t.Length; i++) copy[i] = t[i];
+        return copy;
+    }
+
+    [Theory]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void NonFiniteGradient_LeavesEveryParameterUntouched(float badGradient)
+    {
+        var (plan, param) = BuildPlan(badGradient);
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+            var before = Snapshot(param);
+
+            plan.Step();
+
+            Assert.True(plan.LastStepSkippedNonFiniteGradients,
+                "a step with non-finite gradients must report that it was skipped");
+            Assert.Equal(1, plan.NonFiniteStepsSkipped);
+
+            for (int i = 0; i < param.Length; i++)
+            {
+                Assert.True(before[i].Equals(param[i]),
+                    $"parameter[{i}] changed on a discarded step: {before[i]:G9} -> {param[i]:G9}");
+            }
+        }
+    }
+
+    [Fact]
+    public void FiniteGradient_StillUpdates_AndReportsNoSkip()
+    {
+        // The gate must not become a blanket refusal: an ordinary step still has to train.
+        var (plan, param) = BuildPlan(2.0f);
+        using (plan)
+        {
+            plan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+            var before = Snapshot(param);
+
+            plan.Step();
+
+            Assert.False(plan.LastStepSkippedNonFiniteGradients);
+            Assert.Equal(0, plan.NonFiniteStepsSkipped);
+
+            // d(sum(param * x))/d(param) = x = 2, so SGD at lr 0.1 moves every entry by -0.2.
+            for (int i = 0; i < param.Length; i++)
+            {
+                Assert.True(System.Math.Abs((before[i] - 0.2f) - param[i]) < 1e-5f,
+                    $"parameter[{i}] did not take the expected step: {before[i]:G9} -> {param[i]:G9}");
+            }
+        }
+    }
+
+    [Fact]
+    public void TrainingRecovers_AfterASkippedStep()
+    {
+        // The point of skipping rather than clamping: the model is still trainable afterwards.
+        // A single poisoned step used to make every later step NaN forever.
+        var (badPlan, param) = BuildPlan(float.NaN);
+        using (badPlan)
+        {
+            badPlan.ConfigureOptimizer(OptimizerType.SGD, learningRate: 0.1f);
+            badPlan.Step();
+            Assert.True(badPlan.LastStepSkippedNonFiniteGradients);
+        }
+
+        for (int i = 0; i < param.Length; i++)
+        {
+            Assert.False(float.IsNaN(param[i]), $"parameter[{i}] is NaN after a step that was skipped");
+            Assert.False(float.IsInfinity(param[i]), $"parameter[{i}] is Infinity after a skipped step");
+        }
+    }
+
+    [Fact]
+    public void AllFiniteScan_AgreesWithElementwiseChecks_AcrossVectorBoundaries()
+    {
+        // The scan is vectorized with a scalar tail, so a bad value has to be caught wherever it
+        // falls relative to the vector width -- including the very last element of the tail.
+        for (int length = 1; length <= 40; length++)
+        {
+            for (int bad = 0; bad < length; bad++)
+            {
+                var values = new float[length];
+                for (int i = 0; i < length; i++) values[i] = 1.0f;
+                values[bad] = float.NaN;
+
+                bool expected = false;
+                bool actual;
+                unsafe
+                {
+                    fixed (float* p = values)
+                    {
+                        actual = AiDotNet.Tensors.Engines.Compilation.FusedOptimizer.AllFiniteSimd(p, length);
+                    }
+                }
+
+                Assert.True(expected == actual,
+                    $"length={length} bad-index={bad}: scan returned {actual}");
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -267,10 +267,12 @@ public class FusedOptimizerNonFiniteGradientTests
             Assert.True(plan.LastStepSkippedNonFiniteGradients);
             Assert.Equal(1, plan.NonFiniteStepsSkipped);
             Assert.Equal(2, state.ClassifyFloatCalls);
-            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(1, state.FillCalls);
+            Assert.Equal(2, state.MultiplyCalls);
+            Assert.Equal(1, state.ScalarMinCalls);
             Assert.Empty(state.OptimizerCalls);
             Assert.Equal(0, state.DownloadBufferCalls);
-            Assert.Equal(new[] { 16 }, state.AllocationSizes);
+            Assert.Equal(new[] { 16, 16 }, state.AllocationSizes);
             Assert.Equal(0, GetOptimizerStep(plan));
 
             foreach (var gradient in gradients) AttachGpuBuffer(gradient, backend, 1f);
@@ -302,10 +304,12 @@ public class FusedOptimizerNonFiniteGradientTests
             Assert.False(plan.LastStepSkippedNonFiniteGradients);
             Assert.Equal(0, plan.NonFiniteStepsSkipped);
             Assert.Equal(2, state.ClassifyFloatCalls);
-            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(1, state.FillCalls);
+            Assert.Equal(2, state.MultiplyCalls);
+            Assert.Equal(1, state.ScalarMinCalls);
             Assert.Equal(new[] { "SgdUpdate", "SgdUpdate" }, state.OptimizerCalls);
             Assert.Equal(0, state.DownloadBufferCalls);
-            Assert.Equal(new[] { 16 }, state.AllocationSizes);
+            Assert.Equal(new[] { 16, 16 }, state.AllocationSizes);
         }
     }
 
@@ -330,7 +334,9 @@ public class FusedOptimizerNonFiniteGradientTests
             Assert.Equal(1, plan.NonFiniteStepsSkipped);
             Assert.Empty(state.OptimizerCalls);
             Assert.Equal(2, state.ClassifyFloatCalls);
-            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(1, state.FillCalls);
+            Assert.Equal(2, state.MultiplyCalls);
+            Assert.Equal(1, state.ScalarMinCalls);
             Assert.Equal(0, state.DownloadBufferCalls);
         }
     }
@@ -355,7 +361,9 @@ public class FusedOptimizerNonFiniteGradientTests
             Assert.Equal(0, plan.NonFiniteStepsSkipped);
             Assert.Equal(new[] { "AdamMultiTensorUpdate" }, state.OptimizerCalls);
             Assert.Equal(2, state.ClassifyFloatCalls);
-            Assert.Equal(2, state.ScalarMinCalls);
+            Assert.Equal(1, state.FillCalls);
+            Assert.Equal(2, state.MultiplyCalls);
+            Assert.Equal(1, state.ScalarMinCalls);
             Assert.Equal(0, state.DownloadBufferCalls);
         }
     }
@@ -384,8 +392,10 @@ public class FusedOptimizerNonFiniteGradientTests
             Assert.True(plan.LastStepSkippedNonFiniteGradients);
             Assert.Equal(1, plan.NonFiniteStepsSkipped);
             Assert.Empty(state.OptimizerCalls);
-            Assert.Equal(1, state.ClassifyFloatCalls);
-            Assert.Equal(1, state.ScalarMinCalls);
+            Assert.Equal(0, state.FillCalls);
+            Assert.Equal(0, state.ClassifyFloatCalls);
+            Assert.Equal(0, state.MultiplyCalls);
+            Assert.Equal(0, state.ScalarMinCalls);
             Assert.Equal(0, state.DownloadBufferCalls);
         }
     }
@@ -422,8 +432,14 @@ public class FusedOptimizerNonFiniteGradientTests
 
                     using var gradient = backend!.AllocateBuffer(values);
                     using var scratch = backend.AllocateBuffer(length);
+                    using var aggregate = backend.AllocateBuffer(length);
+                    using var finitePrefix = backend.AllocateBuffer(new float[] { 1f });
+                    backend.Fill(aggregate, 1f, length);
+                    backend.ClassifyFloat(finitePrefix, scratch, mode: 2, size: 1);
+                    backend.Multiply(scratch, aggregate, aggregate, size: 1);
                     backend.ClassifyFloat(gradient, scratch, mode: 2, size: length);
-                    Assert.Equal(allFinite ? 1f : 0f, backend.Min(scratch, length));
+                    backend.Multiply(scratch, aggregate, aggregate, size: length);
+                    Assert.Equal(allFinite ? 1f : 0f, backend.Min(aggregate, length));
                 }
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -63,6 +63,8 @@ internal sealed class MockBackendState
     public List<int> AllocationSizes { get; } = new();
     public List<MockGpuBuffer> AllocatedBuffers { get; } = new();
     public int DownloadBufferCalls { get; set; }
+    public int ClassifyFloatCalls { get; set; }
+    public int ScalarMinCalls { get; set; }
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
     public List<string> OptimizerCalls { get; } = new();
@@ -84,6 +86,13 @@ public class MockDirectGpuBackend : DispatchProxy
         var proxy = (MockDirectGpuBackend)Create<IDirectGpuBackend, MockDirectGpuBackend>();
         proxy._state = state;
         return (IDirectGpuBackend)(object)proxy;
+    }
+
+    internal static IMultiTensorGpuOptimizerBackend CreateMultiTensor(MockBackendState state)
+    {
+        var proxy = (MockDirectGpuBackend)Create<IMultiTensorGpuOptimizerBackend, MockDirectGpuBackend>();
+        proxy._state = state;
+        return (IMultiTensorGpuOptimizerBackend)(object)proxy;
     }
 
     protected override object Invoke(MethodInfo targetMethod, object[] args)
@@ -142,6 +151,31 @@ public class MockDirectGpuBackend : DispatchProxy
                 return null!;
             }
 
+            // Device-resident non-finite-gradient preflight used by compiled optimizers.
+            // ClassifyFloat mode 2 writes an exact 0/1 finite mask; scalar Min then returns
+            // one iff every inspected element was finite, without downloading the gradient.
+            case "ClassifyFloat":
+            {
+                _state.ClassifyFloatCalls++;
+                var input = (MockGpuBuffer)args[0]!;
+                var output = (MockGpuBuffer)args[1]!;
+                int mode = (int)args[2]!;
+                int size = (int)args[3]!;
+                if (mode != 2) throw new NotSupportedException("Mock ClassifyFloat supports isfinite mode only.");
+                for (int i = 0; i < size; i++)
+                    output.Data[i] = float.IsNaN(input.Data[i]) || float.IsInfinity(input.Data[i]) ? 0f : 1f;
+                return null!;
+            }
+            case "Min" when args.Length == 2:
+            {
+                _state.ScalarMinCalls++;
+                var input = (MockGpuBuffer)args[0]!;
+                int size = (int)args[1]!;
+                float minimum = float.PositiveInfinity;
+                for (int i = 0; i < size; i++) minimum = Math.Min(minimum, input.Data[i]);
+                return minimum;
+            }
+
             // Optimizer dispatch probes. These methods are void on IDirectGpuBackend; tests
             // verify the wrapper reached the backend and marked only the mutated tensors current.
             case "AdamUpdate":
@@ -160,6 +194,8 @@ public class MockDirectGpuBackend : DispatchProxy
             case "LionUpdate":
             case "NadamUpdate":
             case "FtrlUpdate":
+            case "AdamMultiTensorUpdate":
+            case "AdamWMultiTensorUpdate":
             case "SparseAdamUpdate":
             case "SparseAdamWUpdate":
             case "SparseSgdUpdate":

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -64,6 +64,8 @@ internal sealed class MockBackendState
     public List<MockGpuBuffer> AllocatedBuffers { get; } = new();
     public int DownloadBufferCalls { get; set; }
     public int ClassifyFloatCalls { get; set; }
+    public int FillCalls { get; set; }
+    public int MultiplyCalls { get; set; }
     public int ScalarMinCalls { get; set; }
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
@@ -152,8 +154,15 @@ public class MockDirectGpuBackend : DispatchProxy
             }
 
             // Device-resident non-finite-gradient preflight used by compiled optimizers.
-            // ClassifyFloat mode 2 writes an exact 0/1 finite mask; scalar Min then returns
-            // one iff every inspected element was finite, without downloading the gradient.
+            case "Fill":
+            {
+                _state.FillCalls++;
+                var output = (MockGpuBuffer)args[0]!;
+                float value = (float)args[1]!;
+                int size = (int)args[2]!;
+                for (int i = 0; i < size; i++) output.Data[i] = value;
+                return null!;
+            }
             case "ClassifyFloat":
             {
                 _state.ClassifyFloatCalls++;
@@ -164,6 +173,16 @@ public class MockDirectGpuBackend : DispatchProxy
                 if (mode != 2) throw new NotSupportedException("Mock ClassifyFloat supports isfinite mode only.");
                 for (int i = 0; i < size; i++)
                     output.Data[i] = float.IsNaN(input.Data[i]) || float.IsInfinity(input.Data[i]) ? 0f : 1f;
+                return null!;
+            }
+            case "Multiply":
+            {
+                _state.MultiplyCalls++;
+                var left = (MockGpuBuffer)args[0]!;
+                var right = (MockGpuBuffer)args[1]!;
+                var output = (MockGpuBuffer)args[2]!;
+                int size = (int)args[3]!;
+                for (int i = 0; i < size; i++) output.Data[i] = left.Data[i] * right.Data[i];
                 return null!;
             }
             case "Min" when args.Length == 2:


### PR DESCRIPTION
## Outcome

Compiled training now treats non-finite gradients as an atomic, recoverable skipped step on both CPU and GPU. The original iteration protected only materialized CPU arrays; GPU-resident gradients, uploaded host gradients for GPU parameters, grouped plans, and the multi-tensor fast path could still update with NaN or infinity. This revision closes those gaps.

## New capabilities

- Detects `NaN`, `+Infinity`, and `-Infinity` before any fused optimizer update.
- Covers CPU gradients and device-resident gradients through the shared direct-GPU backend contract used by CUDA, HIP, OpenCL, Metal, Vulkan, and WebGPU.
- Exposes `LastStepSkippedNonFiniteGradients` and `NonFiniteStepsSkipped` so callers can distinguish an intentionally discarded step from stalled learning.
- Allows the next finite step to recover normally from the last valid model and optimizer state.
- Preserves the multi-tensor Adam/AdamW fast path for finite gradients.

## Existing behavior fixed

- A bad gradient can no longer partially update earlier parameters before a later tensor is inspected.
- Skipped steps leave parameters, optimizer moments, Schedule-Free visible weights, and Adam's bias-correction step unchanged.
- The update consumes the exact gradient source that the preflight checked. This fixes the grouped route's former unconditional trust of a stale resident gradient when eager backward had produced newer host values.
- Lazy gradients that materialize after optimizer configuration are rebound before inspection.
- GPU-resident parameters no longer bypass the guard merely because their host parameter arrays are empty.
- Per-tensor, grouped, and multi-tensor GPU optimizer routes now have the same skip semantics as the CPU route.

## GPU design and performance contract

The GPU path does not download gradients. It classifies each device gradient into an IEEE-bitwise 0/1 finite mask, combines every mask on-device, and downloads one scalar reduction result per distinct backend.

- CPU-authoritative gradients are scanned first, so a known host failure launches no GPU work.
- GPU masks are aggregated before readback, preventing one device synchronization per parameter.
- Persistent scratch is bounded to two buffers sized to the largest tensor per backend, rather than one allocation per gradient or the sum of model sizes.
- `Min(mask) == 1` is used instead of summing mask values, so a single zero cannot disappear through FP32 rounding for tensors larger than 2²⁴ elements.
- The mock contract asserts two GPU gradients produce two classifications but only one scalar reduction, zero full-buffer downloads, and no optimizer call when rejected.

## CUDA defects found by hardware validation

The physical-GPU probe exposed two pre-existing scalar-reduction bugs that mock tests could not reveal:

1. The final warp used a partial active mask while shuffling from inactive lanes. A four-element all-ones mask could reduce to zero and falsely reject every optimizer step.
2. Multi-pass reductions retained a scratch buffer whose physical capacity exceeded the final logical size, then attempted to download it into a one-element destination.

The CUDA sum/min/max final-warp reduction now uses identity-filled lanes with a full warp mask, and scalar readback always lands in an exact one-element device allocation.

## Validation evidence

| Evidence | Result |
|---|---:|
| Focused .NET 10 suite | 26/26 passed |
| Focused .NET Framework 4.7.1 suite | 25/25 passed |
| Related fused dispatch, GPU residency, and GPU classification regressions | 69/69 passed |
| Physical GPU | NVIDIA GeForce GTX 1660 Ti, CUDA compute capability 7.5 |
| Hardware values | finite, NaN, +Infinity, -Infinity |
| Hardware reduction lengths | 1, 4, 31, 32, 33, 255, 256, 257, 1025 |
| Full gradient readbacks in GPU route tests | 0 |
| Scalar reductions for two gradients on one backend | 1 |
| Merge with current `main` | clean |

The boundary sizes cover scalar/small inputs, both sides of a CUDA warp boundary, both sides of the 256-thread block boundary, and multi-pass reduction. The live probe executes the same Fill → ClassifyFloat → on-device mask aggregation → scalar Min composition used by compiled training.

## Route coverage

- CPU float and double, including grouped schedules
- GPU-resident and host-authoritative gradients for GPU parameters
- stale resident-gradient selection
- per-tensor SGD route
- multi-tensor Adam/AdamW route
- grouped GPU route
- skip recovery and optimizer-step accounting
- Schedule-Free restoration
- SIMD vector boundaries and scalar tails
