### PR TITLE
fix: mask the b loads in the n-tail direct gemm kernels

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -3085,10 +3085,41 @@ internal static partial class SimdGemm
         float* pA4 = pA + lda * 4;
         float* pA5 = pA + lda * 5;
 
+        // COLUMN LANE MASKS, HOISTED ABOVE THE K-LOOP because the B LOADS need them too.
+        //
+        // These kernels are entered for the N tail, where ncActual is 1..Nr-1, and they used to
+        // load a full 16-wide B row on every k step regardless:
+        //
+        //     var b0 = Avx.LoadVector256(pB);
+        //     var b1 = Avx.LoadVector256(pB + 8);
+        //
+        // The masks existed but were built AFTER the loop and used only to mask the STORE, so the
+        // reads ran past the end of B. On the final k row the last address touched is
+        // (k-1)*ldb + j + 15 while the operand check guarantees only (k-1)*ldb + n, and j + ncActual
+        // equals n -- so a tail of ncActual columns over-reads by 16 - ncActual floats with no
+        // slack to absorb it. It is harmless until that overhang crosses onto an unmapped page, and
+        // then it is an AccessViolationException that kills the process rather than failing a test:
+        // observed on a Linux CI runner as "Test Run Aborted / the host process exited
+        // unexpectedly" inside a backward-pass GEMM, on a shard that reported 250 tests executed
+        // and 0 failed.
+        //
+        // DirectKernelMxNarrow in this same file already loads B this way; these two kernels simply
+        // did not. The full-width lane keeps its unmasked load so the ncActual == Nr callers (the M
+        // tail, which passes ncActual: Nr) are not slowed down.
+        int lane0N = ncActual >= 8 ? 8 : ncActual;
+        int lane1N = ncActual >= 8 ? ncActual - 8 : 0;
+        var mask0 = _partialNrMasks[lane0N].AsSingle();
+        var mask1 = _partialNrMasks[lane1N].AsSingle();
+        bool bLane0Full = lane0N == 8;
+        bool bLane1Full = lane1N == 8;
+        bool bLane1Any = lane1N > 0;
+
         for (int p = 0; p < k; p++)
         {
-            var b0 = Avx.LoadVector256(pB);
-            var b1 = Avx.LoadVector256(pB + 8);
+            var b0 = bLane0Full ? Avx.LoadVector256(pB) : Avx.MaskLoad(pB, mask0);
+            var b1 = bLane1Full
+                ? Avx.LoadVector256(pB + 8)
+                : (bLane1Any ? Avx.MaskLoad(pB + 8, mask1) : Vector256<float>.Zero);
 
             // Row 0 always active (mcActual >= 1 guaranteed by caller).
             var a0 = Vector256.Create(pA0[p]);
@@ -3123,11 +3154,6 @@ internal static partial class SimdGemm
             pB += ldb;
         }
 
-        // Build column lane masks from ncActual (same logic as MicroKernelMxNMasked).
-        int lane0N = ncActual >= 8 ? 8 : ncActual;
-        int lane1N = ncActual >= 8 ? ncActual - 8 : 0;
-        var mask0 = _partialNrMasks[lane0N].AsSingle();
-        var mask1 = _partialNrMasks[lane1N].AsSingle();
 
         // Masked accumulate-and-store, row by row, skipping rows past mcActual.
         if (mcActual > 0) StoreMaskedAccumRowDirect(pC,            mask0, mask1, c00, c01);
@@ -3244,10 +3270,41 @@ internal static partial class SimdGemm
         float* pA4 = pA + lda * 4;
         float* pA5 = pA + lda * 5;
 
