### PR TITLE
fix(compilation): capture custom fused training kernels

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -48,6 +48,11 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     // AIDOTNET_FP16_GPU_CACHE=1). Lazily constructed on first hetero forward.
     private MixedPrecisionCompiledPlan? _fp16PagedPlan;
     private readonly IEngine _engine;
+    // Every replay mutates plan-owned forward buffers, gradient buffers, saved-state holders,
+    // optimizer moments, and (on CUDA) graph-lifetime state. A compiled plan is therefore one
+    // state machine, not a bag of independent delegates. Serialize Step so two callers cannot let
+    // one forward overwrite saved state while the other caller's backward is consuming it.
+    private readonly object _stepSync = new();
 
     // ---- CUDA-graph capture of the whole compiled training step (opt-in, default OFF) ----
     // When AIDOTNET_CUDA_GRAPH_STEP=1 on a CUDA float plan, the fixed forward+grad-zero+
@@ -1551,6 +1556,12 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Tensor<T> Step()
+    {
+        lock (_stepSync)
+            return StepCore();
+    }
+
+    private Tensor<T> StepCore()
     {
         using var graphModeSuspension = GraphMode.SuspendRecording();
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.AbcScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -71,6 +72,32 @@ public partial class CpuEngine
             throw new ArgumentException(
                 $"slotKeys must be [numHeads={numHeads}, numSlots >= 1, headDim={headDim}]; got numSlots={numSlots}.",
                 nameof(slotKeys));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedQ = qProj;
+            var capturedK = kProj;
+            var capturedV = vProj;
+            var capturedForgetGate = forgetGate;
+            var capturedSlotKeys = slotKeys;
+            int capturedNumHeads = numHeads;
+            double capturedSlotInitScale = slotInitScale;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "AbcScan",
+                new[] { qProj, kProj, vProj, forgetGate, slotKeys },
+                new[] { batch, seqLen, modelDim },
+                (eng, output) =>
+                {
+                    var result = eng.AbcScanForward(
+                        capturedQ, capturedK, capturedV, capturedForgetGate, capturedSlotKeys,
+                        capturedNumHeads, capturedSlotInitScale);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                AbcScanBackward<T>,
+                new object[] { numHeads, slotInitScale });
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.ComplexDiagonalSsmScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -23,6 +24,38 @@ public partial class CpuEngine
             input, transitionReal, transitionImag, inputMapReal, inputMapImag,
             outputMapReal, outputMapImag, skip,
             out int batch, out int time, out int groups, out int width, out int state);
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedInput = input;
+            var capturedTransitionReal = transitionReal;
+            var capturedTransitionImag = transitionImag;
+            var capturedInputMapReal = inputMapReal;
+            var capturedInputMapImag = inputMapImag;
+            var capturedOutputMapReal = outputMapReal;
+            var capturedOutputMapImag = outputMapImag;
+            var capturedSkip = skip;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "ComplexDiagonalSsmScan",
+                new[]
+                {
+                    input, transitionReal, transitionImag, inputMapReal, inputMapImag,
+                    outputMapReal, outputMapImag, skip
+                },
+                new[] { batch, time, groups, width },
+                (eng, output) =>
+                {
+                    var result = eng.ComplexDiagonalSsmScanForward(
+                        capturedInput, capturedTransitionReal, capturedTransitionImag,
+                        capturedInputMapReal, capturedInputMapImag, capturedOutputMapReal,
+                        capturedOutputMapImag, capturedSkip);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                ComplexDiagonalSsmScanBackward<T>,
+                savedState: null);
+        }
 
         var output = new Tensor<T>(new[] { batch, time, groups, width });
         ComplexDiagonalSsmScanForwardCore(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -65,6 +66,32 @@ public partial class CpuEngine
             if (ids[r] < 0 || ids[r] >= vocab)
                 throw new ArgumentOutOfRangeException(nameof(targetIds),
                     $"targetIds[{r}] ({ids[r]}) must be in [0, vocab={vocab}).");
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedHidden = hidden;
+            var capturedWeight = weight;
+            var capturedBias = bias;
+            var capturedTargetIds = targetIds;
+            var compiledSavedState = new object[] { (int[])ids.Clone(), vocab };
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "FusedLinearCrossEntropy",
+                new[] { hidden, weight, bias },
+                new[] { 1 },
+                (eng, output) =>
+                {
+                    // Labels are not differentiable graph inputs, but they are live training data.
+                    // Refresh the backward state on every replay instead of freezing the trace batch.
+                    compiledSavedState[0] = (int[])capturedTargetIds.GetDataArray()!.Clone();
+                    var result = eng.FusedLinearCrossEntropyWithLogits(
+                        capturedHidden, capturedWeight, capturedBias, capturedTargetIds);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                FusedLinearCrossEntropyIndexBackward<T>,
+                compiledSavedState);
+        }
 
         // logits = hidden·weight + bias, computed off-tape (this op records its own node).
         //
@@ -148,6 +175,28 @@ public partial class CpuEngine
         // IndexOutOfRangeException instead of this clear argument error).
         if (target.Rank != 2 || target.Shape[0] != n || target.Shape[1] != vocab)
             throw new ArgumentException($"target must be rank-2 [N={n}, vocab={vocab}].", nameof(target));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedHidden = hidden;
