### PR TITLE
perf(gpu): stop uploading a tensor to the GPU just because it was registered

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -2511,7 +2511,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Thin wrapper: the version gate itself lives in the shared persistent-cache lookup below, so EVERY
         // persistent-weight read path that passes the host Tensor.Version gets the same in-place-load
         // protection — not just this one (CodeRabbit #821). We hold the Version at read time.
-        => GetOrCacheWeightBuffer(backend, weights.GetDataArray(), role, weights.Version);
+        // READ-ONLY accessor: GetDataArray is write-intent and calls EnsureOwnedForWrite, so using
+        // it to key this cache PRIVATISED every copy-on-write clone as a side effect of looking up
+        // its buffer. A cloned model therefore got fresh arrays, missed the cache, and uploaded a
+        // second identical copy of every weight. Reading through GetReadOnlyDataArray keeps the
+        // clone sharing its source's storage, so the key matches and the existing GPU buffer is
+        // reused -- until a genuine write privatises the storage, which is exactly when a
+        // re-upload is correct. This is the read/write split GetDataArray's own remarks call
+        // "Stage 2"; weights are an input operand the GPU only reads.
+        => GetOrCacheWeightBuffer(backend, weights.GetReadOnlyDataArray(), role, weights.Version);
 
     /// <summary>
     /// Gets a GPU buffer for weight/bias tensor, auto-caching if not already persistent.

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12038,34 +12038,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         base.RegisterPersistentTensor(tensor, role);
 