+        // COLUMN LANE MASKS, HOISTED ABOVE THE K-LOOP because the B LOADS need them too.
+        //
+        // These kernels are entered for the N tail, where ncActual is 1..Nr-1, and they used to
+        // load a full 16-wide B row on every k step regardless:
+        //
+        //     var b0 = Avx.LoadVector256(pB);
+        //     var b1 = Avx.LoadVector256(pB + 8);
+        //
+        // The masks existed but were built AFTER the loop and used only to mask the STORE, so the
+        // reads ran past the end of B. On the final k row the last address touched is
+        // (k-1)*ldb + j + 15 while the operand check guarantees only (k-1)*ldb + n, and j + ncActual
+        // equals n -- so a tail of ncActual columns over-reads by 16 - ncActual floats with no
+        // slack to absorb it. It is harmless until that overhang crosses onto an unmapped page, and
+        // then it is an AccessViolationException that kills the process rather than failing a test:
+        // observed on a Linux CI runner as "Test Run Aborted / the host process exited
+        // unexpectedly" inside a backward-pass GEMM, on a shard that reported 250 tests executed
+        // and 0 failed.
+        //
+        // DirectKernelMxNarrow in this same file already loads B this way; these two kernels simply
+        // did not. The full-width lane keeps its unmasked load so the ncActual == Nr callers (the M
+        // tail, which passes ncActual: Nr) are not slowed down.
+        int lane0N = ncActual >= 8 ? 8 : ncActual;
+        int lane1N = ncActual >= 8 ? ncActual - 8 : 0;
+        var mask0 = _partialNrMasks[lane0N].AsSingle();
+        var mask1 = _partialNrMasks[lane1N].AsSingle();
+        bool bLane0Full = lane0N == 8;
+        bool bLane1Full = lane1N == 8;
+        bool bLane1Any = lane1N > 0;
+
         for (int p = 0; p < k; p++)
         {
-            var b0 = Avx.LoadVector256(pB);
-            var b1 = Avx.LoadVector256(pB + 8);
+            var b0 = bLane0Full ? Avx.LoadVector256(pB) : Avx.MaskLoad(pB, mask0);
+            var b1 = bLane1Full
+                ? Avx.LoadVector256(pB + 8)
+                : (bLane1Any ? Avx.MaskLoad(pB + 8, mask1) : Vector256<float>.Zero);
 
             var a0 = Vector256.Create(pA0[p]);
             c00 = Fma.MultiplyAdd(a0, b0, c00); c01 = Fma.MultiplyAdd(a0, b1, c01);
@@ -3281,10 +3338,6 @@ internal static partial class SimdGemm
             pB += ldb;
         }
 
