### PR TITLE
fix: cut lossless streaming-encode peak from ~3.7n to ~1.7n

### DIFF
--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -26,6 +26,16 @@ internal static class StreamingStoreCodec
     /// <summary>bf16 element size in bytes (stored little-endian).</summary>
     internal const int Bf16ElementSize = 2;
 
+    // Lossless payload framing: one leading tag byte, then the body. These are WIRE FORMAT - a
+    // stored buffer written by an older build is decoded by these same values, so they may not
+    // change meaning.
+    /// <summary>Tag: body is the byte-plane-shuffled bytes, stored uncompressed.</summary>
+    private const byte RawShuffledTag = 0;
+    /// <summary>Tag: body is the Deflate-compressed byte-plane-shuffled bytes.</summary>
+    private const byte DeflateCompressedTag = 1;
+    /// <summary>Length of the leading tag byte.</summary>
+    private const int LosslessTagLength = sizeof(byte);
+
     // Fast, non-crypto per-thread PRNG for stochastic rounding. Stochastic
     // rounding is a NUMERICAL technique (PyTorch/CUDA use Philox counters) — it
     // needs a cheap high-rate source, not cryptographic randomness, so a
@@ -1012,33 +1022,34 @@ internal static class StreamingStoreCodec
         // MemoryStream..ctor, then, once a redundant copy was removed upstream in WeightRegistry,
         // one allocation later at MemoryStream.ToArray. Writing the tag into the stream ahead of the
         // compressed bytes removes the prepend copy too, leaving the stream buffer and one ToArray.
-        using var ms = new MemoryStream((raw.Length - (raw.Length >> 3)) + 1);
-        ms.WriteByte(1); // Deflate-compressed
+        using var ms = new MemoryStream((raw.Length - (raw.Length >> 3)) + LosslessTagLength);
+        ms.WriteByte(DeflateCompressedTag);
         using (var ds = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true))
             WriteShuffledPlanes(raw, elem, ds);
 
-        // ms.Length counts the tag byte, so the compressed payload is ms.Length - 1.
-        if (ms.Length - 1 < raw.Length)
+        // ms.Length counts the tag byte, so the compressed payload is ms.Length - LosslessTagLength.
+        if (ms.Length - LosslessTagLength < raw.Length)
             return ms.ToArray();
 
         // Didn't shrink (rare — tiny or high-entropy) — store the raw shuffled bytes so the
         // round-trip is still exact and never larger than shuffled + 1. Re-shuffling costs a second
         // pass on a path that is already the uncommon one, and it is what lets the common path
         // avoid holding the shuffled copy at all.
