### PR TITLE
feat(autodiff): add fused abc slot-recurrence scan kernel

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -177,6 +177,7 @@ internal static class OpRegistry
         "RoutedDiagonalSsmScanForward",
         "RgLruScanForward",
         "GlaScanForward",
+        "AbcScanForward",
         "GatedDeltaNetScanForward",
         "XLstmScanForward",
         "Mamba2SsdScanForward",

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
@@ -1,0 +1,609 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Fused ABC (Attention with Bounded-memory Control) slot recurrence over a whole sequence in a
+    /// SINGLE op (forward + custom autodiff backward), replacing the per-element detached scalar loop
+    /// <c>ABCLayer.SlotCompetitionForward</c> ran — which was DETACHED from the autodiff tape, so the
+    /// q/k/v and forget-gate weights received no gradient at all through the recurrence (the same
+    /// defect class as issue ooples/AiDotNet#1464, of which this is the remaining ABC case).
+    /// Per head (modelDim split into <paramref name="numHeads"/> blocks of headDim), with slot state
+    /// seeded from the trainable slot keys and scale = 1/sqrt(headDim):
+    /// <code>
+    ///   slot_-1[s,d] = slotInitScale * SK[h,s,d]
+    ///   wScore_t[s]  = scale * sum_d K_t[d] * SK[h,s,d]
+    ///   w_t          = softmax_s(wScore_t)                  (competitive write)
+    ///   slot_t[s,d]  = fg_t * slot_{t-1}[s,d] + w_t[s] * V_t[d]
+    ///   rScore_t[s]  = scale * sum_d Q_t[d] * slot_t[s,d]
+    ///   r_t          = softmax_s(rScore_t)                  (competitive read)
+    ///   O_t[d]       = sum_s r_t[s] * slot_t[s,d]
+    /// </code>
+    /// Records one tape node whose backward is the exact BPTT adjoint, so it is differentiable under an
+    /// active <c>GradientTape</c> and the gradient reaches q/k/v, the forget gate AND the slot keys —
+    /// the slot keys twice over, through the write scores at every step and through the initial state.
+    /// The softmax is the standard max-subtracted form with no epsilon in the denominator: after the
+    /// row max is subtracted the largest term is exactly 1, so the sum is always at least 1 and the
+    /// guard the scalar loop carried could only bias the result.
+    /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="forgetGate">Post-sigmoid scalar-per-head forget gate [batch, seqLen, numHeads].</param>
+    /// <param name="slotKeys">Trainable slot keys [numHeads, numSlots, headDim].</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
+    /// <param name="slotInitScale">Scale applied to the slot keys to seed the initial slot state.</param>
+    /// <returns>The slot-read output [batch, seqLen, modelDim].</returns>
+    public virtual Tensor<T> AbcScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
+        Tensor<T> slotKeys, int numHeads, double slotInitScale = 0.1)
+    {
+        if (qProj is null) throw new ArgumentNullException(nameof(qProj));
+        if (kProj is null) throw new ArgumentNullException(nameof(kProj));
+        if (vProj is null) throw new ArgumentNullException(nameof(vProj));
+        if (forgetGate is null) throw new ArgumentNullException(nameof(forgetGate));
+        if (slotKeys is null) throw new ArgumentNullException(nameof(slotKeys));
+        if (numHeads < 1) throw new ArgumentOutOfRangeException(nameof(numHeads));
+        if (qProj.Rank != 3)
+            throw new ArgumentException($"AbcScanForward expects rank-3 inputs [batch, seqLen, modelDim]; got rank {qProj.Rank}.", nameof(qProj));
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        if (modelDim % numHeads != 0)
+            throw new ArgumentException($"modelDim ({modelDim}) must be divisible by numHeads ({numHeads}).", nameof(numHeads));
+        int headDim = modelDim / numHeads;
+        EnsureSameShape(qProj, kProj, nameof(kProj));
+        EnsureSameShape(qProj, vProj, nameof(vProj));
+        if (forgetGate.Rank != 3 || forgetGate.Shape[0] != batch || forgetGate.Shape[1] != seqLen || forgetGate.Shape[2] != numHeads)
+            throw new ArgumentException($"forgetGate must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(forgetGate));
+        if (slotKeys.Rank != 3 || slotKeys.Shape[0] != numHeads || slotKeys.Shape[2] != headDim)
+            throw new ArgumentException($"slotKeys must be [numHeads={numHeads}, numSlots, headDim={headDim}].", nameof(slotKeys));
+        int numSlots = slotKeys.Shape[1];
+
+        var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            AbcForwardDouble(
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)forgetGate.GetDataArray()!,
+                (double[])(object)slotKeys.GetDataArray()!, (double[])(object)output.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim, numSlots, slotInitScale);
+        }
+        else
+        {
+            AbcForwardGeneric<T>(
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                forgetGate.GetDataArray()!, slotKeys.GetDataArray()!, output.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim, numSlots, slotInitScale);
+        }
+
+        DifferentiableOps.RecordIfActive<T>(
+            "AbcScan", output,
+            new[] { qProj, kProj, vProj, forgetGate, slotKeys },
+            AbcScanBackward<T>,
+            savedState: new object[] { numHeads, slotInitScale });
+
+        return output;
+    }
+
+    // One (batch, head) pair per chunk: slot state and output region are both private to the pair.
+    private const int AbcBhGrain = 1;
+
+    // ── Double fast path ─────────────────────────────────────────────────────────────────
+    private static void AbcForwardDouble(
+        double[] Q, double[] K, double[] V, double[] FG, double[] SK, double[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim, int numSlots, double initScale)
+    {
+        int sd = numSlots * headDim;
+        double scale = 1.0 / Math.Sqrt(headDim);
+        // Every (batch, head) pair is fully independent (private slot state, disjoint output region),
+        // so the combined (b*numHeads) axis is embarrassingly parallel with no cross-channel reduction.
+        CpuParallelSettings.ParallelForChunks(batch * numHeads, AbcBhGrain, (bhStart, bhCount) =>
+        {
+            var slot = new double[sd];
+            var w = new double[numSlots];
+            var r = new double[numSlots];
+            int bhEnd = bhStart + bhCount;
+            for (int bh = bhStart; bh < bhEnd; bh++)
+            {
+                int b = bh / numHeads;
+                int h = bh % numHeads;
+                int hOff = h * headDim;
+                int skOff = h * sd;
+
+                for (int i = 0; i < sd; i++) slot[i] = initScale * SK[skOff + i];
+
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    double fg = FG[(b * seqLen + t) * numHeads + h];
+
+                    // Write scores against the slot keys, then softmax over slots.
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        double dot = 0.0;
+                        int krow = skOff + s * headDim;
+                        for (int d = 0; d < headDim; d++) dot += K[baseOff + d] * SK[krow + d];
+                        w[s] = dot * scale;
+                    }
+                    SoftmaxInPlaceDouble(w, 0, numSlots);
+
+                    // Forget old content, write new content.
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        double ws = w[s];
+                        int srow = s * headDim;
+                        for (int d = 0; d < headDim; d++)
+                            slot[srow + d] = fg * slot[srow + d] + ws * V[baseOff + d];
+                    }
+
+                    // Read scores against the updated slot content, then softmax over slots.
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        double dot = 0.0;
+                        int srow = s * headDim;
+                        for (int d = 0; d < headDim; d++) dot += Q[baseOff + d] * slot[srow + d];
+                        r[s] = dot * scale;
+                    }
+                    SoftmaxInPlaceDouble(r, 0, numSlots);
+
+                    for (int d = 0; d < headDim; d++)
+                    {
+                        double o = 0.0;
+                        for (int s = 0; s < numSlots; s++) o += r[s] * slot[s * headDim + d];
+                        outp[baseOff + d] = o;
+                    }
+                }
+            }
+        });
+    }
+
+    private static void SoftmaxInPlaceDouble(double[] x, int off, int n)
+    {
+        double max = x[off];
+        for (int i = 1; i < n; i++) if (x[off + i] > max) max = x[off + i];
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) { x[off + i] = Math.Exp(x[off + i] - max); sum += x[off + i]; }
+        double inv = 1.0 / sum;
+        for (int i = 0; i < n; i++) x[off + i] *= inv;
+    }
+
+    // dScore[i] = y[i] * (dy[i] - sum_j dy[j]*y[j]), the standard softmax Jacobian-vector product.
+    // The max subtraction cancels exactly in the true softmax, so it contributes nothing here.
+    private static void SoftmaxBackwardInPlaceDouble(double[] dy, double[] y, int yOff, int n)
+    {
+        double dotp = 0.0;
+        for (int i = 0; i < n; i++) dotp += dy[i] * y[yOff + i];
+        for (int i = 0; i < n; i++) dy[i] = y[yOff + i] * (dy[i] - dotp);
+    }
+
+    private static void AbcBackwardDouble(
+        double[] dOut, double[] Q, double[] K, double[] V, double[] FG, double[] SK,
+        double[] dQ, double[] dK, double[] dV, double[] dFG, double[] dSK,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim, int numSlots, double initScale)
+    {
+        int sd = numSlots * headDim;
+        double scale = 1.0 / Math.Sqrt(headDim);
+        // Parallelize over HEADS only, not (batch*head): dSK[h] is shared by every batch element, so
+        // the batch loop stays sequential inside a head to keep the accumulation lock-free.
+        CpuParallelSettings.ParallelForChunks(numHeads, AbcBhGrain, (hStart, hCount) =>
+        {
+            var slot = new double[sd];
+            var slotTraj = new double[seqLen * sd];
+            var wTraj = new double[seqLen * numSlots];
+            var rTraj = new double[seqLen * numSlots];
+            var dSlot = new double[sd];
+            var dw = new double[numSlots];
+            var dr = new double[numSlots];
+            int hEnd = hStart + hCount;
+            for (int h = hStart; h < hEnd; h++)
+            {
+                int hOff = h * headDim;
+                int skOff = h * sd;
+                for (int b = 0; b < batch; b++)
+                {
+                    // Forward recompute, saving the slot trajectory and both softmax outputs.
+                    for (int i = 0; i < sd; i++) slot[i] = initScale * SK[skOff + i];
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (b * seqLen + t) * modelDim + hOff;
+                        double fg = FG[(b * seqLen + t) * numHeads + h];
+                        int wOff = t * numSlots;
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double dot = 0.0;
+                            int krow = skOff + s * headDim;
+                            for (int d = 0; d < headDim; d++) dot += K[baseOff + d] * SK[krow + d];
+                            wTraj[wOff + s] = dot * scale;
+                        }
+                        SoftmaxInPlaceDouble(wTraj, wOff, numSlots);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double ws = wTraj[wOff + s];
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                                slot[srow + d] = fg * slot[srow + d] + ws * V[baseOff + d];
+                        }
+                        Array.Copy(slot, 0, slotTraj, t * sd, sd);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double dot = 0.0;
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++) dot += Q[baseOff + d] * slot[srow + d];
+                            rTraj[wOff + s] = dot * scale;
+                        }
+                        SoftmaxInPlaceDouble(rTraj, wOff, numSlots);
+                    }
+
+                    // Reverse sweep.
+                    Array.Clear(dSlot, 0, sd);
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int baseOff = (b * seqLen + t) * modelDim + hOff;
+                        int gOff = (b * seqLen + t) * numHeads + h;
+                        int wOff = t * numSlots;
+                        int stOff = t * sd;
+                        double fg = FG[gOff];
+
+                        // O_t[d] = sum_s r[s] * slot_t[s,d]
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double rs = rTraj[wOff + s];
+                            int srow = s * headDim;
+                            double acc = 0.0;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                double dO = dOut[baseOff + d];
+                                acc += dO * slotTraj[stOff + srow + d];
+                                dSlot[srow + d] += dO * rs;
+                            }
+                            dr[s] = acc;
+                        }
+
+                        // Softmax backward for the read weights, then the read scores.
+                        SoftmaxBackwardInPlaceDouble(dr, rTraj, wOff, numSlots);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double drs = dr[s] * scale;
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                dQ[baseOff + d] += drs * slotTraj[stOff + srow + d];
+                                dSlot[srow + d] += drs * Q[baseOff + d];
+                            }
+                        }
+
+                        // slot_t[s,d] = fg * slot_{t-1}[s,d] + w[s] * V_t[d]
+                        double dfg = 0.0;
+                        int sprevOff = (t - 1) * sd;
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            int srow = s * headDim;
+                            double accW = 0.0;
+                            double ws = wTraj[wOff + s];
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                double ds = dSlot[srow + d];
+                                double sprev = t > 0
+                                    ? slotTraj[sprevOff + srow + d]
+                                    : initScale * SK[skOff + srow + d];
+                                dfg += ds * sprev;
+                                accW += ds * V[baseOff + d];
+                                dV[baseOff + d] += ds * ws;
+                            }
+                            dw[s] = accW;
+                        }
+                        dFG[gOff] += dfg;
+
+                        // Carry the state adjoint back one step: dslot_{t-1} = fg * dslot_t.
+                        for (int i = 0; i < sd; i++) dSlot[i] *= fg;
+
+                        // Softmax backward for the write weights, then the write scores.
+                        SoftmaxBackwardInPlaceDouble(dw, wTraj, wOff, numSlots);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            double dws = dw[s] * scale;
+                            int krow = skOff + s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                dK[baseOff + d] += dws * SK[krow + d];
+                                dSK[krow + d] += dws * K[baseOff + d];
+                            }
+                        }
+                    }
+
+                    // Boundary: slot_-1[s,d] = initScale * SK[h,s,d]; dSlot now holds dL/dslot_-1.
+                    for (int i = 0; i < sd; i++) dSK[skOff + i] += initScale * dSlot[i];
+                }
+            }
+        });
+    }
+
+    // ── Generic-T path ───────────────────────────────────────────────────────────────────
+    private static void AbcForwardGeneric<T>(
+        T[] Q, T[] K, T[] V, T[] FG, T[] SK, T[] outp,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim, int numSlots, double initScale)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int sd = numSlots * headDim;
+        T scale = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        T init = ops.FromDouble(initScale);
+        // Parallelize lock-free over the independent (b*numHeads) axis; see the double path.
+        CpuParallelSettings.ParallelForChunks(batch * numHeads, AbcBhGrain, (bhStart, bhCount) =>
+        {
+            var slot = new T[sd];
+            var w = new T[numSlots];
+            var r = new T[numSlots];
+            int bhEnd = bhStart + bhCount;
+            for (int bh = bhStart; bh < bhEnd; bh++)
+            {
+                int b = bh / numHeads;
+                int h = bh % numHeads;
+                int hOff = h * headDim;
+                int skOff = h * sd;
+
+                for (int i = 0; i < sd; i++) slot[i] = ops.Multiply(init, SK[skOff + i]);
+
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int baseOff = (b * seqLen + t) * modelDim + hOff;
+                    T fg = FG[(b * seqLen + t) * numHeads + h];
+
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        T dot = ops.Zero;
+                        int krow = skOff + s * headDim;
+                        for (int d = 0; d < headDim; d++)
+                            dot = ops.Add(dot, ops.Multiply(K[baseOff + d], SK[krow + d]));
+                        w[s] = ops.Multiply(dot, scale);
+                    }
+                    SoftmaxInPlaceGeneric(w, 0, numSlots, ops);
+
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        T ws = w[s];
+                        int srow = s * headDim;
+                        for (int d = 0; d < headDim; d++)
+                            slot[srow + d] = ops.Add(ops.Multiply(fg, slot[srow + d]), ops.Multiply(ws, V[baseOff + d]));
+                    }
+
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        T dot = ops.Zero;
+                        int srow = s * headDim;
+                        for (int d = 0; d < headDim; d++)
+                            dot = ops.Add(dot, ops.Multiply(Q[baseOff + d], slot[srow + d]));
+                        r[s] = ops.Multiply(dot, scale);
+                    }
+                    SoftmaxInPlaceGeneric(r, 0, numSlots, ops);
+
+                    for (int d = 0; d < headDim; d++)
+                    {
+                        T o = ops.Zero;
+                        for (int s = 0; s < numSlots; s++)
+                            o = ops.Add(o, ops.Multiply(r[s], slot[s * headDim + d]));
+                        outp[baseOff + d] = o;
+                    }
+                }
+            }
+        });
+    }
+
+    private static void SoftmaxInPlaceGeneric<T>(T[] x, int off, int n, INumericOperations<T> ops)
+    {
+        T max = x[off];
+        for (int i = 1; i < n; i++) if (ops.GreaterThan(x[off + i], max)) max = x[off + i];
+        T sum = ops.Zero;
+        for (int i = 0; i < n; i++) { x[off + i] = ops.Exp(ops.Subtract(x[off + i], max)); sum = ops.Add(sum, x[off + i]); }
+        T inv = ops.Divide(ops.One, sum);
+        for (int i = 0; i < n; i++) x[off + i] = ops.Multiply(x[off + i], inv);
+    }
+
+    private static void SoftmaxBackwardInPlaceGeneric<T>(T[] dy, T[] y, int yOff, int n, INumericOperations<T> ops)
+    {
+        T dotp = ops.Zero;
+        for (int i = 0; i < n; i++) dotp = ops.Add(dotp, ops.Multiply(dy[i], y[yOff + i]));
+        for (int i = 0; i < n; i++) dy[i] = ops.Multiply(y[yOff + i], ops.Subtract(dy[i], dotp));
+    }
+
+    private static void AbcBackwardGeneric<T>(
+        T[] dOut, T[] Q, T[] K, T[] V, T[] FG, T[] SK,
+        T[] dQ, T[] dK, T[] dV, T[] dFG, T[] dSK,
+        int batch, int seqLen, int modelDim, int numHeads, int headDim, int numSlots, double initScale)
+    {
+        var ops = MathHelper.GetNumericOperations<T>();
+        int sd = numSlots * headDim;
+        T scale = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+        T init = ops.FromDouble(initScale);
+        // Parallelize over HEADS only; dSK[h] is shared across the batch. See the double path.
+        CpuParallelSettings.ParallelForChunks(numHeads, AbcBhGrain, (hStart, hCount) =>
+        {
+            var slot = new T[sd];
+            var slotTraj = new T[seqLen * sd];
+            var wTraj = new T[seqLen * numSlots];
+            var rTraj = new T[seqLen * numSlots];
+            var dSlot = new T[sd];
+            var dw = new T[numSlots];
+            var dr = new T[numSlots];
+            int hEnd = hStart + hCount;
+            for (int h = hStart; h < hEnd; h++)
+            {
+                int hOff = h * headDim;
+                int skOff = h * sd;
+                for (int b = 0; b < batch; b++)
+                {
+                    for (int i = 0; i < sd; i++) slot[i] = ops.Multiply(init, SK[skOff + i]);
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        int baseOff = (b * seqLen + t) * modelDim + hOff;
+                        T fg = FG[(b * seqLen + t) * numHeads + h];
+                        int wOff = t * numSlots;
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T dot = ops.Zero;
+                            int krow = skOff + s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                                dot = ops.Add(dot, ops.Multiply(K[baseOff + d], SK[krow + d]));
+                            wTraj[wOff + s] = ops.Multiply(dot, scale);
+                        }
+                        SoftmaxInPlaceGeneric(wTraj, wOff, numSlots, ops);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T ws = wTraj[wOff + s];
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                                slot[srow + d] = ops.Add(ops.Multiply(fg, slot[srow + d]), ops.Multiply(ws, V[baseOff + d]));
+                        }
+                        Array.Copy(slot, 0, slotTraj, t * sd, sd);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T dot = ops.Zero;
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                                dot = ops.Add(dot, ops.Multiply(Q[baseOff + d], slot[srow + d]));
+                            rTraj[wOff + s] = ops.Multiply(dot, scale);
+                        }
+                        SoftmaxInPlaceGeneric(rTraj, wOff, numSlots, ops);
+                    }
+
+                    for (int i = 0; i < sd; i++) dSlot[i] = ops.Zero;
+                    for (int t = seqLen - 1; t >= 0; t--)
+                    {
+                        int baseOff = (b * seqLen + t) * modelDim + hOff;
+                        int gOff = (b * seqLen + t) * numHeads + h;
+                        int wOff = t * numSlots;
+                        int stOff = t * sd;
+                        T fg = FG[gOff];
+
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T rs = rTraj[wOff + s];
+                            int srow = s * headDim;
+                            T acc = ops.Zero;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                T dO = dOut[baseOff + d];
+                                acc = ops.Add(acc, ops.Multiply(dO, slotTraj[stOff + srow + d]));
+                                dSlot[srow + d] = ops.Add(dSlot[srow + d], ops.Multiply(dO, rs));
+                            }
+                            dr[s] = acc;
+                        }
+
+                        SoftmaxBackwardInPlaceGeneric(dr, rTraj, wOff, numSlots, ops);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T drs = ops.Multiply(dr[s], scale);
+                            int srow = s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                dQ[baseOff + d] = ops.Add(dQ[baseOff + d], ops.Multiply(drs, slotTraj[stOff + srow + d]));
+                                dSlot[srow + d] = ops.Add(dSlot[srow + d], ops.Multiply(drs, Q[baseOff + d]));
+                            }
+                        }
+
+                        T dfg = ops.Zero;
+                        int sprevOff = (t - 1) * sd;
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            int srow = s * headDim;
+                            T accW = ops.Zero;
+                            T ws = wTraj[wOff + s];
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                T ds = dSlot[srow + d];
+                                T sprev = t > 0
+                                    ? slotTraj[sprevOff + srow + d]
+                                    : ops.Multiply(init, SK[skOff + srow + d]);
+                                dfg = ops.Add(dfg, ops.Multiply(ds, sprev));
+                                accW = ops.Add(accW, ops.Multiply(ds, V[baseOff + d]));
+                                dV[baseOff + d] = ops.Add(dV[baseOff + d], ops.Multiply(ds, ws));
+                            }
+                            dw[s] = accW;
+                        }
+                        dFG[gOff] = ops.Add(dFG[gOff], dfg);
+
+                        for (int i = 0; i < sd; i++) dSlot[i] = ops.Multiply(dSlot[i], fg);
+
+                        SoftmaxBackwardInPlaceGeneric(dw, wTraj, wOff, numSlots, ops);
+                        for (int s = 0; s < numSlots; s++)
+                        {
+                            T dws = ops.Multiply(dw[s], scale);
+                            int krow = skOff + s * headDim;
+                            for (int d = 0; d < headDim; d++)
+                            {
+                                dK[baseOff + d] = ops.Add(dK[baseOff + d], ops.Multiply(dws, SK[krow + d]));
+                                dSK[krow + d] = ops.Add(dSK[krow + d], ops.Multiply(dws, K[baseOff + d]));
+                            }
+                        }
+                    }
+
+                    for (int i = 0; i < sd; i++)
+                        dSK[skOff + i] = ops.Add(dSK[skOff + i], ops.Multiply(init, dSlot[i]));
+                }
+            }
+        });
+    }
+
+    private static void AbcScanBackward<T>(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output, object[] savedState,
+        IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        int numHeads = (int)savedState[0];
+        double initScale = (double)savedState[1];
+        var qProj = inputs[0];
+        var kProj = inputs[1];
+        var vProj = inputs[2];
+        var forgetGate = inputs[3];
+        var slotKeys = inputs[4];
+
+        int batch = qProj.Shape[0];
+        int seqLen = qProj.Shape[1];
+        int modelDim = qProj.Shape[2];
+        int headDim = modelDim / numHeads;
+        int numSlots = slotKeys.Shape[1];
+
+        var dQ = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dK = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dV = new Tensor<T>(new[] { batch, seqLen, modelDim });
+        var dFG = new Tensor<T>(new[] { batch, seqLen, numHeads });
+        var dSK = new Tensor<T>(new[] { numHeads, numSlots, headDim });
+
+        if (typeof(T) == typeof(double))
+        {
+            AbcBackwardDouble(
+                (double[])(object)gradOutput.GetDataArray()!,
+                (double[])(object)qProj.GetDataArray()!, (double[])(object)kProj.GetDataArray()!,
+                (double[])(object)vProj.GetDataArray()!, (double[])(object)forgetGate.GetDataArray()!,
+                (double[])(object)slotKeys.GetDataArray()!,
+                (double[])(object)dQ.GetDataArray()!, (double[])(object)dK.GetDataArray()!,
+                (double[])(object)dV.GetDataArray()!, (double[])(object)dFG.GetDataArray()!,
+                (double[])(object)dSK.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim, numSlots, initScale);
+        }
+        else
+        {
+            AbcBackwardGeneric<T>(
+                gradOutput.GetDataArray()!,
+                qProj.GetDataArray()!, kProj.GetDataArray()!, vProj.GetDataArray()!,
+                forgetGate.GetDataArray()!, slotKeys.GetDataArray()!,
+                dQ.GetDataArray()!, dK.GetDataArray()!, dV.GetDataArray()!,
+                dFG.GetDataArray()!, dSK.GetDataArray()!,
+                batch, seqLen, modelDim, numHeads, headDim, numSlots, initScale);
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, qProj, dQ, engine);
+        DifferentiableOps.AccumulateGrad(grads, kProj, dK, engine);
+        DifferentiableOps.AccumulateGrad(grads, vProj, dV, engine);
+        DifferentiableOps.AccumulateGrad(grads, forgetGate, dFG, engine);
+        DifferentiableOps.AccumulateGrad(grads, slotKeys, dSK, engine);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
@@ -67,6 +67,10 @@ public partial class CpuEngine
         if (slotKeys.Rank != 3 || slotKeys.Shape[0] != numHeads || slotKeys.Shape[2] != headDim)
             throw new ArgumentException($"slotKeys must be [numHeads={numHeads}, numSlots, headDim={headDim}].", nameof(slotKeys));
         int numSlots = slotKeys.Shape[1];
+        if (numSlots < 1)
+            throw new ArgumentException(
+                $"slotKeys must be [numHeads={numHeads}, numSlots >= 1, headDim={headDim}]; got numSlots={numSlots}.",
+                nameof(slotKeys));
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10089,7 +10089,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             Gpu.GpuPrecisionDiagnostics.Publish(abcPlan);
             return result;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
         {
             throw new InvalidOperationException(
                 $"AbcScanForward failed on the selected {abcBackend.DeviceType} backend; CPU fallback is disabled for this GPU route.",
@@ -18363,7 +18363,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         DeviceDispatch.EnforceStrict(a, b); // no-op unless strict mode is enabled
         if (!ShapesMatch(a.Shape._dims, b.Shape._dims))
+        {
+            if (ThrowOnGpuKernelFallback)
+                throw new ArgumentException("TensorAdd operands must have identical shapes in strict GPU mode.");
             return base.TensorAdd(a, b);
+        }
         if (TryBinaryResidentOutOfPlace(a, b, static (be, ia, ib, o, n) => be.Add(ia, ib, o, n)) is { } radd)
         {
             Autodiff.DifferentiableOps.RecordBinary("TensorAdd", radd, a, b, Autodiff.BackwardFunctions<T>.AddBackward);
@@ -18405,7 +18409,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 return output;
             }
         }
-        catch { }
+        catch
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+        }
+        if (ThrowOnGpuKernelFallback)
+            throw new NotSupportedException("TensorAdd has no eligible GPU route for the selected inputs and precision policy.");
         return base.TensorAdd(a, b);
     }
 
