### PR TITLE
fix: mask the column tail in the 4-row block gemm kernels

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/SimdGemm.cs
@@ -2275,7 +2275,10 @@ internal static partial class SimdGemm
     /// carry pack / macro-loop overhead at thin-M, ~60 GF/s). Each output row is
     /// written by exactly one thread in fixed K order, so it is deterministic across
     /// thread counts. Contiguous row-major (lda=k, ldb=n, ldc=n); requires Fma +
-    /// n % 8 == 0 (caller gates). Every C element is overwritten (full 4-row × 8-col
+    /// Any n: the 8-wide column loop peels its tail into a masked block. It previously declared
+    /// "n % 8 == 0 (caller gates)" and stored full width regardless, which wrote past the end of C
+    /// for any caller that did not gate -- and this entry does not validate operands at all.
+    /// Every C element is overwritten (full 4-row × 8-col
     /// tiles cover the M-full / N region; the M%4 tail rows are computed scalar), so
     /// no pre-clear is needed.
     /// </summary>
@@ -2327,11 +2330,27 @@ internal static partial class SimdGemm
     }
 
     /// <summary>4-row × 8-col register-blocked FP64 microkernel over M-blocks
-    /// [blockStart, blockEnd). n % 8 == 0 (caller-guaranteed); overwrites C.</summary>
+    /// [blockStart, blockEnd). Any n (the column tail is masked); overwrites C.</summary>
     private static unsafe void DgemmDirectBlockRange(
         double* A, double* B, double* C, int blockStart, int blockEnd, int k, int n)
     {
         const int MRd = 4;
+
+        // See SgemmTransABlock for the full account. In short: this loop is 8 columns wide and n
+        // need not be, and a full-width store on the final step writes 8 - n % 8 doubles past the
+        // end of each C row it touches. Those spills corrupted the NEXT row's already-written
+        // values (wrong results for every row but the last of each block), and on the last block ran
+        // past the end of C itself (GC heap corruption, surfacing as an ExecutionEngineException at
+        // some later collection). The header used to declare "n % 8 == 0", but this entry point
+        // does not enforce it -- DgemmDirectParallelMInto does not validate operands at all.
+        int nFull = (n / 8) * 8;
+        int nTail = n - nFull;
+        int tailLane0 = nTail >= 4 ? 4 : nTail;
+        int tailLane1 = nTail > 4 ? nTail - 4 : 0;
+        var tailMask0 = _partialD4Masks[tailLane0].AsDouble();
+        var tailMask1 = _partialD4Masks[tailLane1].AsDouble();
+        bool tailHasHighLane = tailLane1 > 0;
+
         for (int blk = blockStart; blk < blockEnd; blk++)
         {
             int i0 = blk * MRd;
@@ -2339,7 +2358,7 @@ internal static partial class SimdGemm
             double* a1 = A + (long)(i0 + 1) * k;
             double* a2 = A + (long)(i0 + 2) * k;
             double* a3 = A + (long)(i0 + 3) * k;
-            for (int j = 0; j < n; j += 8)
+            for (int j = 0; j < nFull; j += 8)
             {
                 var c00 = Vector256<double>.Zero; var c01 = Vector256<double>.Zero;
                 var c10 = Vector256<double>.Zero; var c11 = Vector256<double>.Zero;
@@ -2361,6 +2380,29 @@ internal static partial class SimdGemm
                 double* o2 = C + (long)(i0 + 2) * n + j; Avx.Store(o2, c20); Avx.Store(o2 + 4, c21);
                 double* o3 = C + (long)(i0 + 3) * n + j; Avx.Store(o3, c30); Avx.Store(o3 + 4, c31);
             }
+
+            if (nTail > 0)
+            {
+                var c00 = Vector256<double>.Zero; var c01 = Vector256<double>.Zero;
+                var c10 = Vector256<double>.Zero; var c11 = Vector256<double>.Zero;
+                var c20 = Vector256<double>.Zero; var c21 = Vector256<double>.Zero;
+                var c30 = Vector256<double>.Zero; var c31 = Vector256<double>.Zero;
+                double* bj = B + nFull;
+                for (int p = 0; p < k; p++)
+                {
+                    double* bp = bj + (long)p * n;
+                    var b0 = Avx.MaskLoad(bp, tailMask0);
+                    var b1 = tailHasHighLane ? Avx.MaskLoad(bp + 4, tailMask1) : Vector256<double>.Zero;
+                    var av = Vector256.Create(a0[p]); c00 = Fma.MultiplyAdd(av, b0, c00); c01 = Fma.MultiplyAdd(av, b1, c01);
+                    av = Vector256.Create(a1[p]); c10 = Fma.MultiplyAdd(av, b0, c10); c11 = Fma.MultiplyAdd(av, b1, c11);
+                    av = Vector256.Create(a2[p]); c20 = Fma.MultiplyAdd(av, b0, c20); c21 = Fma.MultiplyAdd(av, b1, c21);
+                    av = Vector256.Create(a3[p]); c30 = Fma.MultiplyAdd(av, b0, c30); c31 = Fma.MultiplyAdd(av, b1, c31);
+                }
+                double* t0 = C + (long)(i0 + 0) * n + nFull; Avx.MaskStore(t0, tailMask0, c00); if (tailHasHighLane) Avx.MaskStore(t0 + 4, tailMask1, c01);
+                double* t1 = C + (long)(i0 + 1) * n + nFull; Avx.MaskStore(t1, tailMask0, c10); if (tailHasHighLane) Avx.MaskStore(t1 + 4, tailMask1, c11);
+                double* t2 = C + (long)(i0 + 2) * n + nFull; Avx.MaskStore(t2, tailMask0, c20); if (tailHasHighLane) Avx.MaskStore(t2 + 4, tailMask1, c21);
+                double* t3 = C + (long)(i0 + 3) * n + nFull; Avx.MaskStore(t3, tailMask0, c30); if (tailHasHighLane) Avx.MaskStore(t3 + 4, tailMask1, c31);
+            }
         }
     }
 
