### PR TITLE
perf: stop CloneDeepCopy staging through a full intermediate array

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -2658,10 +2658,25 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         {
             _numOps.Copy(_data.AsSpan(), result._data.AsWritableSpan());
         }
+        else if (IsContiguous)
+        {
+            // Contiguous, but either offset into its storage or backed by a pool block longer than
+            // the logical length. Slice straight into the destination. This used to go through
+            // ToArray(), which allocates a SECOND full-length array purely to copy out of it again,
+            // so a deep clone cost 2x the tensor's own bytes. Pooled weights hit this path routinely
+            // (CloneShared already refuses to share them for the same _storage.Length != Length
+            // reason), which made it the common case rather than the exotic one.
+            _data.AsSpan().Slice(_storageOffset, Length)
+                 .CopyTo(result._data.AsWritableSpan().Slice(0, Length));
+        }
         else
         {
-            var srcArray = ToArray();
-            srcArray.AsSpan().CopyTo(result._data.AsWritableSpan());
+            // Genuinely strided view: walk the mapping into the destination, still without
+            // materialising an intermediate array.
+            var srcData = _data.AsSpan();
+            var dst = result._data.AsWritableSpan();
+            for (int i = 0; i < Length; i++)
+                dst[i] = srcData[FlatIndexToStorageIndex(i)];
         }
         return result;
     }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCloneDeepCopyAllocationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorCloneDeepCopyAllocationTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+/// <summary>
+/// <see cref="TensorBase{T}.CloneDeepCopy"/> must copy a tensor's bytes ONCE.
+/// </summary>
+/// <remarks>
+/// The non-fast path used to call <see cref="TensorBase{T}.ToArray"/> and copy out of the result,
+/// which allocates a second full-length array purely as a staging buffer. That is not an exotic
+/// path: <see cref="Tensor{T}.CloneShared"/> refuses to share any tensor whose backing storage is
+/// longer than its logical length, and pooled tensors (TensorAllocator.Rent) are exactly that, so
+/// pooled weights fell through to the deep copy and then paid 2x their own size to be cloned.
+///
+/// Measured on a 41.9M-parameter VAE decoder in AiDotNet: cloning it allocated 2,231MB of
+/// System.Double[] against 320MB of actual weights, and that transient spike is what pushed the
+/// 339-layer clone sweep into OutOfMemoryException.
+/// </remarks>
+public class TensorCloneDeepCopyAllocationTests
+{
+    private const int Rows = 4;
+    private const int Cols = 256 * 1024;   // 1M floats total => 4MB, well clear of measurement noise
+
+    private static Tensor<float> MakeLarge()
+    {
+        var data = new float[Rows * Cols];
+        for (int i = 0; i < data.Length; i++) data[i] = i % 1000;
+        return new Tensor<float>(data, new[] { Rows, Cols });
+    }
+
+#if NET6_0_OR_GREATER
+    // GC.GetTotalAllocatedBytes is not available on net471, and this is the one assertion that
+    // needs it; the correctness tests below run on every target.
+    [Fact]
+    public void CloneDeepCopy_OfAnOffsetView_AllocatesTheTensorOnce()
+    {
+        var view = MakeLarge().Slice(1);
+        long bytes = view.Length * sizeof(float);
+
+        // Warm up so JIT and any first-touch pooling are not counted.
+        view.CloneDeepCopy();
+
+        // THREAD-LOCAL, not GC.GetTotalAllocatedBytes. That counter is process-wide, so with xunit
+        // running classes in parallel this measurement picked up other tests' allocations and read
+        // 2.60x for a copy that is genuinely 1x when run alone -- a flaky assertion, and a false
+        // accusation against this code path.
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        var clone = view.CloneDeepCopy();
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.NotNull(clone);
+
+        // One buffer, plus small object overhead. The staging array made this ~2x.
+        Assert.True(
+            allocated < bytes * 3 / 2,
+            $"CloneDeepCopy allocated {allocated:N0} bytes for a {bytes:N0}-byte tensor "
+                + $"({allocated / (double)bytes:N2}x). Copying once should stay near 1x; ~2x means "
+                + "the copy is still staging through a full intermediate array.");
+    }
+#endif
+
+    [Fact]
+    public void CloneDeepCopy_OfAnOffsetView_ReproducesEveryValue()
+    {
+        var view = MakeLarge().Slice(2);
+        var clone = view.CloneDeepCopy();
+
+        Assert.Equal(view.Length, clone.Length);
+        Assert.Equal(view.Shape, clone.Shape);
+
+        var expected = view.ToArray();
+        var actual = clone.ToArray();
+        for (int i = 0; i < expected.Length; i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Assert.Fail($"element {i} differs: expected {expected[i]}, got {actual[i]}");
+            }
+        }
+    }
+
+    [Fact]
+    public void CloneDeepCopy_OfAnOffsetView_IsIndependentOfTheSource()
+    {
+        var source = MakeLarge();
+        var view = source.Slice(1);
+        var clone = (Tensor<float>)view.CloneDeepCopy();
+
+        var originalFirst = clone.GetFlat(0);
+        view.SetFlat(0, originalFirst + 500f);
+
+        Assert.Equal(originalFirst, clone.GetFlat(0));
+    }
+
+    [Fact]
+    public void CloneDeepCopy_OfAStridedView_ReproducesEveryValue()
+    {
+        // A transpose is the non-contiguous case, which walks FlatIndexToStorageIndex.
+        var source = new Tensor<float>(new float[] { 1, 2, 3, 4, 5, 6 }, new[] { 2, 3 });
+        var strided = source.Transpose(new[] { 1, 0 });
+
+        var clone = strided.CloneDeepCopy();
+
+        Assert.Equal(strided.Shape, clone.Shape);
+        Assert.Equal(strided.ToArray(), clone.ToArray());
+    }
+}