@@ -18436,7 +18445,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         DeviceDispatch.EnforceStrict(a, b); // no-op unless strict mode is enabled
         if (!ShapesMatch(a.Shape._dims, b.Shape._dims))
+        {
+            if (ThrowOnGpuKernelFallback)
+                throw new ArgumentException("TensorMultiply operands must have identical shapes in strict GPU mode.");
             return base.TensorMultiply(a, b);
+        }
         if (TryBinaryResidentOutOfPlace(a, b, static (be, ia, ib, o, n) => be.Multiply(ia, ib, o, n)) is { } rmul)
         {
             Autodiff.DifferentiableOps.RecordBinary("TensorMultiply", rmul, a, b, Autodiff.BackwardFunctions<T>.MultiplyBackward);
@@ -18452,7 +18465,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 return output;
             }
         }
-        catch { }
+        catch
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+        }
+        if (ThrowOnGpuKernelFallback)
+            throw new NotSupportedException("TensorMultiply has no eligible GPU route for the selected inputs and precision policy.");
         return base.TensorMultiply(a, b);
     }
 
@@ -19223,7 +19241,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 }
             }
         }
-        catch { }
+        catch
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+        }
+        if (ThrowOnGpuKernelFallback)
+            throw new NotSupportedException("TensorMultiplyScalar has no eligible GPU route for the selected input and precision policy.");
         return base.TensorMultiplyScalar(tensor, scalar);
     }
 