-        var rawOut = new byte[1 + raw.Length];
-        rawOut[0] = 0;
-        BytePlaneShuffle(raw, rawOut.AsSpan(1), elem);
+        var rawOut = new byte[LosslessTagLength + raw.Length];
+        rawOut[0] = RawShuffledTag;
+        BytePlaneShuffle(raw, rawOut.AsSpan(LosslessTagLength), elem);
         return rawOut;
     }
 
     private static void DecodeLosslessBytes(ReadOnlySpan<byte> src, Span<byte> dstRaw, int elem)
     {
-        if (src.Length < 1) throw new ArgumentException("Lossless payload too short.", nameof(src));
+        if (src.Length < LosslessTagLength)
+            throw new ArgumentException("Lossless payload too short.", nameof(src));
         int shuffledLen = dstRaw.Length;
         byte flag = src[0];
-        var payload = src.Slice(1);
+        var payload = src.Slice(LosslessTagLength);
         byte[] shuffled;
-        if (flag == 1)
+        if (flag == DeflateCompressedTag)
         {
             shuffled = new byte[shuffledLen];
             int dec = DeflateDecompress(payload.ToArray(), shuffled, shuffledLen);

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingStoreCodec.cs
@@ -944,16 +944,45 @@ internal static class StreamingStoreCodec
     }
 #endif
 
-    // DEFLATE (zlib's raw deflate) is the entropy coder: unlike LZ4 (match-only, no entropy
-    // stage → ~1.08x on shuffled fp weights), Deflate's Huffman stage compresses the highly
-    // repetitive sign/exponent byte-plane that the shuffle exposes → ~1.18x, bit-exact, at
-    // ~1.1 GiB/s decode. It's in the BCL on both net471 and net5+ (no extra dependency).
-    private static byte[] DeflateCompress(byte[] src)
+    // Emits the byte-plane shuffle of `src` to `dst` without materializing it, one plane tile at a
+    // time through a pooled buffer. Byte-for-byte what BytePlaneShuffle would have written; see
+    // EncodeLosslessBytes for why the intermediate is worth avoiding. The vectorized shuffle stays
+    // in use on the decode side and on the didn't-shrink fallback, where a real buffer exists.
+    private static void WriteShuffledPlanes(ReadOnlySpan<byte> src, int elem, Stream dst)
     {
-        using var ms = new MemoryStream(src.Length);
-        using (var ds = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true))
-            ds.Write(src, 0, src.Length);
-        return ms.ToArray();
+        int count = src.Length / elem;
+        // At least `elem` so the buffer can also hold the partial-element tail below.
+        int tile = Math.Max(elem, Math.Min(count, ShuffleTileElems));
+        byte[] buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(tile);
+        try
+        {
+            for (int k = 0; k < elem; k++)
+            {
+                for (int i0 = 0; i0 < count; i0 += tile)
+                {
+                    int n = Math.Min(tile, count - i0);
+                    for (int i = 0; i < n; i++) buffer[i] = src[(i0 + i) * elem + k];
+                    dst.Write(buffer, 0, n);
+                }
+            }
+
+            // BytePlaneShuffle only writes count*elem bytes into a dst the length of src, so a
+            // partial trailing element leaves zeros behind. Both callers pass a whole number of
+            // elements (MemoryMarshal.AsBytes over float/double), so this never fires — but emitting
+            // the same zeros keeps the two paths byte-identical rather than merely equivalent on the
+            // inputs that happen to occur. DecodeLosslessBytes requires the full length and would
+            // throw on a short stream, so a divergence here would surface as a decode failure.
+            int tail = src.Length - count * elem;
+            if (tail > 0)
+            {
+                Array.Clear(buffer, 0, tail);
+                dst.Write(buffer, 0, tail);
+            }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     private static int DeflateDecompress(byte[] comp, byte[] dst, int dstLen)
@@ -965,23 +994,40 @@ internal static class StreamingStoreCodec
         return read;
     }
 
+    // DEFLATE (zlib's raw deflate) is the entropy coder: unlike LZ4 (match-only, no entropy
+    // stage → ~1.08x on shuffled fp weights), Deflate's Huffman stage compresses the highly
+    // repetitive sign/exponent byte-plane that the shuffle exposes → ~1.18x, bit-exact, at
+    // ~1.1 GiB/s decode. It's in the BCL on both net471 and net5+ (no extra dependency).
     private static byte[] EncodeLosslessBytes(ReadOnlySpan<byte> raw, int elem)
     {
-        var shuffled = new byte[raw.Length];
-        BytePlaneShuffle(raw, shuffled, elem);
-        var comp = DeflateCompress(shuffled);
-        if (comp.Length < shuffled.Length)
-        {
-            var outp = new byte[1 + comp.Length];
-            outp[0] = 1; // Deflate-compressed
-            Buffer.BlockCopy(comp, 0, outp, 1, comp.Length);
-            return outp;
-        }
+        // Shuffle straight into the compressor rather than materializing the shuffled copy.
+        //
+        // The shuffle is plane-major — dst[k*count + i] = src[i*elem + k] — so each plane is
+        // contiguous in the output and the planes can be emitted in order, a tile at a time,
+        // through a small pooled buffer. The bytes Deflate sees are identical either way; only the
+        // N-sized intermediate goes away, and it was most of the peak. Deflate reaches about 1.18x
+        // on shuffled fp weights (see the note above), so the old path held, at once: shuffled (N)
+        // + a MemoryStream pre-sized to N + ToArray (0.85N) + a further array purely to prepend one
+        // tag byte. InternImage's Huge size hit the 16 GiB ceiling inside it — first at
+        // MemoryStream..ctor, then, once a redundant copy was removed upstream in WeightRegistry,
+        // one allocation later at MemoryStream.ToArray. Writing the tag into the stream ahead of the
+        // compressed bytes removes the prepend copy too, leaving the stream buffer and one ToArray.
+        using var ms = new MemoryStream((raw.Length - (raw.Length >> 3)) + 1);
+        ms.WriteByte(1); // Deflate-compressed
+        using (var ds = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+            WriteShuffledPlanes(raw, elem, ds);
+
+        // ms.Length counts the tag byte, so the compressed payload is ms.Length - 1.
+        if (ms.Length - 1 < raw.Length)
+            return ms.ToArray();
+
         // Didn't shrink (rare — tiny or high-entropy) — store the raw shuffled bytes so the
-        // round-trip is still exact and never larger than shuffled + 1.
-        var rawOut = new byte[1 + shuffled.Length];
+        // round-trip is still exact and never larger than shuffled + 1. Re-shuffling costs a second
+        // pass on a path that is already the uncommon one, and it is what lets the common path
+        // avoid holding the shuffled copy at all.
+        var rawOut = new byte[1 + raw.Length];
         rawOut[0] = 0;
-        Buffer.BlockCopy(shuffled, 0, rawOut, 1, shuffled.Length);
+        BytePlaneShuffle(raw, rawOut.AsSpan(1), elem);
         return rawOut;
     }
 

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -896,12 +896,40 @@ public static class WeightRegistry
     }
 
     /// <summary>Lossless (byte-shuffle + LZ4) serialization — variable size.</summary>
+    /// <remarks>
+    /// <para>
+    /// Reads the live backing array when there is one, instead of copying the tensor first. The
+    /// encoders take a <see cref="ReadOnlySpan{T}"/>, so the copy bought nothing: it existed only
+    /// because <c>T</c> is unconstrained here (this library uses <c>INumericOperations</c> rather
+    /// than a <c>where T : unmanaged</c> constraint), and materializing a <c>T[]</c> is what lets
+    /// the runtime type pivot through <c>object</c>. <c>GetReadOnlyDataArray</c> pivots the same way
+    /// with no allocation on a plain CPU-resident tensor, and still falls back to a snapshot for
+    /// exactly the cases that need one — views, non-zero storage offsets, and GPU-resident tensors
+    /// whose CPU buffer may be stale. It also materializes deferred data first, which a hand-rolled
+    /// live-array read would skip, and unlike <c>GetDataArray</c> it does not privatize a
+    /// copy-on-write clone, so inference on a cloned model never copies its shared weights.
+    /// </para>
+    /// <para>
+    /// This matters most where it is cheapest to overlook. Training mode resolves EVERY streaming
+    /// weight to <see cref="StreamingEncoding.Lossless"/>, so switching a model to training runs
+    /// this path over the whole parameter set, and the encoder already holds the shuffle buffer and
+    /// the compression buffer at once. Adding a third full-size copy on the way in is what made
+    /// InternImage at its Huge size throw OutOfMemoryException from MemoryStream..ctor beneath this
+    /// call — on the code path whose purpose is to make a large model FIT.
+    /// </para>
+    /// </remarks>
     private static byte[] SerializeLossless<T>(Tensor<T> tensor)
     {
         if (typeof(T) == typeof(float))
-            return StreamingStoreCodec.EncodeLosslessFloat((float[])(object)tensor.AsSpan().ToArray());
+        {
+            return StreamingStoreCodec.EncodeLosslessFloat(
+                (float[])(object)tensor.GetReadOnlyDataArray());
+        }
         if (typeof(T) == typeof(double))
-            return StreamingStoreCodec.EncodeLosslessDouble((double[])(object)tensor.AsSpan().ToArray());
+        {
+            return StreamingStoreCodec.EncodeLosslessDouble(
+                (double[])(object)tensor.GetReadOnlyDataArray());
+        }
         throw new NotSupportedException(
             $"Lossless streaming store is only supported for float/double, not {typeof(T).Name}.");
     }
@@ -1031,13 +1059,13 @@ public static class WeightRegistry
         {
             if (typeof(T) == typeof(float))
             {
-                var srcF = (float[])(object)tensor.AsSpan().ToArray();
+                var srcF = (float[])(object)tensor.GetReadOnlyDataArray();
                 StreamingStoreCodec.EncodeFloat(srcF, dst, stochastic);
                 return;
             }
             if (typeof(T) == typeof(double))
             {
-                var srcD = (double[])(object)tensor.AsSpan().ToArray();
+                var srcD = (double[])(object)tensor.GetReadOnlyDataArray();
                 StreamingStoreCodec.EncodeDouble(srcD, dst, stochastic);
                 return;
             }
@@ -1107,31 +1135,31 @@ public static class WeightRegistry
         }
         if (typeof(T) == typeof(float))
         {
-            var src = (float[])(object)tensor.AsSpan().ToArray();
+            var src = (float[])(object)tensor.GetReadOnlyDataArray();
             Buffer.BlockCopy(src, 0, dst, 0, dst.Length);
             return;
         }
         if (typeof(T) == typeof(double))
         {
-            var src = (double[])(object)tensor.AsSpan().ToArray();
+            var src = (double[])(object)tensor.GetReadOnlyDataArray();
             Buffer.BlockCopy(src, 0, dst, 0, dst.Length);
             return;
         }
         if (typeof(T) == typeof(int))
         {
-            var src = (int[])(object)tensor.AsSpan().ToArray();
+            var src = (int[])(object)tensor.GetReadOnlyDataArray();
             Buffer.BlockCopy(src, 0, dst, 0, dst.Length);
             return;
         }
         if (typeof(T) == typeof(long))
         {
-            var src = (long[])(object)tensor.AsSpan().ToArray();
+            var src = (long[])(object)tensor.GetReadOnlyDataArray();
             Buffer.BlockCopy(src, 0, dst, 0, dst.Length);
             return;
         }
         if (typeof(T) == typeof(Half))
         {
-            var arr = (Half[])(object)tensor.AsSpan().ToArray();
+            var arr = (Half[])(object)tensor.GetReadOnlyDataArray();
             for (int i = 0; i < arr.Length; i++)
             {
                 ushort raw = AiDotNet.Tensors.NumericOperations.HalfBits.GetBits(arr[i]);
@@ -1142,7 +1170,7 @@ public static class WeightRegistry
         }
         if (typeof(T) == typeof(AiDotNet.Tensors.NumericOperations.BFloat16))
         {
-            var arr = (AiDotNet.Tensors.NumericOperations.BFloat16[])(object)tensor.AsSpan().ToArray();
+            var arr = (AiDotNet.Tensors.NumericOperations.BFloat16[])(object)tensor.GetReadOnlyDataArray();
             for (int i = 0; i < arr.Length; i++)
             {
                 ushort raw = arr[i].RawValue;


### PR DESCRIPTION
## The problem

Switching a model to training resolves **every** streaming weight to `StreamingEncoding.Lossless`
(inference may use bf16/int8; training may not lose precision), so flipping to training runs
`SerializeLossless` over the whole parameter set. That encoder held **four full-size buffers at once
to compress one**:

1. a copy of the tensor, from `tensor.AsSpan().ToArray()`
2. the N-byte byte-plane-shuffled intermediate
3. a `MemoryStream` pre-sized to the full N
4. `ToArray()`, plus a further array purely to prepend one tag byte

Deflate only reaches ~1.18x on shuffled fp weights — the codec's own comment says so — which makes
3 and 4 about 0.85N each, for a peak of roughly **3.7N to compress N**.

InternImage at its Huge size threw `OutOfMemoryException` inside this, under a 16 GiB runner — on
the code path whose entire purpose is to make a large model *fit*.

## The fix

**Copy 1 — redundant.** The encoders take a `ReadOnlySpan<T>`, so it bought nothing. It existed
because `T` is unconstrained here (this library uses `INumericOperations<T>` rather than
`where T : unmanaged`, so `MemoryMarshal` is unavailable) and materializing a `T[]` is what lets the
runtime type pivot through `object`. `GetReadOnlyDataArray()` pivots the same way with no
allocation, still snapshots for views / non-zero storage offsets / GPU-resident tensors, materializes
deferred data first, and unlike `GetDataArray` does not privatize a copy-on-write clone. Applied at
all nine read sites, not just lossless.

**Copy 2 — avoidable.** The shuffle is plane-major (`dst[k*count + i] = src[i*elem + k]`), so each
plane is contiguous in the output and the planes can be emitted in order, a tile at a time, through
a small pooled buffer. Deflate sees identical bytes; only the intermediate goes away. The vectorized
whole-buffer shuffle stays in use on decode and on the didn't-shrink fallback, where a real buffer
exists.

**Copy 4's prepend — avoidable.** The tag byte is now written into the stream ahead of the
compressed bytes, so the layout is unchanged and the second array is gone.

Peak **~3.7N → ~1.7N**. Wire format, defaults (lossless for training, compression on) and
compression ratio are all unchanged.

## Verification

- 344 net10.0 and 326 net471 streaming / codec / lossless / shuffle / weight-registry tests pass.
- Built clean on net10.0 and net471, 0 warnings.
- End-to-end against the real failure, under GitHub-runner parity in Docker (16 GiB cgroup,
  `--cpuset-cpus 0-3`, `memory.swap.max=0`, `DOTNET_GCHeapHardLimitPercent=0x64`), with the patched
  package proven resolved in `project.assets.json` rather than assumed.

An intermediate build removing only copy 1 still threw — but **one allocation later**, moving the
throw from `MemoryStream..ctor` to `MemoryStream.ToArray()`. That moved frame is what showed the fix
was real but partial, and prompted sizing the rest.

After all three removals, `StreamingStoreCodec` and `WeightRegistry.SerializeLossless` are **absent
from the failure entirely** and 4 of 5 InternImage sizes pass.

## What this does not fix

InternImage `Huge` still fails, at an unrelated site the codec OOM had been masking:

```
at TensorBase`1..ctor(Int32[] shape)
   DeformableConvolutionalLayer`1.InitializeWeights(outC, inC, kH, kW)
   DeformableConvolutionalLayer`1.OnFirstForward(...)
   InternImage`1.PredictCore -> PredictInInferenceMode
```

That is a single lazy weight-tensor allocation during the first forward, in the consuming repo, not
here. Huge is 1.08B parameters and the test already uses `InternImage<float>`, so it is tracked
separately.

## Risk

Byte-identical output, so no format migration. The one subtlety handled explicitly: `BytePlaneShuffle`
writes only `count*elem` bytes into a dst the length of src, and `DecodeLosslessBytes` requires the
full length — so the streaming path emits the same zero tail for a partial trailing element rather
than a short stream. Unreachable from both current callers (`MemoryMarshal.AsBytes` over
`float`/`double` is always a whole number of elements), but a divergence there would surface as a
decode failure, so it is closed rather than left latent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced memory usage and allocation overhead when compressing and serializing tensor data.
  * Improved streaming of lossless data while preserving compression and decoding behavior.
  * Optimized serialization for contiguous and compatible tensor data without changing output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->