-        int lane0N = ncActual >= 8 ? 8 : ncActual;
-        int lane1N = ncActual >= 8 ? ncActual - 8 : 0;
-        var mask0 = _partialNrMasks[lane0N].AsSingle();
-        var mask1 = _partialNrMasks[lane1N].AsSingle();
 
         // Store-only: plain MaskStore (no MaskLoad-add).
         if (mcActual > 0) StoreMaskedRowDirect(pC,            mask0, mask1, c00, c01);

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectGuardPageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectGuardPageTests.cs
@@ -1,0 +1,355 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if NET5_0_OR_GREATER
+// The N-tail direct kernels are AVX2/FMA intrinsics, which SimdGemm declares inside
+// #if NET5_0_OR_GREATER; SgemmDirectParallelMInto does not exist on net471 at all.
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+#if NET5_0_OR_GREATER
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace AiDotNet.Tensors.Tests.Engines
+{
+    /// <summary>
+    /// Proves the N-tail kernels do not read past B, by making the byte after B unreadable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="SgemmDirectNTailBoundsTests"/> can only show that masking the B loads leaves the
+    /// arithmetic unchanged. It cannot show the over-read is gone: the extra lanes were always
+    /// discarded by the masked store, so a kernel that reads 60 bytes past its operand and one that
+    /// does not produce identical output. A managed array does not help either -- `new float[k * n]`
+    /// has no trailing logical elements, but the bytes after it are ordinary readable heap, so the
+    /// old unmasked load completed and every assertion passed.
+    /// </para>
+    /// <para>
+    /// So B is placed in raw pages here, positioned so its last element ends exactly at a page
+    /// boundary, with the next page mapped NO-ACCESS. Any read past the operand hits that page and
+    /// traps. With the loads masked the kernel never touches it and the run completes.
+    /// </para>
+    /// <para>
+    /// A trap is an <c>AccessViolationException</c>, which .NET Core treats as a corrupted state
+    /// exception: it cannot be caught, and it takes the whole test host with it. Running the probe
+    /// in-process would therefore turn a regression into an aborted run with no attribution -- which
+    /// is precisely how the original bug presented in CI. The probe is a separate test that stays
+    /// skipped unless <c>AIDOTNET_SGEMM_GUARD_PROBE</c> is set, and
+    /// <see cref="OverReadPastB_Traps_OnGuardPage"/> runs it in a child process and reads its exit
+    /// code, so a regression is a failing test rather than a dead run.
+    /// </para>
+    /// </remarks>
+    public class SgemmDirectGuardPageTests
+    {
+        private const string ProbeEnvVar = "AIDOTNET_SGEMM_GUARD_PROBE";
+
+        /// <summary>Where the probe records that it finished.</summary>
+        /// <remarks>
+        /// A file, not stdout. <c>dotnet test</c> captures a test's console output and reports it
+        /// through the logger rather than forwarding it to the parent's stdout, so a marker written
+        /// with <c>Console.WriteLine</c> never arrives and the parent cannot tell "the probe ran and
+        /// survived" from "the probe never ran". A file the child creates is visible either way.
+        /// </remarks>
+        private const string MarkerPathEnvVar = "AIDOTNET_SGEMM_GUARD_MARKER";
+
+        private const string ProbeTestName =
+            "AiDotNet.Tensors.Tests.Engines.SgemmDirectGuardPageTests.GuardPageProbe_RunsInChildProcess";
+        private const string CompletedMarker = "AIDOTNET-GUARD-PROBE-COMPLETED";
+
+        /// <summary>The kernels under test are AVX2 + FMA; elsewhere there is nothing to prove.</summary>
+        private static bool KernelsAreLive =>
+#if NET5_0_OR_GREATER
+            Avx2.IsSupported && Fma.IsSupported;
+#else
+            false;
+#endif
+
+        [Fact]
+        public void OverReadPastB_Traps_OnGuardPage()
+        {
+            if (!KernelsAreLive)
+            {
+                return;   // no AVX2/FMA path to exercise
+            }
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return;   // guard pages are mapped per-OS below; only these two are wired up
+            }
+
+            var project = FindTestProject();
+            if (project is null)
+            {
+                return;   // running from a layout where the project file is not locatable
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("test");
+            psi.ArgumentList.Add(project);
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add(Configuration);
+            psi.ArgumentList.Add("-f");
+            psi.ArgumentList.Add(TargetFrameworkMoniker);
+            psi.ArgumentList.Add("--no-build");
+            psi.ArgumentList.Add("--nologo");
+            psi.ArgumentList.Add("--filter");
+            psi.ArgumentList.Add("FullyQualifiedName=" + ProbeTestName);
+
+            string markerPath = Path.Combine(
+                Path.GetTempPath(),
+                "aidotnet-sgemm-guard-" + Guid.NewGuid().ToString("N") + ".marker");
+            psi.Environment[ProbeEnvVar] = "1";
+            psi.Environment[MarkerPathEnvVar] = markerPath;
+
+            var stdout = new StringBuilder();
+            using var child = new Process { StartInfo = psi };
+            child.OutputDataReceived += (_, e) => { if (e.Data is not null) stdout.AppendLine(e.Data); };
+            child.ErrorDataReceived += (_, e) => { if (e.Data is not null) stdout.AppendLine(e.Data); };
+            child.Start();
+            child.BeginOutputReadLine();
+            child.BeginErrorReadLine();
+
+            if (!child.WaitForExit(milliseconds: 10 * 60 * 1000))
+            {
+                try { child.Kill(entireProcessTree: true); } catch (InvalidOperationException) { }
+                Assert.Fail("The guard-page probe did not finish within ten minutes.");
+            }
+
+            child.WaitForExit();   // let the async output handlers drain
+            var log = stdout.ToString();
+
+            string marker = File.Exists(markerPath) ? File.ReadAllText(markerPath) : string.Empty;
+            try { File.Delete(markerPath); } catch (IOException) { }
+
+            // A child that never reached the probe says nothing about the kernels, and must not be
+            // read as a pass. The marker is written by the probe itself, after the GEMMs return.
+            Assert.True(
+                marker.Contains(CompletedMarker, StringComparison.Ordinal),
+                "The guard-page probe did not report completion, so the kernels were never "
+                    + $"exercised. Child exit code {child.ExitCode}. Output:\n{log}");
+
+            Assert.True(
+                child.ExitCode == 0,
+                "The guard-page probe process died. A read past the end of B landed on the "
+                    + "no-access page, which is the over-read this fix removes -- the N-tail kernels "
+                    + "must load B through their column masks, not at full 16-wide width. Child "
+                    + $"exit code {child.ExitCode}. Output:\n{log}");
+        }
+
+        /// <summary>
+        /// The probe itself. Never runs in a normal test pass; see the class remarks.
+        /// </summary>
+        [Fact]
+        public void GuardPageProbe_RunsInChildProcess()
+        {
+            if (Environment.GetEnvironmentVariable(ProbeEnvVar) is null || !KernelsAreLive)
+            {
+                return;
+            }
+
+            // n % 16 == 1: the last column block is a one-wide tail, so the old code read 15 floats
+            // past the final row. Routed through SgemmDirectParallelMInto, which passes
+            // clearedOutput: true and so lands in DirectKernelMxNMaskedStore.
+            RunOnGuardedB(m: 13, k: 9, n: 17, accumulate: false);
+
+            // n % 16 == 8: the only tail width the accumulate path admits (SgemmAddInternal takes
+            // the SgemmDirect branch only when n % 8 == 0), and the worst case -- lane 1's load lay
+            // entirely past the row. Lands in DirectKernelMxNMasked.
+            RunOnGuardedB(m: 13, k: 9, n: 24, accumulate: true);
+
+            // Written only if both GEMMs returned. A fault takes the process down before this line.
+            string? markerPath = Environment.GetEnvironmentVariable(MarkerPathEnvVar);
+            if (markerPath is not null && markerPath.Length > 0)
+            {
+                File.WriteAllText(markerPath, CompletedMarker);
+            }
+        }
+
+        private static unsafe void RunOnGuardedB(int m, int k, int n, bool accumulate)
+        {
+            int pageSize = Environment.SystemPageSize;
+            long operandBytes = (long)k * n * sizeof(float);
+
+            // Round the operand up to whole pages, then add one page to poison. B is placed at the
+            // END of the readable region, so its last element is the last readable byte and the
+            // very next byte faults.
+            long readableBytes = ((operandBytes + pageSize - 1) / pageSize) * pageSize;
+            long totalBytes = readableBytes + pageSize;
+
+            IntPtr region = Reserve(totalBytes);
+            try
+            {
+                Poison(region + (IntPtr)readableBytes, pageSize);
+
+                float* b = (float*)(region + (IntPtr)(readableBytes - operandBytes));
+                var rng = new Random(4242);
+                for (long i = 0; i < (long)k * n; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+                var a = new float[m * k];
+                for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+
+                var c = new float[m * n];
+                var bSpan = new ReadOnlySpan<float>(b, k * n);
+
+                if (accumulate)
+                {
+                    SimdGemm.SgemmAdd(a, bSpan, c, m, k, n);
+                }
+                else
+                {
+                    SimdGemm.SgemmDirectParallelMInto(a, bSpan, c, m, k, n);
+                }
+
+                // Consume the result so nothing above can be optimized away.
+                double sum = 0;
+                for (int i = 0; i < c.Length; i++) sum += c[i];
+                if (double.IsNaN(sum))
+                {
+                    throw new InvalidOperationException("guarded GEMM produced NaN");
+                }
+            }
+            finally
+            {
+                Release(region, totalBytes);
+            }
+        }
+
+        private static string Configuration =>
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        private static string TargetFrameworkMoniker =>
+#if NET10_0_OR_GREATER
+            "net10.0";
+#elif NET8_0_OR_GREATER
+            "net8.0";
+#else
+            "net471";
+#endif
+
+        private static string? FindTestProject()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                string candidate = Path.Combine(dir.FullName, "AiDotNet.Tensors.Tests.csproj");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                dir = dir.Parent;
+            }
+
+            return null;
+        }
+
+        // ---------------------------------------------------------------- raw pages, per OS
+
+        private const uint MEM_COMMIT = 0x1000;
+        private const uint MEM_RESERVE = 0x2000;
+        private const uint MEM_RELEASE = 0x8000;
+        private const uint PAGE_READWRITE = 0x04;
+        private const uint PAGE_NOACCESS = 0x01;
+
+        private const int PROT_NONE = 0x0;
+        private const int PROT_READ = 0x1;
+        private const int PROT_WRITE = 0x2;
+        private const int MAP_PRIVATE = 0x02;
+        private const int MAP_ANONYMOUS_LINUX = 0x20;
+
+        [DllImport("kernel32", SetLastError = true)]
+        private static extern IntPtr VirtualAlloc(
+            IntPtr lpAddress, UIntPtr dwSize, uint flAllocationType, uint flProtect);
+
+        [DllImport("kernel32", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool VirtualProtect(
+            IntPtr lpAddress, UIntPtr dwSize, uint flNewProtect, out uint lpflOldProtect);
+
+        [DllImport("kernel32", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool VirtualFree(IntPtr lpAddress, UIntPtr dwSize, uint dwFreeType);
+
+        [DllImport("libc", SetLastError = true, EntryPoint = "mmap")]
+        private static extern IntPtr Mmap(
+            IntPtr addr, UIntPtr length, int prot, int flags, int fd, IntPtr offset);
+
+        [DllImport("libc", SetLastError = true, EntryPoint = "mprotect")]
+        private static extern int Mprotect(IntPtr addr, UIntPtr len, int prot);
+
+        [DllImport("libc", SetLastError = true, EntryPoint = "munmap")]
+        private static extern int Munmap(IntPtr addr, UIntPtr length);
+
+        private static IntPtr Reserve(long totalBytes)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IntPtr p = VirtualAlloc(
+                    IntPtr.Zero, (UIntPtr)totalBytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+                if (p == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException(
+                        $"VirtualAlloc failed: {Marshal.GetLastWin32Error()}");
+                }
+
+                return p;
+            }
+
+            IntPtr q = Mmap(
+                IntPtr.Zero, (UIntPtr)totalBytes, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS_LINUX, -1, IntPtr.Zero);
+            if (q == IntPtr.Zero || q == new IntPtr(-1))
+            {
+                throw new InvalidOperationException($"mmap failed: {Marshal.GetLastWin32Error()}");
+            }
+
+            return q;
+        }
+
+        private static void Poison(IntPtr pageStart, int pageSize)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (!VirtualProtect(pageStart, (UIntPtr)pageSize, PAGE_NOACCESS, out _))
+                {
+                    throw new InvalidOperationException(
+                        $"VirtualProtect failed: {Marshal.GetLastWin32Error()}");
+                }
+
+                return;
+            }
+
+            if (Mprotect(pageStart, (UIntPtr)pageSize, PROT_NONE) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"mprotect failed: {Marshal.GetLastWin32Error()}");
+            }
+        }
+
+        private static void Release(IntPtr region, long totalBytes)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                VirtualFree(region, UIntPtr.Zero, MEM_RELEASE);
+                return;
+            }
+
+            Munmap(region, (UIntPtr)totalBytes);
+        }
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
@@ -1,4 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
+#if NET5_0_OR_GREATER
+// The N-tail direct kernels are AVX2/FMA intrinsics, which SimdGemm declares inside
+// #if NET5_0_OR_GREATER; SgemmDirectParallelMInto does not exist on net471 at all.
 using System;
 using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Simd;