+            var capturedWeight = weight;
+            var capturedBias = bias;
+            var capturedTarget = target;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "FusedLinearCrossEntropy",
+                new[] { hidden, weight, bias, target },
+                new[] { 1 },
+                (eng, output) =>
+                {
+                    var result = eng.FusedLinearCrossEntropyWithLogits(
+                        capturedHidden, capturedWeight, capturedBias, capturedTarget);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                FusedLinearCrossEntropyBackward<T>,
+                savedState: null);
+        }
 
         // logits = hidden·weight + bias, computed via the fast parallel GEMM but NOT recorded
         // (this op records its own single tape node). The logits tensor is transient — it never

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GatedDeltaNetScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GatedDeltaNetScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -56,6 +57,30 @@ public partial class CpuEngine
             throw new ArgumentException($"alpha must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(alpha));
         if (beta.Rank != 3 || beta.Shape[0] != batch || beta.Shape[1] != seqLen || beta.Shape[2] != numHeads)
             throw new ArgumentException($"beta must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(beta));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedQ = qProj;
+            var capturedK = kProj;
+            var capturedV = vProj;
+            var capturedAlpha = alpha;
+            var capturedBeta = beta;
+            int capturedNumHeads = numHeads;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "GatedDeltaNetScan",
+                new[] { qProj, kProj, vProj, alpha, beta },
+                new[] { batch, seqLen, modelDim },
+                (eng, output) =>
+                {
+                    var result = eng.GatedDeltaNetScanForward(
+                        capturedQ, capturedK, capturedV, capturedAlpha, capturedBeta, capturedNumHeads);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                GatedDeltaNetScanBackward<T>,
+                new object[] { numHeads });
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -8,6 +8,7 @@
 
 using System;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -22,6 +23,45 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (sizes is null) throw new ArgumentNullException(nameof(sizes));
+        if (input.Rank < 3)
+            throw new ArgumentException("Interpolate requires rank >= 3 ([N, C, ...] where ... is 1/2/3 spatial dims).");
+
+        int spatialRank = input.Rank - 2;
+        if (sizes.Length != spatialRank)
+            throw new ArgumentException($"sizes length ({sizes.Length}) must equal spatial rank ({spatialRank}).");
+        ValidateMode(mode, spatialRank);
+
+        var outputShape = (int[])input._shape.Clone();
+        for (int i = 0; i < spatialRank; i++)
+        {
+            if (sizes[i] <= 0) throw new ArgumentException("sizes must be positive.");
+            outputShape[2 + i] = sizes[i];
+        }
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedInput = input;
+            var capturedSizes = (int[])sizes.Clone();
+            var capturedMode = mode;
+            var capturedAlignCorners = alignCorners;
+            return scope.RecordUnary(
+                LazyNodeType.Custom,
+                "Interpolate",
+                input,
+                outputShape,
+                (eng, output) =>
+                {
+                    var replayed = eng.Interpolate(
+                        capturedInput, capturedSizes, capturedMode, capturedAlignCorners);
+                    DirectGpuTensorEngine.CopyResultInto(eng, replayed, output);
+                },
+                BackwardFunctions<T>.InterpolateBackward,
+                new object[] { mode, alignCorners });
+        }
+
         var result = InterpolateImpl(input, sizes, mode, alignCorners);
         AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
             "Interpolate", result, input,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -23,22 +23,7 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
     {
-        if (input is null) throw new ArgumentNullException(nameof(input));
-        if (sizes is null) throw new ArgumentNullException(nameof(sizes));
-        if (input.Rank < 3)
-            throw new ArgumentException("Interpolate requires rank >= 3 ([N, C, ...] where ... is 1/2/3 spatial dims).");
-
-        int spatialRank = input.Rank - 2;
-        if (sizes.Length != spatialRank)
-            throw new ArgumentException($"sizes length ({sizes.Length}) must equal spatial rank ({spatialRank}).");
-        ValidateMode(mode, spatialRank);
-
-        var outputShape = (int[])input._shape.Clone();
-        for (int i = 0; i < spatialRank; i++)
-        {
-            if (sizes[i] <= 0) throw new ArgumentException("sizes must be positive.");
-            outputShape[2 + i] = sizes[i];
-        }
+        var outputShape = ValidateInterpolate(input, sizes, mode);
 
         if (GraphMode.IsActive && GraphMode.Current is { } scope)
         {
@@ -72,23 +57,7 @@ public partial class CpuEngine
 
     private Tensor<T> InterpolateImpl<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners)
     {
-        if (input is null) throw new ArgumentNullException(nameof(input));
-        if (sizes is null) throw new ArgumentNullException(nameof(sizes));
-        if (input.Rank < 3)
-            throw new ArgumentException("Interpolate requires rank >= 3 ([N, C, ...] where ... is 1/2/3 spatial dims).");
-        int spatialRank = input.Rank - 2;
-        if (sizes.Length != spatialRank)
-            throw new ArgumentException($"sizes length ({sizes.Length}) must equal spatial rank ({spatialRank}).");
-        ValidateMode(mode, spatialRank);
-
-        int N = input._shape[0], C = input._shape[1];
-        var outShape = new int[input.Rank];
-        outShape[0] = N; outShape[1] = C;
-        for (int i = 0; i < spatialRank; i++)
-        {
-            if (sizes[i] <= 0) throw new ArgumentException("sizes must be positive.");
-            outShape[2 + i] = sizes[i];
-        }
+        var outShape = ValidateInterpolate(input, sizes, mode);
         var output = new Tensor<T>(outShape);
         if (input.Length == 0 || output.Length == 0) return output;
 
@@ -113,6 +82,27 @@ public partial class CpuEngine
                 throw new ArgumentOutOfRangeException(nameof(mode));
         }
         return output;
+    }
+
+    private static int[] ValidateInterpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (sizes is null) throw new ArgumentNullException(nameof(sizes));
+        if (input.Rank < 3)
+            throw new ArgumentException("Interpolate requires rank >= 3 ([N, C, ...] where ... is 1/2/3 spatial dims).");
+
+        int spatialRank = input.Rank - 2;
+        if (sizes.Length != spatialRank)
+            throw new ArgumentException($"sizes length ({sizes.Length}) must equal spatial rank ({spatialRank}).");
+        ValidateMode(mode, spatialRank);
+
+        var outputShape = (int[])input._shape.Clone();
+        for (int i = 0; i < spatialRank; i++)
+        {
+            if (sizes[i] <= 0) throw new ArgumentException("sizes must be positive.");
+            outputShape[2 + i] = sizes[i];
+        }
+        return outputShape;
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GlaScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -54,6 +55,29 @@ public partial class CpuEngine
         // Gate is scalar-per-head: [batch, seqLen, numHeads], not the full modelDim.
         if (gate.Rank != 3 || gate.Shape[0] != batch || gate.Shape[1] != seqLen || gate.Shape[2] != numHeads)
             throw new ArgumentException($"gate must be [batch={batch}, seqLen={seqLen}, numHeads={numHeads}].", nameof(gate));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedQ = qProj;
+            var capturedK = kProj;
+            var capturedV = vProj;
+            var capturedGate = gate;
+            int capturedNumHeads = numHeads;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "GlaScan",
+                new[] { qProj, kProj, vProj, gate },
+                new[] { batch, seqLen, modelDim },
+                (eng, output) =>
+                {
+                    var result = eng.GlaScanForward(
+                        capturedQ, capturedK, capturedV, capturedGate, capturedNumHeads);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                GlaScanBackward<T>,
+                new object[] { numHeads });
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mamba2SsdScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -65,6 +66,32 @@ public partial class CpuEngine
             throw new ArgumentException($"cParam must be [batch={batch}, seqLen={seqLen}, stateDim={stateDim}].", nameof(cParam));
         if (dParam.Length != numHeads)
             throw new ArgumentException($"dParam length ({dParam.Length}) must equal numHeads ({numHeads}).", nameof(dParam));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedX = x;
+            var capturedDelta = delta;
+            var capturedALog = aLog;
+            var capturedB = bParam;
+            var capturedC = cParam;
+            var capturedD = dParam;
+            int capturedNumHeads = numHeads;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "Mamba2SsdScan",
+                new[] { x, delta, aLog, bParam, cParam, dParam },
+                new[] { batch, seqLen, innerDim },
+                (eng, output) =>
+                {
+                    var result = eng.Mamba2SsdScanForward(
+                        capturedX, capturedDelta, capturedALog, capturedB, capturedC, capturedD,
+                        capturedNumHeads);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                Mamba2SsdScanBackward<T>,
+                new object[] { numHeads });
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, innerDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MambaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MambaScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -60,6 +61,30 @@ public partial class CpuEngine
             throw new ArgumentException($"cParam must be [batch={batch}, seqLen={seqLen}, stateDim={stateDim}].", nameof(cParam));
         if (dParam.Length != innerDim)
             throw new ArgumentException($"dParam length ({dParam.Length}) must equal innerDim ({innerDim}).", nameof(dParam));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedX = x;
+            var capturedDelta = delta;
+            var capturedALog = aLog;
+            var capturedB = bParam;
+            var capturedC = cParam;
+            var capturedD = dParam;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "MambaSelectiveScan",
+                new[] { x, delta, aLog, bParam, cParam, dParam },
+                new[] { batch, seqLen, innerDim },
+                (eng, output) =>
+                {
+                    var result = eng.MambaSelectiveScanForward(
+                        capturedX, capturedDelta, capturedALog, capturedB, capturedC, capturedD);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                MambaSelectiveScanBackward<T>,
+                savedState: null);
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, innerDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MesaScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MesaScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -19,6 +20,31 @@ public partial class CpuEngine
     {
         ValidateMesaScan(q, k, v, initialWeights, regularization, numHeads,
             out int batch, out int time, out int model, out int headDim);
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedQ = q;
+            var capturedK = k;
+            var capturedV = v;
+            var capturedInitialWeights = initialWeights;
+            T capturedRegularization = regularization;
+            int capturedNumHeads = numHeads;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "MesaScanForward",
+                new[] { q, k, v, initialWeights },
+                new[] { batch, time, model },
+                (eng, output) =>
+                {
+                    var result = eng.MesaScanForward(
+                        capturedQ, capturedK, capturedV, capturedInitialWeights,
+                        capturedRegularization, capturedNumHeads);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                MesaScanBackward<T>,
+                new object[] { regularization!, numHeads });
+        }
 
         var output = new Tensor<T>(new[] { batch, time, model });
         if (typeof(T) == typeof(float))

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RgLruScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -60,6 +61,28 @@ public partial class CpuEngine
         EnsureSameShape(value, inpGate, nameof(inpGate));
         if (decay.Length != recDim)
             throw new ArgumentException($"decay length ({decay.Length}) must equal recDim ({recDim}).", nameof(decay));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedValue = value;
+            var capturedRecGate = recGate;
+            var capturedInpGate = inpGate;
+            var capturedDecay = decay;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "RgLruScan",
+                new[] { value, recGate, inpGate, decay },
+                new[] { batch, seqLen, recDim },
+                (eng, output) =>
+                {
+                    var result = eng.RgLruScanForward(
+                        capturedValue, capturedRecGate, capturedInpGate, capturedDecay);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                RgLruScanBackward<T>,
+                null);
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, recDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoutedDiagonalSsmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoutedDiagonalSsmScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -15,6 +16,30 @@ public partial class CpuEngine
     {
         ValidateRoutedDiagonalSsm(input, activeMask, transition, inputMap, outputMap, skip,
             out int batch, out int time, out int model, out int experts, out int state);
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedInput = input;
+            var capturedActiveMask = activeMask;
+            var capturedTransition = transition;
+            var capturedInputMap = inputMap;
+            var capturedOutputMap = outputMap;
+            var capturedSkip = skip;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "RoutedDiagonalSsmScanForward",
+                new[] { input, activeMask, transition, inputMap, outputMap, skip },
+                new[] { batch, time, experts, model },
+                (eng, output) =>
+                {
+                    var result = eng.RoutedDiagonalSsmScanForward(
+                        capturedInput, capturedActiveMask, capturedTransition, capturedInputMap,
+                        capturedOutputMap, capturedSkip);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                RoutedDiagonalSsmBackward<T>,
+                savedState: null);
+        }
         var output = new Tensor<T>(new[] { batch, time, experts, model });
         RoutedDiagonalSsmForwardCore(
             input.GetDataArray()!, activeMask.GetDataArray()!, transition.GetDataArray()!,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv4Wkv.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -63,6 +64,29 @@ public partial class CpuEngine
             throw new ArgumentException($"timeDecay length ({timeDecay.Length}) must equal modelDim ({modelDim}).", nameof(timeDecay));
         if (timeFirst.Length != modelDim)
             throw new ArgumentException($"timeFirst length ({timeFirst.Length}) must equal modelDim ({modelDim}).", nameof(timeFirst));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedR = rProj;
+            var capturedK = kProj;
+            var capturedV = vProj;
+            var capturedTimeDecay = timeDecay;
+            var capturedTimeFirst = timeFirst;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "Rwkv4Wkv",
+                new[] { rProj, kProj, vProj, timeDecay, timeFirst },
+                new[] { batch, seqLen, modelDim },
+                (eng, output) =>
+                {
+                    var result = eng.Rwkv4WkvForward(
+                        capturedR, capturedK, capturedV, capturedTimeDecay, capturedTimeFirst);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                Rwkv4WkvBackward<T>,
+                null);
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv7Sequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Rwkv7Sequence.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -95,6 +96,42 @@ public partial class CpuEngine
         EnsureSameShape(rProj, vProj, nameof(vProj));
         EnsureSameShape(rProj, decayLogit, nameof(decayLogit));
         EnsureSameShape(rProj, iclRate, nameof(iclRate));
+
+        if (GraphMode.IsActive)
+        {
+            var scope = GraphMode.Current;
+            if (scope != null)
+            {
+                scope.BindEngineIfUnset(this);
+                var capturedR = rProj;
+                var capturedKappa = kappa;
+                var capturedKTilde = kTilde;
+                var capturedV = vProj;
+                var capturedDecay = decayLogit;
+                var capturedIclRate = iclRate;
+                int capturedNumHeads = numHeads;
+                var outputShape = new[] { batch, seqLen, modelDim };
+                return scope.RecordVariadic(
+                    LazyNodeType.Custom,
+                    "Rwkv7Sequence",
+                    new[] { rProj, kappa, kTilde, vProj, decayLogit, iclRate },
+                    outputShape,
+                    (eng, output) =>
+                    {
+                        var result = eng.Rwkv7SequenceForward(
+                            capturedR,
+                            capturedKappa,
+                            capturedKTilde,
+                            capturedV,
+                            capturedDecay,
+                            capturedIclRate,
+                            capturedNumHeads);
+                        DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                    },
+                    Rwkv7SequenceBackward<T>,
+                    new object[] { numHeads });
+            }
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.XLstmScan.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -63,6 +64,32 @@ public partial class CpuEngine
         EnsureGateShape(iGate, batch, seqLen, numHeads, nameof(iGate));
         EnsureGateShape(fGate, batch, seqLen, numHeads, nameof(fGate));
         EnsureGateShape(oGate, batch, seqLen, numHeads, nameof(oGate));
+
+        if (GraphMode.IsActive && GraphMode.Current is { } scope)
+        {
+            scope.BindEngineIfUnset(this);
+            var capturedQ = qProj;
+            var capturedK = kProj;
+            var capturedV = vProj;
+            var capturedI = iGate;
+            var capturedF = fGate;
+            var capturedO = oGate;
+            int capturedNumHeads = numHeads;
+            return scope.RecordVariadic(
+                LazyNodeType.Custom,
+                "XLstmScan",
+                new[] { qProj, kProj, vProj, iGate, fGate, oGate },
+                new[] { batch, seqLen, modelDim },
+                (eng, output) =>
+                {
+                    var result = eng.XLstmScanForward(
+                        capturedQ, capturedK, capturedV, capturedI, capturedF, capturedO,
+                        capturedNumHeads);
+                    DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+                },
+                XLstmScanBackward<T>,
+                new object[] { numHeads });
+        }
 
         var output = new Tensor<T>(new[] { batch, seqLen, modelDim });
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Geometry.cs
@@ -15,6 +15,11 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> Interpolate<T>(Tensor<T> input, int[] sizes, InterpolateMode mode, bool alignCorners = false)
     {
+        // Capture the differentiable node before native dispatch. During compiled replay GraphMode
+        // is inactive, so the same node still executes the backend's resident interpolation kernel.
+        if (IsTapeActive<T>() || Compilation.GraphMode.IsActive)
+            return base.Interpolate(input, sizes, mode, alignCorners);
+
         // GPU surface: T=float, 4D NCHW, modes Nearest/Bilinear/Bicubic/Area.
         if (typeof(T) == typeof(float)
             && input.Rank == 4

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -9974,7 +9974,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> GlaScanForward<T>(
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> gate, int numHeads)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
         if (qProj.Rank != 3 || numHeads < 1)
             return base.GlaScanForward(qProj, kProj, vProj, gate, numHeads);
@@ -10041,7 +10042,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> forgetGate,
         Tensor<T> slotKeys, int numHeads, double slotInitScale = 0.1)
     {
-        if (IsTapeActive<T>() || !TryGetBackend(out var abcBackend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() || !TryGetBackend(out var abcBackend))
             return base.AbcScanForward(qProj, kProj, vProj, forgetGate, slotKeys, numHeads, slotInitScale);
         if (abcBackend is Engines.DirectGpu.CUDA.CudaBackend abcCuda && abcCuda.IsStreamCapturing())
             throw new NotSupportedException(
@@ -10424,7 +10425,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj,
         Tensor<T> iGate, Tensor<T> fGate, Tensor<T> oGate, int numHeads)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
         if (qProj.Rank != 3 || numHeads < 1)
             return base.XLstmScanForward(qProj, kProj, vProj, iGate, fGate, oGate, numHeads);
@@ -10477,7 +10479,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> GatedDeltaNetScanForward<T>(
         Tensor<T> qProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> alpha, Tensor<T> beta, int numHeads)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
         if (qProj.Rank != 3 || numHeads < 1)
             return base.GatedDeltaNetScanForward(qProj, kProj, vProj, alpha, beta, numHeads);
@@ -10526,7 +10529,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> RgLruScanForward<T>(
         Tensor<T> value, Tensor<T> recGate, Tensor<T> inpGate, Tensor<T> decay)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.RgLruScanForward(value, recGate, inpGate, decay);
         if (value.Rank != 3)
             return base.RgLruScanForward(value, recGate, inpGate, decay);
@@ -10567,7 +10571,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> Rwkv4WkvForward<T>(
         Tensor<T> rProj, Tensor<T> kProj, Tensor<T> vProj, Tensor<T> timeDecay, Tensor<T> timeFirst)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
         if (rProj.Rank != 3)
             return base.Rwkv4WkvForward(rProj, kProj, vProj, timeDecay, timeFirst);
@@ -10610,7 +10615,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> MambaSelectiveScanForward<T>(
         Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
         if (x.Rank != 3 || aLog.Rank != 2)
             return base.MambaSelectiveScanForward(x, delta, aLog, bParam, cParam, dParam);
@@ -10661,7 +10667,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> inputMapReal, Tensor<T> inputMapImag,
         Tensor<T> outputMapReal, Tensor<T> outputMapImag, Tensor<T> skip)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
             input.Rank != 4 || transitionReal.Rank != 2)
             return base.ComplexDiagonalSsmScanForward(
                 input, transitionReal, transitionImag, inputMapReal, inputMapImag,
@@ -10711,7 +10718,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> q, Tensor<T> k, Tensor<T> v, Tensor<T> initialWeights,
         T regularization, int numHeads)
     {
-        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
+        if (Compilation.GraphMode.IsActive || typeof(T) != typeof(float) ||
+            !TryGetBackend(out var backend) ||
             q.Rank != 3 || numHeads <= 0)
             return base.MesaScanForward(q, k, v, initialWeights, regularization, numHeads);
 
@@ -10762,7 +10770,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         Tensor<T> input, Tensor<T> activeMask, Tensor<T> transition,
         Tensor<T> inputMap, Tensor<T> outputMap, Tensor<T> skip)
     {
-        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
+        if (Compilation.GraphMode.IsActive || typeof(T) != typeof(float) ||
+            !TryGetBackend(out var backend) ||
             input.Rank != 3 || activeMask.Rank != 3 || transition.Rank != 2)
             return base.RoutedDiagonalSsmScanForward(input, activeMask, transition, inputMap, outputMap, skip);
         int batch = input.Shape._dims[0];
@@ -10806,7 +10815,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> Mamba2SsdScanForward<T>(
         Tensor<T> x, Tensor<T> delta, Tensor<T> aLog, Tensor<T> bParam, Tensor<T> cParam, Tensor<T> dParam, int numHeads)
     {
-        if (IsTapeActive<T>() || typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>() ||
+            typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
         if (x.Rank != 3 || numHeads < 1)
             return base.Mamba2SsdScanForward(x, delta, aLog, bParam, cParam, dParam, numHeads);
@@ -10857,10 +10867,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     /// <inheritdoc/>
     /// <remarks>
-    /// The direct-GPU fused kernel currently has no tape-compatible backward. An active gradient tape is
-    /// rejected explicitly so GPU-resident logits are never silently downloaded through the CPU virtual path.
+    /// Graph tracing and tape-active calls use the base fused analytic backward. Replay without an
+    /// active tape still dispatches the resident device forward kernel.
     /// </remarks>
-    /// <exception cref="NotSupportedException">Thrown when a gradient tape is active.</exception>
     public override Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<int> targetIds)
     {
@@ -10868,9 +10877,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (bias is null) throw new ArgumentNullException(nameof(bias));
         if (targetIds is null) throw new ArgumentNullException(nameof(targetIds));
-        if (IsTapeActive<T>())
-            throw new NotSupportedException(
-                "DirectGpuTensorEngine does not yet support tape-active fused linear cross-entropy with index targets; use CpuEngine explicitly for this training operation.");
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>())
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
         if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
         if (hidden.Rank != 2 || weight.Rank != 2)
@@ -10912,10 +10920,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     /// <inheritdoc/>
     /// <remarks>
-    /// The direct-GPU fused kernel currently has no tape-compatible backward. An active gradient tape is
-    /// rejected explicitly so GPU-resident logits are never silently downloaded through the CPU virtual path.
+    /// Graph tracing and tape-active calls use the base fused analytic backward. Replay without an
+    /// active tape still dispatches the resident device forward kernel.
     /// </remarks>
-    /// <exception cref="NotSupportedException">Thrown when a gradient tape is active.</exception>
     public override Tensor<T> FusedLinearCrossEntropyWithLogits<T>(
         Tensor<T> hidden, Tensor<T> weight, Tensor<T> bias, Tensor<T> target)
     {
@@ -10923,9 +10930,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (bias is null) throw new ArgumentNullException(nameof(bias));
         if (target is null) throw new ArgumentNullException(nameof(target));
-        if (IsTapeActive<T>())
-            throw new NotSupportedException(
-                "DirectGpuTensorEngine does not yet support tape-active fused linear cross-entropy with dense targets; use CpuEngine explicitly for this training operation.");
+        if (Compilation.GraphMode.IsActive || IsTapeActive<T>())
+            return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
         if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target);
         if (hidden.Rank != 2 || weight.Rank != 2)
@@ -18363,11 +18369,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         DeviceDispatch.EnforceStrict(a, b); // no-op unless strict mode is enabled
         if (!ShapesMatch(a.Shape._dims, b.Shape._dims))
-        {
-            if (ThrowOnGpuKernelFallback)
-                throw new ArgumentException("TensorAdd operands must have identical shapes in strict GPU mode.");
             return base.TensorAdd(a, b);
-        }
         if (TryBinaryResidentOutOfPlace(a, b, static (be, ia, ib, o, n) => be.Add(ia, ib, o, n)) is { } radd)
         {
             Autodiff.DifferentiableOps.RecordBinary("TensorAdd", radd, a, b, Autodiff.BackwardFunctions<T>.AddBackward);
@@ -18445,11 +18447,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         DeviceDispatch.EnforceStrict(a, b); // no-op unless strict mode is enabled
         if (!ShapesMatch(a.Shape._dims, b.Shape._dims))
-        {
-            if (ThrowOnGpuKernelFallback)
-                throw new ArgumentException("TensorMultiply operands must have identical shapes in strict GPU mode.");
             return base.TensorMultiply(a, b);
-        }
         if (TryBinaryResidentOutOfPlace(a, b, static (be, ia, ib, o, n) => be.Multiply(ia, ib, o, n)) is { } rmul)
         {
             Autodiff.DifferentiableOps.RecordBinary("TensorMultiply", rmul, a, b, Autodiff.BackwardFunctions<T>.MultiplyBackward);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledCustomKernelCaptureTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledCustomKernelCaptureTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+/// <summary>
+/// Custom differentiable kernels must remain live graph nodes during compiled training.
+/// An eager-only implementation can appear correct on the trace batch while freezing its output
+/// as a leaf, which severs both upstream gradients and subsequent replay updates.
+/// </summary>
+public class CompiledCustomKernelCaptureTests
+{
+    private delegate Tensor<float> Forward(CpuEngine engine, Tensor<float>[] parameters);
+
+    private static Tensor<float> Values(int[] shape, float start = 0.08f, float step = 0.013f)
+    {
+        var tensor = new Tensor<float>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = start + step * (i % 11);
+        return tensor;
+    }
+
+    private static void AssertCompiledParity(
+        string operationName,
+        Tensor<float>[] parameters,
+        Forward forward,
+        float lossTolerance = 2e-4f,
+        float gradientTolerance = 2e-3f,
+        CpuEngine? executionEngine = null)
+    {
+        var engine = executionEngine ?? new CpuEngine();
+        var (eagerLoss, eagerGradients) = Eager(engine, parameters, forward);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.EnableTraining(parameters))
+        {
+            var compiledOutput = forward(engine, parameters);
+            var compiledLoss = engine.ReduceSum(compiledOutput, null);
+            plan = scope.CompileTraining(parameters, compiledLoss);
+        }
+
+        using (plan)
+        {
+            float replayedLoss = plan.Step()[0];
+            AssertFiniteAndClose(operationName + " loss", eagerLoss, replayedLoss, lossTolerance);
+
+            var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
+            AssertGradients(operationName, parameters, eagerGradients, compiled.Gradients, gradientTolerance);
+
+            // This specifically distinguishes a graph edge from a plausible-looking value frozen at trace time.
+            float originalLoss = replayedLoss;
+            parameters[0][0] += 0.19f;
+            var (updatedEagerLoss, updatedEagerGradients) = Eager(engine, parameters, forward);
+            float updatedReplayLoss = plan.Step()[0];
+            AssertFiniteAndClose(operationName + " updated loss", updatedEagerLoss, updatedReplayLoss, lossTolerance);
+            Assert.True(Math.Abs(updatedReplayLoss - originalLoss) > 1e-7f,
+                $"{operationName} replay ignored a live upstream parameter change.");
+            AssertGradients(operationName + " updated", parameters, updatedEagerGradients,
+                compiled.Gradients, gradientTolerance);
+        }
+    }
+
+    private static (float Loss, Dictionary<Tensor<float>, Tensor<float>> Gradients) Eager(
+        CpuEngine engine,
+        Tensor<float>[] parameters,
+        Forward forward)
+    {
+        using var tape = new GradientTape<float>();
+        var loss = engine.ReduceSum(forward(engine, parameters), null);
+        return (loss[0], tape.ComputeGradients(loss, parameters));
+    }
+
+    private static void AssertGradients(
+        string operationName,
+        Tensor<float>[] parameters,
+        IReadOnlyDictionary<Tensor<float>, Tensor<float>> expected,
+        IReadOnlyList<Tensor<float>> actual,
+        float tolerance)
+    {
+        Assert.Equal(parameters.Length, actual.Count);
+        for (int parameterIndex = 0; parameterIndex < parameters.Length; parameterIndex++)
+        {
+            Assert.True(expected.TryGetValue(parameters[parameterIndex], out var expectedTensor),
+                $"{operationName} eager backward omitted parameter {parameterIndex}.");
+            var expectedValues = expectedTensor!.ToArray();
+            var actualValues = actual[parameterIndex].ToArray();
+            Assert.Equal(expectedValues.Length, actualValues.Length);
+            for (int element = 0; element < expectedValues.Length; element++)
+                AssertFiniteAndClose(
+                    $"{operationName} gradient {parameterIndex}[{element}]",
+                    expectedValues[element], actualValues[element], tolerance);
+        }
+    }
+
+    private static void AssertFiniteAndClose(string label, float expected, float actual, float tolerance)
+    {
+        Assert.True(float.IsFinite(expected), $"{label}: eager value {expected} is not finite.");
+        Assert.True(float.IsFinite(actual), $"{label}: compiled value {actual} is not finite.");
+        float allowed = tolerance * Math.Max(1f, Math.Abs(expected));
+        Assert.True(Math.Abs(actual - expected) <= allowed,
+            $"{label}: compiled {actual:G9} != eager {expected:G9}; allowed {allowed:G9}.");
+    }
+
+    [Fact]
+    public void AbcScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.11f),
+            Values(new[] { 1, 3, 4 }, 0.17f), Values(new[] { 1, 3, 2 }, 0.55f, 0.02f),
+            Values(new[] { 2, 2, 2 }, 0.09f)
+        };
+        AssertCompiledParity("ABC", p, (e, x) => e.AbcScanForward(x[0], x[1], x[2], x[3], x[4], 2));
+    }
+
+    [Fact]
+    public void GatedDeltaNetScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.12f),
+            Values(new[] { 1, 3, 4 }, 0.18f), Values(new[] { 1, 3, 2 }, 0.65f, 0.01f),
+            Values(new[] { 1, 3, 2 }, 0.35f, 0.02f)
+        };
+        AssertCompiledParity("GatedDeltaNet", p,
+            (e, x) => e.GatedDeltaNetScanForward(x[0], x[1], x[2], x[3], x[4], 2));
+    }
+
+    [Fact]
+    public void GlaScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.12f),
+            Values(new[] { 1, 3, 4 }, 0.18f), Values(new[] { 1, 3, 2 }, 0.65f, 0.01f)
+        };
+        AssertCompiledParity("GLA", p, (e, x) => e.GlaScanForward(x[0], x[1], x[2], x[3], 2));
+    }
+
+    [Fact]
+    public void DirectGpuScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.12f),
+            Values(new[] { 1, 3, 4 }, 0.18f), Values(new[] { 1, 3, 2 }, 0.65f, 0.01f)
+        };
+        AssertCompiledParity(
+            "DirectGpu GLA", p, (e, x) => e.GlaScanForward(x[0], x[1], x[2], x[3], 2),
+            lossTolerance: 4e-4f, gradientTolerance: 3e-3f, executionEngine: engine);
+    }
+
+    [Fact]
+    public void Interpolate_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[] { Values(new[] { 1, 1, 2, 2 }, 0.1f, 0.17f) };
+        AssertCompiledParity(
+            "bilinear interpolate", p,
+            (e, x) => e.Interpolate(x[0], new[] { 4, 4 }, InterpolateMode.Bilinear));
+    }
+
+    [Fact]
+    public void DirectGpuInterpolate_IsCapturedWithGradientsAndLiveReplay()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        var p = new[] { Values(new[] { 1, 1, 2, 2 }, 0.1f, 0.17f) };
+        AssertCompiledParity(
+            "DirectGpu bilinear interpolate", p,
+            (e, x) => e.Interpolate(x[0], new[] { 4, 4 }, InterpolateMode.Bilinear),
+            lossTolerance: 4e-4f,
+            gradientTolerance: 3e-3f,
+            executionEngine: engine);
+    }
+
+    [Fact]
+    public void MambaScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.04f, 0.006f),
+            Values(new[] { 4, 2 }, -0.2f, 0.02f), Values(new[] { 1, 3, 2 }, 0.1f),
+            Values(new[] { 1, 3, 2 }, 0.13f), Values(new[] { 4 }, 0.2f)
+        };
+        AssertCompiledParity("Mamba", p,
+            (e, x) => e.MambaSelectiveScanForward(x[0], x[1], x[2], x[3], x[4], x[5]));
+    }
+
+    [Fact]
+    public void Mamba2Scan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 2 }, 0.04f, 0.006f),
+            Values(new[] { 2 }, -0.2f, 0.03f), Values(new[] { 1, 3, 2 }, 0.1f),
+            Values(new[] { 1, 3, 2 }, 0.13f), Values(new[] { 2 }, 0.2f)
+        };
+        AssertCompiledParity("Mamba2", p,
+            (e, x) => e.Mamba2SsdScanForward(x[0], x[1], x[2], x[3], x[4], x[5], 2));
+    }
+
+    [Fact]
+    public void MesaScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }, 0.04f), Values(new[] { 1, 3, 4 }, 0.06f),
+            Values(new[] { 1, 3, 4 }, 0.08f), Values(new[] { 2, 2, 2 }, 0.03f)
+        };
+        AssertCompiledParity("Mesa", p,
+            (e, x) => e.MesaScanForward(x[0], x[1], x[2], x[3], 0.75f, 2),
+            gradientTolerance: 4e-3f);
+    }
+
+    [Fact]
+    public void RgLruScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }), Values(new[] { 1, 3, 4 }, 0.55f, 0.01f),
+            Values(new[] { 1, 3, 4 }, 0.45f, 0.01f), Values(new[] { 4 }, 0.1f)
+        };
+        AssertCompiledParity("RG-LRU", p, (e, x) => e.RgLruScanForward(x[0], x[1], x[2], x[3]));
+    }
+
+    [Fact]
+    public void Rwkv4Scan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }, -0.1f), Values(new[] { 1, 3, 4 }, 0.06f),
+            Values(new[] { 1, 3, 4 }, 0.09f), Values(new[] { 4 }, -0.3f, 0.03f),
+            Values(new[] { 4 }, 0.12f)
+        };
+        AssertCompiledParity("RWKV4", p,
+            (e, x) => e.Rwkv4WkvForward(x[0], x[1], x[2], x[3], x[4]));
+    }
+
+    [Fact]
+    public void XLstmScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 4 }, 0.04f), Values(new[] { 1, 3, 4 }, 0.06f),
+            Values(new[] { 1, 3, 4 }, 0.08f), Values(new[] { 1, 3, 2 }, 0.7f, 0.02f),
+            Values(new[] { 1, 3, 2 }, 0.6f, 0.01f), Values(new[] { 1, 3, 2 }, 0.55f, 0.01f)
+        };
+        AssertCompiledParity("xLSTM", p,
+            (e, x) => e.XLstmScanForward(x[0], x[1], x[2], x[3], x[4], x[5], 2));
+    }
+
+    [Fact]
+    public void ComplexDiagonalSsmScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 1, 2 }), Values(new[] { 1, 2 }, 0.2f),
+            Values(new[] { 1, 2 }, 0.03f), Values(new[] { 1, 2, 2 }, 0.08f),
+            Values(new[] { 1, 2, 2 }, 0.02f), Values(new[] { 1, 2, 2 }, 0.09f),
+            Values(new[] { 1, 2, 2 }, 0.01f), Values(new[] { 1, 2 }, 0.15f)
+        };
+        AssertCompiledParity("complex diagonal SSM", p,
+            (e, x) => e.ComplexDiagonalSsmScanForward(
+                x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]));
+    }
+
+    [Fact]
+    public void RoutedDiagonalSsmScan_IsCapturedWithGradientsAndLiveReplay()
+    {
+        var p = new[]
+        {
+            Values(new[] { 1, 3, 2 }), Values(new[] { 1, 3, 2 }, 0.4f, 0.03f),
+            Values(new[] { 2, 2 }, 0.2f), Values(new[] { 2, 2, 2 }, 0.08f),
+            Values(new[] { 2, 2, 2 }, 0.09f), Values(new[] { 2, 2 }, 0.15f)
+        };
+        AssertCompiledParity("routed diagonal SSM", p,
+            (e, x) => e.RoutedDiagonalSsmScanForward(x[0], x[1], x[2], x[3], x[4], x[5]));
+    }
+
+    [Fact]
+    public void FusedLinearCrossEntropy_IndexLabelsStayLiveAcrossReplays()
+    {
+        var engine = new CpuEngine();
+        var parameters = new[]
+        {
+            Values(new[] { 2, 3 }, 0.1f), Values(new[] { 3, 4 }, -0.08f, 0.04f),
+            Values(new[] { 4 }, -0.03f, 0.02f)
+        };
+        var targetIds = new Tensor<int>(new[] { 0, 2 }, new[] { 2 });
+        Forward forward = (e, x) => e.FusedLinearCrossEntropyWithLogits(x[0], x[1], x[2], targetIds);
+        var (expectedLoss, expectedGradients) = Eager(engine, parameters, forward);
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.EnableTraining(parameters))
+        {
+            var compiledLoss = forward(engine, parameters);
+            plan = scope.CompileTraining(parameters, compiledLoss);
+        }
+
+        using (plan)
+        {
+            float actualLoss = plan.Step()[0];
+            var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
+            AssertFiniteAndClose("indexed fused CE loss", expectedLoss, actualLoss, 2e-5f);
+            AssertGradients("indexed fused CE", parameters, expectedGradients, compiled.Gradients, 2e-5f);
+
+            targetIds[0] = 1;
+            var (updatedExpectedLoss, updatedExpectedGradients) = Eager(engine, parameters, forward);
+            float updatedActualLoss = plan.Step()[0];
+            AssertFiniteAndClose("indexed fused CE updated loss", updatedExpectedLoss, updatedActualLoss, 2e-5f);
+            Assert.True(Math.Abs(updatedActualLoss - actualLoss) > 1e-7f,
+                "Compiled fused CE reused the labels from tracing instead of the current batch.");
+            AssertGradients("indexed fused CE updated", parameters, updatedExpectedGradients,
+                compiled.Gradients, 2e-5f);
+        }
+    }
+
+    [Fact]
+    public void FusedLinearCrossEntropy_DenseTargetsAreCaptured()
+    {
+        var parameters = new[]
+        {
+            Values(new[] { 2, 3 }, 0.1f), Values(new[] { 3, 4 }, -0.08f, 0.04f),
+            Values(new[] { 4 }, -0.03f, 0.02f)
+        };
+        var target = new Tensor<float>(
+            new[] { 1f, 0f, 0f, 0f, 0f, 0f, 1f, 0f }, new[] { 2, 4 });
+        AssertCompiledParity("dense fused CE", parameters,
+            (e, x) => e.FusedLinearCrossEntropyWithLogits(x[0], x[1], x[2], target),
+            lossTolerance: 2e-5f, gradientTolerance: 2e-5f);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledCustomKernelCaptureTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledCustomKernelCaptureTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.TestHelpers;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
@@ -31,7 +34,8 @@ public class CompiledCustomKernelCaptureTests
         Forward forward,
         float lossTolerance = 2e-4f,
         float gradientTolerance = 2e-3f,
-        CpuEngine? executionEngine = null)
+        CpuEngine? executionEngine = null,
+        Action? mutateReplayInput = null)
     {
         var engine = executionEngine ?? new CpuEngine();
         var (eagerLoss, eagerGradients) = Eager(engine, parameters, forward);
@@ -62,6 +66,20 @@ public class CompiledCustomKernelCaptureTests
                 $"{operationName} replay ignored a live upstream parameter change.");
             AssertGradients(operationName + " updated", parameters, updatedEagerGradients,
                 compiled.Gradients, gradientTolerance);