-        if (!TryGetBackend(out var backend))
-            return;
-
-        // Use the tensor's data array as the cache key
-        object key = tensor.GetDataArray();
-
-        // Check if already registered
-        if (_persistentBufferCache.ContainsKey(key))
-            return;
-
-        try
-        {
-            // Convert tensor data to float and upload to GPU
-            float[] floatData = DirectGpuEngine.ToFloatArray(tensor.GetDataArray());
-            IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
-            backend.Synchronize();
-
-            var entry = new GpuBufferCacheEntry(gpuBuffer, role);
-            _persistentBufferCache.TryAdd(key, entry);
-            _tensorVersions.TryAdd(key, 0);
-            // Stamp the host Version this buffer was uploaded at, so the version-aware weight reader
-            // (GetOrCacheWeightBufferVersionAware) detects a later in-place load and re-uploads.
-            _persistentWeightHostVersion[key] = tensor.Version;
-        }
-        catch
-        {
-            // Silently ignore GPU allocation failures - operations will fall back to CPU
-        }
+        // NO EAGER UPLOAD. Registration used to convert the whole tensor to float and allocate a
+        // GPU buffer immediately. That is work the READ path already does on demand:
+        // GetOrCacheWeightBuffer allocates on a cache miss and re-uploads when the host Version
+        // moves, so uploading here only duplicated it -- and did so for every parameter of every
+        // layer, whether or not that layer was ever used on the GPU.
+        //
+        // It made CLONING quadratic in memory. A cloned layer re-registers each of its parameters,
+        // so every clone re-uploaded an entire model: measured on a 31.5M-parameter VAE decoder,
+        // ~120 MB of float conversion plus a GPU allocation per clone, which exhausted memory
+        // across ten large models in one test process. Deferring makes a clone that is never run
+        // on the GPU cost nothing, and one that is run pay exactly once, on first read.
+        //
+        // The per-tensor backend.Synchronize() went with it: registering a 200-layer model stalled
+        // the GPU 200 times, where the read path already synchronizes when it must.
+        //
+        // base.RegisterPersistentTensor above still pins the tensor in the arena, which is the part
+        // registration is actually for.
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
@@ -1,0 +1,54 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+/// <summary>
+/// Registering a persistent tensor must not upload it.
+/// </summary>
+/// <remarks>
+/// Registration used to convert the tensor to float and allocate a GPU buffer immediately, which
+/// made cloning quadratic in memory: a cloned layer re-registers every parameter, so each clone
+/// re-uploaded a whole model. On a 31.5M-parameter decoder that was ~120 MB of float conversion per
+/// clone, and it exhausted memory across ten large models in one test process.
+///
+/// The read path already allocates on a cache miss and re-uploads when the host Version moves, so
+/// the upload belongs there and nowhere else. This test states that as an invariant rather than
+/// leaving it to be re-broken: it measures managed allocation across a registration, which is where
+/// the float conversion showed up.
+/// </remarks>
+public class PersistentTensorRegistrationTests
+{
+#if NET6_0_OR_GREATER   // GC.GetTotalAllocatedBytes is .NET Core 3.0+; this project also targets net471.
+    [Fact]
+    public void RegisterPersistentTensor_DoesNotMaterialiseTheTensor()
+    {
+        var engine = AiDotNetEngine.Current;
+        var tensor = new Tensor<double>(new[] { 512, 512 });   // 2 MB of doubles
+        for (int i = 0; i < tensor.Length; i += 512) tensor[i] = i * 0.5;
+
+        long payload = (long)tensor.Length * sizeof(double);
+
+        // Warm any one-time engine state so the measurement is of registration alone.
+        engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
+        engine.UnregisterPersistentTensor(tensor);
+
+        long before = System.GC.GetTotalAllocatedBytes(precise: true);
+        engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
+        long allocated = System.GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        engine.UnregisterPersistentTensor(tensor);
+
+        // A float copy of the payload would be half its size; anything approaching that means the
+        // eager upload is back. Bookkeeping is allowed to allocate a little.
+        long floatCopy = payload / 2;
+        Assert.True(
+            allocated < floatCopy / 4,
+            $"registration allocated {allocated:N0} bytes for a {payload:N0}-byte tensor. A float "
+                + $"copy would be about {floatCopy:N0}; the upload belongs on the read path, which "
+                + "allocates on a cache miss and re-uploads when the host Version moves.");
+    }
+#endif
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
@@ -21,11 +21,20 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 /// </remarks>
 public class PersistentTensorRegistrationTests
 {
-#if NET6_0_OR_GREATER   // GC.GetTotalAllocatedBytes is .NET Core 3.0+; this project also targets net471.
+#if NET6_0_OR_GREATER   // GetAllocatedBytesForCurrentThread is .NET Core 3.0+; this project also targets net471.
     [Fact]
     public void RegisterPersistentTensor_DoesNotMaterialiseTheTensor()
     {
-        var engine = AiDotNetEngine.Current;
+        // The engine under test must be the GPU one. AiDotNetEngine.Current starts as CpuEngine and
+        // stays there when GPU detection is off or unavailable, and CpuEngine.RegisterPersistentTensor
+        // is ALREADY a no-op -- so this would have passed without ever running the changed override.
+        using var engine = new DirectGpuTensorEngine();
+        if (!engine.IsGpuAvailable)
+        {
+            // No backend means TryGetBackend early-outs and there is nothing to assert about uploads.
+            return;
+        }
+
         var tensor = new Tensor<double>(new[] { 512, 512 });   // 2 MB of doubles
         for (int i = 0; i < tensor.Length; i += 512) tensor[i] = i * 0.5;
 
@@ -35,9 +44,11 @@ public class PersistentTensorRegistrationTests
         engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
         engine.UnregisterPersistentTensor(tensor);
 
-        long before = System.GC.GetTotalAllocatedBytes(precise: true);
+        // THREAD-LOCAL, not process-wide: GetTotalAllocatedBytes counts every thread, so an
+        // unrelated test running concurrently could push this over the threshold and fail it.
+        long before = System.GC.GetAllocatedBytesForCurrentThread();
         engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
-        long allocated = System.GC.GetTotalAllocatedBytes(precise: true) - before;
+        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
 
         engine.UnregisterPersistentTensor(tensor);
 


### PR DESCRIPTION
## What this fixes

Two defects that together made cloning a model quadratic in GPU memory.

**1. Registration uploaded eagerly.** `DirectGpuTensorEngine.RegisterPersistentTensor` converted every tensor to `float[]` and allocated a GPU buffer the moment it was registered — whether or not that tensor was ever used on the GPU. The read path already does this on demand: `GetOrCacheWeightBuffer` allocates on a cache miss and re-uploads when the host `Version` moves.

**2. The cache lookup privatised copy-on-write clones.** `GetOrCacheWeightBufferVersionAware` keyed the cache on `weights.GetDataArray()`, which is write-intent and calls `EnsureOwnedForWrite`. Merely *looking up* a clone's buffer broke its COW sharing, so the clone held fresh arrays, missed the cache, and uploaded a second identical copy of every weight.

## Why it matters

A cloned layer re-registers each of its parameters, so **every clone re-uploaded an entire model**. Measured on a 31.5M-parameter VAE decoder (240 MB per parameter vector) with PerfView `/DotNetAllocSampled`:

```
DirectGpuEngine.ToFloatArray
  <- DirectGpuTensorEngine.RegisterPersistentTensor
  <- LayerBase<double>.AppendTrainableParameter
  <- ConvolutionalLayer<double>.SetTrainableParameters
  <- LayerCloning.CopyOwnTensors / CopyChildren
```

| path | `System.Single[]` allocated |
|---|---:|
| clone → CopyOwnTensors | 232.4 MB |
| clone → CopyChildren | 226.4 MB |
| clone → CopyChildren (nested) | 20.9 MB |
| EnsureInitialized | 119.9 MB |

All on a run that requested **no GPU work at all**. Downstream in AiDotNet this exhausted memory across ten large models in a single test process — `ClinicalBERTNER`, `CosyVoice3`, `E2TTS`, `GraniteSpeech`, `Helix`, `Informer`, `LLaVAMed`, `LXMERT`, `Qwen3VL` and `TemplateNER` all failed to clone with `OutOfMemoryException`.

## The change

- **Registration no longer uploads.** `base.RegisterPersistentTensor` still pins the tensor in the arena, which is what registration is for.
- **The per-tensor `backend.Synchronize()` goes with it.** Registering a 200-layer model stalled the GPU 200 times; the read path synchronizes where it must.
- **The weight read path uses `GetReadOnlyDataArray`.** This is the read/write split `GetDataArray`'s own remarks describe as "Stage 2", and its documentation names this exact benefit: *"inference on a cloned model never privatizes its shared weights"*. Weights are an input operand the GPU only reads, which is the contract that accessor asks for. A genuine write still privatises, which is precisely when a re-upload is correct.

Net effect: a cloned model costs nothing on the GPU until it is actually run, and running it reuses the source's buffer instead of uploading a duplicate.

## Verification

- A new test asserts registration does not materialise the tensor, so the eager upload cannot return silently. `#if NET6_0_OR_GREATER`, because `GC.GetTotalAllocatedBytes` does not exist on `net471`, which this project also targets.
- 108 GPU, persistent-tensor and copy-on-write tests pass unchanged (21 skipped, hardware-gated).