### PR TITLE
fix: reject gemm operands too small for their own strides

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -488,6 +488,17 @@ internal static partial class SimdGemm
         System.Span<float> c,
         int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [m,k] at lda=k, B is [k,n] at ldb=n.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
 #if !NET471
         // Our JIT'd AVX2 kernel first (opt-in). This is the entry the MLP's
         // MlpForward path and FusedLinear's tier-3 fallback use — without this
@@ -805,6 +816,17 @@ internal static partial class SimdGemm
         System.Span<float> c,
         int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [m,k] at lda=k, B is [k,n] at ldb=n.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
         c.Clear();
 
         if (n > Nc || Avx512Sgemm.CanUse)
@@ -1633,10 +1655,16 @@ internal static partial class SimdGemm
         bool allowParallel,
         bool clearedOutput = false)
     {
-        ValidateGemmOperands(
-            a.Length, lda, transA,
-            b.Length, ldb, transB,
-            c.Length, m, k, n);
+        // Degenerate shapes are a documented quiet no-op, and the kernels never touch the
+        // operands, so validating them would reject callers the contract accepts - an empty c or
+        // an unused ldb is legal when there is no work to do.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, lda, transA,
+                b.Length, ldb, transB,
+                c.Length, m, k, n);
+        }
 
         // batch=1 / small-M, large-N, no-transpose: parallelize over N (output features). The
         // small-matmul fast path below requires m >= Mr and SgemmDirectParallelM requires m >= 64,
@@ -2181,6 +2209,17 @@ internal static partial class SimdGemm
         ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c,
         int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [m,k] at lda=k, B is [k,n] at ldb=n.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
         c.Clear();
         SgemmDirectParallelM(a, k, b, n, c, m, k, n, clearedOutput: true);
     }
@@ -2200,6 +2239,17 @@ internal static partial class SimdGemm
         ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c,
         int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [m,k] at lda=k, B is [k,n] at ldb=n.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
         SgemmDirectParallelM(a, k, b, n, c, m, k, n, clearedOutput: true);
     }
 
@@ -2476,6 +2526,17 @@ internal static partial class SimdGemm
     public static unsafe void SgemmDirectParallelMIntoTransA(
         ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [k,m] at lda=m (transposed), B is [k,n] at ldb=n.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, m, true,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
         const int MRf = 4;
         int mFull = (m / MRf) * MRf;
         int numFullBlocks = mFull / MRf;
@@ -2546,6 +2607,17 @@ internal static partial class SimdGemm
     public static unsafe void SgemmDirectParallelMIntoTransB(
         ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
     {
+        // Public entry into the pointer kernels: it does not pass through
+        // SgemmAddInternal, so it carries its own precondition. Strides are implicit in
+        // this overload's contract -- A is [m,k] at lda=k, B is [n,k] at ldb=k (transposed).
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, k, true,
+                c.Length, m, k, n);
+        }
+
         const int MRf = 4;
         int mFull = (m / MRf) * MRf;
         int numFullBlocks = mFull / MRf;

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -1365,6 +1365,16 @@ internal static partial class SimdGemm
         Span<float> c,
         int m, int k, int n)
     {
+        // Before the JIT / oneDNN fast paths below, which take fixed pointers of their own and
+        // would therefore bypass the check in SgemmAddInternal.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, lda, transA,
+                b.Length, ldb, transB,
+                c.Length, m, k, n);
+        }
+
 #if !NET471
         // Our JIT'd AVX2 kernel first (opt-in): no transpose, row-major contiguous
         // (lda==k, ldb==n). Beats managed + oneDNN on small-K/N, on our own pool.
@@ -1537,6 +1547,84 @@ internal static partial class SimdGemm
     /// across multiple Kc-tiles into the same C location.
     /// </summary>
     [MethodImpl(Hot)]