+
+            if (mutateReplayInput is not null)
+            {
+                float lossBeforeInputMutation = updatedReplayLoss;
+                mutateReplayInput();
+                var (inputUpdatedEagerLoss, inputUpdatedEagerGradients) = Eager(engine, parameters, forward);
+                float inputUpdatedReplayLoss = plan.Step()[0];
+                AssertFiniteAndClose(operationName + " live input loss",
+                    inputUpdatedEagerLoss, inputUpdatedReplayLoss, lossTolerance);
+                Assert.True(Math.Abs(inputUpdatedReplayLoss - lossBeforeInputMutation) > 1e-7f,
+                    $"{operationName} replay ignored a live non-parameter input change.");
+                AssertGradients(operationName + " live input", parameters, inputUpdatedEagerGradients,
+                    compiled.Gradients, gradientTolerance);
+            }
         }
     }
 
@@ -99,8 +117,8 @@ public class CompiledCustomKernelCaptureTests
 
     private static void AssertFiniteAndClose(string label, float expected, float actual, float tolerance)
     {
-        Assert.True(float.IsFinite(expected), $"{label}: eager value {expected} is not finite.");
-        Assert.True(float.IsFinite(actual), $"{label}: compiled value {actual} is not finite.");
+        Assert.True(MathCompat.IsFinite(expected), $"{label}: eager value {expected} is not finite.");
+        Assert.True(MathCompat.IsFinite(actual), $"{label}: compiled value {actual} is not finite.");
         float allowed = tolerance * Math.Max(1f, Math.Abs(expected));
         Assert.True(Math.Abs(actual - expected) <= allowed,
             $"{label}: compiled {actual:G9} != eager {expected:G9}; allowed {allowed:G9}.");
@@ -332,6 +350,69 @@ public class CompiledCustomKernelCaptureTests
             new[] { 1f, 0f, 0f, 0f, 0f, 0f, 1f, 0f }, new[] { 2, 4 });
         AssertCompiledParity("dense fused CE", parameters,
             (e, x) => e.FusedLinearCrossEntropyWithLogits(x[0], x[1], x[2], target),
-            lossTolerance: 2e-5f, gradientTolerance: 2e-5f);
+            lossTolerance: 2e-5f, gradientTolerance: 2e-5f,
+            mutateReplayInput: () =>
+            {
+                for (int i = 0; i < target.Length; i++) target[i] = 0f;
+                target[1] = 1f;
+                target[7] = 1f;
+            });
+    }
+
+    [Fact]
+    public async Task ConcurrentStepCalls_AreSerializedAcrossForwardAndBackward()
+    {
+        var engine = new CpuEngine();
+        var parameter = Values(new[] { 1 });
+        var parameters = new[] { parameter };
+        int activeForwards = 0;
+        int maximumConcurrentForwards = 0;
+
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.EnableTraining(parameters))
+        {
+            var output = scope.RecordUnary(
+                LazyNodeType.Custom,
+                "ConcurrentReplayProbe",
+                parameter,
+                new[] { 1 },
+                (_, destination) =>
+                {
+                    int active = Interlocked.Increment(ref activeForwards);
+                    int observed;
+                    do
+                    {
+                        observed = maximumConcurrentForwards;
+                        if (active <= observed) break;
+                    }
+                    while (Interlocked.CompareExchange(
+                        ref maximumConcurrentForwards, active, observed) != observed);
+
+                    Thread.Sleep(40);
+                    destination[0] = parameter[0];
+                    Interlocked.Decrement(ref activeForwards);
+                },
+                BackwardFunctions<float>.ReshapeBackward,
+                new object[] { new[] { 1 } });
+            var loss = engine.ReduceSum(output, null);
+            plan = scope.CompileTraining(parameters, loss);
+        }
+
+        using (plan)
+        using (var start = new ManualResetEventSlim(false))
+        {
+            Task Replay() => Task.Run(() =>
+            {
+                start.Wait();
+                _ = plan.Step()[0];
+            });
+
+            var first = Replay();
+            var second = Replay();
+            start.Set();
+            await Task.WhenAll(first, second);
+        }
+
+        Assert.Equal(1, maximumConcurrentForwards);
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
@@ -3,6 +3,7 @@ using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.DirectGpu.Cpu;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.TestHelpers;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines;
@@ -115,7 +116,7 @@ public class FusedLinearCeGpuParityTests
             gpuGradients = tape.ComputeGradients(gpuLoss, gpuParameters);
         }
 