@@ -20677,7 +20700,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> Softmax<T>(Tensor<T> input, int axis)
     {
         if (!TryGetBackend(out var backend))
+        {
+            if (ThrowOnGpuKernelFallback)
+                throw new NotSupportedException("Softmax requires an available GPU backend in strict GPU mode.");
             return base.Softmax(input, axis);
+        }
 
         // The GPU softmax kernel here only handles softmax over the LAST
         // axis correctly — it reshapes the tensor as (outerSize, features)
@@ -20688,7 +20715,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         int rank = input.Rank;
         int ea = axis < 0 ? rank + axis : axis;
         if (ea != rank - 1)
+        {
+            if (ThrowOnGpuKernelFallback)
+                throw new NotSupportedException("The direct GPU softmax route supports only the last axis.");
             return base.Softmax(input, axis);
+        }
 
         try
         {
@@ -20750,8 +20781,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 Autodiff.BackwardFunctions<T>.SoftmaxBackward, new object[] { axis });
             return output;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.Softmax(input, axis);
         }
     }
@@ -23133,7 +23165,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 handedOff = true;
                 return result;
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException)
+            catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
             {
                 System.Diagnostics.Trace.TraceWarning($"GPU pixel shuffle fallback: {ex.GetType().Name}: {ex.Message}");
             }
@@ -23421,8 +23453,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // GPU concat failed — fall back to the CPU base. Surface the reason at Trace level
                 // (don't swallow silently); never mask OOM, which must propagate. (#652 review)
                 System.Diagnostics.Trace.TraceWarning($"GPU TensorConcatenate fallback to CPU: {ex.GetType().Name}: {ex.Message}");
+                if (ThrowOnGpuKernelFallback) throw;
             }
         }
+        if (ThrowOnGpuKernelFallback)
+            throw new NotSupportedException("TensorConcatenate has no eligible GPU route for the selected inputs.");
         return base.TensorConcatenate(tensors, axis);
     }
 
@@ -23928,6 +23963,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (IsTapeActive<T>()) return base.TensorSliceAxis(tensor, axis, index);
         int normalizedAxis = axis < 0 ? tensor.Rank + axis : axis;
         if (TryDeviceSliceAxis(tensor, normalizedAxis, index) is { } resident) return resident;
+        if (ThrowOnGpuKernelFallback)
+            throw new NotSupportedException("TensorSliceAxis has no eligible GPU route for the selected input.");
         return base.TensorSliceAxis(tensor, axis, index);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -9951,6 +9951,124 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    /// <summary>
+    /// Fused ABC slot recurrence (#1464). GPU inference fast path; tape-active / non-float /
+    /// no-backend defer to the differentiable CpuEngine path, which owns the single fused tape node.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the other scans in this file there is no dedicated ABC device kernel yet. The work is
+    /// instead COMPOSED from GPU-resident primitives, so it genuinely executes on-device: the write
+    /// scores for the entire sequence are one batched GEMM plus one softmax (they do not depend on
+    /// the recurrent state at all), and only the state update and the read remain per-step. That
+    /// composition is the reason a dedicated kernel is not required for residency — see the note in
+    /// BackendCompletenessTests. A fused device kernel is still the faster end state, and would slot
+    /// in here behind the same guards.
+    /// </remarks>
+    public override Tensor<T> AbcScanForward<T>(
+        Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
+        Tensor<T> slotKeys, int numHeads, double slotInitScale = 0.1)
+    {
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out _))
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        if (qProj.Rank != 3 || kProj.Rank != 3 || vProj.Rank != 3 || numHeads < 1)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+
+        int batch = qProj.Shape._dims[0];
+        int seqLen = qProj.Shape._dims[1];
+        int modelDim = qProj.Shape._dims[2];
+        if (kProj.Shape._dims[0] != batch || kProj.Shape._dims[1] != seqLen || kProj.Shape._dims[2] != modelDim ||
+            vProj.Shape._dims[0] != batch || vProj.Shape._dims[1] != seqLen || vProj.Shape._dims[2] != modelDim)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        if (modelDim % numHeads != 0)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        int headDim = modelDim / numHeads;
+        if (forgetGate.Rank != 3 || forgetGate.Shape._dims[0] != batch ||
+            forgetGate.Shape._dims[1] != seqLen || forgetGate.Shape._dims[2] != numHeads)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        if (slotKeys.Rank != 3 || slotKeys.Shape._dims[0] != numHeads || slotKeys.Shape._dims[2] != headDim)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        int numSlots = slotKeys.Shape._dims[1];
+
+        try
+        {
+            return AbcScanComposed(this, qProj, kProj, vProj, forgetGate, slotKeys,
+                batch, seqLen, modelDim, numHeads, headDim, numSlots, slotInitScale);
+        }
+        catch
+        {
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        }
+    }
+
+    /// <summary>
+    /// The ABC recurrence expressed purely as IEngine primitive calls. Engine-agnostic on purpose:
+    /// run through <c>this</c> it executes on the GPU, and run through a <see cref="CpuEngine"/> it
+    /// is the very same op sequence, so the shape algebra and the math can be verified against the
+    /// fused kernel WITHOUT a device present. Only the dispatch target differs on real hardware.
+    /// </summary>
+    internal static Tensor<T> AbcScanComposed<T>(
+        IEngine e, Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
+        Tensor<T> slotKeys, int batch, int seqLen, int modelDim, int numHeads, int headDim,
+        int numSlots, double slotInitScale)
+    {
+        int hb = numHeads * batch;
+        var ops = MathHelper.GetNumericOperations<T>();
+        var scale = ops.FromDouble(1.0 / Math.Sqrt(headDim));
+
+        // [B,S,M] -> [H,B,S,D]: the head axis leads so every later reshape to [H*B, ...] is a
+        // no-op view over contiguous per-(head,batch) blocks.
+        Tensor<T> ToHeadMajor(Tensor<T> x) =>
+            e.TensorPermute(e.Reshape(x, new[] { batch, seqLen, numHeads, headDim }), new[] { 2, 0, 1, 3 });
+
+        var qh = ToHeadMajor(qProj);
+        var vh = ToHeadMajor(vProj);
+        var kh = ToHeadMajor(kProj);
+        var fgh = e.TensorPermute(forgetGate, new[] { 2, 0, 1 });   // [H,B,S]
+
+        // Write scores for the WHOLE sequence at once: they depend only on k and the slot keys,
+        // never on the recurrent state. [H, B*S, D] x [H, D, N] -> [H, B*S, N].
+        var wAll = e.Softmax(
+            e.TensorMultiplyScalar(
+                e.BatchMatMul(
+                    e.Reshape(kh, new[] { numHeads, batch * seqLen, headDim }),
+                    e.TensorPermute(slotKeys, new[] { 0, 2, 1 })),
+                scale),
+            axis: 2);
+        wAll = e.Reshape(wAll, new[] { numHeads, batch, seqLen, numSlots });
+
+        // slot_-1 = slotInitScale * slotKeys, one copy per batch element: [H,N,D] -> [H*B,N,D].
+        var slot = e.Reshape(
+            e.TensorTile(
+                e.Reshape(e.TensorMultiplyScalar(slotKeys, ops.FromDouble(slotInitScale)),
+                    new[] { numHeads, 1, numSlots, headDim }),
+                new[] { 1, batch, 1, 1 }),
+            new[] { hb, numSlots, headDim });
+
+        var steps = new Tensor<T>[seqLen];
+        for (int t = 0; t < seqLen; t++)
+        {
+            var wT = e.Reshape(e.TensorSliceAxis(wAll, 2, t), new[] { hb, numSlots, 1 });   // [H,B,N]
+            var vT = e.Reshape(e.TensorSliceAxis(vh, 2, t), new[] { hb, 1, headDim });      // [H,B,D]
+            var qT = e.Reshape(e.TensorSliceAxis(qh, 2, t), new[] { hb, 1, headDim });
+            // fg is scalar per (head,batch); tile it to the state shape rather than relying on
+            // broadcast semantics, which IEngine does not promise for TensorMultiply.
+            var fgT = e.TensorTile(e.Reshape(e.TensorSliceAxis(fgh, 2, t), new[] { hb, 1, 1 }),
+                new[] { 1, numSlots, headDim });
+
+            // slot_t = fg_t * slot_{t-1} + outer(w_t, v_t)
+            slot = e.TensorAdd(e.TensorMultiply(slot, fgT), e.BatchMatMul(wT, vT));
+
+            // Read: softmax over slots of q_t . slot_t, then the weighted slot read.
+            var r = e.Softmax(
+                e.TensorMultiplyScalar(e.BatchMatMul(qT, e.TensorPermute(slot, new[] { 0, 2, 1 })), scale),
+                axis: 2);                                                                   // [H*B,1,N]
+            steps[t] = e.Reshape(e.BatchMatMul(r, slot), new[] { numHeads, batch, 1, headDim });
+        }
+
+        var stacked = seqLen == 1 ? steps[0] : e.TensorConcatenate(steps, axis: 2);          // [H,B,S,D]
+        return e.Reshape(e.TensorPermute(stacked, new[] { 1, 2, 0, 3 }), new[] { batch, seqLen, modelDim });
+    }
+
     // Fused xLSTM scan (#1464). GPU inference fast path; tape-active / non-float / no-backend /
     // headDim over the kernel cap defer to the differentiable CpuEngine path.
     public override Tensor<T> XLstmScanForward<T>(

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -9968,8 +9968,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
         Tensor<T> slotKeys, int numHeads, double slotInitScale = 0.1)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out _))
+        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var abcBackend))
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        if (abcBackend is Engines.DirectGpu.CUDA.CudaBackend abcCuda && abcCuda.IsStreamCapturing())
+            throw new NotSupportedException(
+                "AbcScanForward's composed GPU path allocates per recurrence step and cannot run during CUDA stream capture.");
         if (qProj.Rank != 3 || kProj.Rank != 3 || vProj.Rank != 3 || numHeads < 1)
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
 
@@ -9988,15 +9991,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (slotKeys.Rank != 3 || slotKeys.Shape._dims[0] != numHeads || slotKeys.Shape._dims[2] != headDim)
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
         int numSlots = slotKeys.Shape._dims[1];
+        if (numSlots < 1)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        if (batch == 0 || seqLen == 0 || modelDim == 0)
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
 
+        bool previousThrowOnFallback = ThrowOnGpuKernelFallback;
         try
         {
+            // Once a usable GPU backend and supported shape have selected this route, every
+            // primitive must remain on-device. A hidden primitive fallback would make the public
+            // operation look correct while defeating both residency and its performance contract.
+            ThrowOnGpuKernelFallback = true;
             return AbcScanComposed(this, qProj, kProj, vProj, forgetGate, slotKeys,
                 batch, seqLen, modelDim, numHeads, headDim, numSlots, slotInitScale);
         }
-        catch
+        catch (Exception ex)
         {
-            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+            throw new InvalidOperationException(
+                $"AbcScanForward failed on the selected {abcBackend.DeviceType} backend; CPU fallback is disabled for this GPU route.",
+                ex);
+        }
+        finally
+        {
+            ThrowOnGpuKernelFallback = previousThrowOnFallback;
         }
     }
 
@@ -10015,58 +10033,136 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var ops = MathHelper.GetNumericOperations<T>();
         var scale = ops.FromDouble(1.0 / Math.Sqrt(headDim));
 
