### PR TITLE
fix: make conv2d and conv2dinto compute the same function for float

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — internal call sites pending migration to BlasManaged.Gemm<T> in later K tasks.
+﻿#pragma warning disable CS0618 // SimdGemm.Sgemm/Dgemm (no-trans shims) are [Obsolete] — internal call sites pending migration to BlasManaged.Gemm<T> in later K tasks.
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -9495,17 +9495,42 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var result = TensorAllocator.Rent<T>(new[] { batch, outChannels, outputHeight, outputWidth });
 
-        // Use im2col + GEMM for float (significantly faster)
+        // SAME KERNEL AS Conv2DInto. These two entry points used to dispatch differently for
+        // float -- this one to Conv2DWithIm2ColFloat (the SIMD-direct / Winograd cascade), and
+        // Conv2DInto to Conv2DIm2colGemm -- on the stated grounds that the results are
+        // "numerically equivalent (im2col-GEMM vs direct differ only by FP summation order)".
+        //
+        // At float32 they are not. Measured on a 3x3 stride-1 conv, 8 output channels over a
+        // [1,3,16,16] input: 1658 of 2048 outputs differed, by up to 2.3e-4 RELATIVE, and against a
+        // float64 reference the two land at rms 5.13e-08 and 6.77e-08 -- either side of the float
+        // epsilon, so the disagreement is not confined to the last bits.
+        //
+        // Callers cannot see which entry point they reached. AiDotNet's ConvolutionalLayer picks
+        // between them by whether a GradientTape is recording, since the in-place variant bypasses
+        // the tape, so the SAME layer with the SAME weights computed a different function in
+        // training than at inference -- and its serialize-replay test failed intermittently in CI
+        // depending on whether a tape happened to be active. That is a dispatch bug here, not a
+        // layer bug there: PyTorch selects a convolution algorithm from shape and hardware, never
+        // from grad mode, and torch.no_grad() changes whether a graph is built rather than the
+        // values flowing through it.
+        //
+        // Routing both to Conv2DIm2colGemm also makes THIS path faster: the cascade is roughly 15x
+        // slower for the small 3x3 stride-1 convolutions that dominate CNN inference, which is the
+        // measurement that moved Conv2DInto onto the GEMM path in the first place.
         if (typeof(T) == typeof(float))
         {
-            Conv2DWithIm2ColFloat(
-                input as Tensor<float> ?? throw new InvalidCastException(),
-                kernel as Tensor<float> ?? throw new InvalidCastException(),
-                result as Tensor<float> ?? throw new InvalidCastException(),
+            // GetReadOnlyDataArray for the two INPUTS: GetDataArray privatizes a copy-on-write
+            // tensor, and a read must not. TensorCowInferenceReadPathTests.Conv2D_DoesNotPrivatizeCowKernel
+            // asserts exactly that the kernel stays COW-shared across a convolution. The output is a
+            // tensor this method just rented, so it is written through GetDataArray as normal.
+            Conv2DIm2colGemm(
+                (float[])(object)input.GetReadOnlyDataArray(),
+                (float[])(object)kernel.GetReadOnlyDataArray(),
+                (float[])(object)result.GetDataArray(),
                 batch, inChannels, height, width,
                 outChannels, kernelHeight, kernelWidth,
-                stride, padding, dilation,
-                outputHeight, outputWidth);
+                outputHeight, outputWidth,
+                stride, stride, padding, padding, dilation, dilation);
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                 BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
             if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => eng.Conv2D(inputOrig, kernel, stride, padding, dilation));

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) AiDotNet. All rights reserved.
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines
+{
+    /// <summary>
+    /// <see cref="CpuEngine.Conv2D{T}(Tensor{T}, Tensor{T}, int, int, int)"/> and
+    /// <see cref="CpuEngine.Conv2DInto{T}(Tensor{T}, Tensor{T}, Tensor{T}, int, int, int)"/> must
+    /// compute the same function, bit for bit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// They dispatched differently for float: the allocating overload used the SIMD-direct /
+    /// Winograd cascade, the in-place one used im2col-GEMM. The difference was assumed to be
+    /// confined to summation order, and at float32 it is not -- on a 3x3 stride-1 conv over
+    /// [1,3,16,16], 1442 of 2048 outputs differed, and on a 16-to-32 channel 14x14 conv 5465 of
+    /// 6272 did.
+    /// </para>
+    /// <para>
+    /// A caller cannot see which entry point it reached, and the two are not interchangeable in
+    /// practice: the in-place variant bypasses the gradient tape, so a layer that wants gradients
+    /// must call the allocating one. AiDotNet's ConvolutionalLayer therefore picked between them by
+    /// whether a tape was recording, which made the same layer with the same weights compute a
+    /// different function in training than at inference. That is this dispatch's problem, not the
+    /// layer's: PyTorch chooses a convolution algorithm from shape and hardware, never from grad
+    /// mode, and <c>no_grad</c> governs whether a graph is built rather than the values in it.
+    /// </para>
+    /// <para>
+    /// Bit-for-bit is the right assertion rather than a tolerance. A tolerance would pass while the
+    /// two kernels drifted apart, which is exactly the state this test exists to prevent, and the
+    /// two are supposed to be the same computation reaching two different destinations.
+    /// </para>
+    /// </remarks>
+    public class Conv2DEntryPointParityTests
+    {
+        public static IEnumerable<object[]> Shapes()
+        {
+            // kernel, stride, padding, inChannels, outChannels, spatial
+            yield return new object[] { 3, 1, 1, 3, 8, 16 };     // the reported case
+            yield return new object[] { 3, 1, 1, 16, 32, 14 };   // the shape the GEMM route was tuned on
+            yield return new object[] { 3, 1, 1, 64, 64, 32 };
+            yield return new object[] { 3, 1, 1, 256, 128, 8 };  // high channel count, separate routing
+            yield return new object[] { 3, 2, 1, 3, 8, 16 };
+            yield return new object[] { 1, 1, 0, 3, 8, 16 };
+            yield return new object[] { 4, 1, 1, 3, 8, 16 };
+            yield return new object[] { 4, 2, 1, 16, 32, 14 };
+            yield return new object[] { 5, 1, 2, 3, 8, 16 };
+            yield return new object[] { 7, 1, 3, 3, 8, 16 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void Conv2DAndConv2DInto_ProduceIdenticalFloatResults(
+            int kernelSize, int stride, int padding, int inChannels, int outChannels, int spatial)
+        {
+            var engine = new CpuEngine();
+            var rng = new Random(11);
+
+            var input = new Tensor<float>(new[] { 1, inChannels, spatial, spatial });
+            for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var kernel = new Tensor<float>(new[] { outChannels, inChannels, kernelSize, kernelSize });
+            for (int i = 0; i < kernel.Length; i++) kernel[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var allocating = engine.Conv2D(input, kernel, stride, padding, 1);
+
+            var inPlace = new Tensor<float>(allocating.Shape.ToArray());
+            engine.Conv2DInto(inPlace, input, kernel, stride, padding, 1);
+
+            int differing = 0;
+            int firstIndex = -1;
+            for (int i = 0; i < allocating.Length; i++)
+            {
+                if (allocating[i] == inPlace[i]) continue;
+                differing++;
+                if (firstIndex < 0) firstIndex = i;
+            }
+
+            Assert.True(
+                differing == 0,
+                $"Conv2D and Conv2DInto disagree on {differing} of {allocating.Length} outputs for "
+                    + $"k{kernelSize} s{stride} p{padding} {inChannels}->{outChannels} @{spatial}x{spatial}. "
+                    + (firstIndex >= 0
+                        ? $"First at [{firstIndex}]: allocating={allocating[firstIndex]:G9}, "
+                          + $"inPlace={inPlace[firstIndex]:G9}. "
+                        : string.Empty)
+                    + "These entry points must select the same kernel: callers cannot observe which "
+                    + "one they reached, and choosing between them by whether a gradient tape is "
+                    + "recording would make a layer compute a different function in training than "
+                    + "at inference.");
+        }
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void Conv2DAndConv2DInto_ProduceIdenticalDoubleResults(
+            int kernelSize, int stride, int padding, int inChannels, int outChannels, int spatial)
+        {
+            var engine = new CpuEngine();
+            var rng = new Random(11);
+
+            var input = new Tensor<double>(new[] { 1, inChannels, spatial, spatial });
+            for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
+
+            var kernel = new Tensor<double>(new[] { outChannels, inChannels, kernelSize, kernelSize });
+            for (int i = 0; i < kernel.Length; i++) kernel[i] = rng.NextDouble() * 2 - 1;
+
+            var allocating = engine.Conv2D(input, kernel, stride, padding, 1);
+
+            var inPlace = new Tensor<double>(allocating.Shape.ToArray());
+            engine.Conv2DInto(inPlace, input, kernel, stride, padding, 1);
+
+            int differing = 0;
+            for (int i = 0; i < allocating.Length; i++)
+                if (allocating[i] != inPlace[i]) differing++;
+
+            Assert.True(
+                differing == 0,
+                $"Conv2D and Conv2DInto disagree on {differing} of {allocating.Length} double outputs "
+                    + $"for k{kernelSize} s{stride} p{padding} {inChannels}->{outChannels} "
+                    + $"@{spatial}x{spatial}.");
+        }
+    }
+}


### PR DESCRIPTION
## The problem

`Conv2D` (allocating) and `Conv2DInto` (in-place) dispatch to different float kernels — the first to `Conv2DWithIm2ColFloat` (SIMD-direct / Winograd cascade), the second to `Conv2DIm2colGemm`. A comment in `Conv2DInto` records the split as intentional, on the grounds that:

> Output is numerically equivalent (im2col-GEMM vs direct differ only by FP summation order).

At float32 that is not so. Measured on this branch before the change:

| shape | differing outputs |
|---|---|
| k3 s1 p1, 3→8 @16×16 | 1442 / 2048 |
| k3 s1 p1, 16→32 @14×14 | 5465 / 6272 |
| k3 s1 p1, 64→64 @32×32 | 16378 / 65536 |
| k4 s1 p1, 3→8 @16×16 | 996 / 1800 |
| k5 s1 p2, 3→8 @16×16 | 1187 / 2048 |
| k7 s1 p3, 3→8 @16×16 | 1263 / 2048 |

Up to **2.3e-4 relative**. Against a float64 reference the two land at rms 5.13e-08 and 6.77e-08 — either side of the float epsilon, so this is not confined to the last bits. Stride-2 and 1×1 already agreed; every stride-1 shape did not.

## Why it matters beyond the numbers

Callers cannot see which entry point they reached, and the two are not interchangeable: the in-place variant bypasses the gradient tape, so anything needing gradients must call the allocating one.

AiDotNet's `ConvolutionalLayer` selected between them on exactly that basis. The result was that one layer with one set of weights **computed a different function in training than at inference**, and its serialize-replay test failed intermittently in CI depending on whether a tape happened to be recording.

That is a dispatch problem here rather than a layer problem there. PyTorch selects a convolution algorithm from shape and hardware, never from grad mode — `torch.no_grad()` governs whether a graph is built, not the values flowing through it.

## The change

`Conv2D`'s float branch now calls `Conv2DIm2colGemm`, the same kernel `Conv2DInto` uses.

This also makes the allocating path **faster**: the cascade is roughly 15× slower for the small 3×3 stride-1 convolutions that dominate CNN inference, which is the measurement that moved `Conv2DInto` onto the GEMM path in the first place. Double was already consistent and is unchanged.

The two inputs are read via `GetReadOnlyDataArray` rather than `GetDataArray`, so a copy-on-write kernel is not privatized by a read — `Conv2D_DoesNotPrivatizeCowKernel` covers this and passes.

## Test

`Conv2DEntryPointParityTests` asserts the entry points agree bit for bit across ten shapes in float and double. It fails on exactly the six configurations above without the change and passes with it.

Bit-for-bit rather than a tolerance: a tolerance would pass while the two kernels drifted apart, which is the state the test exists to prevent.

## Verification

- `--filter FullyQualifiedName~Conv`: **616 passed, 0 failed**, 21 skipped
- New parity tests: 20 passed; 6 fail when the fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in 2D convolution results across standard and in-place processing.
  * Ensured convolution outputs remain identical across a broad range of tensor shapes, strides, padding, and channel configurations.

* **Tests**
  * Added coverage for both single-precision and double-precision convolution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->