-        Assert.True(float.IsFinite(gpuLoss[0]), $"{label} DirectGpu loss is not finite.");
+        Assert.True(MathCompat.IsFinite(gpuLoss[0]), $"{label} DirectGpu loss is not finite.");
         Assert.InRange(Math.Abs(gpuLoss[0] - cpuLoss[0]), 0f, 1e-4f);
         for (int parameterIndex = 0; parameterIndex < cpuParameters.Length; parameterIndex++)
         {
@@ -124,7 +125,7 @@ public class FusedLinearCeGpuParityTests
             Assert.Equal(expected.Length, actual.Length);
             for (int element = 0; element < expected.Length; element++)
             {
-                Assert.True(float.IsFinite(actual[element]),
+                Assert.True(MathCompat.IsFinite(actual[element]),
                     $"{label} DirectGpu gradient {parameterIndex}[{element}] is not finite.");
                 Assert.InRange(Math.Abs(actual[element] - expected[element]), 0f, 2e-4f);
             }

--- a/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/FusedLinearCeGpuParityTests.cs
@@ -59,23 +59,77 @@ public class FusedLinearCeGpuParityTests
     }
 
     [Fact]
-    public void TapeActiveDirectGpuOverloads_RejectSilentCpuFallback()
+    public void TapeActiveDirectGpuOverloads_ProduceAnalyticGradients()
     {
-        using var engine = new DirectGpuTensorEngine();
-        var hidden = new Tensor<float>(Gen(8, 1), new[] { 2, 4 });
-        var weight = new Tensor<float>(Gen(12, 2), new[] { 4, 3 });
-        var bias = new Tensor<float>(Gen(3, 3), new[] { 3 });
+        var cpu = new CpuEngine();
+        using var gpu = new DirectGpuTensorEngine();
         var ids = new Tensor<int>(new[] { 0, 2 }, new[] { 2 });
         var target = new Tensor<float>(new[] { 1f, 0f, 0f, 0f, 0f, 1f }, new[] { 2, 3 });
 
-        using var tape = new GradientTape<float>();
-        NotSupportedException indexError = Assert.Throws<NotSupportedException>(() =>
-            engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, ids));
-        NotSupportedException denseError = Assert.Throws<NotSupportedException>(() =>
-            engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target));
+        AssertTapeParity(
+            cpu,
+            gpu,
+            (engine, hidden, weight, bias) =>
+                engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, ids),
+            "index");
+        AssertTapeParity(
+            cpu,
+            gpu,
+            (engine, hidden, weight, bias) =>
+                engine.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, target),
+            "dense");
+    }
 