### PR DESCRIPTION
## What

`TensorBase.CloneDeepCopy()`'s non-fast path called `ToArray()` and copied out of the result, allocating a **second full-length array purely as a staging buffer**. A deep clone therefore cost **2× the tensor's own bytes**.

That path is not exotic. `Tensor.CloneShared()` refuses to share any tensor whose backing storage is longer than its logical length:

```csharp
if (IsSparse || IsView || !IsContiguous || _storageOffset != 0
    || _storage.Length != Length || ...)
    return CloneDeepCopy();
```

Pooled tensors (`TensorAllocator.Rent`) are exactly `_storage.Length != Length`, so pooled weights fall out of the O(1) copy-on-write path into the deep copy — and then pay double.

## The fix

Split the fallback in two, both mirroring what `ToArray()` already does, minus the intermediate:

- **contiguous but offset / oversized storage** → slice straight into the destination
- **genuinely strided view** → walk `FlatIndexToStorageIndex` into the destination

`CloneDeepCopy` already calls `EnsureMaterialized()` and `ThrowIfSparse()` at the top, so dropping the `ToArray()` call skips no guard.

## Measured

Thread-local (`GC.GetAllocatedBytesForCurrentThread`), 1,048,576-byte offset view:

| | allocated | ratio |
|---|---|---|
| before | 2,097,736 bytes | **2.00×** |
| after | ~1× | passes |

Verified by mutation: reverting the fix makes the new assertion fail at exactly 2.00×.

## Why this was worth chasing

Found while diagnosing an `OutOfMemoryException` in AiDotNet's 339-layer clone sweep. Cloning a 41.9M-parameter VAE decoder allocated **2,231 MB of `System.Double[]` against 320 MB of actual weights**. Allocation-by-type via `GCAllocationTick` confirmed it was all `Double[]`, and counters showed **96 tensors copied / 96 distinct** — no duplication, so this was per-tensor copy cost, not the clone walking tensors repeatedly.

Managed heap across the whole sweep peaked at 578 MB, so this was never aggregate exhaustion — it was one oversized allocation burst.

## Tests

4 new tests in `TensorCloneDeepCopyAllocationTests`:

- allocation stays near 1× (guarded to net6+ — `GC.GetAllocatedBytesForCurrentThread` has no net471 equivalent)
- value fidelity for an offset view
- value fidelity for a strided (transposed) view
- clone independence from the source

675 `LinearAlgebra` tests pass. The allocation assertion deliberately uses the **thread-local** counter: with `GC.GetTotalAllocatedBytes` it read 2.60× under xunit's parallel run by counting other tests' allocations — flaky, and an unfair accusation against this path.

`Engines.Compilation.CompilationABBenchmarks.MLP_Training_CompiledVsEager` failed once under the loaded full-suite run and passes 3/3 in isolation; it is a wall-clock A/B assertion, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved deep-copy performance for tensors with offset, padded, or strided layouts.
  * Reduced unnecessary memory allocations during tensor cloning.

* **Reliability**
  * Deep copies continue to preserve all tensor values.
  * Cloned tensors remain independent from their source tensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->