@@ -181,3 +184,4 @@ namespace AiDotNet.Tensors.Tests.Engines
         }
     }
 }
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) AiDotNet. All rights reserved.
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines
+{
+    /// <summary>
+    /// The N-tail direct kernels must read B only within the operand the caller supplied, and must
+    /// still compute the same product while doing so.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>DirectKernelMxNMasked</c> and <c>DirectKernelMxNMaskedStore</c> are entered when the
+    /// column count leaves a tail, so <c>ncActual</c> is between 1 and Nr-1. Both used to load a
+    /// full 16-wide B row on every k step regardless of that, masking only the store. On the last k
+    /// row the final address touched is <c>(k-1)*ldb + j + 15</c>, while the operand check
+    /// guarantees only <c>(k-1)*ldb + n</c> and <c>j + ncActual == n</c> -- an over-read of
+    /// <c>16 - ncActual</c> floats with no slack to absorb it. It surfaced as an
+    /// AccessViolationException that killed a Linux CI host inside a backward-pass GEMM, on a shard
+    /// that reported 250 tests executed and 0 failed.
+    /// </para>
+    /// <para>
+    /// The over-read is not directly observable from managed code: the extra lanes are masked out
+    /// of the store, so results are unchanged and the read only faults when the overhang happens to
+    /// cross onto an unmapped page. What IS checkable, and what this fixes' correctness rests on, is
+    /// that switching those loads to masked ones leaves the product identical for every tail width.
+    /// The widths below cover ncActual = 1..15 across both lanes of the 16-wide tile, which is
+    /// exactly the range the masked loads changed.
+    /// </para>
+    /// </remarks>
+    public class SgemmDirectNTailBoundsTests
+    {
+        public static TheoryData<int, int, int> TailShapes()
+        {
+            var data = new TheoryData<int, int, int>();
+            // n chosen so n % 16 walks every tail width; m spans full tiles and an m tail.
+            foreach (int n in new[] { 1, 7, 8, 9, 15, 17, 23, 31, 33, 47 })
+            {
+                data.Add(6, 5, n);    // exactly one full M tile
+                data.Add(13, 9, n);   // two M tiles plus an M tail
+            }
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(TailShapes))]
+        public void SgemmDirect_NTail_MatchesReference(int m, int k, int n)
+        {
+            var rng = new Random(20260829);
+
+            // Exactly sized operands: no slack after the last element, which is the condition the
+            // over-read had no room for.
+            var a = new float[m * k];
+            var b = new float[k * n];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            var actual = new float[m * n];
+            SimdGemm.SgemmDirectParallelMInto(a, b, actual, m, k, n);
+
+            var expected = new double[m * n];
+            for (int i = 0; i < m; i++)
+                for (int p = 0; p < k; p++)
+                {
+                    double av = a[i * k + p];
+                    for (int j = 0; j < n; j++)
+                        expected[i * n + j] += av * b[p * n + j];
+                }
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                double want = expected[i];
+                double got = actual[i];
+                double tol = 1e-4 * Math.Max(1.0, Math.Abs(want));
+                Assert.True(
+                    Math.Abs(want - got) <= tol,
+                    $"m={m} k={k} n={n} (tail {n % 16}) index {i}: expected {want:G9}, got {got:G9}. "
+                        + "The N-tail kernels must produce the same product with masked B loads as "
+                        + "with full-width ones -- the masked lanes contribute nothing to any stored "
+                        + "column.");
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SgemmDirectNTailBoundsTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) AiDotNet. All rights reserved.
 using System;
+using System.Collections.Generic;
 using AiDotNet.Tensors.Engines.Simd;
 using Xunit;
 
@@ -21,45 +22,136 @@ namespace AiDotNet.Tensors.Tests.Engines
     /// that reported 250 tests executed and 0 failed.
     /// </para>
     /// <para>
-    /// The over-read is not directly observable from managed code: the extra lanes are masked out
-    /// of the store, so results are unchanged and the read only faults when the overhang happens to
-    /// cross onto an unmapped page. What IS checkable, and what this fixes' correctness rests on, is
-    /// that switching those loads to masked ones leaves the product identical for every tail width.
-    /// The widths below cover ncActual = 1..15 across both lanes of the 16-wide tile, which is
-    /// exactly the range the masked loads changed.
+    /// The over-read is not directly observable from managed code: the extra lanes are discarded by
+    /// the masked store, so results are unchanged and the read only faults when the overhang happens
+    /// to cross onto an unmapped page. What IS checkable, and what this fix's correctness rests on,
+    /// is that switching those loads to masked ones leaves the product identical for every tail
+    /// width -- so these tests walk the whole range the masked loads changed.
+    /// </para>
+    /// <para>
+    /// THE TWO KERNELS NEED TWO DIFFERENT ENTRY POINTS, which is the part that is easy to get wrong.
+    /// <c>SgemmDirect</c> selects between them on <c>clearedOutput</c>: the store kernel overwrites
+    /// C, the plain one accumulates into it. <see cref="SimdGemm.SgemmDirectParallelMInto"/> passes
+    /// <c>clearedOutput: true</c> unconditionally, so a test written only against it exercises
+    /// <c>DirectKernelMxNMaskedStore</c> and never touches <c>DirectKernelMxNMasked</c> at all.
+    /// <see cref="AccumulatePath_NTail_MatchesReference"/> covers the other half through
+    /// <c>SgemmAdd</c>.
     /// </para>
     /// </remarks>
     public class SgemmDirectNTailBoundsTests
     {
-        public static TheoryData<int, int, int> TailShapes()
+        /// <summary>Every tail width the masked loads changed, on both lanes of the tile.</summary>
+        /// <remarks>
+        /// <c>ncActual</c> is <c>n % 16</c>, so each width is generated twice at different n to keep
+        /// the tail from only ever being the first block. Both an M-full and an M-tail shape run, so
+        /// the M-edge call sites (which pass <c>ncActual: Nr</c> and must stay unmasked) execute
+        /// beside the tail ones.
+        /// </remarks>
+        public static TheoryData<int, int, int> StoreTailShapes()
         {
             var data = new TheoryData<int, int, int>();
-            // n chosen so n % 16 walks every tail width; m spans full tiles and an m tail.
-            foreach (int n in new[] { 1, 7, 8, 9, 15, 17, 23, 31, 33, 47 })
+            for (int tail = 1; tail <= 15; tail++)
             {
-                data.Add(6, 5, n);    // exactly one full M tile
-                data.Add(13, 9, n);   // two M tiles plus an M tail
+                data.Add(6, 5, 16 + tail);    // one full M tile, tail in the second N block
+                data.Add(13, 9, 48 + tail);   // two M tiles plus an M tail, later N block
+            }
+
+            // Exact multiples of Nr: no tail at all, so the masked kernels must not be entered and
+            // the result must still be right. Guards against a fix that "works" by always masking.
+            data.Add(6, 5, 16);
+            data.Add(13, 9, 64);
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(StoreTailShapes))]
+        public void StorePath_NTail_MatchesReference(int m, int k, int n)
+        {
+            var (a, b) = MakeOperands(m, k, n, seed: 20260829);
+
+            var actual = new float[m * n];
+            SimdGemm.SgemmDirectParallelMInto(a, b, actual, m, k, n);
+
+            AssertMatches(Reference(a, b, m, k, n, seed: null), actual, m, k, n, "store");
+        }
+
+        /// <summary>
+        /// The accumulate kernel, <c>DirectKernelMxNMasked</c>, which the store-path test cannot
+        /// reach.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Only ONE tail width is reachable here, and it is not an arbitrary choice. The dispatch in
+        /// <c>SgemmAddInternal</c> admits the <c>SgemmDirect</c> branch only when <c>n % 8 == 0</c>,
+        /// and a tail needs <c>n % 16 != 0</c>; together those force <c>n % 16 == 8</c>, so
+        /// <c>ncActual</c> is 8. The other widths are unreachable through the public accumulate API
+        /// rather than merely untested.
+        /// </para>
+        /// <para>
+        /// Eight is also the worst case of the bug. At <c>ncActual == 8</c> the row holds exactly the
+        /// eight columns lane 0 reads, so the old unconditional <c>Avx.LoadVector256(pB + 8)</c> for
+        /// lane 1 lay ENTIRELY past the end of the row -- the full 8-float over-read, not a partial
+        /// one. The fix supplies <c>Vector256&lt;float&gt;.Zero</c> there instead.
+        /// </para>
+        /// <para>
+        /// Shapes are kept small so the work stays under <c>ParallelDirectWorkThreshold</c> and m
+        /// under <c>ParallelDirectMinM</c>, which is what keeps the call in <c>SgemmDirect</c>
+        /// instead of the parallel variant.
+        /// </para>
+        /// </remarks>
+        public static TheoryData<int, int, int> AccumulateTailShapes()
+        {
+            var data = new TheoryData<int, int, int>();
+            foreach (int n in new[] { 24, 40, 56 })   // n % 16 == 8
+            {
+                data.Add(6, 5, n);
+                data.Add(13, 9, n);
+                data.Add(20, 17, n);
             }
             return data;
         }
 
         [Theory]
-        [MemberData(nameof(TailShapes))]
-        public void SgemmDirect_NTail_MatchesReference(int m, int k, int n)
+        [MemberData(nameof(AccumulateTailShapes))]
+        public void AccumulatePath_NTail_MatchesReference(int m, int k, int n)
         {
-            var rng = new Random(20260829);
+            Assert.Equal(8, n % 16);   // the case under test is genuinely a tail of 8
 
-            // Exactly sized operands: no slack after the last element, which is the condition the
-            // over-read had no room for.
+            var (a, b) = MakeOperands(m, k, n, seed: 20260830);
+
+            // Pre-filled C: SgemmAdd is C += A*B, so a zero C would not distinguish accumulate from
+            // overwrite and the test would pass against the wrong kernel.
+            var c = new float[m * n];
+            var rng = new Random(99);
+            for (int i = 0; i < c.Length; i++) c[i] = (float)(rng.NextDouble() * 2 - 1);
+            var seeded = (float[])c.Clone();
+
+            SimdGemm.SgemmAdd(a, b, c, m, k, n);
+
+            AssertMatches(Reference(a, b, m, k, n, seeded), c, m, k, n, "accumulate");
+        }
+
+        /// <summary>Exactly sized operands: no slack after the last element, which is the condition
+        /// the over-read had no room for.</summary>
+        private static (float[] A, float[] B) MakeOperands(int m, int k, int n, int seed)
+        {
+            var rng = new Random(seed);
             var a = new float[m * k];
             var b = new float[k * n];
             for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
             for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+            return (a, b);
+        }
 
-            var actual = new float[m * n];
-            SimdGemm.SgemmDirectParallelMInto(a, b, actual, m, k, n);
-
+        private static double[] Reference(
+            float[] a, float[] b, int m, int k, int n, IReadOnlyList<float>? seed)
+        {
             var expected = new double[m * n];
+            if (seed is not null)
+            {
+                for (int i = 0; i < expected.Length; i++) expected[i] = seed[i];
+            }
+
             for (int i = 0; i < m; i++)
                 for (int p = 0; p < k; p++)
                 {
@@ -68,6 +160,12 @@ namespace AiDotNet.Tensors.Tests.Engines
                         expected[i * n + j] += av * b[p * n + j];
                 }
 
+            return expected;
+        }
+
+        private static void AssertMatches(
+            double[] expected, float[] actual, int m, int k, int n, string path)
+        {
             for (int i = 0; i < expected.Length; i++)
             {
                 double want = expected[i];
@@ -75,10 +173,10 @@ namespace AiDotNet.Tensors.Tests.Engines
                 double tol = 1e-4 * Math.Max(1.0, Math.Abs(want));
                 Assert.True(
                     Math.Abs(want - got) <= tol,
-                    $"m={m} k={k} n={n} (tail {n % 16}) index {i}: expected {want:G9}, got {got:G9}. "
-                        + "The N-tail kernels must produce the same product with masked B loads as "
-                        + "with full-width ones -- the masked lanes contribute nothing to any stored "
-                        + "column.");
+                    $"{path} path, m={m} k={k} n={n} (tail {n % 16}) index {i}: expected {want:G9}, "
+                        + $"got {got:G9}. The N-tail kernels must produce the same product with "
+                        + "masked B loads as with full-width ones -- the masked lanes contribute "
+                        + "nothing to any stored column.");
             }
         }
     }