-        Assert.Contains("tape-active", indexError.Message, StringComparison.Ordinal);
-        Assert.Contains("tape-active", denseError.Message, StringComparison.Ordinal);
+    private static void AssertTapeParity(
+        CpuEngine cpu,
+        DirectGpuTensorEngine gpu,
+        Func<CpuEngine, Tensor<float>, Tensor<float>, Tensor<float>, Tensor<float>> forward,
+        string label)
+    {
+        var cpuParameters = new[]
+        {
+            new Tensor<float>(Gen(8, 1), new[] { 2, 4 }),
+            new Tensor<float>(Gen(12, 2), new[] { 4, 3 }),
+            new Tensor<float>(Gen(3, 3), new[] { 3 })
+        };
+        var gpuParameters = new[]
+        {
+            new Tensor<float>(Gen(8, 1), new[] { 2, 4 }),
+            new Tensor<float>(Gen(12, 2), new[] { 4, 3 }),
+            new Tensor<float>(Gen(3, 3), new[] { 3 })
+        };
+
+        Tensor<float> cpuLoss;
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> cpuGradients;
+        using (var tape = new GradientTape<float>())
+        {
+            cpuLoss = forward(cpu, cpuParameters[0], cpuParameters[1], cpuParameters[2]);
+            cpuGradients = tape.ComputeGradients(cpuLoss, cpuParameters);
+        }
+
+        Tensor<float> gpuLoss;
+        System.Collections.Generic.Dictionary<Tensor<float>, Tensor<float>> gpuGradients;
+        using (var tape = new GradientTape<float>())
+        {
+            gpuLoss = forward(gpu, gpuParameters[0], gpuParameters[1], gpuParameters[2]);
+            gpuGradients = tape.ComputeGradients(gpuLoss, gpuParameters);
+        }
+
+        Assert.True(float.IsFinite(gpuLoss[0]), $"{label} DirectGpu loss is not finite.");
+        Assert.InRange(Math.Abs(gpuLoss[0] - cpuLoss[0]), 0f, 1e-4f);
+        for (int parameterIndex = 0; parameterIndex < cpuParameters.Length; parameterIndex++)
+        {
+            var expected = cpuGradients[cpuParameters[parameterIndex]].ToArray();
+            var actual = gpuGradients[gpuParameters[parameterIndex]].ToArray();
+            Assert.Equal(expected.Length, actual.Length);
+            for (int element = 0; element < expected.Length; element++)
+            {
+                Assert.True(float.IsFinite(actual[element]),
+                    $"{label} DirectGpu gradient {parameterIndex}[{element}] is not finite.");
+                Assert.InRange(Math.Abs(actual[element] - expected[element]), 0f, 2e-4f);
+            }
+        }
+
     }
 
     private static float[] F(Tensor<float> t) => (float[])(object)t.GetDataArray()!;