+        // TensorPermute intentionally has view semantics. That is ideal on the CPU, but a view of
+        // an authoritative GPU tensor is strided while the direct backend primitives consume flat,
+        // contiguous buffers. Materialize those permutations device-to-device for this composition;
+        // otherwise GetOrAllocateBuffer must download the resident parent merely to pack the view.
+        Tensor<T> PermuteForCompute(Tensor<T> input, int[] axes) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.PermuteContiguousGpu(input, axes)
+                : e.TensorPermute(input, axes);
+
         // [B,S,M] -> [H,B,S,D]: the head axis leads so every later reshape to [H*B, ...] is a
         // no-op view over contiguous per-(head,batch) blocks.
-        Tensor<T> ToHeadMajor(Tensor<T> x) =>
-            e.TensorPermute(e.Reshape(x, new[] { batch, seqLen, numHeads, headDim }), new[] { 2, 0, 1, 3 });
+        Tensor<T> ToHeadMajor(Tensor<T> x)
+        {
+            using var reshaped = e.Reshape(x, new[] { batch, seqLen, numHeads, headDim });
+            return PermuteForCompute(reshaped, new[] { 2, 0, 1, 3 });
+        }
 
-        var qh = ToHeadMajor(qProj);
-        var vh = ToHeadMajor(vProj);
-        var kh = ToHeadMajor(kProj);
-        var fgh = e.TensorPermute(forgetGate, new[] { 2, 0, 1 });   // [H,B,S]
+        using var qh = ToHeadMajor(qProj);
+        using var vh = ToHeadMajor(vProj);
+        using var kh = ToHeadMajor(kProj);
+        using var fgh = PermuteForCompute(forgetGate, new[] { 2, 0, 1 });   // [H,B,S]
 
         // Write scores for the WHOLE sequence at once: they depend only on k and the slot keys,
         // never on the recurrent state. [H, B*S, D] x [H, D, N] -> [H, B*S, N].
-        var wAll = e.Softmax(
-            e.TensorMultiplyScalar(
-                e.BatchMatMul(
-                    e.Reshape(kh, new[] { numHeads, batch * seqLen, headDim }),
-                    e.TensorPermute(slotKeys, new[] { 0, 2, 1 })),
-                scale),
-            axis: 2);
-        wAll = e.Reshape(wAll, new[] { numHeads, batch, seqLen, numSlots });
+        Tensor<T> BuildWriteScores()
+        {
+            using var keyMatrix = e.Reshape(kh, new[] { numHeads, batch * seqLen, headDim });
+            using var slotKeyMatrix = PermuteForCompute(slotKeys, new[] { 0, 2, 1 });
+            using var scores = e.BatchMatMul(keyMatrix, slotKeyMatrix);
+            using var scaledScores = e.TensorMultiplyScalar(scores, scale);
+            using var probabilities = e.Softmax(scaledScores, axis: 2);
+            return e.Reshape(probabilities, new[] { numHeads, batch, seqLen, numSlots });
+        }
+        using var wAll = BuildWriteScores();
 
         // slot_-1 = slotInitScale * slotKeys, one copy per batch element: [H,N,D] -> [H*B,N,D].
-        var slot = e.Reshape(
-            e.TensorTile(
-                e.Reshape(e.TensorMultiplyScalar(slotKeys, ops.FromDouble(slotInitScale)),
-                    new[] { numHeads, 1, numSlots, headDim }),
-                new[] { 1, batch, 1, 1 }),
-            new[] { hb, numSlots, headDim });
-
-        var steps = new Tensor<T>[seqLen];
-        for (int t = 0; t < seqLen; t++)
+        Tensor<T> BuildInitialSlot()
         {
-            var wT = e.Reshape(e.TensorSliceAxis(wAll, 2, t), new[] { hb, numSlots, 1 });   // [H,B,N]
-            var vT = e.Reshape(e.TensorSliceAxis(vh, 2, t), new[] { hb, 1, headDim });      // [H,B,D]
-            var qT = e.Reshape(e.TensorSliceAxis(qh, 2, t), new[] { hb, 1, headDim });
-            // fg is scalar per (head,batch); tile it to the state shape rather than relying on
-            // broadcast semantics, which IEngine does not promise for TensorMultiply.
-            var fgT = e.TensorTile(e.Reshape(e.TensorSliceAxis(fgh, 2, t), new[] { hb, 1, 1 }),
-                new[] { 1, numSlots, headDim });
-
-            // slot_t = fg_t * slot_{t-1} + outer(w_t, v_t)
-            slot = e.TensorAdd(e.TensorMultiply(slot, fgT), e.BatchMatMul(wT, vT));
-
-            // Read: softmax over slots of q_t . slot_t, then the weighted slot read.
-            var r = e.Softmax(
-                e.TensorMultiplyScalar(e.BatchMatMul(qT, e.TensorPermute(slot, new[] { 0, 2, 1 })), scale),
-                axis: 2);                                                                   // [H*B,1,N]
-            steps[t] = e.Reshape(e.BatchMatMul(r, slot), new[] { numHeads, batch, 1, headDim });
+            using var scaledKeys = e.TensorMultiplyScalar(slotKeys, ops.FromDouble(slotInitScale));
+            using var withBatchAxis = e.Reshape(scaledKeys, new[] { numHeads, 1, numSlots, headDim });
+            using var tiled = e.TensorTile(withBatchAxis, new[] { 1, batch, 1, 1 });
+            return e.Reshape(tiled, new[] { hb, numSlots, headDim });
         }
 
-        var stacked = seqLen == 1 ? steps[0] : e.TensorConcatenate(steps, axis: 2);          // [H,B,S,D]
-        return e.Reshape(e.TensorPermute(stacked, new[] { 1, 2, 0, 3 }), new[] { batch, seqLen, modelDim });
+        Tensor<T>? slot = BuildInitialSlot();
+        var steps = new Tensor<T>[seqLen];
+        try
+        {
+            for (int t = 0; t < seqLen; t++)
+            {
+                using var wSlice = e.TensorSliceAxis(wAll, 2, t);
+                using var wT = e.Reshape(wSlice, new[] { hb, numSlots, 1 });                  // [H,B,N]
+                using var vSlice = e.TensorSliceAxis(vh, 2, t);
+                using var vT = e.Reshape(vSlice, new[] { hb, 1, headDim });                   // [H,B,D]
+                using var qSlice = e.TensorSliceAxis(qh, 2, t);
+                using var qT = e.Reshape(qSlice, new[] { hb, 1, headDim });
+                using var fgSlice = e.TensorSliceAxis(fgh, 2, t);
+                using var fgScalar = e.Reshape(fgSlice, new[] { hb, 1, 1 });
+                // fg is scalar per (head,batch). Tile one axis at a time so every step uses the
+                // direct device copy route; IEngine does not promise broadcast semantics for
+                // TensorMultiply, and the generic multi-axis tile is a CPU implementation.
+                using var fgRow = e.TensorTile(fgScalar, new[] { 1, 1, headDim });
+                using var fgT = e.TensorTile(fgRow, new[] { 1, numSlots, 1 });
+
+                // slot_t = fg_t * slot_{t-1} + outer(w_t, v_t)
+                using var retained = e.TensorMultiply(slot!, fgT);
+                using var written = e.BatchMatMul(wT, vT);
+                var nextSlot = e.TensorAdd(retained, written);
+                slot!.Dispose();
+                slot = nextSlot;
+
+                // Read: softmax over slots of q_t . slot_t, then the weighted slot read.
+                using var slotTranspose = PermuteForCompute(slot, new[] { 0, 2, 1 });
+                using var readScores = e.BatchMatMul(qT, slotTranspose);
+                using var scaledReadScores = e.TensorMultiplyScalar(readScores, scale);
+                using var readWeights = e.Softmax(scaledReadScores, axis: 2);                 // [H*B,1,N]
+                using var read = e.BatchMatMul(readWeights, slot);
+                steps[t] = e.Reshape(read, new[] { numHeads, batch, 1, headDim });
+            }
+
+            Tensor<T> stacked = seqLen == 1
+                ? steps[0]
+                : e.TensorConcatenate(steps, axis: 2);                                        // [H,B,S,D]
+            try
+            {
+                using var batchMajor = PermuteForCompute(stacked, new[] { 1, 2, 0, 3 });
+                return e.Reshape(batchMajor, new[] { batch, seqLen, modelDim });
+            }
+            finally
+            {
+                stacked.Dispose();
+            }
+        }
+        finally
+        {
+            slot?.Dispose();
+            for (int t = 0; t < steps.Length; t++)
+                steps[t]?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Materializes a permutation into a contiguous, authoritative GPU buffer without the eager
+    /// <see cref="TensorPermuteInto{T}(Tensor{T}, Tensor{T}, int[])"/> host download. This is an
+    /// internal compute-layout primitive, not the public metadata-view contract of TensorPermute.
+    /// </summary>
+    private Tensor<T> PermuteContiguousGpu<T>(Tensor<T> tensor, int[] axes)
+    {
+        if (!TryGetBackend(out var backend))
+            throw new InvalidOperationException("A GPU backend is required to materialize an ABC compute permutation.");
+        if (axes.Length != tensor.Rank)
+            throw new ArgumentException("Axes length must match tensor rank.", nameof(axes));
+
+        var outputShape = new int[axes.Length];
+        Span<bool> seen = axes.Length <= 32 ? stackalloc bool[axes.Length] : new bool[axes.Length];
+        for (int i = 0; i < axes.Length; i++)
+        {
+            int axis = axes[i];
+            if ((uint)axis >= (uint)axes.Length || seen[axis])
+                throw new ArgumentException("Axes must be a permutation of the tensor dimensions.", nameof(axes));
+            seen[axis] = true;
+            outputShape[i] = tensor.Shape._dims[axis];
+        }
+
+        using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
+        using var outputBuffer = AllocateOutputBuffer(backend, tensor.Length);
+        backend.Permute(inputBuffer.Buffer, outputBuffer.Buffer, tensor.Shape._dims, axes);
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, tensor.Length, outputShape);
+        outputBuffer.RelinquishOwnership();
+        return result;
     }
 
     // Fused xLSTM scan (#1464). GPU inference fast path; tape-active / non-float / no-backend /
@@ -19412,6 +19508,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
         catch (Exception)
         {
+            if (ThrowOnGpuKernelFallback) throw;
             return base.BatchMatMul(a, b);
         }
     }
@@ -22974,6 +23071,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             System.Diagnostics.Trace.TraceWarning($"GPU axis slice fallback: {ex.GetType().Name}: {ex.Message}");
+            if (ThrowOnGpuKernelFallback) throw;
             return null;
         }
         finally
@@ -23258,11 +23356,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         bool handedOff = false;
         try
         {
-            var input = UploadTensorRaw(backend, tensor);
+            // Preserve an authoritative resident input. UploadTensorRaw materializes the tensor's
+            // host array first, which turns a tile inside a composed GPU recurrence into a hidden
+            // device-to-host-to-device round trip.
+            using var input = GetOrAllocateBuffer(backend, tensor);
             output = backend.AllocateBuffer(total);
             for (int o = 0; o < outer; o++)
                 for (int r = 0; r < repeats; r++)
-                    backend.Copy(input, o * block, output, (o * repeats + r) * block, block);
+                    backend.Copy(input.Buffer, o * block, output, (o * repeats + r) * block, block);
 
             var outShape = (int[])tensor.Shape._dims.Clone();
             outShape[tiledAxis] = checked(outShape[tiledAxis] * repeats);
@@ -23273,6 +23374,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             System.Diagnostics.Trace.TraceWarning($"GPU tile fallback: {ex.GetType().Name}: {ex.Message}");
+            if (ThrowOnGpuKernelFallback) throw;
             return null;
         }
         finally
@@ -23313,6 +23415,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
         }
         if (TryTileSingleAxisOnDevice(tensor, multiples) is { } resident) return resident;
+        if (ThrowOnGpuKernelFallback)
+            throw new InvalidOperationException(
+                $"TensorTile has no resident GPU route for shape [{string.Join(",", tensor.Shape._dims)}], " +
+                $"multiples [{string.Join(",", multiples)}], contiguous={tensor.IsContiguous}.");
         return base.TensorTile(tensor,multiples);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -10023,8 +10023,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     }
 
     /// <summary>
-    /// Fused ABC slot recurrence (#1464). GPU inference fast path; tape-active / non-float /
-    /// no-backend defer to the differentiable CpuEngine path, which owns the single fused tape node.
+    /// Fused ABC slot recurrence (#1464). Tape-active and no-backend calls defer to the
+    /// differentiable CpuEngine path, which owns the single fused tape node. Inference follows the
+    /// shared GPU precision policy: speed-first generic tensors convert through the selected device
+    /// format, while preserve-input-type uses the CPU when no exact device route exists.
     /// </summary>
     /// <remarks>
     /// Unlike the other scans in this file there is no dedicated ABC device kernel yet. The work is
@@ -10039,11 +10041,19 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
         Tensor<T> slotKeys, int numHeads, double slotInitScale = 0.1)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var abcBackend))
+        if (IsTapeActive<T>() || !TryGetBackend(out var abcBackend))
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
         if (abcBackend is Engines.DirectGpu.CUDA.CudaBackend abcCuda && abcCuda.IsStreamCapturing())
             throw new NotSupportedException(
                 "AbcScanForward's composed GPU path allocates per recurrence step and cannot run during CUDA stream capture.");