### PR DESCRIPTION
## The observed failure

AiDotNet CI, shard `ModelFamily - Generated Layers St-Su`:

```
The active test run was aborted. Reason: Test host process crashed : Fatal error.
System.AccessViolationException: Attempted to read or write protected memory.
   at AiDotNet.Tensors.Engines.Simd.SimdGemm.SgemmDirect(...)
   at AiDotNet.Tensors.Engines.Simd.SimdGemm.Sgemm(...)
   at AiDotNet.Tensors.Engines.CpuEngine.TensorMatMul2D<Single>(...)
   at AiDotNet.Tensors.Engines.Autodiff.BackwardFunctions<Single>...
   at AiDotNet.Tensors.Engines.Compilation.CompiledTrainingPlan<Single>...
   at AiDotNet.NeuralNetworks.NeuralNetworkBase<Single>.TrainWithTape...
   at AiDotNet.Finance.Base.FinancialModelBase<Single>.Train(...)

The test running when the crash occurred:
AiDotNet.Tests.ModelFamilyTests.Generated.StockformerTests.MoreData_ShouldNotDegrade
```

The shard reported `Passed: 250` and `Total tests: Unknown` — the host died rather than failing a test. This was **not** memory pressure: the run's own sampler logged `MemAvailable: 13886652 kB` four seconds before the fault.