--- a/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexOpsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexOpsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,15 +10,19 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// <summary>
 /// Full coverage tests for native Tensor&lt;Complex&lt;T&gt;&gt; IEngine operations.
 /// </summary>
-public class NativeComplexOpsTests
+public class NativeComplexOpsTests : IDisposable
 {
     private readonly IEngine _engine = AiDotNetEngine.Current;
+    private readonly GpuExecutionPolicyScope _precisionPolicy =
+        new(GpuExecutionPolicy.Preserve);
     private readonly ITestOutputHelper _output;
 
     public NativeComplexOpsTests(ITestOutputHelper output)
     {
         _output = output;
     }
+
+    public void Dispose() => _precisionPolicy.Dispose();
 
     // ================================================================
     // FFT Round-Trip

--- a/tests/AiDotNet.Tensors.Tests/Engines/Rwkv7SequenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Rwkv7SequenceTests.cs
@@ -3,6 +3,7 @@ using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.TestHelpers;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines;
@@ -199,44 +200,50 @@ public class Rwkv7SequenceTests
             eagerGradients = tape.ComputeGradients(eagerLossTensor, parameters);
         }
 
-        using var scope = GraphMode.EnableTraining(parameters);
-        var compiledOutput = engine.Rwkv7SequenceForward(
-            parameters[0], parameters[1], parameters[2], parameters[3],
-            parameters[4], parameters[5], numHeads);
-        var compiledLossTensor = engine.ReduceSum(compiledOutput, null);
-        using var plan = scope.CompileTraining(parameters, compiledLossTensor);
-
-        var replayedLoss = plan.Step()[0];
-        Assert.True(float.IsFinite(replayedLoss));
-        Assert.InRange(Math.Abs(replayedLoss - eagerLoss), 0f, 2e-5f);
-
-        var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
-        for (int parameterIndex = 0; parameterIndex < parameters.Length; parameterIndex++)
+        ICompiledTrainingPlan<float> plan;
+        using (var scope = GraphMode.EnableTraining(parameters))
         {
-            Assert.True(eagerGradients.ContainsKey(parameters[parameterIndex]),
-                $"Eager backward omitted parameter {parameterIndex}.");
-            var expected = eagerGradients[parameters[parameterIndex]].ToArray();
-            var actual = compiled.Gradients[parameterIndex].ToArray();
-            Assert.Equal(expected.Length, actual.Length);
-            for (int element = 0; element < expected.Length; element++)
-            {
-                Assert.True(float.IsFinite(actual[element]),
-                    $"Compiled gradient {parameterIndex}[{element}] is not finite.");
-                Assert.InRange(Math.Abs(actual[element] - expected[element]), 0f, 3e-4f);
-            }
+            var compiledOutput = engine.Rwkv7SequenceForward(
+                parameters[0], parameters[1], parameters[2], parameters[3],
+                parameters[4], parameters[5], numHeads);
+            var compiledLossTensor = engine.ReduceSum(compiledOutput, null);
+            plan = scope.CompileTraining(parameters, compiledLossTensor);
         }
 