+
+        var abcPlan = Gpu.GpuPrecisionPlanner.CreatePlan<T>(
+            abcBackend, Gpu.GpuPrecisionOperation.General, "AbcScanForward");
+        if (abcPlan.Route == Gpu.GpuExecutionRoute.Cpu)
+        {
+            Gpu.GpuPrecisionDiagnostics.Publish(abcPlan);
+            return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
+        }
         if (qProj.Rank != 3 || kProj.Rank != 3 || vProj.Rank != 3 || numHeads < 1)
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
 
@@ -10074,8 +10084,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // primitive must remain on-device. A hidden primitive fallback would make the public
             // operation look correct while defeating both residency and its performance contract.
             ThrowOnGpuKernelFallback = true;
-            return AbcScanComposed(this, qProj, kProj, vProj, forgetGate, slotKeys,
+            var result = AbcScanComposed(this, qProj, kProj, vProj, forgetGate, slotKeys,
                 batch, seqLen, modelDim, numHeads, headDim, numSlots, slotInitScale);
+            Gpu.GpuPrecisionDiagnostics.Publish(abcPlan);
+            return result;
         }
         catch (Exception ex)
         {
@@ -10112,6 +10124,32 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             e is DirectGpuTensorEngine gpu
                 ? gpu.PermuteContiguousGpu(input, axes)
                 : e.TensorPermute(input, axes);
+        Tensor<T> SliceAxisForCompute(Tensor<T> input, int axis, int index) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.SliceAxisContiguousGpu(input, axis, index)
+                : e.TensorSliceAxis(input, axis, index);
+        Tensor<T> TileForCompute(Tensor<T> input, int[] multiples) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.TileSingleAxisContiguousGpu(input, multiples)
+                : e.TensorTile(input, multiples);
+        Tensor<T> ScaleForCompute(Tensor<T> input, T scalar) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.ScaleContiguousGpu(input, scalar)
+                : e.TensorMultiplyScalar(input, scalar);
+        Tensor<T> MultiplyForCompute(Tensor<T> left, Tensor<T> right) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.BinaryContiguousGpu(left, right, static (backend, a, b, output, length) =>
+                    backend.Multiply(a, b, output, length))
+                : e.TensorMultiply(left, right);
+        Tensor<T> AddForCompute(Tensor<T> left, Tensor<T> right) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.BinaryContiguousGpu(left, right, static (backend, a, b, output, length) =>
+                    backend.Add(a, b, output, length))
+                : e.TensorAdd(left, right);
+        Tensor<T> ConcatenateForCompute(Tensor<T>[] tensors, int axis) =>
+            e is DirectGpuTensorEngine gpu
+                ? gpu.ConcatenateContiguousGpu(tensors, axis)
+                : e.TensorConcatenate(tensors, axis);
 
         // [B,S,M] -> [H,B,S,D]: the head axis leads so every later reshape to [H*B, ...] is a
         // no-op view over contiguous per-(head,batch) blocks.
@@ -10133,7 +10171,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             using var keyMatrix = e.Reshape(kh, new[] { numHeads, batch * seqLen, headDim });
             using var slotKeyMatrix = PermuteForCompute(slotKeys, new[] { 0, 2, 1 });
             using var scores = e.BatchMatMul(keyMatrix, slotKeyMatrix);
-            using var scaledScores = e.TensorMultiplyScalar(scores, scale);
+            using var scaledScores = ScaleForCompute(scores, scale);
             using var probabilities = e.Softmax(scaledScores, axis: 2);
             return e.Reshape(probabilities, new[] { numHeads, batch, seqLen, numSlots });
         }
@@ -10142,9 +10180,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // slot_-1 = slotInitScale * slotKeys, one copy per batch element: [H,N,D] -> [H*B,N,D].
         Tensor<T> BuildInitialSlot()
         {
-            using var scaledKeys = e.TensorMultiplyScalar(slotKeys, ops.FromDouble(slotInitScale));
+            using var scaledKeys = ScaleForCompute(slotKeys, ops.FromDouble(slotInitScale));
             using var withBatchAxis = e.Reshape(scaledKeys, new[] { numHeads, 1, numSlots, headDim });
-            using var tiled = e.TensorTile(withBatchAxis, new[] { 1, batch, 1, 1 });
+            using var tiled = TileForCompute(withBatchAxis, new[] { 1, batch, 1, 1 });
             return e.Reshape(tiled, new[] { hb, numSlots, headDim });
         }
 
@@ -10154,31 +10192,31 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             for (int t = 0; t < seqLen; t++)
             {
-                using var wSlice = e.TensorSliceAxis(wAll, 2, t);
+                using var wSlice = SliceAxisForCompute(wAll, 2, t);
                 using var wT = e.Reshape(wSlice, new[] { hb, numSlots, 1 });                  // [H,B,N]
-                using var vSlice = e.TensorSliceAxis(vh, 2, t);
+                using var vSlice = SliceAxisForCompute(vh, 2, t);
                 using var vT = e.Reshape(vSlice, new[] { hb, 1, headDim });                   // [H,B,D]
-                using var qSlice = e.TensorSliceAxis(qh, 2, t);
+                using var qSlice = SliceAxisForCompute(qh, 2, t);
                 using var qT = e.Reshape(qSlice, new[] { hb, 1, headDim });
-                using var fgSlice = e.TensorSliceAxis(fgh, 2, t);
+                using var fgSlice = SliceAxisForCompute(fgh, 2, t);
                 using var fgScalar = e.Reshape(fgSlice, new[] { hb, 1, 1 });
                 // fg is scalar per (head,batch). Tile one axis at a time so every step uses the
                 // direct device copy route; IEngine does not promise broadcast semantics for
                 // TensorMultiply, and the generic multi-axis tile is a CPU implementation.
-                using var fgRow = e.TensorTile(fgScalar, new[] { 1, 1, headDim });
-                using var fgT = e.TensorTile(fgRow, new[] { 1, numSlots, 1 });
+                using var fgRow = TileForCompute(fgScalar, new[] { 1, 1, headDim });
+                using var fgT = TileForCompute(fgRow, new[] { 1, numSlots, 1 });
 
                 // slot_t = fg_t * slot_{t-1} + outer(w_t, v_t)
-                using var retained = e.TensorMultiply(slot!, fgT);
+                using var retained = MultiplyForCompute(slot!, fgT);
                 using var written = e.BatchMatMul(wT, vT);
-                var nextSlot = e.TensorAdd(retained, written);
+                var nextSlot = AddForCompute(retained, written);
                 slot!.Dispose();
                 slot = nextSlot;
 
                 // Read: softmax over slots of q_t . slot_t, then the weighted slot read.
                 using var slotTranspose = PermuteForCompute(slot, new[] { 0, 2, 1 });
                 using var readScores = e.BatchMatMul(qT, slotTranspose);
-                using var scaledReadScores = e.TensorMultiplyScalar(readScores, scale);
+                using var scaledReadScores = ScaleForCompute(readScores, scale);
                 using var readWeights = e.Softmax(scaledReadScores, axis: 2);                 // [H*B,1,N]
                 using var read = e.BatchMatMul(readWeights, slot);
                 steps[t] = e.Reshape(read, new[] { numHeads, batch, 1, headDim });
@@ -10186,7 +10224,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
             Tensor<T> stacked = seqLen == 1
                 ? steps[0]
-                : e.TensorConcatenate(steps, axis: 2);                                        // [H,B,S,D]
+                : ConcatenateForCompute(steps, axis: 2);                                      // [H,B,S,D]
             try
             {
                 using var batchMajor = PermuteForCompute(stacked, new[] { 1, 2, 0, 3 });
@@ -10232,6 +10270,150 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         using var outputBuffer = AllocateOutputBuffer(backend, tensor.Length);
         backend.Permute(inputBuffer.Buffer, outputBuffer.Buffer, tensor.Shape._dims, axes);
         var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, tensor.Length, outputShape);
+        outputBuffer.RelinquishOwnership();
+        return result;
+    }
+
+    private Tensor<T> SliceAxisContiguousGpu<T>(Tensor<T> tensor, int axis, int index)
+    {
+        if (!TryGetBackend(out var backend))
+            throw new InvalidOperationException("A GPU backend is required to slice an ABC compute tensor.");
+        int normalizedAxis = axis < 0 ? tensor.Rank + axis : axis;
+        if (!tensor.IsContiguous || normalizedAxis < 0 || normalizedAxis >= tensor.Rank ||
+            index < 0 || index >= tensor.Shape._dims[normalizedAxis])
+            throw new ArgumentException("ABC compute slices require a contiguous tensor and an in-range axis/index.");
+
+        int outer = 1;
+        for (int d = 0; d < normalizedAxis; d++) outer = checked(outer * tensor.Shape._dims[d]);
+        int inner = 1;
+        for (int d = normalizedAxis + 1; d < tensor.Rank; d++) inner = checked(inner * tensor.Shape._dims[d]);
+        int axisSize = tensor.Shape._dims[normalizedAxis];
+        int length = checked(outer * inner);
+        var outputShape = new int[tensor.Rank - 1];
+        for (int d = 0, od = 0; d < tensor.Rank; d++)
+            if (d != normalizedAxis) outputShape[od++] = tensor.Shape._dims[d];
+
+        using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
+        using var outputBuffer = AllocateOutputBuffer(backend, length);
+        for (int o = 0; o < outer; o++)
+            backend.Copy(inputBuffer.Buffer, (o * axisSize + index) * inner,
+                outputBuffer.Buffer, o * inner, inner);
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, length, outputShape);
+        outputBuffer.RelinquishOwnership();
+        return result;
+    }
+
+    private Tensor<T> TileSingleAxisContiguousGpu<T>(Tensor<T> tensor, int[] multiples)
+    {
+        if (!TryGetBackend(out var backend))
+            throw new InvalidOperationException("A GPU backend is required to tile an ABC compute tensor.");
+        if (!tensor.IsContiguous || multiples.Length != tensor.Rank)
+            throw new ArgumentException("ABC compute tiles require a contiguous tensor and one multiple per axis.");
+
+        int tiledAxis = -1;
+        for (int d = 0; d < multiples.Length; d++)
+        {
+            if (multiples[d] < 1)
+                throw new ArgumentOutOfRangeException(nameof(multiples), "Tile multiples must be positive.");
+            if (multiples[d] == 1) continue;
+            if (tiledAxis >= 0)
+                throw new NotSupportedException("ABC compute tiles expand one axis per device operation.");
+            tiledAxis = d;
+        }
+        if (tiledAxis < 0)
+            return tensor.Reshape(tensor.Shape.ToArray());
+
+        int outer = 1;
+        for (int d = 0; d < tiledAxis; d++) outer = checked(outer * tensor.Shape._dims[d]);
+        int block = 1;
+        for (int d = tiledAxis; d < tensor.Rank; d++) block = checked(block * tensor.Shape._dims[d]);
+        int repeats = multiples[tiledAxis];
+        int length = checked(tensor.Length * repeats);
+        var outputShape = tensor.Shape.ToArray();
+        outputShape[tiledAxis] = checked(outputShape[tiledAxis] * repeats);
+
+        using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
+        using var outputBuffer = AllocateOutputBuffer(backend, length);
+        for (int o = 0; o < outer; o++)
+            for (int r = 0; r < repeats; r++)
+                backend.Copy(inputBuffer.Buffer, o * block, outputBuffer.Buffer,
+                    (o * repeats + r) * block, block);
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, length, outputShape);
+        outputBuffer.RelinquishOwnership();
+        return result;
+    }
+
+    private Tensor<T> ScaleContiguousGpu<T>(Tensor<T> tensor, T scalar)
+    {
+        if (!TryGetBackend(out var backend))
+            throw new InvalidOperationException("A GPU backend is required to scale an ABC compute tensor.");
+        float scale = scalar is float value ? value : Convert.ToSingle(scalar);
+        using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
+        using var outputBuffer = AllocateOutputBuffer(backend, tensor.Length);
+        backend.Scale(inputBuffer.Buffer, outputBuffer.Buffer, scale, tensor.Length);
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, tensor.Length, tensor.Shape.ToArray());
+        outputBuffer.RelinquishOwnership();
+        return result;
+    }
+
+    private Tensor<T> BinaryContiguousGpu<T>(Tensor<T> left, Tensor<T> right,
+        Action<IDirectGpuBackend, IGpuBuffer, IGpuBuffer, IGpuBuffer, int> operation)
+    {
+        if (!TryGetBackend(out var backend))
+            throw new InvalidOperationException("A GPU backend is required for an ABC binary compute operation.");
+        if (!ShapesMatch(left.Shape._dims, right.Shape._dims))
+            throw new ArgumentException("ABC binary compute operands must have identical shapes.");
+
+        using var leftBuffer = GetOrAllocateBuffer(backend, left);
+        using var rightBuffer = GetOrAllocateBuffer(backend, right);
+        using var outputBuffer = AllocateOutputBuffer(backend, left.Length);
+        operation(backend, leftBuffer.Buffer, rightBuffer.Buffer, outputBuffer.Buffer, left.Length);
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, left.Length, left.Shape.ToArray());
+        outputBuffer.RelinquishOwnership();
+        return result;
+    }
+
+    private Tensor<T> ConcatenateContiguousGpu<T>(Tensor<T>[] tensors, int axis)
+    {
+        if (!TryGetBackend(out var backend) || tensors.Length == 0)
+            throw new InvalidOperationException("A GPU backend and at least one tensor are required for ABC concatenation.");
+        var first = tensors[0];
+        int normalizedAxis = axis < 0 ? first.Rank + axis : axis;
+        if (normalizedAxis < 0 || normalizedAxis >= first.Rank)
+            throw new ArgumentOutOfRangeException(nameof(axis));
+
+        int axisLength = 0;
+        foreach (var tensor in tensors)
+        {
+            if (!tensor.IsContiguous || tensor.Rank != first.Rank)
+                throw new ArgumentException("ABC concatenation requires equal-rank contiguous tensors.", nameof(tensors));
+            for (int d = 0; d < first.Rank; d++)
+                if (d != normalizedAxis && tensor.Shape._dims[d] != first.Shape._dims[d])
+                    throw new ArgumentException("ABC concatenation tensor shapes do not match.", nameof(tensors));
+            axisLength = checked(axisLength + tensor.Shape._dims[normalizedAxis]);
+        }
+
+        int outer = 1;
+        for (int d = 0; d < normalizedAxis; d++) outer = checked(outer * first.Shape._dims[d]);
+        int inner = 1;
+        for (int d = normalizedAxis + 1; d < first.Rank; d++) inner = checked(inner * first.Shape._dims[d]);
+        int length = checked(outer * axisLength * inner);
+        var outputShape = first.Shape.ToArray();
+        outputShape[normalizedAxis] = axisLength;
+
+        using var outputBuffer = AllocateOutputBuffer(backend, length);
+        int axisOffset = 0;
+        foreach (var tensor in tensors)
+        {
+            int tensorAxis = tensor.Shape._dims[normalizedAxis];
+            int sliceLength = tensorAxis * inner;
+            using var inputBuffer = GetOrAllocateBuffer(backend, tensor);
+            for (int o = 0; o < outer; o++)
+                backend.Copy(inputBuffer.Buffer, o * sliceLength, outputBuffer.Buffer,
+                    (o * axisLength + axisOffset) * inner, sliceLength);
+            axisOffset += tensorAxis;
+        }
+        var result = DeferTensorResult<T>(backend, outputBuffer.Buffer, length, outputShape);
         outputBuffer.RelinquishOwnership();
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4400,6 +4400,26 @@ public interface IEngine
         int numHeads);
 
     /// <summary>
