### PR TITLE
fix(perf): bound the buffer caches in aggregate, not just per bucket

### DIFF
--- a/src/AiDotNet.Tensors/Helpers/TensorArena.cs
+++ b/src/AiDotNet.Tensors/Helpers/TensorArena.cs
@@ -94,7 +94,54 @@ public sealed class TensorArena : IDisposable
     // a model with many distinct shapes can't grow the pool without bound.
     // ---------------------------------------------------------------------
     [ThreadStatic]
-    private static Dictionary<(Type, int), Stack<Array>>? _persistent;
+    private static Dictionary<(Type, int), Bucket>? _persistent;
+
+    /// <summary>
+    /// One (type, size) bucket plus the arena generation that last touched it.
+    /// </summary>
+    /// <remarks>
+    /// The generation stamp is what makes retention self-limiting ACROSS models.
+    /// <see cref="MaxPersistPerSize"/> bounds a single bucket, but nothing bounded the NUMBER of
+    /// buckets, and the bucket key is an EXACT (type, element-count) pair — so a process that runs
+    /// many distinct shapes accumulated one bucket per shape and released none of them until
+    /// <see cref="ClearPersistentPool"/> was called by hand. Every retained buffer is at least
+    /// <see cref="PersistThresholdElems"/> elements (256 KB at float, 512 KB at double) and there
+    /// can be up to <see cref="MaxPersistPerSize"/> of them per bucket, so the ceiling was
+    /// shapes × 64 × 256 KB — hundreds of MB of Gen2 for a few dozen shapes.
+    /// Measured on AiDotNet's RecurrentGemma finite-difference gradcheck: 11-13 s in a clean
+    /// process, past its entire 120 s budget once 29 sibling model tests had filled the pool on the
+    /// same thread. Nothing was wrong with the gradcheck; it was paying for buffers no one would
+    /// ever rent again.
+    /// </remarks>
+    private sealed class Bucket
+    {
+        internal readonly Stack<Array> Arrays = new Stack<Array>(MaxPersistPerSize);
+
+        internal long LastTouchedGeneration;
+    }
+
+    /// <summary>
+    /// Completed top-level arena lifetimes on this thread. Buckets are stamped with it on every
+    /// rent and return, and <see cref="PruneStaleCrossArenaBuckets"/> drops those that have gone
+    /// <see cref="MaxIdleGenerations"/> lifetimes without a touch.
+    /// </summary>
+    [ThreadStatic]
+    private static long _arenaGeneration;
+
+    /// <summary>
+    /// How many arena lifetimes a bucket may sit untouched before it is dropped.
+    /// </summary>
+    /// <remarks>
+    /// The pool's stated purpose is that "the NEXT arena on the same thread reuses the buffers", so
+    /// a bucket untouched for several lifetimes is not serving that purpose — it is holding a
+    /// previous model's working set resident. Two preserves steady-state reuse for a train loop that
+    /// rents the same shapes every step (touched every generation, so never stale) while releasing a
+    /// different model's shapes within two lifetimes. This is deliberately a generation policy and
+    /// not a byte budget: a byte cap cannot tell "one paper-scale model's ~1 GB working set, which
+    /// the next step genuinely wants" apart from "twenty models' leftovers", and picking a number
+    /// low enough to bound the second would evict the first every step and undo issue #478.
+    /// </remarks>
+    private const long MaxIdleGenerations = 2;
 
     // Test/diagnostic: counts how many times a large buffer was served from the
     // cross-arena persistent pool (a reuse hit) rather than freshly allocated.
@@ -134,9 +181,10 @@ public sealed class TensorArena : IDisposable
         if (elementCount < PersistThresholdElems) return null;
         var pool = _persistent;
         if (pool is null) return null;