-        // The recurrence used to execute eagerly DURING tracing and enter the graph as a frozen leaf.
-        // A first replay could therefore look plausible, but changing an upstream tensor had no effect.
-        parameters[0][0] += 0.25f;
-        float expectedUpdatedLoss = engine.ReduceSum(
-            engine.Rwkv7SequenceForward(
-                parameters[0], parameters[1], parameters[2], parameters[3],
-                parameters[4], parameters[5], numHeads),
-            null)[0];
-        float replayedUpdatedLoss = plan.Step()[0];
-        Assert.InRange(Math.Abs(replayedUpdatedLoss - expectedUpdatedLoss), 0f, 2e-5f);
-        Assert.NotEqual(replayedLoss, replayedUpdatedLoss);
+        using (plan)
+        {
+            var replayedLoss = plan.Step()[0];
+            Assert.True(MathCompat.IsFinite(replayedLoss));
+            Assert.InRange(Math.Abs(replayedLoss - eagerLoss), 0f, 2e-5f);
+
+            var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
+            for (int parameterIndex = 0; parameterIndex < parameters.Length; parameterIndex++)
+            {
+                Assert.True(eagerGradients.ContainsKey(parameters[parameterIndex]),
+                    $"Eager backward omitted parameter {parameterIndex}.");
+                var expected = eagerGradients[parameters[parameterIndex]].ToArray();
+                var actual = compiled.Gradients[parameterIndex].ToArray();
+                Assert.Equal(expected.Length, actual.Length);
+                for (int element = 0; element < expected.Length; element++)
+                {
+                    Assert.True(MathCompat.IsFinite(actual[element]),
+                        $"Compiled gradient {parameterIndex}[{element}] is not finite.");
+                    Assert.InRange(Math.Abs(actual[element] - expected[element]), 0f, 3e-4f);
+                }
+            }
+
+            // The recurrence used to execute eagerly DURING tracing and enter the graph as a frozen leaf.
+            // A first replay could therefore look plausible, but changing an upstream tensor had no effect.
+            parameters[0][0] += 0.25f;
+            float expectedUpdatedLoss = engine.ReduceSum(
+                engine.Rwkv7SequenceForward(
+                    parameters[0], parameters[1], parameters[2], parameters[3],
+                    parameters[4], parameters[5], numHeads),
+                null)[0];
+            float replayedUpdatedLoss = plan.Step()[0];
+            Assert.InRange(Math.Abs(replayedUpdatedLoss - expectedUpdatedLoss), 0f, 2e-5f);
+            Assert.NotEqual(replayedLoss, replayedUpdatedLoss);
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Rwkv7SequenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Rwkv7SequenceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -168,6 +169,74 @@ public class Rwkv7SequenceTests
         var dst = new float[src.Length];
         for (int i = 0; i < src.Length; i++) dst[i] = (float)src[i];
         return new Tensor<float>(dst, t.Shape.ToArray());
+    }
+
+    [Fact]
+    public void CompiledTraining_CapturesForwardAndBackwardDependencies()
+    {
+        var engine = new CpuEngine();
+        const int batch = 1, seqLen = 4, modelDim = 4, numHeads = 2;
+        var source = MakeInputs(batch, seqLen, modelDim, 37);
+        var parameters = new[]
+        {
+            ToFloat(source.R),
+            ToFloat(source.Kappa),
+            ToFloat(source.KTilde),
+            ToFloat(source.V),
+            ToFloat(source.Decay),
+            ToFloat(source.Icl)
+        };
+
+        Dictionary<Tensor<float>, Tensor<float>> eagerGradients;
+        float eagerLoss;
+        using (var tape = new GradientTape<float>())
+        {
+            var eagerOutput = engine.Rwkv7SequenceForward(
+                parameters[0], parameters[1], parameters[2], parameters[3],
+                parameters[4], parameters[5], numHeads);
+            var eagerLossTensor = engine.ReduceSum(eagerOutput, null);
+            eagerLoss = eagerLossTensor[0];
+            eagerGradients = tape.ComputeGradients(eagerLossTensor, parameters);
+        }
+
+        using var scope = GraphMode.EnableTraining(parameters);
+        var compiledOutput = engine.Rwkv7SequenceForward(
+            parameters[0], parameters[1], parameters[2], parameters[3],
+            parameters[4], parameters[5], numHeads);
+        var compiledLossTensor = engine.ReduceSum(compiledOutput, null);
+        using var plan = scope.CompileTraining(parameters, compiledLossTensor);
+
+        var replayedLoss = plan.Step()[0];
+        Assert.True(float.IsFinite(replayedLoss));
+        Assert.InRange(Math.Abs(replayedLoss - eagerLoss), 0f, 2e-5f);
+
+        var compiled = Assert.IsType<CompiledTrainingPlan<float>>(plan);
+        for (int parameterIndex = 0; parameterIndex < parameters.Length; parameterIndex++)
+        {
+            Assert.True(eagerGradients.ContainsKey(parameters[parameterIndex]),
+                $"Eager backward omitted parameter {parameterIndex}.");
+            var expected = eagerGradients[parameters[parameterIndex]].ToArray();
+            var actual = compiled.Gradients[parameterIndex].ToArray();
+            Assert.Equal(expected.Length, actual.Length);
+            for (int element = 0; element < expected.Length; element++)
+            {
+                Assert.True(float.IsFinite(actual[element]),
+                    $"Compiled gradient {parameterIndex}[{element}] is not finite.");
+                Assert.InRange(Math.Abs(actual[element] - expected[element]), 0f, 3e-4f);
+            }
+        }
+
+        // The recurrence used to execute eagerly DURING tracing and enter the graph as a frozen leaf.
+        // A first replay could therefore look plausible, but changing an upstream tensor had no effect.
+        parameters[0][0] += 0.25f;
+        float expectedUpdatedLoss = engine.ReduceSum(
+            engine.Rwkv7SequenceForward(
+                parameters[0], parameters[1], parameters[2], parameters[3],
+                parameters[4], parameters[5], numHeads),
+            null)[0];
+        float replayedUpdatedLoss = plan.Step()[0];
+        Assert.InRange(Math.Abs(replayedUpdatedLoss - expectedUpdatedLoss), 0f, 2e-5f);
+        Assert.NotEqual(replayedLoss, replayedUpdatedLoss);
     }
 
     [Fact]