+    /// Fused ABC (Attention with Bounded-memory Control) slot recurrence over a whole sequence as one
+    /// differentiable op (forward + analytic BPTT backward); see <c>CpuEngine.AbcScan.cs</c> (#1464).
+    /// </summary>
+    /// <param name="qProj">Query projection [batch, seqLen, modelDim].</param>
+    /// <param name="kProj">Key projection [batch, seqLen, modelDim].</param>
+    /// <param name="vProj">Value projection [batch, seqLen, modelDim].</param>
+    /// <param name="forgetGate">Post-sigmoid scalar-per-head forget gate [batch, seqLen, numHeads].</param>
+    /// <param name="slotKeys">Trainable slot keys [numHeads, numSlots, headDim].</param>
+    /// <param name="numHeads">Number of heads; modelDim must be divisible by it.</param>
+    /// <param name="slotInitScale">Scale applied to the slot keys to seed the initial slot state.</param>
+    Tensor<T> AbcScanForward<T>(
+        Tensor<T> qProj,
+        Tensor<T> kProj,
+        Tensor<T> vProj,
+        Tensor<T> forgetGate,
+        Tensor<T> slotKeys,
+        int numHeads,
+        double slotInitScale = 0.1);
+
+    /// <summary>
     /// Fused Gated DeltaNet (delta-rule) recurrence over a whole sequence as one differentiable op
     /// (forward + analytic BPTT backward); see <c>CpuEngine.GatedDeltaNetScan.cs</c> (#1464).
     /// </summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
@@ -1,6 +1,7 @@
 using System;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -34,6 +35,13 @@ public class AbcScanGpuParityTests
         var a = new float[n];
         for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.3 * s))));
         return a;
+    }
+
+    private static double[] ToDouble(float[] values)
+    {
+        var result = new double[values.Length];
+        for (int i = 0; i < values.Length; i++) result[i] = values[i];
+        return result;
     }
 
     /// <summary>
@@ -80,6 +88,19 @@ public class AbcScanGpuParityTests
                 new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape),
                 new Tensor<float>(GenGate(batch * seqLen * numHeads, 4), new[] { batch, seqLen, numHeads }),
                 new Tensor<float>(Gen(numHeads * numSlots * headDim, 5), new[] { numHeads, numSlots, headDim }));
+    }
+
+    private static (Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> fg, Tensor<double> sk)
+        MakeDoubleInputs(int batch, int seqLen, int modelDim, int numHeads, int numSlots, int headDim)
+    {
+        var shape = new[] { batch, seqLen, modelDim };
+        return (new Tensor<double>(ToDouble(Gen(batch * seqLen * modelDim, 1)), shape),
+                new Tensor<double>(ToDouble(Gen(batch * seqLen * modelDim, 2)), shape),
+                new Tensor<double>(ToDouble(Gen(batch * seqLen * modelDim, 3)), shape),
+                new Tensor<double>(ToDouble(GenGate(batch * seqLen * numHeads, 4)),
+                    new[] { batch, seqLen, numHeads }),
+                new Tensor<double>(ToDouble(Gen(numHeads * numSlots * headDim, 5)),
+                    new[] { numHeads, numSlots, headDim }));
     }
 
     [SkippableTheory]
@@ -134,5 +155,72 @@ public class AbcScanGpuParityTests
             GpuLaunchProbe.CaptureReadbackSites = savedCaptureReadbackSites;
             DirectGpuTensorEngine.ThrowOnGpuKernelFallback = savedThrowOnFallback;
         }
+    }
+
+    [SkippableFact]
+    public void SpeedFirstDouble_ConvertsThroughGpuWithoutChangingPublicType()
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        Skip.IfNot(gpu.IsGpuAvailable, "No DirectGpu backend available");
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Default);
+
+        const int batch = 2, seqLen = 3, modelDim = 8, numHeads = 2, numSlots = 3;
+        const int headDim = modelDim / numHeads;
+        var (q, k, v, fg, sk) = MakeDoubleInputs(batch, seqLen, modelDim, numHeads, numSlots, headDim);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
+        using var expectedTensor = new CpuEngine().AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var expected = (double[])(object)expectedTensor.GetDataArray()!;
+
+        bool savedCaptureReadbackSites = GpuLaunchProbe.CaptureReadbackSites;
+        try
+        {
+            GpuLaunchProbe.CaptureReadbackSites = true;
+            GpuLaunchProbe.Reset();
+            using var result = gpu.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+
+            Assert.True(GpuLaunchProbe.Count > 0, "Speed-first double ABC launched no GPU work.");
+            Assert.True(GpuLaunchProbe.Readbacks == 0,
+                $"Speed-first double ABC performed {GpuLaunchProbe.Readbacks} internal readbacks: " +
+                string.Join("; ", GpuLaunchProbe.ReadbackSites));
+            Assert.Empty(GpuLaunchProbe.Fallbacks);
+
+            var actual = (double[])(object)result.GetDataArray()!;
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.True(Math.Abs(expected[i] - actual[i]) < 2e-5,
+                    $"speed-first double[{i}] cpu={expected[i]} gpu-fp32={actual[i]}");
+        }
+        finally
+        {
+            GpuLaunchProbe.CaptureReadbackSites = savedCaptureReadbackSites;
+        }
+    }
+
+    [SkippableFact]
+    public void PreserveInputTypeDouble_UsesExactCpuRoute()
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        Skip.IfNot(gpu.IsGpuAvailable, "No DirectGpu backend available");
+        using var policy = new GpuExecutionPolicyScope(GpuExecutionPolicy.Preserve);
+
+        const int batch = 1, seqLen = 2, modelDim = 4, numHeads = 2, numSlots = 2;
+        const int headDim = modelDim / numHeads;
+        var (q, k, v, fg, sk) = MakeDoubleInputs(batch, seqLen, modelDim, numHeads, numSlots, headDim);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
+        using var expectedTensor = new CpuEngine().AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var expected = (double[])(object)expectedTensor.GetDataArray()!;
+
+        GpuLaunchProbe.Reset();
+        using var result = gpu.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        Assert.Equal(0, GpuLaunchProbe.Count);
+        Assert.Equal(expected, (double[])(object)result.GetDataArray()!);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -15,6 +16,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// silently changes behaviour between training and GPU inference.
 /// They SKIP when no backend is present rather than passing vacuously.
 /// </summary>
+[Collection("DirectGpuSerial")]
 public class AbcScanGpuParityTests
 {
     private const double InitScale = 0.1;
@@ -50,11 +52,17 @@ public class AbcScanGpuParityTests
         var cpu = new CpuEngine();
         int headDim = modelDim / numHeads;
         var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, headDim);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
 
-        var expected = (float[])(object)cpu.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
-        var composed = (float[])(object)DirectGpuTensorEngine.AbcScanComposed(
-            cpu, q, k, v, fg, sk, batch, seqLen, modelDim, numHeads, headDim, numSlots, InitScale)
-            .GetDataArray()!;
+        using var expectedTensor = cpu.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        using var composedTensor = DirectGpuTensorEngine.AbcScanComposed(
+            cpu, q, k, v, fg, sk, batch, seqLen, modelDim, numHeads, headDim, numSlots, InitScale);
+        var expected = (float[])(object)expectedTensor.GetDataArray()!;
+        var composed = (float[])(object)composedTensor.GetDataArray()!;
 
         Assert.Equal(expected.Length, composed.Length);
         for (int i = 0; i < expected.Length; i++)
@@ -80,25 +88,51 @@ public class AbcScanGpuParityTests
     [InlineData(2, 1, 8, 4, 2)]   // seqLen 1 takes the no-concat path
     public void GpuComposedPath_MatchesCpuEngine(int batch, int seqLen, int modelDim, int numHeads, int numSlots)
     {
-        var gpu = new DirectGpuTensorEngine();
-        Skip.IfNot(gpu.DirectGpu?.IsAvailable ?? false, "No DirectGpu backend available");
+        using var gpu = new DirectGpuTensorEngine();
+        Skip.IfNot(gpu.IsGpuAvailable, "No DirectGpu backend available");
 
         int headDim = modelDim / numHeads;
-        var shape = new[] { batch, seqLen, modelDim };
-        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
-        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
-        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
-        var fg = new Tensor<float>(GenGate(batch * seqLen * numHeads, 4), new[] { batch, seqLen, numHeads });
-        var sk = new Tensor<float>(Gen(numHeads * numSlots * headDim, 5), new[] { numHeads, numSlots, headDim });
+        var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, headDim);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
 
-        var expected = (float[])(object)new CpuEngine()
-            .AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
-        var got = (float[])(object)gpu
-            .AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+        using var expectedTensor = new CpuEngine().AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var expected = (float[])(object)expectedTensor.GetDataArray()!;
 