-        if (pool.TryGetValue((type, elementCount), out var stack) && stack.Count > 0)
+        if (pool.TryGetValue((type, elementCount), out var bucket) && bucket.Arrays.Count > 0)
         {
-            var arr = stack.Pop();
+            var arr = bucket.Arrays.Pop();
+            bucket.LastTouchedGeneration = _arenaGeneration;
             _persistentReuseHits++;
             // Zero the recycled buffer. The arena's previous behaviour allocated
             // every first-use-per-arena buffer via `new T[]`, which the CLR
@@ -157,15 +205,16 @@ public sealed class TensorArena : IDisposable
     private static void ReturnPersistent(Type type, int elementCount, Array arr)
     {
         if (elementCount < PersistThresholdElems) return; // let small buffers GC
-        var pool = _persistent ??= new Dictionary<(Type, int), Stack<Array>>();
+        var pool = _persistent ??= new Dictionary<(Type, int), Bucket>();
         var key = (type, elementCount);
-        if (!pool.TryGetValue(key, out var stack))
+        if (!pool.TryGetValue(key, out var bucket))
         {
-            stack = new Stack<Array>(MaxPersistPerSize);
-            pool[key] = stack;
+            bucket = new Bucket();
+            pool[key] = bucket;
         }
-        if (stack.Count < MaxPersistPerSize)
-            stack.Push(arr);
+        bucket.LastTouchedGeneration = _arenaGeneration;
+        if (bucket.Arrays.Count < MaxPersistPerSize)
+            bucket.Arrays.Push(arr);
         // else: at cap — drop the reference, let GC reclaim (don't hoard).
     }
 
@@ -215,15 +264,16 @@ public sealed class TensorArena : IDisposable
     // staying bounded. Thread-static, matching the [ThreadStatic] pool contract.
     // ---------------------------------------------------------------------
     [ThreadStatic]
-    private static Dictionary<(Type, int), Stack<Array>>? _carryPool;
+    private static Dictionary<(Type, int), Bucket>? _carryPool;
 
     private static Array? RentCarry(Type type, int elementCount)
     {
         var pool = _carryPool;
         if (pool is null) return null;
-        if (pool.TryGetValue((type, elementCount), out var stack) && stack.Count > 0)
+        if (pool.TryGetValue((type, elementCount), out var bucket) && bucket.Arrays.Count > 0)
         {
-            var arr = stack.Pop();
+            var arr = bucket.Arrays.Pop();
+            bucket.LastTouchedGeneration = _arenaGeneration;
             _persistentReuseHits++;
             return arr; // caller overwrites every element from the boundary — no clear needed
         }
@@ -232,22 +282,81 @@ public sealed class TensorArena : IDisposable
 
     private static void ReturnCarry(Type type, int elementCount, Array arr)
     {
-        var pool = _carryPool ??= new Dictionary<(Type, int), Stack<Array>>();
+        var pool = _carryPool ??= new Dictionary<(Type, int), Bucket>();
         var key = (type, elementCount);
-        if (!pool.TryGetValue(key, out var stack))
+        if (!pool.TryGetValue(key, out var bucket))
         {
-            stack = new Stack<Array>(MaxPersistPerSize);
-            pool[key] = stack;
+            bucket = new Bucket();
+            pool[key] = bucket;
         }
-        if (stack.Count < MaxPersistPerSize)
-            stack.Push(arr);
+        bucket.LastTouchedGeneration = _arenaGeneration;
+        if (bucket.Arrays.Count < MaxPersistPerSize)
+            bucket.Arrays.Push(arr);
     }
 
     /// <summary>
-    /// Drops every buffer held in the calling thread's cross-arena persistent
-    /// pool. For tests / explicit memory-pressure handling; production code
-    /// never needs this (the pool is bounded by <see cref="MaxPersistPerSize"/>).
+    /// Drops cross-arena buckets that have gone <see cref="MaxIdleGenerations"/> arena lifetimes
+    /// without a rent or a return. Called once per top-level <see cref="Dispose"/>, after the
+    /// generation counter advances, so the cost is one dictionary walk per arena rather than per
+    /// buffer.
     /// </summary>
+    private static void PruneStaleCrossArenaBuckets()
+    {
+        Prune(_persistent);
+        Prune(_carryPool);
+
+        static void Prune(Dictionary<(Type, int), Bucket>? pool)
+        {
+            if (pool is null || pool.Count == 0) return;
+
+            List<(Type, int)>? stale = null;
+            foreach (var kvp in pool)
+            {
+                if (kvp.Value.LastTouchedGeneration + MaxIdleGenerations >= _arenaGeneration) continue;
+                (stale ??= new List<(Type, int)>()).Add(kvp.Key);
+            }
+
+            if (stale is null) return;
+            for (int i = 0; i < stale.Count; i++) pool.Remove(stale[i]);
+        }
+    }
+
+    /// <summary>
+    /// Buckets currently held across the two cross-arena pools on this thread. Diagnostic: lets a
+    /// test assert that retention stays bounded as distinct shapes keep arriving, which is the
+    /// property <see cref="MaxPersistPerSize"/> alone does not give.
+    /// </summary>
+    internal static int CrossArenaBucketCount =>
+        (_persistent?.Count ?? 0) + (_carryPool?.Count ?? 0);
+
+    /// <summary>
+    /// Arrays currently retained across the two cross-arena pools on this thread. Diagnostic.
+    /// </summary>
+    internal static int CrossArenaRetainedArrayCount
+    {
+        get
+        {
+            int total = 0;
+            if (_persistent is not null)
+                foreach (var kvp in _persistent) total += kvp.Value.Arrays.Count;
+            if (_carryPool is not null)
+                foreach (var kvp in _carryPool) total += kvp.Value.Arrays.Count;
+            return total;
+        }
+    }
+
+    /// <summary>
+    /// Drops every buffer held in the calling thread's cross-arena pools.
+    /// </summary>
+    /// <remarks>
+    /// This used to say production code never needs it "(the pool is bounded by
+    /// <see cref="MaxPersistPerSize"/>)". That was not true: MaxPersistPerSize bounds one bucket,
+    /// and nothing bounded how many buckets a thread accumulated, so the only thing keeping the pool
+    /// from growing with the number of distinct shapes a process saw was a caller remembering to
+    /// come here. Retention is now genuinely bounded by <see cref="MaxIdleGenerations"/>, so this is
+    /// once again what it claims to be: a hard reset for tests and for explicit memory-pressure
+    /// handling, not a leak valve.
+    /// </remarks>
     public static void ClearPersistentPool()
     {
         _persistent?.Clear();
@@ -862,6 +971,16 @@ public sealed class TensorArena : IDisposable
         {
             Array.Clear(_tensorRing, 0, _tensorRingCount);
             _tensorRingCount = 0;
+        }
+
+        // One arena lifetime has ended: advance the generation and drop whatever has not been
+        // touched for MaxIdleGenerations of them. Only a TOP-LEVEL arena counts as a lifetime — a
+        // nested arena disposing back into a live outer scope is part of the OUTER lifetime, and
+        // counting it would age the outer scope's own buckets out from under it.
+        if (_previous is null)
+        {
+            _arenaGeneration++;
+            PruneStaleCrossArenaBuckets();
         }
     }
 

--- a/src/AiDotNet.Tensors/Helpers/ThreadLocalTensorCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/ThreadLocalTensorCache.cs
@@ -9,29 +9,82 @@ namespace AiDotNet.Tensors.Helpers;
 ///
 /// This is the facade that makes <see cref="TensorAllocator.Rent{T}"/> zero-alloc without
 /// any caller changes. The cache is per-thread and per-type, so float and double operations
-/// maintain separate pools. Each size bucket holds up to <see cref="MaxBuffersPerSize"/>
-/// buffers to prevent unbounded memory growth.
+/// maintain separate pools.
 ///
 /// Flow:
 /// 1. TensorAllocator.Rent(shape) → ThreadLocalTensorCache.TryRent(totalSize) → reuse or allocate
 /// 2. TensorAllocator.Return(tensor) → ThreadLocalTensorCache.Return(array) → cache for reuse
 /// </summary>
+/// <remarks>
+/// <para><b>Retention is bounded by bytes, not just by bucket depth.</b> This used to keep up to
+/// <see cref="MaxBuffersPerSize"/> buffers per size and describe that as preventing "unbounded
+/// memory growth". It did not: the key is an EXACT element count, nothing capped how many distinct
+/// sizes a thread accumulated, and unlike the arena's cross-lifetime pool this one caches at ANY
+/// size. A process that keeps meeting new shapes — a model-family test class, a service hosting
+/// several models, a shape-polymorphic pipeline — therefore grew one bucket per size it had ever
+/// seen and released none of them until someone called <see cref="Clear"/> by hand.
+/// </para>
+/// <para>
+/// The cache now tracks retained bytes and trims least-recently-touched buckets when a return would
+/// push it past <see cref="MaxRetainedBytes"/>. Recency is a cheap monotonic counter stamped on the
+/// bucket, so the hot path stays two dictionary operations and the O(buckets) trim runs only on the
+/// rare return that actually hits the budget.
+/// </para>
+/// </remarks>
 /// <typeparam name="T">The element type (float, double, etc.)</typeparam>
 internal static class ThreadLocalTensorCache<T>
 {
     /// <summary>
-    /// Maximum buffers cached per size bucket per thread. Prevents unbounded memory growth.
+    /// Maximum buffers cached per size bucket per thread.
     /// 4 is sufficient for most forward passes (conv output, norm output, activation output, residual).
     /// </summary>
     private const int MaxBuffersPerSize = 4;
 
     /// <summary>
-    /// Thread-local cache: size → stack of reusable buffers.
+    /// Total bytes this thread may retain for this element type.
+    /// </summary>
+    /// <remarks>
+    /// The cache exists to make the buffers of a single forward/backward reusable, so the budget only
+    /// has to cover one pass's working set — 64 MiB is generous for that and small enough that a
+    /// process cycling through many models cannot accumulate their combined working sets in Gen2.
+    /// It is per (element type, thread), matching the <c>[ThreadStatic]</c> generic-static contract.
+    /// </remarks>
+    private const long MaxRetainedBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// How far below <see cref="MaxRetainedBytes"/> a trim reclaims to, so that hitting the budget
+    /// does not make every subsequent return pay for another trim.
+    /// </summary>
+    private const double TrimTargetFraction = 0.75;
+
+    private static readonly int ElementSize = Unsafe.SizeOf<T>();
+
+    private sealed class Bucket
+    {
+        internal readonly Stack<T[]> Buffers = new Stack<T[]>(MaxBuffersPerSize);
+
+        internal long LastTouch;
+    }
+
+    /// <summary>
+    /// Thread-local cache: size → bucket of reusable buffers.
     /// [ThreadStatic] ensures zero lock contention — each thread has its own cache.
     /// Generic type parameter ensures float[] and double[] caches are separate.
     /// </summary>
     [ThreadStatic]
-    private static Dictionary<int, Stack<T[]>>? _cache;
+    private static Dictionary<int, Bucket>? _cache;
+
+    [ThreadStatic]
+    private static long _retainedBytes;
+
+    [ThreadStatic]
+    private static long _touchCounter;
+
+    /// <summary>Bytes currently retained on this thread for this element type. Diagnostic.</summary>
+    internal static long RetainedBytes => _retainedBytes;
+
+    /// <summary>Size buckets currently held on this thread for this element type. Diagnostic.</summary>
+    internal static int BucketCount => _cache?.Count ?? 0;
 
     /// <summary>
     /// Tries to get a reusable buffer of exactly <paramref name="minSize"/> elements.
@@ -43,9 +96,12 @@ internal static class ThreadLocalTensorCache<T>
     {
         if (_cache is null) return null;
 
-        if (_cache.TryGetValue(minSize, out var stack) && stack.Count > 0)
+        if (_cache.TryGetValue(minSize, out var bucket) && bucket.Buffers.Count > 0)
         {
-            return stack.Pop();
+            var array = bucket.Buffers.Pop();
+            _retainedBytes -= (long)array.Length * ElementSize;
+            bucket.LastTouch = ++_touchCounter;
+            return array;
         }
 
         return null;
@@ -53,28 +109,70 @@ internal static class ThreadLocalTensorCache<T>
 
     /// <summary>
     /// Returns a buffer to the thread-local cache for reuse.
-    /// If the cache is full for this size bucket, the buffer is not cached (let GC collect it
-    /// or caller can fall through to ArrayPool.Return).
+    /// If the bucket for this size is full, or caching the buffer would exceed
+    /// <see cref="MaxRetainedBytes"/> even after trimming, the buffer is not cached (let GC collect
+    /// it or caller can fall through to ArrayPool.Return).
     /// </summary>
-    /// <returns>true if cached for reuse, false if cache was full (caller should dispose otherwise).</returns>
+    /// <returns>true if cached for reuse, false if not cached (caller should dispose otherwise).</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryReturn(T[] array)
     {
-        _cache ??= new Dictionary<int, Stack<T[]>>();
+        _cache ??= new Dictionary<int, Bucket>();
 
         int size = array.Length;
+        long bytes = (long)size * ElementSize;
 
-        if (!_cache.TryGetValue(size, out var stack))
+        // A single buffer larger than the whole budget is never worth evicting everything for.
+        if (bytes > MaxRetainedBytes) return false;
+
+        // Trim BEFORE get-or-add so a bucket this call creates cannot be dropped underneath it.
+        if (_retainedBytes + bytes > MaxRetainedBytes) Trim(bytes);
+
+        if (!_cache.TryGetValue(size, out var bucket))
         {
-            stack = new Stack<T[]>(MaxBuffersPerSize);
-            _cache[size] = stack;
+            bucket = new Bucket();
+            _cache[size] = bucket;
         }
 
-        if (stack.Count >= MaxBuffersPerSize)
-            return false; // Cache full, don't hoard
+        bucket.LastTouch = ++_touchCounter;
 
-        stack.Push(array);
+        if (bucket.Buffers.Count >= MaxBuffersPerSize)
+            return false; // Bucket full, don't hoard
+
+        if (_retainedBytes + bytes > MaxRetainedBytes)
+            return false; // Still over budget after trimming — this thread is saturated
+
+        bucket.Buffers.Push(array);
+        _retainedBytes += bytes;
         return true;
+    }
+
+    /// <summary>
+    /// Drops least-recently-touched buckets until retention leaves room for
+    /// <paramref name="incomingBytes"/> with headroom to spare.
+    /// </summary>
+    private static void Trim(long incomingBytes)
+    {
+        var cache = _cache;
+        if (cache is null || cache.Count == 0) return;
+
+        long target = (long)(MaxRetainedBytes * TrimTargetFraction) - incomingBytes;
+        if (target < 0) target = 0;
+
+        var byAge = new List<KeyValuePair<int, Bucket>>(cache);
+        byAge.Sort(static (left, right) => left.Value.LastTouch.CompareTo(right.Value.LastTouch));
+
+        for (int i = 0; i < byAge.Count && _retainedBytes > target; i++)
+        {
+            var bucket = byAge[i].Value;
+            while (bucket.Buffers.Count > 0 && _retainedBytes > target)
+            {
+                var array = bucket.Buffers.Pop();
+                _retainedBytes -= (long)array.Length * ElementSize;
+            }
+
+            if (bucket.Buffers.Count == 0) cache.Remove(byAge[i].Key);
+        }
     }
 
     /// <summary>
@@ -84,5 +182,6 @@ internal static class ThreadLocalTensorCache<T>
     public static void Clear()
     {
         _cache?.Clear();
+        _retainedBytes = 0;
     }
 }

--- a/src/AiDotNet.Tensors/Helpers/ThreadLocalTensorCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/ThreadLocalTensorCache.cs
@@ -25,8 +25,8 @@ namespace AiDotNet.Tensors.Helpers;
 /// seen and released none of them until someone called <see cref="Clear"/> by hand.
 /// </para>
 /// <para>
-/// The cache now tracks retained bytes and trims least-recently-touched buckets when a return would
-/// push it past <see cref="MaxRetainedBytes"/>. Recency is a cheap monotonic counter stamped on the
+/// The cache now tracks retained bytes AND bucket count, evicting least-recently-touched buckets when
+/// a return would push it past <see cref="MaxRetainedBytes"/> or <see cref="MaxBuckets"/>. Recency is a cheap monotonic counter stamped on the
 /// bucket, so the hot path stays two dictionary operations and the O(buckets) trim runs only on the
 /// rare return that actually hits the budget.
 /// </para>
@@ -52,8 +52,28 @@ internal static class ThreadLocalTensorCache<T>
     private const long MaxRetainedBytes = 64L * 1024 * 1024;
 
     /// <summary>
-    /// How far below <see cref="MaxRetainedBytes"/> a trim reclaims to, so that hitting the budget
-    /// does not make every subsequent return pay for another trim.
+    /// Maximum size buckets this thread may keep for this element type.
+    /// </summary>
+    /// <remarks>
+    /// The byte budget alone does not bound the dictionary. <see cref="TryRent"/> pops a buffer and
+    /// drops <see cref="_retainedBytes"/> back down, so a caller that returns and immediately rents
+    /// one buffer per distinct size holds zero bytes, never trips the budget, and would still leave
+    /// one empty entry behind per size it ever touched — the same "bounded per bucket, unbounded in
+    /// buckets" defect one level up. Measured before this cap: 4,000 sizes left 4,000 entries.
+    ///
+    /// The entry is deliberately NOT dropped the moment its last buffer is rented, which is the
+    /// obvious alternative. A single buffer cycling return -> rent -> return is the hottest pattern
+    /// this cache serves, and recreating the Bucket (and its Stack) on every return costs an
+    /// allocation per cycle: measured at 1,212,984 bytes over 10,000 cycles, in the one place the
+    /// whole class exists to keep allocation-free. Keeping the empty entry and bounding how many
+    /// there can be gives both — the hot bucket survives because every rent stamps it as touched,
+    /// and stale entries are evicted oldest-first.
+    /// </remarks>
+    private const int MaxBuckets = 1024;
+
+    /// <summary>
+    /// How far below <see cref="MaxRetainedBytes"/> / <see cref="MaxBuckets"/> an eviction reclaims
+    /// to, so that hitting a limit does not make every subsequent return pay for another sweep.
     /// </summary>
     private const double TrimTargetFraction = 0.75;
 
@@ -125,8 +145,10 @@ internal static class ThreadLocalTensorCache<T>
         // A single buffer larger than the whole budget is never worth evicting everything for.
         if (bytes > MaxRetainedBytes) return false;
 
-        // Trim BEFORE get-or-add so a bucket this call creates cannot be dropped underneath it.
-        if (_retainedBytes + bytes > MaxRetainedBytes) Trim(bytes);
+        // Evict BEFORE get-or-add so a bucket this call creates cannot be dropped underneath it.
+        // Count pressure is checked as well as bytes: renting drains bytes but leaves the entry.
+        if (_retainedBytes + bytes > MaxRetainedBytes || _cache.Count >= MaxBuckets)
+            Evict(bytes);
 
         if (!_cache.TryGetValue(size, out var bucket))
         {
@@ -149,28 +171,39 @@ internal static class ThreadLocalTensorCache<T>
 
     /// <summary>
     /// Drops least-recently-touched buckets until retention leaves room for
-    /// <paramref name="incomingBytes"/> with headroom to spare.
+    /// <paramref name="incomingBytes"/> and the dictionary is back under
+    /// <see cref="MaxBuckets"/>, both with headroom to spare.
     /// </summary>
-    private static void Trim(long incomingBytes)
+    /// <remarks>
+    /// Oldest-first by touch stamp, so a bucket a caller is actively cycling survives even while
+    /// momentarily empty — every rent stamps it — while entries left behind by shapes the thread has
+    /// moved on from are the first to go.
+    /// </remarks>
+    private static void Evict(long incomingBytes)
     {
         var cache = _cache;
         if (cache is null || cache.Count == 0) return;
 
-        long target = (long)(MaxRetainedBytes * TrimTargetFraction) - incomingBytes;
-        if (target < 0) target = 0;
+        long byteTarget = (long)(MaxRetainedBytes * TrimTargetFraction) - incomingBytes;
+        if (byteTarget < 0) byteTarget = 0;
+        int countTarget = (int)(MaxBuckets * TrimTargetFraction);
 
         var byAge = new List<KeyValuePair<int, Bucket>>(cache);
         byAge.Sort(static (left, right) => left.Value.LastTouch.CompareTo(right.Value.LastTouch));
 
-        for (int i = 0; i < byAge.Count && _retainedBytes > target; i++)
+        for (int i = 0; i < byAge.Count; i++)
         {
+            if (_retainedBytes <= byteTarget && cache.Count <= countTarget) return;
+
             var bucket = byAge[i].Value;
-            while (bucket.Buffers.Count > 0 && _retainedBytes > target)
+            while (bucket.Buffers.Count > 0 && _retainedBytes > byteTarget)
             {
                 var array = bucket.Buffers.Pop();
                 _retainedBytes -= (long)array.Length * ElementSize;
             }
 
+            // Drop the entry when it holds nothing — that is what relieves count pressure, and an
+            // empty bucket is pure bookkeeping either way.
             if (bucket.Buffers.Count == 0) cache.Remove(byAge[i].Key);
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/TensorArenaPersistentPoolTests.cs
@@ -102,6 +102,66 @@ public class TensorArenaPersistentPoolTests
     /// sees exactly `cap` reuse hits (not all 65). Pins MaxPersistPerSize as the
     /// sole guard against unbounded per-size pool growth (CodeRabbit #767).
     /// </summary>
+    /// <summary>
+    /// MaxPersistPerSize bounds ONE bucket; it never bounded how many buckets a thread kept. The
+    /// key is an exact (type, element-count) pair, so a process that keeps meeting new shapes — a
+    /// model-family test class, a service hosting several models — accumulated a bucket per shape
+    /// and freed none of it until someone called ClearPersistentPool by hand. At up to 64 buffers of
+    /// >= PersistThresholdElems each, that is ~16 MB per shape held in Gen2.
+    ///
+    /// Observed downstream in AiDotNet: RecurrentGemma's finite-difference gradcheck runs in 11-13 s
+    /// in a clean process and blew its entire 120 s budget once 29 sibling model tests had filled
+    /// this pool on the same thread.
+    ///
+    /// Retention is now bounded by MaxIdleGenerations instead: a bucket nothing has rented or
+    /// returned for that many arena lifetimes is dropped.
+    /// </summary>
+    [Fact]
+    public void ManyDistinctShapes_RetentionStaysBounded()
+    {
+        TensorArena.ClearPersistentPool();
+
+        const int shapes = 40;
+        // Distinct element counts, each above PersistThresholdElems (64Ki) so every one is retained.
+        for (int i = 0; i < shapes; i++)
+        {
+            int[] shape = { (64 * 1024) + (i * 4096) };
+            using var arena = TensorArena.Create();
+            TensorAllocator.RentUninitialized<float>(shape).AsWritableSpan()[0] = i;
+        }
+
+        // Before the generation policy this was `shapes` buckets, all still resident. Each arena
+        // above is its own lifetime and never revisits an earlier shape, so every bucket goes stale
+        // within MaxIdleGenerations and only the most recent handful can survive.
+        Assert.InRange(TensorArena.CrossArenaBucketCount, 0, 4);
+        Assert.InRange(TensorArena.CrossArenaRetainedArrayCount, 0, 4);
+    }
+
+    /// <summary>
+    /// The other half of the contract: bounding retention must not cost the issue #478 win. A train
+    /// loop that rents the SAME shapes every step touches its bucket every generation, so it never
+    /// goes stale however long the loop runs, and reuse keeps hitting.
+    /// </summary>
+    [Fact]
+    public void SteadyStateSameShape_StillReusedAfterManyLifetimes()
+    {
+        TensorArena.ClearPersistentPool();
+        int[] shape = { 128 * 1024 };
+
+        // Cycle 1 populates the pool; cycles 2..N must each rent it straight back.
+        const int steps = 12;
+        for (int i = 0; i < steps; i++)
+        {
+            using var arena = TensorArena.Create();
+            TensorAllocator.RentUninitialized<float>(shape).AsWritableSpan()[0] = i;
+        }
+
+        // One hit per step after the first — the bucket is touched every generation, so
+        // MaxIdleGenerations never elapses for it.
+        Assert.Equal(steps - 1, TensorArena.PersistentReuseHits);
+        Assert.Equal(1, TensorArena.CrossArenaBucketCount);
+    }
+
     [Fact]
     public void SameSizeBuffers_BeyondCap_RetentionIsCapped()
     {

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
@@ -14,6 +14,11 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Helpers;
 
+// Serialized with the arena tests: these poke [ThreadStatic] caches, and the allocation assertion
+// below reads GC.GetTotalAllocatedBytes, which is PROCESS-wide — a sibling collection allocating on
+// another thread lands in the same counter and makes the measurement meaningless. Same reason
+// TensorArenaPersistentPoolTests joins this collection.
+[Collection(nameof(TensorArenaPinnedTests))]
 public class ThreadLocalTensorCacheBoundsTests
 {
     /// <summary>
@@ -67,6 +72,79 @@ public class ThreadLocalTensorCacheBoundsTests
 
         ThreadLocalTensorCache<float>.Clear();
     }
+
+    /// <summary>
+    /// Renting a bucket's last buffer must not leave the bucket behind forever. Return-then-rent for
+    /// each distinct size keeps RetainedBytes at zero, so the byte budget never fires — and if the
+    /// dictionary entry survives, _cache grows with the number of sizes the thread has ever seen.
+    /// That is the same "bounded per bucket, unbounded in buckets" defect this class was fixing,
+    /// one level up.
+    /// </summary>
+    [Fact]
+    public void ReturnThenRentEachSize_DoesNotGrowTheDictionary()
+    {
+        ThreadLocalTensorCache<float>.Clear();
+
+        for (int i = 0; i < 4000; i++)
+        {
+            int size = (64 * 1024) + i;
+            ThreadLocalTensorCache<float>.TryReturn(new float[size]);
+            Assert.NotNull(ThreadLocalTensorCache<float>.TryRent(size));
+        }
+
+        // Every buffer was rented straight back, so nothing is retained...
+        Assert.Equal(0, ThreadLocalTensorCache<float>.RetainedBytes);
+        // ...and the bookkeeping must not have kept 4,000 entries alive to say so.
+        Assert.InRange(ThreadLocalTensorCache<float>.BucketCount, 0, 1024);
+
+        ThreadLocalTensorCache<float>.Clear();
+    }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// The single hottest pattern this cache serves is one buffer of a size cycling return -> rent
+    /// -> return. That must stay allocation-free in steady state: the whole point of the class is
+    /// that <c>TensorAllocator.Rent</c> costs nothing after warmup. Pins it directly, because the
+    /// obvious way to stop empty buckets accumulating — dropping the dictionary entry the moment its
+    /// last buffer is rented — reintroduces a Bucket + Stack allocation on every cycle.
+    /// </summary>
+    [Fact]
+    public void HotSize_ReturnRentCycle_DoesNotAllocate()
+    {
+        ThreadLocalTensorCache<float>.Clear();
+        const int size = 4096;
+
+        var buffer = new float[size];
+        // Warm up: create the bucket and let the JIT settle.
+        for (int i = 0; i < 50; i++)
+        {
+            ThreadLocalTensorCache<float>.TryReturn(buffer);
+            buffer = ThreadLocalTensorCache<float>.TryRent(size)!;
+        }
+
+        const int cycles = 50_000;
+        long before = GC.GetTotalAllocatedBytes(precise: true);
+        for (int i = 0; i < cycles; i++)
+        {
+            ThreadLocalTensorCache<float>.TryReturn(buffer);
+            buffer = ThreadLocalTensorCache<float>.TryRent(size)!;
+        }
+        long allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        Assert.NotNull(buffer);
+
+        // The cache's own steady-state path allocates nothing here — a dictionary lookup and a
+        // Stack push/pop — so what this measures is ambient allocation on the test thread, which
+        // came in around 0.2 MB. Dropping the dictionary entry when its last buffer is rented
+        // instead costs a Bucket + Stack per cycle, measured at 1,212,984 bytes over 10,000 cycles
+        // (~121 B/cycle), i.e. ~6 MB at this iteration count. A 1 MB ceiling separates the two by
+        // several times over in both directions rather than sitting on top of the noise.
+        Assert.True(allocated < 1024 * 1024,
+            $"steady-state return/rent cycle allocated {allocated} bytes over {cycles} iterations");
+
+        ThreadLocalTensorCache<float>.Clear();
+    }
+#endif
 
     /// <summary>
     /// A buffer larger than the entire budget is not worth evicting the whole cache for, so it is

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// ThreadLocalTensorCache<T> caps buffers PER SIZE BUCKET and its doc used to call that "prevents
+// unbounded memory growth". It did not: the key is an exact element count, nothing capped how many
+// distinct sizes a thread accumulated, and this cache pools at ANY size. A process that keeps
+// meeting new shapes grew a bucket per size and released none until someone called Clear() by hand.
+//
+// Downstream symptom that led here (AiDotNet): RecurrentGemma's finite-difference gradcheck runs in
+// 11-13 s in a clean process and blew its whole 120 s budget once 29 sibling model tests had filled
+// this cache on the same thread. With retention bounded it completes inside the budget.
+
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers;
+
+public class ThreadLocalTensorCacheBoundsTests
+{
+    /// <summary>
+    /// Returning buffers across a long tail of DISTINCT sizes must not retain them all. Before the
+    /// byte budget this grew without limit — one bucket per size, up to MaxBuffersPerSize buffers
+    /// each, none ever released.
+    /// </summary>
+    [Fact]
+    public void ManyDistinctSizes_RetentionStaysWithinBudget()
+    {
+        ThreadLocalTensorCache<float>.Clear();
+
+        // 4000 distinct sizes around 64Ki floats (256 KB each). Unbounded retention would be on the
+        // order of a gigabyte; the budget is 64 MiB.
+        for (int i = 0; i < 4000; i++)
+            ThreadLocalTensorCache<float>.TryReturn(new float[(64 * 1024) + i]);
+
+        long retained = ThreadLocalTensorCache<float>.RetainedBytes;
+        Assert.True(retained <= 64L * 1024 * 1024,
+            $"retained {retained} bytes, above the 64 MiB budget");
+
+        // And the bookkeeping must agree with reality: no empty buckets left behind, no negative
+        // counter from a mismatched rent/return.
+        Assert.True(retained >= 0, $"retained byte counter went negative: {retained}");
+
+        ThreadLocalTensorCache<float>.Clear();
+        Assert.Equal(0, ThreadLocalTensorCache<float>.RetainedBytes);
+        Assert.Equal(0, ThreadLocalTensorCache<float>.BucketCount);
+    }
+
+    /// <summary>
+    /// The other half of the contract: bounding retention must not stop the cache doing its job. A
+    /// hot size returned and re-rented in a loop is touched constantly, so it stays cached and every
+    /// rent after the first hits.
+    /// </summary>
+    [Fact]
+    public void HotSize_StillServedFromCache()
+    {
+        ThreadLocalTensorCache<float>.Clear();
+        const int size = 4096;
+
+        Assert.True(ThreadLocalTensorCache<float>.TryReturn(new float[size]));
+
+        for (int i = 0; i < 100; i++)
+        {
+            var rented = ThreadLocalTensorCache<float>.TryRent(size);
+            Assert.NotNull(rented);
+            Assert.Equal(size, rented!.Length);
+            Assert.True(ThreadLocalTensorCache<float>.TryReturn(rented));
+        }
+
+        ThreadLocalTensorCache<float>.Clear();
+    }
+
+    /// <summary>
+    /// A buffer larger than the entire budget is not worth evicting the whole cache for, so it is
+    /// refused outright rather than trimming everything else away.
+    /// </summary>
+    [Fact]
+    public void BufferLargerThanBudget_IsNotCached()
+    {
+        ThreadLocalTensorCache<float>.Clear();
+
+        // 32M floats = 128 MB, past the 64 MiB budget.
+        Assert.False(ThreadLocalTensorCache<float>.TryReturn(new float[32 * 1024 * 1024]));
+        Assert.Equal(0, ThreadLocalTensorCache<float>.RetainedBytes);
+    }
+}


### PR DESCRIPTION
## Summary

Both cross-call buffer caches capped how many buffers **one bucket** may hold and described that as preventing unbounded memory growth. It does not. The bucket key is an exact element count, nothing capped how many buckets a thread accumulated, and `ThreadLocalTensorCache` pools at **any** size — so a process that keeps meeting new shapes grew a bucket per shape it had ever seen and released none of it until a caller remembered to invoke `ClearPersistentPool()` / `Clear()` by hand.

| cache | old bound | pools |
|---|---|---|
| `TensorArena` persistent pool | `MaxPersistPerSize = 64` per `(Type, exact count)` | arrays >= 64Ki elements |
| `ThreadLocalTensorCache<T>` | `MaxBuffersPerSize = 4` per exact count | **any** size, on every `TensorAllocator.Rent` |

Measured: 4,000 distinct sizes around 64Ki floats retain **1,080,568,000 bytes** on one thread for one element type.

## What changed

**`TensorArena` is bounded by age.** Buckets are stamped with a per-thread arena generation on every rent and return; the generation advances when a **top-level** arena disposes (a nested arena is part of the outer lifetime, so counting it would age the outer scope's own buckets out from under it), and buckets untouched for `MaxIdleGenerations` are dropped.

A generation policy rather than a byte budget, because a byte cap cannot tell *"one paper-scale model's ~1 GB working set, which the next step genuinely wants"* apart from *"twenty models' leftovers"* — and a cap low enough to bound the second would evict the first every step and undo #478. A train loop renting the same shapes every step touches its bucket every generation, so it never goes stale.

**`ThreadLocalTensorCache` is bounded by bytes**, since it has no lifetime to hang a generation on. It tracks retained bytes and trims least-recently-touched buckets when a return would cross the budget. Recency is a monotonic counter stamped on the bucket, so the hot path stays two dictionary operations and the O(buckets) trim runs only on the rare return that actually hits the budget.

The budget's *value* is not load-bearing — 16 MiB and 64 MiB measured identically downstream — so it is set generously to leave legitimate reuse alone.

Both doc comments now say what the code does, and `ClearPersistentPool` is once again the hard reset it claims to be rather than the only thing standing between the pool and unbounded growth.

## Why this was worth chasing

Downstream in AiDotNet, `RecurrentGemmaLanguageModelTests.Gradients_MatchFiniteDifference` runs in **11-13 s** in a clean process and exceeded its entire **120 s** `[Fact(Timeout)]` once ~29 sibling model tests had filled these caches on the same thread. Nothing was wrong with the gradcheck; it was paying for buffers nothing would ever rent again. With retention bounded it completes in **~116 s** in that same loaded run and the class goes fully green (29 passed / 1 skipped / 0 failed, from 8 failing).

Worth noting for whoever looks next: bounding the **arena** pool alone changed nothing downstream. `ThreadLocalTensorCache` is the one that mattered, because it pools at every size on every allocation.

Also, for the record: AiDotNet's `xunit.runner.json` blames its parallel-collection failures on this pool being "shared process-wide" and not thread-safe. That premise is false — `_persistent` has been `[ThreadStatic]` since 0.115.0, well before the 0.128.0 AiDotNet consumes. Whatever makes `parallelizeTestCollections=true` fail there, it is not cross-thread pool sharing, and this PR does not claim to fix it.

## Tests

Added four, and checked that they actually discriminate:

- `ManyDistinctShapes_RetentionStaysBounded` — **fails** on the unbounded code.
- `ManyDistinctSizes_RetentionStaysWithinBudget` — **fails** on the unbounded code, reporting the 1.03 GB above.
- `SteadyStateSameShape_StillReusedAfterManyLifetimes` — passes either way; pins that the age bound does not cost the reuse #478 exists for.
- `HotSize_StillServedFromCache` — passes either way; same for the byte bound.

Green locally: `TensorArenaPersistentPoolTests` + `ThreadLocalTensorCacheBoundsTests` 12/12 (net10.0) and 11/11 (net471); the arena/allocator suites 44/44.

**One caveat, stated plainly:** the full suite aborts partway on this machine (it did so on pristine `main` too — the host is unstable for long runs), so I do not have a clean full-suite pass locally. It reached 7,029 passed / 1 failed before aborting, and that single failure — `FusedOptimizerNonFiniteGradientTests.ActiveGpuBackend_ClassifyAndReduceDetectsEveryNonFiniteKind` — **reproduces identically on pristine `main`** (1 failed / 25 passed), so it is pre-existing and environmental rather than anything this PR did. CI's full run is the authoritative signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved tensor buffer reuse while limiting retained memory across arena lifetimes.
  * Added automatic cleanup of stale cached buffers and least-recently-used entries.
  * Frequently reused tensor shapes and buffer sizes remain available for faster reuse.
  * Oversized buffers are no longer retained when they exceed configured memory limits.
  * Reduced unnecessary cache growth when handling many distinct tensor sizes.

* **Diagnostics**
  * Added visibility into retained memory, cache buckets, and retained arrays.
  * Cache accounting resets correctly when cached buffers are cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->