### PR DESCRIPTION
## Outcome

This fixes fused compiled training at the graph boundary instead of disabling it on affected models. Custom recurrent kernels, fused linear cross-entropy, and interpolation now enter the compiled graph with their real inputs and analytical backwards. DirectGPU traces through the differentiable contract and still executes its resident native forward during replay.

No `SupportsFusedCompiledTraining = false` escape hatch is added. The non-finite guard from #972 remains defense in depth, but valid models now produce finite gradients and commit real parameter updates.

## Why #972 and #975 were not sufficient

#972 made a corrupt step failure-atomic: it prevented NaN/Infinity gradients from damaging parameters. #975 fixed the missing compiled producer for RoPE. The same structural defect still existed in the custom scan, CE, and interpolation surfaces: eager tape recording existed, but `GraphMode` executed the operation during tracing and exposed its result as a frozen leaf.

That caused three user-visible failure modes:

- replay reused trace-time output instead of current inputs;
- pooled trace storage could be reused before replay, producing intermittent non-finite activations/gradients;
- the optimizer correctly skipped the bad step, so training looked safe but made no progress.

## New compiled-training support

- Variadic compiled nodes with analytical backwards for:
  - ABC, GLA, Gated DeltaNet, RG-LRU, RWKV-4, and RWKV-7;
  - Mamba selective scan and Mamba-2 SSD;
  - xLSTM, Mesa, complex diagonal SSM, and routed diagonal SSM.
- Compiled `FusedLinearCrossEntropyWithLogits` for both index and dense targets.
  - Index labels are refreshed on every replay rather than frozen at trace time.
  - DirectGPU tape-active calls use the existing analytical backward instead of throwing.
- Compiled `Interpolate` with shape validation and analytical backward.
- CPU and DirectGPU graph scopes bind the actual execution engine.
- DirectGPU records through the base differentiable path only while tracing/taping; replay with `GraphMode` inactive still dispatches the backend's resident scan, CE, or interpolation forward.

## Existing behavior fixed

- RWKV and other recurrence models no longer compile a trace-time leaf in place of their stateful scan.
- SAM2's training interpolation now remains connected to upstream mask parameters.
- Fused CE propagates finite gradients to hidden state, weight, and bias for both target representations.
- Changing a parameter after compilation changes replay loss and gradients, proving replay liveness rather than first-step-only numerical coincidence.
- Valid implicit broadcasts are allowed to reach the rank-generic GPU implementation even when fallback diagnostics are strict.
- Exact complex-number tests now opt into `GpuExecutionPolicy.Preserve`; their original double-precision assertions remain unchanged.

## Type and backend parity

This builds on #971 without changing its public contract:

- speed-first remains the default for GPU work;
- the result is converted back to the caller's declared `T`;
- `GpuExecutionPolicy.Preserve` remains the correctness-sensitive opt-in and selects a native exact route when advertised, otherwise the generic CPU route;
- CPU implementations remain generic in `T`;
- CUDA, HIP, Metal, OpenCL, Vulkan, and WebGPU continue to use the shared capability/autocast planner rather than a hard-coded assumption that FP32, FP16, or BF16 is universally best.

#971's deterministic matrix covers `float`, `double`, `Half`, `BFloat16`, `Float8E4M3`, `Float8E5M2`, `int`, `long`, and `decimal`, including conversion back to the declared type and exact-preservation fallbacks. This change sits above that planner: it restores graph/autodiff parity for the fused operations and deliberately does not relabel an emulated format as native support.

The hardware evidence from #971 remains the applicable conversion boundary on the tested GTX 1660 Ti:

|  FP64 matrix | GPU `double -> Auto -> double` | Exact CPU `double` | Net converted-GPU result |
|---:|---:|---:|---:|
| 256 x 256 | 1.338 ms | 0.932 ms | 0.70x (conversion loses) |
| 1024 x 1024 | 16.495 ms | 27.232 ms | 1.65x faster |
| 2048 x 2048 | 65.843 ms | 125.982 ms | 1.91x faster |

That evidence is intentionally device-specific: small work does not amortize conversion, and FP16 was slower than FP32 on that device. Backend capability selection remains the design requirement, not a universal low-precision claim.

## Validation evidence

### Tensors

- `CompiledCustomKernelCaptureTests`: 18/18 passed.
  - eager/compiled loss parity;
  - every input gradient finite and numerically matched;
  - parameter mutation followed by replay, proving live dependencies;
  - CPU and active DirectGPU coverage;
  - index-label and dense-target mutation between CE replays;
  - concurrent `Step()` calls proven serialized across the complete forward/backward transaction.
- Compiled/custom/geometry/CE/RWKV combined gate: 82 passed, 1 environment-specific skip, 0 failed.
- All affected scan suites: 74 passed, 2 environment-specific backend/op-parity skips, 0 failed.
- DirectGPU tape-active fused CE: CPU-parity loss and every hidden/weight/bias gradient for index and dense targets.
- Library net10.0 build: 0 errors.
- Test net10.0 build: 0 errors.
- Test net471 build: 0 errors.
- `git diff --check`: clean.

### Review follow-up

- All 6 inline review threads are resolved in `8423e223`.
- The exact review-affected test selection is 47 passed / 0 failed on net10.0 and 43 passed / 0 failed on net471.
- `CompiledTrainingPlan.Step()` is now step-atomic: plan-owned activations, saved state, gradients, optimizer moments, and CUDA graph state cannot be interleaved by overlapping callers.
- The RWKV replay-liveness reference executes after the graph scope is disposed, so it is genuinely eager rather than another recorded node.
- Every new finite-value assertion uses the repository's net471-compatible `MathCompat.IsFinite` surface. The suggested `DirectGpuTensorEngine.cs` site was verified against the current head and does not contain an unguarded `IsFinite` call.

### Baseline failures from merged #971

On the exact parent commit (`f592c46a`), the focused control reproduced 5 failures: four double-complex precision assertions ran through speed-first FP32, and strict mode rejected a valid broadcast before GPU dispatch. Result: 5 failed, 36 passed, 1 skipped.

After this change, the identical 42-test set is 41 passed, 1 pre-existing explicitly skipped FFT-real test, 0 failed. No tolerances or numerical assertions were weakened.

### Downstream AiDotNet proof

- The 12 model gates that had been proposed for capability opt-out all pass with fused support enabled: 12/12.
- RWKV fused training passed in 8/8 fresh processes after previously failing intermittently (approximately 5/8 bad runs).
- The RWKV probe produced finite output/gradients, loss `0.3680228`, and changed 7,304 live parameters.
- SAM2's direct fused-training gate passes after interpolation capture was restored.

These downstream gates assert real fused-optimizer hits and persisted parameter changes; they cannot pass merely by falling back to eager training or by reporting a finite loss from an internal buffer.