-        Assert.Equal(expected.Length, got.Length);
-        for (int i = 0; i < expected.Length; i++)
-            Assert.True(Math.Abs(expected[i] - got[i]) < 1e-4f,
-                $"[{batch}x{seqLen}x{modelDim}, H={numHeads}, N={numSlots}] element {i}: cpu={expected[i]} gpu={got[i]}");
+        bool savedThrowOnFallback = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        bool savedCaptureReadbackSites = GpuLaunchProbe.CaptureReadbackSites;
+        Tensor<float>? gpuResult = null;
+        try
+        {
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+            GpuLaunchProbe.CaptureReadbackSites = true;
+            GpuLaunchProbe.Reset();
+            // Invoke the composition directly: the public wrapper must not be able to hide a
+            // primitive failure by returning the CPU reference result.
+            gpuResult = DirectGpuTensorEngine.AbcScanComposed(
+                gpu, q, k, v, fg, sk, batch, seqLen, modelDim, numHeads, headDim, numSlots, InitScale);
+
+            Assert.True(GpuLaunchProbe.Count > 0, "ABC composition launched no GPU work.");
+            Assert.True(GpuLaunchProbe.Readbacks == 0,
+                $"ABC composition performed {GpuLaunchProbe.Readbacks} device-to-host transfers: " +
+                string.Join("; ", GpuLaunchProbe.ReadbackSites));
+            Assert.Empty(GpuLaunchProbe.Fallbacks);
+
+            var got = (float[])(object)gpuResult.GetDataArray()!;
+
+            Assert.Equal(expected.Length, got.Length);
+            for (int i = 0; i < expected.Length; i++)
+                Assert.True(Math.Abs(expected[i] - got[i]) < 1e-4f,
+                    $"[{batch}x{seqLen}x{modelDim}, H={numHeads}, N={numSlots}] element {i}: cpu={expected[i]} gpu={got[i]}");
+        }
+        finally
+        {
+            gpuResult?.Dispose();
+            GpuLaunchProbe.CaptureReadbackSites = savedCaptureReadbackSites;
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = savedThrowOnFallback;
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/AbcScanGpuParityTests.cs
@@ -1,0 +1,104 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// GPU parity for the ABC slot recurrence (issue ooples/AiDotNet#1464).
+/// <see cref="DirectGpuTensorEngine.AbcScanForward{T}"/> has no dedicated device kernel; it composes
+/// the recurrence from GPU-resident primitives (one batched GEMM plus a softmax for the whole
+/// sequence of write scores, then a per-step state update and read). These tests run that composed
+/// path on a real device and require it to agree with the differentiable
+/// <see cref="CpuEngine.AbcScanForward{T}"/> that owns the tape node — if the two disagree, a model
+/// silently changes behaviour between training and GPU inference.
+/// They SKIP when no backend is present rather than passing vacuously.
+/// </summary>
+public class AbcScanGpuParityTests
+{
+    private const double InitScale = 0.1;
+
+    private static float[] Gen(int n, int s, float scale = 0.5f)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(Math.Sin(0.5 * (i + 1) + 1.3 * s) * scale);
+        return a;
+    }
+
+    // The forget gate is a sigmoid output in (0,1).
+    private static float[] GenGate(int n, int s)
+    {
+        var a = new float[n];
+        for (int i = 0; i < n; i++) a[i] = (float)(1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.3 * s))));
+        return a;
+    }
+
+    /// <summary>
+    /// Runs the composed op sequence itself — the exact code the GPU override executes — through a
+    /// CpuEngine and requires it to reproduce the fused kernel. This is what actually validates the
+    /// composition's shape algebra and math; it needs no device, so unlike the parity test below it
+    /// can never pass vacuously. On real hardware only the dispatch target changes.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 4, 8, 2, 3)]
+    [InlineData(2, 5, 12, 3, 4)]
+    [InlineData(2, 1, 8, 4, 2)]   // seqLen 1 takes the no-concat path
+    [InlineData(3, 6, 4, 1, 5)]   // single head
+    public void ComposedOpSequence_MatchesFusedKernel(int batch, int seqLen, int modelDim, int numHeads, int numSlots)
+    {
+        var cpu = new CpuEngine();
+        int headDim = modelDim / numHeads;
+        var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, headDim);
+
+        var expected = (float[])(object)cpu.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+        var composed = (float[])(object)DirectGpuTensorEngine.AbcScanComposed(
+            cpu, q, k, v, fg, sk, batch, seqLen, modelDim, numHeads, headDim, numSlots, InitScale)
+            .GetDataArray()!;
+
+        Assert.Equal(expected.Length, composed.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(expected[i] - composed[i]) < 1e-4f,
+                $"[{batch}x{seqLen}x{modelDim}, H={numHeads}, N={numSlots}] element {i}: " +
+                $"fused={expected[i]} composed={composed[i]}");
+    }
+
+    private static (Tensor<float> q, Tensor<float> k, Tensor<float> v, Tensor<float> fg, Tensor<float> sk)
+        MakeInputs(int batch, int seqLen, int modelDim, int numHeads, int numSlots, int headDim)
+    {
+        var shape = new[] { batch, seqLen, modelDim };
+        return (new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape),
+                new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape),
+                new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape),
+                new Tensor<float>(GenGate(batch * seqLen * numHeads, 4), new[] { batch, seqLen, numHeads }),
+                new Tensor<float>(Gen(numHeads * numSlots * headDim, 5), new[] { numHeads, numSlots, headDim }));
+    }
+
+    [SkippableTheory]
+    [InlineData(1, 4, 8, 2, 3)]
+    [InlineData(2, 5, 12, 3, 4)]
+    [InlineData(2, 1, 8, 4, 2)]   // seqLen 1 takes the no-concat path
+    public void GpuComposedPath_MatchesCpuEngine(int batch, int seqLen, int modelDim, int numHeads, int numSlots)
+    {
+        var gpu = new DirectGpuTensorEngine();
+        Skip.IfNot(gpu.DirectGpu?.IsAvailable ?? false, "No DirectGpu backend available");
+
+        int headDim = modelDim / numHeads;
+        var shape = new[] { batch, seqLen, modelDim };
+        var q = new Tensor<float>(Gen(batch * seqLen * modelDim, 1), shape);
+        var k = new Tensor<float>(Gen(batch * seqLen * modelDim, 2), shape);
+        var v = new Tensor<float>(Gen(batch * seqLen * modelDim, 3), shape);
+        var fg = new Tensor<float>(GenGate(batch * seqLen * numHeads, 4), new[] { batch, seqLen, numHeads });
+        var sk = new Tensor<float>(Gen(numHeads * numSlots * headDim, 5), new[] { numHeads, numSlots, headDim });
+
+        var expected = (float[])(object)new CpuEngine()
+            .AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+        var got = (float[])(object)gpu
+            .AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+
+        Assert.Equal(expected.Length, got.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(expected[i] - got[i]) < 1e-4f,
+                $"[{batch}x{seqLen}x{modelDim}, H={numHeads}, N={numSlots}] element {i}: cpu={expected[i]} gpu={got[i]}");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/AbcScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/AbcScanTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// Correctness tests for the fused ABC slot-recurrence kernel
+/// (<see cref="CpuEngine.AbcScanForward{T}"/>, issue ooples/AiDotNet#1464).
+/// Forward is checked against an independent reference; the custom autodiff backward is checked
+/// against central finite differences for every input, including the slot keys — which reach the
+/// output by two separate routes (the write scores at each step, and the initial slot state), so a
+/// backward that drops either route fails here.
+/// </summary>
+public class AbcScanTests
+{
+    private const double InitScale = 0.1;
+
+    private static void SoftmaxRef(double[] x)
+    {
+        double max = x[0];
+        for (int i = 1; i < x.Length; i++) if (x[i] > max) max = x[i];
+        double sum = 0.0;
+        for (int i = 0; i < x.Length; i++) { x[i] = Math.Exp(x[i] - max); sum += x[i]; }
+        for (int i = 0; i < x.Length; i++) x[i] /= sum;
+    }
+
+    /// <summary>
+    /// Independent transcription of the ABC recurrence, written straight from the layer's documented
+    /// formulation rather than sharing any code with the kernel under test.
+    /// </summary>
+    private static double[] ReferenceForward(
+        double[] Q, double[] K, double[] V, double[] FG, double[] SK,
+        int batch, int seqLen, int modelDim, int numHeads, int numSlots)
+    {
+        int headDim = modelDim / numHeads;
+        double scale = 1.0 / Math.Sqrt(headDim);
+        var outp = new double[Q.Length];
+
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < numHeads; h++)
+            {
+                int hOff = h * headDim;
+                int skOff = h * numSlots * headDim;
+                var slot = new double[numSlots][];
+                for (int s = 0; s < numSlots; s++)
+                {
+                    slot[s] = new double[headDim];
+                    for (int d = 0; d < headDim; d++)
+                        slot[s][d] = InitScale * SK[skOff + s * headDim + d];
+                }
+
+                for (int t = 0; t < seqLen; t++)
+                {
+                    int off = (b * seqLen + t) * modelDim + hOff;
+                    double fg = FG[(b * seqLen + t) * numHeads + h];
+
+                    var w = new double[numSlots];
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        double dot = 0.0;
+                        for (int d = 0; d < headDim; d++) dot += K[off + d] * SK[skOff + s * headDim + d];
+                        w[s] = dot * scale;
+                    }
+                    SoftmaxRef(w);
+
+                    for (int s = 0; s < numSlots; s++)
+                        for (int d = 0; d < headDim; d++)
+                            slot[s][d] = fg * slot[s][d] + w[s] * V[off + d];
+
+                    var r = new double[numSlots];
+                    for (int s = 0; s < numSlots; s++)
+                    {
+                        double dot = 0.0;
+                        for (int d = 0; d < headDim; d++) dot += Q[off + d] * slot[s][d];
+                        r[s] = dot * scale;
+                    }
+                    SoftmaxRef(r);
+
+                    for (int d = 0; d < headDim; d++)
+                    {
+                        double o = 0.0;
+                        for (int s = 0; s < numSlots; s++) o += r[s] * slot[s][d];
+                        outp[off + d] = o;
+                    }
+                }
+            }
+        return outp;
+    }
+
+    private static double[] Gen(int n, int s, double scale = 0.5)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = Math.Sin(0.5 * (i + 1) + 1.3 * s) * scale;
+        return arr;
+    }
+
+    // The forget gate is a sigmoid output in (0,1); keep it below 1 for a stable recurrence.
+    private static double[] GenGate(int n, int s)
+    {
+        var arr = new double[n];
+        for (int i = 0; i < n; i++) arr[i] = 1.0 / (1.0 + Math.Exp(-Math.Sin(0.5 * (i + 1) + 1.3 * s)));
+        return arr;
+    }
+
+    private static (Tensor<double> q, Tensor<double> k, Tensor<double> v, Tensor<double> fg, Tensor<double> sk)
+        MakeInputs(int batch, int seqLen, int modelDim, int numHeads, int numSlots, int seed)
+    {
+        int headDim = modelDim / numHeads;
+        int n = batch * seqLen * modelDim;
+        var shape = new[] { batch, seqLen, modelDim };
+        int gn = batch * seqLen * numHeads;
+        int skn = numHeads * numSlots * headDim;
+        return (new Tensor<double>(Gen(n, seed), shape),
+                new Tensor<double>(Gen(n, seed + 1), shape),
+                new Tensor<double>(Gen(n, seed + 2), shape),
+                new Tensor<double>(GenGate(gn, seed + 3), new[] { batch, seqLen, numHeads }),
+                new Tensor<double>(Gen(skn, seed + 4), new[] { numHeads, numSlots, headDim }));
+    }
+
+    [Fact]
+    public void Forward_MatchesReference()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 4, modelDim = 6, numHeads = 3, numSlots = 4;
+        var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 9);
+
+        var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var expected = ReferenceForward(
+            (double[])(object)q.GetDataArray()!, (double[])(object)k.GetDataArray()!,
+            (double[])(object)v.GetDataArray()!, (double[])(object)fg.GetDataArray()!,
+            (double[])(object)sk.GetDataArray()!,
+            batch, seqLen, modelDim, numHeads, numSlots);
+
+        var got = (double[])(object)outp.GetDataArray()!;
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-10,
+                $"Forward[{i}] = {got[i]} vs reference {expected[i]}");
+    }
+
+    [Fact]
+    public void Backward_MatchesFiniteDifferences()
+    {
+        var engine = new CpuEngine();
+        int batch = 1, seqLen = 3, modelDim = 4, numHeads = 2, numSlots = 3;
+        var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 5);
+
+        // A NON-uniform output weighting. Under a plain sum(output) the two softmax Jacobians can
+        // partially cancel, which would let a wrong softmax backward pass; distinct per-element
+        // weights keep every path observable.
+        var weights = new Tensor<double>(Gen(batch * seqLen * modelDim, 77, 1.0),
+            new[] { batch, seqLen, modelDim });
+
+        Dictionary<Tensor<double>, Tensor<double>> grads;
+        var analytic = new Dictionary<Tensor<double>, double[]>();
+        var inputs = new[] { q, k, v, fg, sk };
+        using (var tape = new GradientTape<double>())
+        {
+            var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+            var loss = engine.ReduceSum(engine.TensorMultiply(outp, weights), new[] { 0, 1, 2 }, keepDims: false);
+            grads = tape.ComputeGradients(loss, inputs);
+            // Copy inside the tape scope: gradient tensors are pooled buffers and are recycled once
+            // the tape is disposed, which would silently fabricate values here.
+            foreach (var input in inputs)
+            {
+                var g = grads[input];
+                var copy = new double[g.Length];
+                for (int i = 0; i < copy.Length; i++) copy[i] = g.GetFlat(i);
+                analytic[input] = copy;
+            }
+        }
+
+        const double eps = 1e-6;
+        var names = new[] { "q", "k", "v", "forgetGate", "slotKeys" };
+        for (int ai = 0; ai < inputs.Length; ai++)
+        {
+            var input = inputs[ai];
+            var data = (double[])(object)input.GetDataArray()!;
+            var grad = analytic[input];
+            for (int i = 0; i < data.Length; i++)
+            {
+                double orig = data[i];
+                data[i] = orig + eps;
+                double sp = WeightedForward(engine, q, k, v, fg, sk, numHeads, weights);
+                data[i] = orig - eps;
+                double sm = WeightedForward(engine, q, k, v, fg, sk, numHeads, weights);
+                data[i] = orig;
+                double numeric = (sp - sm) / (2.0 * eps);
+                double tol = 1e-5 + 1e-4 * Math.Abs(grad[i]);
+                Assert.True(Math.Abs(numeric - grad[i]) < tol,
+                    $"{names[ai]} grad mismatch at element {i}: analytic={grad[i]}, finite-diff={numeric}");
+            }
+        }
+    }
+
+    [Fact]
+    public void GenericPath_MatchesDoublePath()
+    {
+        // T = float takes the generic implementation rather than the double fast path; the two must
+        // agree to float precision, otherwise the layers (which run float) get different numbers.
+        var engine = new CpuEngine();
+        int batch = 2, seqLen = 3, modelDim = 4, numHeads = 2, numSlots = 3;
+        var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 21);
+
+        var expected = (double[])(object)engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+
+        var qf = ToFloat(q); var kf = ToFloat(k); var vf = ToFloat(v);
+        var fgf = ToFloat(fg); var skf = ToFloat(sk);
+        var got = (float[])(object)engine.AbcScanForward(qf, kf, vf, fgf, skf, numHeads, InitScale).GetDataArray()!;
+
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(Math.Abs(got[i] - expected[i]) < 1e-5,
+                $"generic[{i}] = {got[i]} vs double path {expected[i]}");
+    }
+
+    private static Tensor<float> ToFloat(Tensor<double> t)
+    {
+        var src = (double[])(object)t.GetDataArray()!;
+        var dst = new float[src.Length];
+        for (int i = 0; i < src.Length; i++) dst[i] = (float)src[i];
+        return new Tensor<float>(dst, t.Shape.ToArray());
+    }
+
+    private static double WeightedForward(
+        CpuEngine engine, Tensor<double> q, Tensor<double> k, Tensor<double> v,
+        Tensor<double> fg, Tensor<double> sk, int numHeads, Tensor<double> weights)
+    {
+        var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var data = (double[])(object)outp.GetDataArray()!;
+        var w = (double[])(object)weights.GetDataArray()!;
+        double s = 0.0;
+        for (int i = 0; i < data.Length; i++) s += data[i] * w[i];
+        return s;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/AbcScanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/AbcScanTests.cs
@@ -127,8 +127,13 @@ public class AbcScanTests
         var engine = new CpuEngine();
         int batch = 2, seqLen = 4, modelDim = 6, numHeads = 3, numSlots = 4;
         var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 9);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
 