@@ -2369,8 +2411,8 @@ internal static partial class SimdGemm
     /// (lda=m) and B is [k,n]. Same broadcast-A 4×8 kernel as
     /// <see cref="DgemmDirectParallelMInto"/> but A is read strided (a[i,p] = A[p·m+i],
     /// the 4 row values at a depth are contiguous), so NO transpose is materialised —
-    /// the transpose-into-scratch alternative regresses at thin-M. n % 8 == 0; n-major
-    /// contiguous B and C; parallel over disjoint M-row-blocks (deterministic).
+    /// the transpose-into-scratch alternative regresses at thin-M. Any n (the column tail is
+    /// masked); n-major contiguous B and C; parallel over disjoint M-row-blocks (deterministic).
     /// </summary>
     [MethodImpl(Hot)]
     public static unsafe void DgemmDirectParallelMIntoTransA(
@@ -2412,10 +2454,22 @@ internal static partial class SimdGemm
     private static unsafe void DgemmTransABlock(double* A, double* B, double* C, int blockStart, int blockEnd, int k, int n, int m)
     {
         const int MRd = 4;
+
+        // Same 8-wide column loop, same unguarded tail, same consequence as DgemmDirectBlockRange:
+        // a full-width store on the final step runs past the end of each C row, and past the end of
+        // C on the last block. See SgemmTransABlock for the full account.
+        int nFull = (n / 8) * 8;
+        int nTail = n - nFull;
+        int tailLane0 = nTail >= 4 ? 4 : nTail;
+        int tailLane1 = nTail > 4 ? nTail - 4 : 0;
+        var tailMask0 = _partialD4Masks[tailLane0].AsDouble();
+        var tailMask1 = _partialD4Masks[tailLane1].AsDouble();
+        bool tailHasHighLane = tailLane1 > 0;
+
         for (int blk = blockStart; blk < blockEnd; blk++)
         {
             int i0 = blk * MRd;
-            for (int j = 0; j < n; j += 8)
+            for (int j = 0; j < nFull; j += 8)
             {
                 var c00 = Vector256<double>.Zero; var c01 = Vector256<double>.Zero;
                 var c10 = Vector256<double>.Zero; var c11 = Vector256<double>.Zero;
@@ -2437,6 +2491,30 @@ internal static partial class SimdGemm
                 double* o1 = C + (long)(i0 + 1) * n + j; Avx.Store(o1, c10); Avx.Store(o1 + 4, c11);
                 double* o2 = C + (long)(i0 + 2) * n + j; Avx.Store(o2, c20); Avx.Store(o2 + 4, c21);
                 double* o3 = C + (long)(i0 + 3) * n + j; Avx.Store(o3, c30); Avx.Store(o3 + 4, c31);
+            }
+
+            if (nTail > 0)
+            {
+                var c00 = Vector256<double>.Zero; var c01 = Vector256<double>.Zero;
+                var c10 = Vector256<double>.Zero; var c11 = Vector256<double>.Zero;
+                var c20 = Vector256<double>.Zero; var c21 = Vector256<double>.Zero;
+                var c30 = Vector256<double>.Zero; var c31 = Vector256<double>.Zero;
+                double* bj = B + nFull;
+                for (int p = 0; p < k; p++)
+                {
+                    double* bp = bj + (long)p * n;
+                    var b0 = Avx.MaskLoad(bp, tailMask0);
+                    var b1 = tailHasHighLane ? Avx.MaskLoad(bp + 4, tailMask1) : Vector256<double>.Zero;
+                    double* ap = A + (long)p * m + i0;
+                    var av = Vector256.Create(ap[0]); c00 = Fma.MultiplyAdd(av, b0, c00); c01 = Fma.MultiplyAdd(av, b1, c01);
+                    av = Vector256.Create(ap[1]); c10 = Fma.MultiplyAdd(av, b0, c10); c11 = Fma.MultiplyAdd(av, b1, c11);
+                    av = Vector256.Create(ap[2]); c20 = Fma.MultiplyAdd(av, b0, c20); c21 = Fma.MultiplyAdd(av, b1, c21);
+                    av = Vector256.Create(ap[3]); c30 = Fma.MultiplyAdd(av, b0, c30); c31 = Fma.MultiplyAdd(av, b1, c31);
+                }
+                double* t0 = C + (long)(i0 + 0) * n + nFull; Avx.MaskStore(t0, tailMask0, c00); if (tailHasHighLane) Avx.MaskStore(t0 + 4, tailMask1, c01);
+                double* t1 = C + (long)(i0 + 1) * n + nFull; Avx.MaskStore(t1, tailMask0, c10); if (tailHasHighLane) Avx.MaskStore(t1 + 4, tailMask1, c11);
+                double* t2 = C + (long)(i0 + 2) * n + nFull; Avx.MaskStore(t2, tailMask0, c20); if (tailHasHighLane) Avx.MaskStore(t2 + 4, tailMask1, c21);
+                double* t3 = C + (long)(i0 + 3) * n + nFull; Avx.MaskStore(t3, tailMask0, c30); if (tailHasHighLane) Avx.MaskStore(t3 + 4, tailMask1, c31);
             }
         }
     }
@@ -2534,8 +2612,9 @@ internal static partial class SimdGemm
     }
 
     /// <summary>FP32 thin-M GEMM with A transposed (#368): C = Aᵀ·B, A stored [k,m]