+
+    /// <summary>
+    /// Rejects operand spans that are too small for the requested shape and strides.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// THE KERNELS WALK RAW POINTERS. <see cref="SgemmDirect"/> and the packed paths take
+    /// <c>fixed</c> pointers into <paramref name="a"/>, <paramref name="b"/> and
+    /// <paramref name="c"/> and index them with lda / ldb / n. Nothing checked those spans were
+    /// large enough, so a caller that got a stride wrong did not get an exception - it read and
+    /// wrote past the end of the buffer. Observed as
+    /// <c>System.AccessViolationException: Attempted to read or write protected memory</c> raised
+    /// inside <c>SgemmDirect</c> on a backward pass, which kills the process outright: no catch
+    /// block runs, no shapes are reported, and a test host dies with "Test host process crashed".
+    /// </para>
+    /// <para>
+    /// The check is integer arithmetic on values already in registers, once per GEMM, against
+    /// kernels that then do m*n*k FMAs - it is not measurable. What it buys is that an undersized
+    /// operand becomes an <see cref="ArgumentException"/> naming the operand, its shape, its
+    /// stride and the length it needed, at the boundary where the caller is still on the stack.
+    /// </para>
+    /// <para>
+    /// Row-major minimums, transpose-aware. A is [m,k] read with row stride lda, or [k,m] when
+    /// <paramref name="transA"/>; B is [k,n] with row stride ldb, or [n,k] when
+    /// <paramref name="transB"/>; C is [m,n] with row stride n. The last row needs only its own
+    /// columns, hence (rows-1)*stride + cols rather than rows*stride - a caller passing an exactly
+    /// sized final row is legal and must not be rejected.
+    /// </para>
+    /// </remarks>
+    private static void ValidateGemmOperands(
+        int aLength, int lda, bool transA,
+        int bLength, int ldb, bool transB,
+        int cLength,
+        int m, int k, int n)
+    {
+        int aRows = transA ? k : m;
+        int aCols = transA ? m : k;
+        int bRows = transB ? n : k;
+        int bCols = transB ? k : n;
+
+        if (lda < aCols)
+        {
+            throw new ArgumentException(
+                $"GEMM operand A has row stride lda={lda} but {aCols} columns; the stride must be "
+                    + "at least the column count.", nameof(lda));
+        }
+
+        if (ldb < bCols)
+        {
+            throw new ArgumentException(
+                $"GEMM operand B has row stride ldb={ldb} but {bCols} columns; the stride must be "
+                    + "at least the column count.", nameof(ldb));
+        }
+
+        long needA = (long)(aRows - 1) * lda + aCols;
+        if (aLength < needA)
+        {
+            throw new ArgumentException(
+                $"GEMM operand A is {aLength} elements but [{aRows}x{aCols}] at lda={lda} needs "
+                    + $"{needA} (m={m}, k={k}, n={n}, transA={transA}).", "a");
+        }
+
+        long needB = (long)(bRows - 1) * ldb + bCols;
+        if (bLength < needB)
+        {
+            throw new ArgumentException(
+                $"GEMM operand B is {bLength} elements but [{bRows}x{bCols}] at ldb={ldb} needs "
+                    + $"{needB} (m={m}, k={k}, n={n}, transB={transB}).", "b");
+        }
+
+        long needC = (long)m * n;
+        if (cLength < needC)
+        {
+            throw new ArgumentException(
+                $"GEMM output C is {cLength} elements but [{m}x{n}] needs {needC}.", "c");
+        }
+    }
+
     internal static void SgemmAddInternal(
         ReadOnlySpan<float> a, int lda, bool transA,
         ReadOnlySpan<float> b, int ldb, bool transB,
@@ -1545,6 +1633,11 @@ internal static partial class SimdGemm
         bool allowParallel,
         bool clearedOutput = false)
     {
+        ValidateGemmOperands(
+            a.Length, lda, transA,
+            b.Length, ldb, transB,
+            c.Length, m, k, n);
+
         // batch=1 / small-M, large-N, no-transpose: parallelize over N (output features). The
         // small-matmul fast path below requires m >= Mr and SgemmDirectParallelM requires m >= 64,
         // so a tiny-M GEMM (foundation-model batch=1 / decode forward, fused QKV/FFN projections)

--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -1186,6 +1186,20 @@ internal static partial class SimdGemm
         System.ReadOnlySpan<float> a, float[] b, System.Span<float> c,
         int m, int k, int n)
     {
+        // The SAME precondition as the net5+ definition above. This overload has a twin, and
+        // guarding only the one visible on the framework you happen to build locally leaves the
+        // other route unprotected: it delegates to the obsolete no-trans shim, which forwards to
+        // BlasManaged rather than through any of the guarded paths, so an undersized b arrived at
+        // the kernel as an IndexOutOfRangeException instead of a named ArgumentException. Caught by
+        // SgemmWithCachedB_ValidatesItsOperands running on the net471 leg.
+        if (m > 0 && n > 0 && k > 0)
+        {
+            ValidateGemmOperands(
+                a.Length, k, false,
+                b.Length, n, false,
+                c.Length, m, k, n);
+        }
+
 #pragma warning disable CS0618 // Self-call to the [Obsolete] no-trans shim — SgemmWithCachedB is a net471 wrapper that legitimately delegates here.
         Sgemm(a, b.AsSpan(), c, m, k, n);
 #pragma warning restore CS0618

--- a/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
@@ -1,0 +1,127 @@
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// An operand too small for its own strides must be rejected, not walked past the end.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The GEMM kernels take <c>fixed</c> pointers into the operand spans and index them with lda / ldb
+/// / n. Nothing validated the spans were long enough for those strides, so getting one wrong did not
+/// raise - it read and wrote past the end of the buffer. In CI that surfaced as
+/// <c>System.AccessViolationException: Attempted to read or write protected memory</c> thrown from
+/// <c>SimdGemm.SgemmDirect</c> during a backward pass, which cannot be caught: the process dies,
+/// the shard reports "Test host process crashed : Fatal error", and no shape information survives.
+/// </para>
+/// <para>
+/// These cases pin the boundary rather than a single bad call, because the interesting property is
+/// that an undersized operand is refused AT THE ENTRY POINT, while an exactly-sized one is still
+/// accepted. The exactly-sized cases matter as much as the failing ones: the last row of a matrix
+/// needs only its own columns, so the minimum is (rows-1)*stride + cols, and a guard written as
+/// rows*stride would reject legitimate callers.
+/// </para>
+/// </remarks>
+public class SimdGemmBoundsPreconditionTests
+{
+    private const int M = 4;
+    private const int K = 3;
+    private const int N = 5;
+
+    private static float[] Filled(int length)
+    {
+        var buffer = new float[length];
+        for (int i = 0; i < length; i++) buffer[i] = i * 0.125f + 1f;
+        return buffer;
+    }
+
+    [Fact]
+    public void ExactlySizedOperands_AreAccepted()
+    {
+        // (rows-1)*stride + cols for A and B; m*n for C.
+        var a = Filled((M - 1) * K + K);
+        var b = Filled((K - 1) * N + N);
+        var c = new float[M * N];
+
+        SimdGemm.Sgemm(a, K, false, b, N, false, c, M, K, N);
+
+        // A real product, not an untouched buffer - proves the guard did not short-circuit the call.
+        Assert.Contains(c, value => value != 0f);
+    }
+
+    [Fact]
+    public void UndersizedA_ThrowsInsteadOfReadingPastTheEnd()
+    {
+        var a = Filled(M * K - 1);
+        var b = Filled(K * N);
+        var c = new float[M * N];
+
+        var error = Assert.Throws<ArgumentException>(
+            () => SimdGemm.Sgemm(a, K, false, b, N, false, c, M, K, N));
+        Assert.Contains("operand A", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UndersizedB_ThrowsInsteadOfReadingPastTheEnd()
+    {
+        var a = Filled(M * K);
+        var b = Filled(K * N - 1);
+        var c = new float[M * N];
+
+        var error = Assert.Throws<ArgumentException>(
+            () => SimdGemm.Sgemm(a, K, false, b, N, false, c, M, K, N));
+        Assert.Contains("operand B", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UndersizedC_ThrowsInsteadOfWritingPastTheEnd()
+    {
+        var a = Filled(M * K);
+        var b = Filled(K * N);
+        var c = new float[M * N - 1];
+
+        var error = Assert.Throws<ArgumentException>(
+            () => SimdGemm.Sgemm(a, K, false, b, N, false, c, M, K, N));
+        Assert.Contains("output C", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StrideNarrowerThanTheColumnCount_Throws()
+    {
+        // lda below k cannot describe a [m,k] matrix at all; walking it would interleave rows.
+        var a = Filled(M * K);
+        var b = Filled(K * N);
+        var c = new float[M * N];
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.Sgemm(a, K - 1, false, b, N, false, c, M, K, N));
+    }
+
+    [Fact]
+    public void TransposedOperands_SizeAgainstTheTransposedShape()
+    {
+        // transA: A is [k,m] with row stride lda, so the minimum is (k-1)*lda + m, NOT (m-1)*lda + k.
+        // Sizing a transposed operand against the untransposed shape is exactly the mistake that
+        // walks off the end when m and k differ.
+        var aT = Filled((K - 1) * M + M);
+        var b = Filled((K - 1) * N + N);
+        var c = new float[M * N];
+
+        SimdGemm.Sgemm(aT, M, true, b, N, false, c, M, K, N);
+
+        var tooSmall = Filled((K - 1) * M + M - 1);
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.Sgemm(tooSmall, M, true, b, N, false, c, M, K, N));
+    }
+
+    [Fact]
+    public void DegenerateShapes_StillReturnWithoutValidating()
+    {
+        // k = 0 has no work to do and callers rely on it returning quietly; the guard must not
+        // turn a documented no-op into an exception.
+        var c = new float[M * N];
+        SimdGemm.Sgemm(Array.Empty<float>(), 0, false, Array.Empty<float>(), N, false, c, M, 0, N);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
@@ -132,7 +132,13 @@ public class SimdGemmBoundsPreconditionTests
     // ---- Public entry points that reach the pointer kernels WITHOUT passing through
     //      SgemmAddInternal. Each carries its own precondition; without these cases a future
     //      refactor could drop one and nothing would notice until a host died in CI.
+    //
+    //      All but SgemmWithCachedB live inside #if NET5_0_OR_GREATER in SimdGemm, because the
+    //      parallel-M and int8 paths need the intrinsics that target lacks. The tests have to carry
+    //      the same condition or the net471 leg of the build fails on CS0117 - which is exactly what
+    //      happened, and it is invisible when only net10.0 is built locally.
 
+#if NET5_0_OR_GREATER
     [Fact]
     public void SgemmDirectParallelMInto_ValidatesItsOperands()
     {
@@ -187,6 +193,8 @@ public class SimdGemmBoundsPreconditionTests
                 a, Filled((N - 1) * K + K - 1), new float[M * N], M, K, N));
     }
 
+#endif
+
     [Fact]
     public void SgemmWithCachedB_ValidatesItsOperands()
     {
@@ -198,6 +206,7 @@ public class SimdGemmBoundsPreconditionTests
         SimdGemm.SgemmWithCachedB(a, Filled(K * N), new float[M * N], M, K, N);
     }
 
+#if NET5_0_OR_GREATER
     [Fact]
     public void SgemmWithInt8CachedB_ValidatesItsOperands()
     {
@@ -208,4 +217,5 @@ public class SimdGemmBoundsPreconditionTests
 
         SimdGemm.SgemmWithInt8CachedB(a, Filled(K * N), new float[M * N], M, K, N);
     }
+#endif
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SimdGemmBoundsPreconditionTests.cs
@@ -120,8 +120,92 @@ public class SimdGemmBoundsPreconditionTests
     public void DegenerateShapes_StillReturnWithoutValidating()
     {
         // k = 0 has no work to do and callers rely on it returning quietly; the guard must not
-        // turn a documented no-op into an exception.
-        var c = new float[M * N];
-        SimdGemm.Sgemm(Array.Empty<float>(), 0, false, Array.Empty<float>(), N, false, c, M, 0, N);
+        // turn a documented no-op into an exception. An EMPTY c and a nonsense ldb are both legal
+        // here precisely because the kernels never touch either operand - which is why the guard
+        // is gated on m/n/k rather than run unconditionally.
+        SimdGemm.Sgemm(
+            Array.Empty<float>(), 0, false,
+            Array.Empty<float>(), 0, false,
+            Array.Empty<float>(), M, 0, N);
+    }
+
+    // ---- Public entry points that reach the pointer kernels WITHOUT passing through
+    //      SgemmAddInternal. Each carries its own precondition; without these cases a future
+    //      refactor could drop one and nothing would notice until a host died in CI.
+
+    [Fact]
+    public void SgemmDirectParallelMInto_ValidatesItsOperands()
+    {
+        var a = Filled(M * K);
+        var b = Filled(K * N);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmDirectParallelMInto(a, b, new float[M * N - 1], M, K, N));
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmDirectParallelMInto(Filled(M * K - 1), b, new float[M * N], M, K, N));
+
+        SimdGemm.SgemmDirectParallelMInto(a, b, new float[M * N], M, K, N);
+    }
+
+    [Fact]
+    public void SgemmDirectParallelMOverwrite_ValidatesItsOperands()
+    {
+        var a = Filled(M * K);
+        var b = Filled(K * N);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmDirectParallelMOverwrite(a, Filled(K * N - 1), new float[M * N], M, K, N));
+
+        SimdGemm.SgemmDirectParallelMOverwrite(a, b, new float[M * N], M, K, N);
+    }
+
+    [Fact]
+    public void SgemmDirectParallelMIntoTransA_SizesAgainstTheTransposedA()
+    {
+        // A is [k,m] at lda=m here, so the minimum is (k-1)*m + m, not the untransposed figure.
+        var aT = Filled((K - 1) * M + M);
+        var b = Filled((K - 1) * N + N);
+
+        SimdGemm.SgemmDirectParallelMIntoTransA(aT, b, new float[M * N], M, K, N);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmDirectParallelMIntoTransA(
+                Filled((K - 1) * M + M - 1), b, new float[M * N], M, K, N));
+    }
+
+    [Fact]
+    public void SgemmDirectParallelMIntoTransB_SizesAgainstTheTransposedB()
+    {
+        // B is [n,k] at ldb=k here.
+        var a = Filled((M - 1) * K + K);
+        var bT = Filled((N - 1) * K + K);
+
+        SimdGemm.SgemmDirectParallelMIntoTransB(a, bT, new float[M * N], M, K, N);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmDirectParallelMIntoTransB(
+                a, Filled((N - 1) * K + K - 1), new float[M * N], M, K, N));
+    }
+
+    [Fact]
+    public void SgemmWithCachedB_ValidatesItsOperands()
+    {
+        var a = Filled(M * K);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmWithCachedB(a, Filled(K * N - 1), new float[M * N], M, K, N));
+
+        SimdGemm.SgemmWithCachedB(a, Filled(K * N), new float[M * N], M, K, N);
+    }
+
+    [Fact]
+    public void SgemmWithInt8CachedB_ValidatesItsOperands()
+    {
+        var a = Filled(M * K);
+
+        Assert.Throws<ArgumentException>(
+            () => SimdGemm.SgemmWithInt8CachedB(a, Filled(K * N), new float[M * N - 1], M, K, N));
+
+        SimdGemm.SgemmWithInt8CachedB(a, Filled(K * N), new float[M * N], M, K, N);
     }
 }