-        var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        using var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
         var expected = ReferenceForward(
             (double[])(object)q.GetDataArray()!, (double[])(object)k.GetDataArray()!,
             (double[])(object)v.GetDataArray()!, (double[])(object)fg.GetDataArray()!,
@@ -147,11 +152,16 @@ public class AbcScanTests
         var engine = new CpuEngine();
         int batch = 1, seqLen = 3, modelDim = 4, numHeads = 2, numSlots = 3;
         var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 5);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
 
         // A NON-uniform output weighting. Under a plain sum(output) the two softmax Jacobians can
         // partially cancel, which would let a wrong softmax backward pass; distinct per-element
         // weights keep every path observable.
-        var weights = new Tensor<double>(Gen(batch * seqLen * modelDim, 77, 1.0),
+        using var weights = new Tensor<double>(Gen(batch * seqLen * modelDim, 77, 1.0),
             new[] { batch, seqLen, modelDim });
 
         Dictionary<Tensor<double>, Tensor<double>> grads;
@@ -159,8 +169,9 @@ public class AbcScanTests
         var inputs = new[] { q, k, v, fg, sk };
         using (var tape = new GradientTape<double>())
         {
-            var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
-            var loss = engine.ReduceSum(engine.TensorMultiply(outp, weights), new[] { 0, 1, 2 }, keepDims: false);
+            using var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+            using var weighted = engine.TensorMultiply(outp, weights);
+            using var loss = engine.ReduceSum(weighted, new[] { 0, 1, 2 }, keepDims: false);
             grads = tape.ComputeGradients(loss, inputs);
             // Copy inside the tape scope: gradient tensors are pooled buffers and are recycled once
             // the tape is disposed, which would silently fabricate values here.
@@ -204,16 +215,38 @@ public class AbcScanTests
         var engine = new CpuEngine();
         int batch = 2, seqLen = 3, modelDim = 4, numHeads = 2, numSlots = 3;
         var (q, k, v, fg, sk) = MakeInputs(batch, seqLen, modelDim, numHeads, numSlots, 21);
+        using var qOwner = q;
+        using var kOwner = k;
+        using var vOwner = v;
+        using var fgOwner = fg;
+        using var skOwner = sk;
 
-        var expected = (double[])(object)engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale).GetDataArray()!;
+        using var expectedTensor = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        var expected = (double[])(object)expectedTensor.GetDataArray()!;
 
-        var qf = ToFloat(q); var kf = ToFloat(k); var vf = ToFloat(v);
-        var fgf = ToFloat(fg); var skf = ToFloat(sk);
-        var got = (float[])(object)engine.AbcScanForward(qf, kf, vf, fgf, skf, numHeads, InitScale).GetDataArray()!;
+        using var qf = ToFloat(q); using var kf = ToFloat(k); using var vf = ToFloat(v);
+        using var fgf = ToFloat(fg); using var skf = ToFloat(sk);
+        using var actualTensor = engine.AbcScanForward(qf, kf, vf, fgf, skf, numHeads, InitScale);
+        var got = (float[])(object)actualTensor.GetDataArray()!;
 
         for (int i = 0; i < expected.Length; i++)
             Assert.True(Math.Abs(got[i] - expected[i]) < 1e-5,
                 $"generic[{i}] = {got[i]} vs double path {expected[i]}");
+    }
+
+    [Fact]
+    public void ZeroSlots_FailsWithShapeError()
+    {
+        var engine = new CpuEngine();
+        using var q = new Tensor<double>(new double[4], new[] { 1, 1, 4 });
+        using var k = new Tensor<double>(new double[4], new[] { 1, 1, 4 });
+        using var v = new Tensor<double>(new double[4], new[] { 1, 1, 4 });
+        using var fg = new Tensor<double>(new double[2], new[] { 1, 1, 2 });
+        using var slotKeys = new Tensor<double>(Array.Empty<double>(), new[] { 2, 0, 2 });
+
+        var error = Assert.Throws<ArgumentException>(
+            () => engine.AbcScanForward(q, k, v, fg, slotKeys, numHeads: 2, slotInitScale: InitScale));
+        Assert.Contains("numSlots >= 1", error.Message);
     }
 
     private static Tensor<float> ToFloat(Tensor<double> t)
@@ -228,7 +261,7 @@ public class AbcScanTests
         CpuEngine engine, Tensor<double> q, Tensor<double> k, Tensor<double> v,
         Tensor<double> fg, Tensor<double> sk, int numHeads, Tensor<double> weights)
     {
-        var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
+        using var outp = engine.AbcScanForward(q, k, v, fg, sk, numHeads, InitScale);
         var data = (double[])(object)outp.GetDataArray()!;
         var w = (double[])(object)weights.GetDataArray()!;
         double s = 0.0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -329,6 +329,9 @@ public class DifferentiableOpsGradCheckSweep
                                          SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), 2],
         ["GlaScanForward"] = r => [SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r),
                                    SafeTensor([1, 3, 2], r), 2],
+        // ABC additionally takes per-head slot keys [numHeads, numSlots, headDim] and an initial-state scale.
+        ["AbcScanForward"] = r => [SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r),
+                                   SafeTensor([1, 3, 2], r), SafeTensor([2, 3, 2], r), 2, 0.1],
         ["GatedDeltaNetScanForward"] = r => [SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r),
                                              SafeTensor([1, 3, 2], r), SafeTensor([1, 3, 2], r), 2],
         ["XLstmScanForward"] = r => [SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r), SafeTensor([1, 3, 4], r),
@@ -818,7 +821,7 @@ public class DifferentiableOpsGradCheckSweep
         // without a ratchet the next op whose parameters the synthesizer cannot handle would slip
         // back in silently and CI would stay green while coverage rotted.
         //
-        // Measured 0 skips on BOTH target frameworks (net10.0 and net471, 251 ops verified on each),
+        // Measured 0 skips on BOTH target frameworks (net10.0 and net471, 252 ops verified on each),
         // so 0 is the honest floor rather than a number chosen to make the assertion pass.
         //
         // An op that genuinely cannot be gradient-checked has a supported escape hatch — add it to

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -498,10 +498,11 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         // fused recurrence / LM-head scans (#1464) — q/k/v [B,S,D] vs gate/alpha/etc. [B,S,H],
         // or [N,d]+[d,vocab]+[N] CE shapes: distinct shapes per tensor arg the generic single-shape
         // generator can't drive. Each has a dedicated GPU-vs-CPU parity suite:
-        //   GlaScanGpuParityTests, XLstmScanGpuParityTests, GatedDeltaNetScanGpuParityTests,
+        //   AbcScanGpuParityTests, GlaScanGpuParityTests, XLstmScanGpuParityTests, GatedDeltaNetScanGpuParityTests,
         //   RgLruScanGpuParityTests, Rwkv4WkvGpuParityTests, MambaScanGpuParityTests,
         //   Mamba2ScanGpuParityTests, FusedLinearCeGpuParityTests.
         "GlaScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
+        "AbcScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32,Double)",
         "XLstmScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
         "GatedDeltaNetScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>,Int32)",
         "RgLruScanForward(Tensor<T>,Tensor<T>,Tensor<T>,Tensor<T>)",


### PR DESCRIPTION
## Outcome  This PR makes ABC (Attention with Bounded-memory Control) a first-class differentiable engine operation and completes its inference path as a strict, device-resident GPU composition.  It fixes the original ABC training defect, where 5 of 9 trainable tensors received no gradient, and replaces the first GPU iteration's silent CPU fallback with observable, capability-aware execution.  ## New capabilities  - Adds AbcScanForward to the engine contract with a fused CPU forward and exact BPTT backward. - Propagates gradients through all five inputs: Q projection, K projection, V projection, forget gate, and slot keys. - Adds GPU inference without requiring a backend-specific ABC kernel. The recurrence is composed from the shared direct-backend primitive contract: device permutation/copy, scale, add/multiply, batched GEMM, softmax, slice, tile, and concatenate. - Applies the shared capability-aware precision policy introduced by #971:   - SpeedFirst keeps the caller's public Tensor<T> type while converting through the backend-selected device format.   - PreserveInputType routes to the exact CPU implementation when the backend cannot preserve T.   - Tape-active execution stays on the differentiable fused CPU node. - Supports every in-tree direct backend that implements the shared primitive and precision-capability contracts. A missing or failed primitive is reported; it is not disguised as successful GPU execution.  ## Existing behavior fixed  - ABC scalar-loop training severed autodiff upstream of the recurrence. Q/K/V projections and both forget-gate parameters never learned. - AbcScanForward caught every GPU exception and returned a CPU result, making broken device routes look successful. - The hardware test checked an inherited CpuEngine.DirectGpu property that always returned null, so it always skipped even with a working GPU. - The hardware test called the public wrapper, allowing a failed GPU composition to compare one CPU result with another and pass. - Strided compute permutations caused hidden device-to-host packing. - Recurrent gate expansion used a generic multi-axis CPU tile and caused one readback per timestep. - Intermediate recurrence tensors were left for GC instead of being disposed deterministically. - CUDA stream capture could enter an allocation-heavy recurrence and abort with CUDA 906. - numSlots == 0 failed inside softmax with a wrapped indexing exception instead of a shape error. - The global gradcheck factory and GPU dedicated-coverage registry did not recognize the new operation.  ## Type and execution semantics  | Mode | Declared type | Execution | Returned type | | --- | --- | --- | --- | | SpeedFirst | float | Backend-selected GPU format | Tensor<float> | | SpeedFirst | double | Approximate GPU path through FP32 on the tested GTX 1660 Ti | Tensor<double> | | PreserveInputType | double on a backend without FP64 ABC support | Exact CPU route | Tensor<double> | | Training / active tape | Any supported T | Fused differentiable CPU route | Tensor<T> |  The implementation is generic and delegates format selection to the backend capability planner. Physical type-policy evidence in this PR covers float and double. Reduced formats and non-CUDA devices are capability-driven but are not falsely presented here as physically tested.  ## GPU residency and performance design  - Write probabilities for the complete sequence are computed once with one batched GEMM plus one softmax. - Only the recurrent state update and slot read remain per timestep. - Compute-layout permutations are materialized device-to-device. - Gate expansion is split into supported single-axis device tiles. - The physical tests require at least one GPU launch, zero device-to-host transfers before final result materialization, and zero recorded CPU fallbacks. - Temporary tensor ownership is deterministic and bounded by the active recurrence state plus retained output steps.  This PR proves removal of host round trips; it does not claim an unmeasured wall-clock speedup for arbitrary tensor sizes.  ## Evidence  Physical device:  - NVIDIA GeForce GTX 1660 Ti, compute capability 7.5 - NVIDIA driver 610.88 - CUDA backend selected explicitly  Physical CUDA cases:  - float: [B=1, S=4, M=8, H=2, N=3] - float: [B=2, S=5, M=12, H=3, N=4] - float: [B=2, S=1, M=8, H=4, N=2], covering the no-concatenate branch - double SpeedFirst: [B=2, S=3, M=8, H=2, N=3], public double result through GPU FP32 - double PreserveInputType: [B=1, S=2, M=4, H=2, N=2], zero GPU launches and exact CPU result  Observed assertions:  - All three direct float composition cases launched device work. - SpeedFirst double launched device work and retained Tensor<double>. - Internal readbacks before result materialization: 0. - Recorded GPU-to-CPU fallbacks: 0. - SpeedFirst double versus the double CPU oracle: every element within 2e-5. - PreserveInputType double versus the CPU oracle: exact equality. - Fused CPU forward versus an independent reference: within 1e-10. - Analytic backward versus central finite differences: all five inputs covered under a non-uniform output weighting.  Post-merge test results at head a8c4975d:  - net10.0 focused ABC plus both former CI gates: 15 passed, 1 expected generated-parity skip, 0 failed. - net471 CPU/generic and gate coverage with GPU disabled: 9 passed, 5 hardware skips, 0 failed. - A forced net471 CUDA run on this CUDA-13-only host fails explicitly because .NET Framework requests cublas64_12 while only cuBLAS 13 is installed. It does not return CPU output. Therefore net471 is counted as compile/CPU evidence here, not physical GPU evidence.  ## Validation and safety  - Current with main, including #971 capability-aware autocast/type policy and #868 direct-PTX softmax work. - CUDA stream capture is rejected before input inspection or device work because this composed recurrence allocates per step. - Invalid shapes retain the canonical CPU validation surface. - numSlots must be at least one and has a dedicated regression test. - All four unresolved review threads were answered and resolved.