-    /// (lda=m), strided-A 4×8 broadcast kernel (no transpose). n % 8 == 0; parallel-M
-    /// (deterministic). Float analog of <see cref="DgemmDirectParallelMIntoTransA"/>.</summary>
+    /// (lda=m), strided-A 4×8 broadcast kernel (no transpose). Any n (the column tail is masked);
+    /// parallel-M (deterministic). Float analog of
+    /// <see cref="DgemmDirectParallelMIntoTransA"/>.</summary>
     [MethodImpl(Hot)]
     public static unsafe void SgemmDirectParallelMIntoTransA(
         ReadOnlySpan<float> a, ReadOnlySpan<float> b, Span<float> c, int m, int k, int n)
@@ -2588,10 +2667,43 @@ internal static partial class SimdGemm
     private static unsafe void SgemmTransABlock(float* A, float* B, float* C, int blockStart, int blockEnd, int k, int n, int m)
     {
         const int MRf = 4;
+
+        // THE COLUMN LOOP IS 8 WIDE AND n NEED NOT BE. It used to run `j < n; j += 8` and finish
+        // every step with a full-width Avx.Store, so when n was not a multiple of 8 the final step
+        // wrote 8 - n % 8 floats past the end of each of the four C rows it touched. That is two
+        // separate defects, and the quieter one is the worse.
+        //
+        // WRONG RESULTS. The j loop is OUTSIDE the four row stores, so the spill from row i at the
+        // last j overwrites the start of row i+1 -- which an EARLIER j step had already written
+        // correctly, and which no later step rewrites. Every row but the last of each block came
+        // back wrong. Measured on the pre-fix code at m=4 k=3 n=13: C[1,0] is 0.33678542 where the
+        // product is 0.694251873.
+        //
+        // HEAP CORRUPTION. The spill from the last row of the last block has no next row to land
+        // in; it goes past the end of C. Writing past a managed array corrupts the GC heap and
+        // nothing fails at the call: the process dies at some later, unrelated allocation as
+        // "Internal CLR error (0x80131506)" / ExecutionEngineException, reported against whatever
+        // code happened to trigger that collection. This is how it was found -- as a test-host death
+        // two classes away from any GEMM, via
+        // SgemmDirectParallelMIntoTransA_SizesAgainstTheTransposedA, whose M=4 K=3 N=5 case stores
+        // 8 floats at offset 15 of a 20-element C.
+        //
+        // The load has the same shape of bug: it reads a full 8 floats from B, whose rows are also
+        // only n wide.
+        //
+        // The header used to declare "n % 8 == 0". The internal dispatch does gate on that, but this
+        // kernel's public entry point does not: it validates operand LENGTHS and lets any n through.
+        //
+        // The full-width blocks below are untouched -- the tail is peeled into its own masked block
+        // so the hot path keeps its unmasked load and store.
+        int nFull = (n / 8) * 8;
+        int nTail = n - nFull;
+        var tailMask = _partialNrMasks[nTail].AsSingle();
+
         for (int blk = blockStart; blk < blockEnd; blk++)
         {
             int i0 = blk * MRf;
-            for (int j = 0; j < n; j += 8)
+            for (int j = 0; j < nFull; j += 8)
             {
                 var c0 = Vector256<float>.Zero; var c1 = Vector256<float>.Zero;
                 var c2 = Vector256<float>.Zero; var c3 = Vector256<float>.Zero;
@@ -2609,6 +2721,26 @@ internal static partial class SimdGemm
                 Avx.Store(C + (long)(i0 + 1) * n + j, c1);
                 Avx.Store(C + (long)(i0 + 2) * n + j, c2);
                 Avx.Store(C + (long)(i0 + 3) * n + j, c3);
+            }
+
+            if (nTail > 0)
+            {
+                var c0 = Vector256<float>.Zero; var c1 = Vector256<float>.Zero;
+                var c2 = Vector256<float>.Zero; var c3 = Vector256<float>.Zero;
+                float* bj = B + nFull;
+                for (int p = 0; p < k; p++)
+                {
+                    var b0 = Avx.MaskLoad(bj + (long)p * n, tailMask);
+                    float* ap = A + (long)p * m + i0;
+                    c0 = Fma.MultiplyAdd(Vector256.Create(ap[0]), b0, c0);
+                    c1 = Fma.MultiplyAdd(Vector256.Create(ap[1]), b0, c1);
+                    c2 = Fma.MultiplyAdd(Vector256.Create(ap[2]), b0, c2);
+                    c3 = Fma.MultiplyAdd(Vector256.Create(ap[3]), b0, c3);
+                }
+                Avx.MaskStore(C + (long)(i0 + 0) * n + nFull, tailMask, c0);
+                Avx.MaskStore(C + (long)(i0 + 1) * n + nFull, tailMask, c1);
+                Avx.MaskStore(C + (long)(i0 + 2) * n + nFull, tailMask, c2);
+                Avx.MaskStore(C + (long)(i0 + 3) * n + nFull, tailMask, c3);
             }
         }
     }