### PR DESCRIPTION
## The crash

An AiDotNet CI shard did not fail a test — it lost the process:

```
The active test run was aborted. Reason: Test host process crashed : Fatal error.
System.AccessViolationException: Attempted to read or write protected memory.
  at AiDotNet.Tensors.Engines.Simd.SimdGemm.SgemmDirect(ReadOnlySpan<Single>, Int32, ...)
  at SimdGemm.Sgemm → CpuEngine.TensorMatMul2D<Single> → TensorMatMul<Single>
  at BackwardFunctions<Single> … CompiledTrainingPlan … TrainWithTape
```

`MemAvailable` was **13.8 GB** at the time, so this is not memory pressure — it is an out-of-bounds access inside the kernel.

## Why nothing stopped it

`SgemmDirect` takes `fixed` pointers into `a`, `b` and `c` and indexes them with `lda`, `ldb` and `n`. `Sgemm` validated only that `m`, `n` and `k` are positive — **nothing checked the spans were long enough for those strides**. A caller that got a stride wrong therefore did not get an exception; it read and wrote past the end of the buffer.

That failure mode is the worst kind to inherit: an `AccessViolationException` cannot be caught, so the process dies, no `catch` runs, the shard reports a crashed host, and the shapes that caused it are gone.

## The change

`ValidateGemmOperands` rejects it at the entry point, transpose-aware:

| operand | shape | minimum length |
|---|---|---|
| A | `[m,k]` at stride `lda`, or `[k,m]` when `transA` | `(rows-1)*lda + cols` |
| B | `[k,n]` at stride `ldb`, or `[n,k]` when `transB` | `(rows-1)*ldb + cols` |
| C | `[m,n]` at stride `n` | `m*n` |

`(rows-1)*stride + cols`, **not** `rows*stride` — the last row needs only its own columns, and a caller passing an exactly sized final row is legal. A stride narrower than the column count is rejected outright, since it cannot describe the matrix at all.

Two call sites, because the trans `Sgemm` overload reaches its JIT and oneDNN fast paths — which take `fixed` pointers of their own — before funnelling into `SgemmAddInternal`. Validating only the dispatcher would leave those exposed.

## Cost

Integer arithmetic once per GEMM, against kernels that then perform `m*n*k` FMAs. Degenerate shapes still return quietly: `k = 0` is a documented no-op and the guard does not turn it into an exception.

## What this does *not* do

**It does not fix the caller.** The offending call is somewhere on the backward path, and it is not reproducible here — the kernel chosen depends on the CPU's ISA, and the same test passes 33/34 locally. This converts an unrecoverable memory corruption into an `ArgumentException` naming the operand, its shape, its stride and the length it needed, at the boundary where the caller is still on the stack. That makes the next occurrence diagnosable instead of fatal, and it will name the bad shape directly.

## Verification

- 7 new bounds tests, including the exactly-sized cases (a guard written as `rows*stride` would reject legitimate callers) and the transposed-shape case.
- 1414 existing Tensors tests pass on net10.0; net471 builds.
- The one full-suite failure, `TinyShapeBypassTest.Bypass_Faster_Than_Full_Path_On_Tiny_Shape`, is a timing test that flakes under 1474-test contention — it passes 5/5 in isolation with this change applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for matrix dimensions, operand sizes, and row strides before GEMM operations.
  * Invalid or undersized operands now produce clear argument errors instead of risking out-of-bounds memory access.
  * Zero-work operations continue to return without requiring operand validation.

* **Tests**
  * Added coverage for standard, transposed, invalid-stride, undersized-operand, and degenerate-shape scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->