`SgemmDirect` is the frame that faults, and 8 of the 11 call sites into the two kernels below are inside it.

## The bug

`DirectKernelMxNMasked` and `DirectKernelMxNMaskedStore` are the kernels for the **N tail**, so `ncActual` is `1..Nr-1`. Both built column masks and used them for the store — but loaded a full 16-wide `B` row on every `k` step regardless:

```csharp
for (int p = 0; p < k; p++)
{
    var b0 = Avx.LoadVector256(pB);        // 16 floats, unconditionally
    var b1 = Avx.LoadVector256(pB + 8);
```

The masks were computed *after* the loop, so they never protected the reads.

**Why that is out of bounds.** `ValidateGemmOperands` guarantees exactly:

```csharp
long needB = (long)(bRows - 1) * ldb + bCols;   // (k-1)*ldb + n
```

The tail block starts at column `j` with `j + ncActual == n`, so on the last `k` row the kernel touches `(k-1)*ldb + j + 15` — `16 - ncActual` floats past the guarantee. There is no slack: `ldb > n` is explicitly permitted, so `B` may be a **view** into a wider matrix whose last row genuinely ends at the guaranteed bound.

**Why it stayed hidden.** The over-read cannot change results — the extra lanes are discarded by the masked store — so no assertion can see it. It is inert until the overhang crosses onto an unmapped page, and then it is not a failing test but a dead process.