@@ -4320,6 +4452,23 @@ internal static partial class SimdGemm
         Vector256.Create(-1, -1, -1, -1, -1, -1,  0,  0),
         Vector256.Create(-1, -1, -1, -1, -1, -1, -1,  0),
         Vector256.Create(-1, -1, -1, -1, -1, -1, -1, -1),
+    };
+
+    /// <summary>
+    /// The FP64 counterpart of <see cref="_partialNrMasks"/>, indexed by active lanes (0..4).
+    /// </summary>
+    /// <remarks>
+    /// A <c>Vector256&lt;double&gt;</c> holds four lanes, so the FP64 block kernels -- which walk
+    /// columns eight at a time as two of these -- need a four-entry table rather than the eight-entry
+    /// one above. MSB=1 in a lane means that lane is active for MaskLoad/MaskStore.
+    /// </remarks>
+    private static readonly Vector256<long>[] _partialD4Masks = new[]
+    {
+        Vector256.Create(0L, 0L, 0L, 0L),
+        Vector256.Create(-1L, 0L, 0L, 0L),
+        Vector256.Create(-1L, -1L, 0L, 0L),
+        Vector256.Create(-1L, -1L, -1L, 0L),
+        Vector256.Create(-1L, -1L, -1L, -1L),
     };
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/GemmColumnTailWriteBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GemmColumnTailWriteBoundsTests.cs
@@ -1,0 +1,232 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if NET5_0_OR_GREATER
+// These entry points and their block kernels are AVX2/FMA intrinsics, which SimdGemm declares
+// inside #if NET5_0_OR_GREATER.
+using System;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines
+{
+    /// <summary>
+    /// The 4-row block kernels must not write past C when n is not a multiple of 8.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Three block kernels walk columns eight at a time -- <c>SgemmTransABlock</c>,
+    /// <c>DgemmDirectBlockRange</c> and <c>DgemmTransABlock</c> -- and each used to finish every
+    /// step with a full-width store. C rows are only n wide, so when n was not a multiple of 8 the
+    /// final step wrote <c>8 - n % 8</c> elements past the end of every row it touched.
+    /// </para>
+    /// <para>
+    /// Three of those four overruns were invisible: they landed in the following row and the next
+    /// store overwrote them, so the arithmetic came out right and every existing assertion passed.
+    /// The fourth is the last row of the block, and for the final block it lands past the end of C
+    /// itself -- a write into the GC heap.
+    /// </para>
+    /// <para>
+    /// Nothing fails at the call. The process dies at some later, unrelated allocation with
+    /// <c>Internal CLR error (0x80131506)</c> / <c>ExecutionEngineException</c>, reported against
+    /// whatever code happened to trigger the collection. It was found as a test-host death two
+    /// classes away from any GEMM.
+    /// </para>
+    /// <para>
+    /// The headers declared <c>n % 8 == 0</c>, and the INTERNAL dispatch does gate on it -- but
+    /// these public entry points bypass that gate. <c>SgemmDirectParallelMIntoTransA</c> validates
+    /// operand LENGTHS and lets any n through; <c>DgemmDirectParallelMInto</c> does not validate at
+    /// all. A public method that silently corrupts the heap for n = 5 is a defect whichever way the
+    /// contract is read, and every sibling here already handles arbitrary n, as does BLAS.
+    /// </para>
+    /// <para>
+    /// An over-WRITE is directly testable, unlike an over-read: C is allocated with a
+    /// sentinel-filled margin and the margin is checked afterwards.
+    /// </para>
+    /// </remarks>
+    public class GemmColumnTailWriteBoundsTests
+    {
+        private const float SentinelF = -987654.5f;
+        private const double SentinelD = -987654.5;
+
+        /// <summary>A margin no kernel may touch; one full vector is the most a store can spill.</summary>
+        private const int Margin = 8;
+
+        /// <summary>Column counts around the 8-wide step, and m on both sides of the 4-row block.</summary>
+        /// <remarks>
+        /// m must reach 4 for the vectorized block to run at all; below that everything falls to the
+        /// scalar edge path, which was never the problem. m = 13 exercises three full blocks plus the
+        /// scalar remainder, so both paths run in one case.
+        /// </remarks>
+        public static TheoryData<int, int, int> Shapes()
+        {
+            var data = new TheoryData<int, int, int>();
+            for (int n = 1; n <= 20; n++)
+            {
+                data.Add(4, 3, n);     // exactly one block -- the case that overruns C itself
+                data.Add(8, 5, n);     // two blocks
+                data.Add(13, 7, n);    // three blocks plus a scalar edge
+            }
+            return data;
+        }
+
+        // ------------------------------------------------------------------ FP32, A transposed
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void SgemmTransA_DoesNotWritePastC(int m, int k, int n)
+        {
+            var (a, b) = FloatOperands(k * m, k * n);
+            var c = FilledF(m * n + Margin);
+
+            SimdGemm.SgemmDirectParallelMIntoTransA(a, b, c.AsSpan(0, m * n), m, k, n);
+
+            AssertMarginF(c, m, k, n, "SgemmDirectParallelMIntoTransA");
+        }
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void SgemmTransA_MatchesReference(int m, int k, int n)
+        {
+            var (a, b) = FloatOperands(k * m, k * n);
+            var c = new float[m * n];
+
+            SimdGemm.SgemmDirectParallelMIntoTransA(a, b, c, m, k, n);
+
+            // A is [k,m] at lda=m; B is [k,n] at ldb=n.
+            AssertProduct(m, n, k, (i, p) => a[p * m + i], (p, j) => b[p * n + j], i => c[i], m, k, n);
+        }
+
+        // ------------------------------------------------------------------ FP64, A transposed
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void DgemmTransA_DoesNotWritePastC(int m, int k, int n)
+        {
+            var (a, b) = DoubleOperands(k * m, k * n);
+            var c = FilledD(m * n + Margin);
+
+            SimdGemm.DgemmDirectParallelMIntoTransA(a, b, c.AsSpan(0, m * n), m, k, n);
+
+            AssertMarginD(c, m, k, n, "DgemmDirectParallelMIntoTransA");
+        }
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void DgemmTransA_MatchesReference(int m, int k, int n)
+        {
+            var (a, b) = DoubleOperands(k * m, k * n);
+            var c = new double[m * n];
+
+            SimdGemm.DgemmDirectParallelMIntoTransA(a, b, c, m, k, n);
+
+            AssertProduct(m, n, k, (i, p) => a[p * m + i], (p, j) => b[p * n + j], i => c[i], m, k, n);
+        }
+
+        // ------------------------------------------------------------- FP64, no transpose
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void DgemmDirect_DoesNotWritePastC(int m, int k, int n)
+        {
+            var (a, b) = DoubleOperands(m * k, k * n);
+            var c = FilledD(m * n + Margin);
+
+            SimdGemm.DgemmDirectParallelMInto(a, b, c.AsSpan(0, m * n), m, k, n);
+
+            AssertMarginD(c, m, k, n, "DgemmDirectParallelMInto");
+        }
+
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void DgemmDirect_MatchesReference(int m, int k, int n)
+        {
+            var (a, b) = DoubleOperands(m * k, k * n);
+            var c = new double[m * n];
+
+            SimdGemm.DgemmDirectParallelMInto(a, b, c, m, k, n);
+
+            // A is [m,k] at lda=k; B is [k,n] at ldb=n.
+            AssertProduct(m, n, k, (i, p) => a[i * k + p], (p, j) => b[p * n + j], i => c[i], m, k, n);
+        }
+
+        // ------------------------------------------------------------------------- helpers
+
+        private static float[] FilledF(int length)
+        {
+            var c = new float[length];
+            for (int i = 0; i < c.Length; i++) c[i] = SentinelF;
+            return c;
+        }
+
+        private static double[] FilledD(int length)
+        {
+            var c = new double[length];
+            for (int i = 0; i < c.Length; i++) c[i] = SentinelD;
+            return c;
+        }
+
+        private static (float[] A, float[] B) FloatOperands(int aLen, int bLen)
+        {
+            var rng = new Random(20260829);
+            var a = new float[aLen];
+            var b = new float[bLen];
+            for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+            return (a, b);
+        }
+
+        private static (double[] A, double[] B) DoubleOperands(int aLen, int bLen)
+        {
+            var rng = new Random(20260830);
+            var a = new double[aLen];
+            var b = new double[bLen];
+            for (int i = 0; i < a.Length; i++) a[i] = rng.NextDouble() * 2 - 1;
+            for (int i = 0; i < b.Length; i++) b[i] = rng.NextDouble() * 2 - 1;
+            return (a, b);
+        }
+
+        private static void AssertMarginF(float[] c, int m, int k, int n, string entry)
+        {
+            for (int i = 0; i < Margin; i++)
+            {
+                int at = m * n + i;
+                Assert.True(c[at] == SentinelF, Message(entry, at, c[at], m, k, n));
+            }
+        }
+
+        private static void AssertMarginD(double[] c, int m, int k, int n, string entry)
+        {
+            for (int i = 0; i < Margin; i++)
+            {
+                int at = m * n + i;
+                Assert.True(c[at] == SentinelD, Message(entry, at, c[at], m, k, n));
+            }
+        }
+
+        private static string Message(string entry, int at, double actual, int m, int k, int n) =>
+            $"{entry}: m={m} k={k} n={n} (tail {n % 8}) wrote {actual} at C[{at}], past the end of "
+                + $"the {m * n}-element output. The column loop steps 8 at a time and must mask its "
+                + "final store; a full-width store there writes into the GC heap, and the process "
+                + "dies at some later collection rather than here.";
+
+        private static void AssertProduct(
+            int m, int n, int k,
+            Func<int, int, double> a, Func<int, int, double> b, Func<int, double> c,
+            int mm, int kk, int nn)
+        {
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++)
+                {
+                    double want = 0;
+                    for (int p = 0; p < k; p++) want += a(i, p) * b(p, j);
+
+                    double got = c(i * n + j);
+                    double tol = 1e-4 * Math.Max(1.0, Math.Abs(want));
+                    Assert.True(
+                        Math.Abs(want - got) <= tol,
+                        $"m={mm} k={kk} n={nn} at [{i},{j}]: expected {want:G9}, got {got:G9}. "
+                            + "Masking the tail store must not change the values it does write.");
+                }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## What broke

`SimdGemmBoundsPreconditionTests` and `SoftmaxForwardGpuReproTests`, run together, kill the test host — reproducibly, on unmodified `main`. Neither class does it alone.

```
The active test run was aborted. Reason: Test host process crashed : Fatal error.
Internal CLR error. (0x80131506)
```

The dump names a thread marked `(GC)` carrying `System.ExecutionEngineException`, faulting here:

```
DirectOpenClProgram.TryCreateFromCache  ←  OpenClBackend.CompileOrLoadCached
  ←  CompileKernels  ←  OpenClBackend..ctor  ←  DirectGpuEngine..ctor
  ←  SoftmaxForwardGpuReproTests.DeferredGraph_FusedLinearSoftmax_SeparateNodeRoute
```

That frame's only crime is **allocating**. It is where the corruption is *detected*, not caused. Bisecting the pair identified the actual culprit: `SgemmDirectParallelMIntoTransA_SizesAgainstTheTransposedA`.

## The bug

Three block kernels — `SgemmTransABlock`, `DgemmDirectBlockRange`, `DgemmTransABlock` — walk columns eight at a time and finished every step with a full-width store:

```csharp
for (int j = 0; j < n; j += 8)
{
    ...
    Avx.Store(C + (long)(i0 + 3) * n + j, c3);   // 8 wide, always
}
```

C rows are only `n` wide, so for `n % 8 != 0` the last step writes `8 - n % 8` elements past the end of each of the four rows it touches. Two defects follow.

**Wrong results.** The `j` loop is *outside* the four row stores, so row `i`'s spill at the last `j` overwrites the start of row `i+1` — which an **earlier** `j` step already wrote correctly, and which no later step rewrites. Every row but the last of each block came back wrong:

```
m=4 k=3 n=13 at [1,0]: expected 0.694251873, got 0.33678542
```

**Heap corruption.** The spill from the last row of the last block has no next row to land in; it goes past the end of C. Writing past a managed array corrupts the GC heap, and nothing fails at the call — the process dies at some later, unrelated allocation, blamed on whatever triggered that collection. The test above stores 8 floats at offset 15 of a 20-element C.

## Why the contract does not excuse it

The headers declared `n % 8 == 0`, and the *internal* dispatch really does gate on it. But these **public** entry points bypass that gate:

- `SgemmDirectParallelMIntoTransA` validates operand **lengths** and lets any `n` through
- `DgemmDirectParallelMInto` does not validate at all

A public method that silently corrupts the GC heap at `n = 5` is a defect whichever way the contract is read. Every sibling kernel in this file already handles an arbitrary `n` — that is what `_partialNrMasks` is for — and so does BLAS.

## The fix

The tail is peeled into its own masked block in all three kernels, so the full-width hot path keeps its unmasked load and store and only the cold tail pays for masking. FP64 needs 4-lane masks, so `_partialD4Masks` joins the existing 8-lane `_partialNrMasks`. The stale `n % 8 == 0` headers are corrected.

## Evidence

| | result |
|---|---|
| with this fix | 360/360 new bounds + parity cases pass |
| `SimdGemm.cs` at `origin/main` | **216 of 360 fail** — all three entry points overrun their margin, and all three also return wrong values |
| the pair that killed the host, with this fix | 20/20, three runs running |
| the pair that killed the host, on `main` | dies every time |

The overrun is a **write**, which makes it directly testable unlike an over-read: C is allocated with a sentinel-filled margin and the margin is checked afterwards. Parity against a `double` reference covers the same shapes, so masking the tail is shown not to change the values it does write.

Regression suite: `Gemm`/`MatMul`/`Blas`/`Simd` — 1623 passed, 0 failed, 45 skipped. On `main` that same filter got 1154 tests in before the host died. Both `net10.0` and `net471` build.

Separate from, and independent of, #991 (an over-*read* in the N-tail masked kernels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4