## The fix

The masks move above the `k` loop so the loads can use them:

```csharp
var b0 = bLane0Full ? Avx.LoadVector256(pB) : Avx.MaskLoad(pB, mask0);
var b1 = bLane1Full
    ? Avx.LoadVector256(pB + 8)
    : (bLane1Any ? Avx.MaskLoad(pB + 8, mask1) : Vector256<float>.Zero);
```

`DirectKernelMxNarrow` **in this same file already loads `B` this way** — these two kernels simply did not.

The full-width lane keeps its unmasked load, so the `ncActual == Nr` call sites (the M-tail path) execute exactly the instructions they did before. All eleven call sites pass either `Nr` or an `ncTail`; only the latter changes behaviour.

## Evidence

**The fault is reproduced deterministically, and the fix removes it.** `SgemmDirectGuardPageTests` puts `B` in raw pages positioned so its last element ends exactly at a page boundary, with the next page mapped NO-ACCESS:

| | result |
|---|---|
| with this fix | probe completes, exit 0, 43/43 pass |
| `SimdGemm.cs` at `origin/main` | `AccessViolationException: Attempted to read or write protected memory` |

An `AccessViolationException` cannot be caught on .NET Core and takes the host down — which is exactly how this presented in CI, as an aborted run with no attribution. So the probe runs in a **child process** and the parent asserts on its exit code: a regression here is a failing test, not a dead run.

**Numerics are unchanged.** `SgemmDirectNTailBoundsTests` walks `ncActual` 1..15 at two different `n` each, plus two exact multiples of `Nr` that must not enter a masked kernel at all, against a `double` reference on exactly sized operands. Both kernels are covered: `SgemmDirectParallelMInto` passes `clearedOutput: true` and reaches only the *store* kernel, so the accumulate half goes through `SgemmAdd`, where `n % 16 == 8` is the sole reachable tail width — and the worst case, since lane 1's load lay entirely past the row.

Routing was verified rather than assumed: each kernel was made to throw under an env var, and 40 of the 41 cases entered one. The single case that did not is `(m: 6, k: 5, n: 16)` — the only shape with neither an M tail nor an N tail.

**No regressions** — the `Gemm`/`MatMul`/`Blas`/`Simd` suite is green: 1154 passed, 0 failed, 57 skipped. Both `net10.0` and `net471` build.

## Separately

While testing this I found a **second, unrelated memory-safety bug** in `SgemmDirectParallelMIntoTransA`: after it runs, the GC later dies with `Internal CLR error (0x80131506)` / `ExecutionEngineException` on a corrupted heap. It reproduces on unmodified `main` and is fixed in #993, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4