### PR TITLE
fix: gpu tape gaps, categorical residency, and non-power-of-two reductions

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210.cs
@@ -1087,6 +1087,38 @@ public partial class CpuEngine
             (outShape[0], outShape[1]) = (outShape[1], outShape[0]);
         }
 
+        // WHEN THE TAPE IS RECORDING, BUILD THE GRIDS FROM DIFFERENTIABLE OPS. The element loop
+        // below writes into a rented buffer directly, which produces correct VALUES and no gradient
+        // whatsoever: the outputs are new tensors with nothing linking them to the inputs they were
+        // copied from. Measured: TensorMeshgrid[3;4;xy] recorded ZERO differentiable leaves on CPU
+        // against two on GPU, so a model that differentiated through a meshgrid got silent zeros
+        // from the CPU engine and real gradients from the GPU one.
+        //
+        // torch.meshgrid is differentiable, and each output is just the input broadcast along its
+        // own axis, so composing reshape + broadcast is both the correct gradient and the same
+        // construction the GPU engine already uses for its tape-active path — which is why the two
+        // engines now agree by construction rather than by coincidence.
+        if (DifferentiableOps.IsTapeActiveForThread<T>() || GraphMode.IsActive)
+        {
+            var taped = new Tensor<T>[d];
+            for (int k = 0; k < d; k++)
+            {
+                int axis = k;
+                if (indexing == "xy" && d >= 2)
+                {
+                    if (k == 0) axis = 1;
+                    else if (k == 1) axis = 0;
+                }
+
+                var rshape = new int[d];
+                for (int i = 0; i < d; i++) rshape[i] = 1;
+                rshape[axis] = tensors[k]._shape[0];
+                taped[k] = TensorBroadcastTo(tensors[k].Reshape(rshape), outShape);
+            }
+
+            return taped;
+        }
+
         var results = new Tensor<T>[d];
         var strides = ComputeRowMajorStrides(outShape);
         int total = 1; foreach (var s in outShape) total *= s;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -22928,7 +22928,20 @@ public partial class CpuEngine : ITensorLevelEngine
         int innerSize = 1;
         for (int i = 0; i < normalizedAxis; i++) outerSize = checked(outerSize * probabilities.Shape[i]);
         for (int i = normalizedAxis + 1; i < rank; i++) innerSize = checked(innerSize * probabilities.Shape[i]);
-        Random random = seed.HasValue ? new Random(seed.Value) : RandomHelper.ThreadSafeRandom;
+        // SEEDED DRAWS COME FROM THE SHARED STATELESS RNG, not System.Random. Every other seeded
+        // random op here keys StatelessRandom on (seed, element index) -- a counter-based PCG hash
+        // that the CUDA, Metal and OpenCL kernels reproduce constant-for-constant, which is what
+        // lets those ops run on the device AND still match the CPU bit for bit.
+        //
+        // System.Random cannot be reproduced in a kernel, so this op alone had no device-side
+        // implementation available to it: every GPU backend without a bespoke categorical kernel
+        // fell back to the CPU, silently, after the caller had selected the GPU engine. Keying the
+        // draw on the ROW index rather than on draw order is the part that matters -- a parallel
+        // kernel computes any row's uniform without replaying the ones before it.
+        //
+        // The seeded sequence changes as a result. The contract is reproducibility, which is kept:
+        // the same seed still yields the same sample, and the existing tests assert that plus
+        // one-hot-ness rather than any particular draw.
 
         for (int outer = 0; outer < outerSize; outer++)
         {
@@ -22947,7 +22960,11 @@ public partial class CpuEngine : ITensorLevelEngine
                 if (!(sum > 0d) || double.IsNaN(sum) || double.IsInfinity(sum))
                     throw new ArgumentException(
                         "Every categorical slice must have a finite positive sum.", nameof(probabilities));
-                double target = random.NextDouble() * sum;
+                int row = outer * innerSize + inner;
+                double uniform = seed.HasValue
+                    ? StatelessRandom.Uniform01(unchecked((uint)seed.Value), unchecked((uint)row))
+                    : RandomHelper.ThreadSafeRandom.NextDouble();
+                double target = uniform * sum;
                 double cumulative = 0d;
                 int selected = classes - 1;
                 for (int category = 0; category < classes; category++)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -16565,6 +16565,12 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
             return;
 
         _disposed = true;
+
+        // Drop the diagnostics registrations for these handles. The registry is process-lifetime but
+        // kernel handles are not, and a driver may reuse a freed handle address -- a stale entry
+        // would then name a later kernel wrongly, which in crash forensics is worse than no name.
+        foreach (var handle in _kernelCache.Values) GpuKernelDiagnostics.UnregisterKernelName(handle);
+
         // Finalizer path (disposing == false) or any process/domain teardown:
         //   - The managed members (GpuBufferPool's ConcurrentBag/ThreadLocal, the cuDNN
         //     helpers) may already have been finalized by the runtime — touching them

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.cs
@@ -234,7 +234,21 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
     [ThreadStatic]
     private static IntPtr _threadCurrentContext;
 
-    public bool IsAvailable { get; }
+    private bool _isAvailable;
+
+    /// <summary>
+    /// Whether this backend can serve work. FALSE ONCE DISPOSED, which is load-bearing:
+    /// DirectGpuBackendFactory caches one backend per process and hands the cached instance back
+    /// while it reports available. Dispose() clears the kernel cache, so a disposed-but-still-cached
+    /// backend answers every later kernel lookup with KeyNotFoundException ("add_vectors") on a
+    /// completely unrelated caller. Reporting unavailable makes the factory build a fresh backend
+    /// instead. VulkanBackend and MetalBackend already did this; these three did not.
+    /// </summary>
+    public bool IsAvailable
+    {
+        get => _isAvailable && !_disposed;
+        private set => _isAvailable = value;
+    }
     public string BackendName => "CUDA";
     public TensorDevice DeviceType => TensorDevice.CUDA;
     public string DeviceName { get; }
@@ -721,6 +735,7 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                             CudaNativeBindings.cuModuleGetFunction(out IntPtr kernel, cachedModule, kernelName),
                             $"cuModuleGetFunction({kernelName})");
                         _kernelCache[kernelName] = kernel;
+                        GpuKernelDiagnostics.RegisterKernelName(kernel, kernelName);
                     }
 
                     return cachedModule;
@@ -827,6 +842,8 @@ public sealed partial class CudaBackend : IAsyncGpuBackend, IFusedAdvancedKernel
                 CudaNativeBindings.cuModuleGetFunction(out IntPtr kernel, module, kernelName),
                 $"cuModuleGetFunction({kernelName})");
             _kernelCache[kernelName] = kernel;
+            // Lets the native-launch choke point journal this kernel BY NAME (Issue #996).
+            GpuKernelDiagnostics.RegisterKernelName(kernel, kernelName);
         }
 
         return module;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaNativeBindings.cs
@@ -158,7 +158,7 @@ internal static class CudaNativeBindings
         IntPtr function, CudaFunctionAttribute attribute, int value);
 
     [DllImport(CudaLibrary, EntryPoint = "cuLaunchKernel")]
-    public static extern CudaResult cuLaunchKernel(
+    private static extern CudaResult cuLaunchKernelNative(
         IntPtr function,
         uint gridDimX, uint gridDimY, uint gridDimZ,
         uint blockDimX, uint blockDimY, uint blockDimZ,
@@ -166,6 +166,35 @@ internal static class CudaNativeBindings
         IntPtr stream,
         IntPtr kernelParams,
         IntPtr extra);
+
+    /// <summary>
+    /// Journals the launch, then forwards to the driver.
+    /// </summary>
+    /// <remarks>
+    /// THE CHOKE POINT. CudaBackend reaches the driver from roughly two dozen call sites, all of
+    /// which hold only a kernel handle. Wrapping the single P/Invoke covers every one of them, and
+    /// covers whichever site is added next, instead of threading a name through two dozen
+    /// signatures. The name comes from the handle registered at kernel registration.
+    /// </remarks>
+    public static CudaResult cuLaunchKernel(
+        IntPtr function,
+        uint gridDimX, uint gridDimY, uint gridDimZ,
+        uint blockDimX, uint blockDimY, uint blockDimZ,
+        uint sharedMemBytes,
+        IntPtr stream,
+        IntPtr kernelParams,
+        IntPtr extra)
+    {
+        GpuKernelDiagnostics.RecordLaunchByHandle(
+            function,
+            (long)gridDimX * gridDimY * gridDimZ * blockDimX * blockDimY * blockDimZ,
+            (long)blockDimX * blockDimY * blockDimZ,
+            -1);
+
+        return cuLaunchKernelNative(
+            function, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, stream, kernelParams, extra);
+    }
 
     [DllImport(CudaLibrary, EntryPoint = "cuLaunchCooperativeKernel")]
     public static extern CudaResult cuLaunchCooperativeKernel(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
@@ -335,8 +335,8 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
     }
     sdata[tid] = acc;
     __syncthreads();
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     if (tid == 0) outScores[v] = sdata[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaComplexKernels.cs
@@ -335,8 +335,8 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
     }
     sdata[tid] = acc;
     __syncthreads();
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     if (tid == 0) outScores[v] = sdata[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedKernels.cs
@@ -557,8 +557,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -573,8 +573,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -612,8 +612,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -628,8 +628,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -677,8 +677,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -694,8 +694,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -735,8 +735,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localMax;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             if (smem[tid + s] > smem[tid]) smem[tid] = smem[tid + s];
         }
         __syncthreads();
@@ -753,8 +753,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) smem[tid] += smem[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) smem[tid] += smem[tid + s];
         __syncthreads();
     }
     float sumExp = smem[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaFusedKernels.cs
@@ -557,8 +557,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -573,8 +573,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -612,8 +612,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -628,8 +628,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -677,8 +677,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -694,8 +694,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -735,8 +735,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localMax;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             if (smem[tid + s] > smem[tid]) smem[tid] = smem[tid + s];
         }
         __syncthreads();
@@ -753,8 +753,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) smem[tid] += smem[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) smem[tid] += smem[tid + s];
         __syncthreads();
     }
     float sumExp = smem[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLinalgKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLinalgKernels.cs
@@ -243,8 +243,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
                 partial += Qb[i * k + p] * Qb[i * k + j];
             partials[tid] = partial;
             __syncthreads();
-            for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-                if (tid < s) partials[tid] += partials[tid + s];
+            for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+                if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
                 __syncthreads();
             }
             if (tid == 0) { sScalar = partials[0]; Rb[p * n + j] = sScalar; }
@@ -264,8 +264,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
         }
         partials[tid] = partialN;
         __syncthreads();
-        for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-            if (tid < s) partials[tid] += partials[tid + s];
+        for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+            if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
             __syncthreads();
         }
         if (tid == 0) { sScalar = sqrtf(partials[0]); Rb[j * n + j] = sScalar; }
@@ -291,8 +291,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
                 partial += Qb[i * k + p] * Ab[i * n + c];
             partials[tid] = partial;
             __syncthreads();
-            for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-                if (tid < s) partials[tid] += partials[tid + s];
+            for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+                if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
                 __syncthreads();
             }
             if (tid == 0) Rb[p * n + c] = partials[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLinalgKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLinalgKernels.cs
@@ -243,8 +243,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
                 partial += Qb[i * k + p] * Qb[i * k + j];
             partials[tid] = partial;
             __syncthreads();
-            for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-                if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
+            for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+                if (tid < s && tid + s < s_active) partials[tid] += partials[tid + s];
                 __syncthreads();
             }
             if (tid == 0) { sScalar = partials[0]; Rb[p * n + j] = sScalar; }
@@ -264,8 +264,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
         }
         partials[tid] = partialN;
         __syncthreads();
-        for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-            if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
+        for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+            if (tid < s && tid + s < s_active) partials[tid] += partials[tid + s];
             __syncthreads();
         }
         if (tid == 0) { sScalar = sqrtf(partials[0]); Rb[j * n + j] = sScalar; }
@@ -291,8 +291,8 @@ extern ""C"" __global__ void parity211_qr_reduced(
                 partial += Qb[i * k + p] * Ab[i * n + c];
             partials[tid] = partial;
             __syncthreads();
-            for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-                if (tid < s && tid + s < blockDim.x) partials[tid] += partials[tid + s];
+            for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+                if (tid < s && tid + s < s_active) partials[tid] += partials[tid + s];
                 __syncthreads();
             }
             if (tid == 0) Rb[p * n + c] = partials[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLossForwardKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLossForwardKernels.cs
@@ -298,8 +298,8 @@ extern ""C"" __global__ void cosine_similarity_batch(
     smem[tid + 2 * blockDim.x] = local_normB;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             smem[tid] += smem[tid + s];
             smem[tid + blockDim.x] += smem[tid + blockDim.x + s];
             smem[tid + 2 * blockDim.x] += smem[tid + 2 * blockDim.x + s];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLossForwardKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaLossForwardKernels.cs
@@ -298,8 +298,8 @@ extern ""C"" __global__ void cosine_similarity_batch(
     smem[tid + 2 * blockDim.x] = local_normB;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             smem[tid] += smem[tid + s];
             smem[tid + blockDim.x] += smem[tid + blockDim.x + s];
             smem[tid + 2 * blockDim.x] += smem[tid + 2 * blockDim.x + s];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMeshPoolKernels.cs
@@ -207,8 +207,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_find_max(
     __syncthreads();
 
     // Parallel reduction within block
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -238,8 +238,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_max(
     __syncthreads();
 
     // Parallel reduction
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -279,8 +279,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_exp_sum(
     __syncthreads();
 
     // Parallel sum reduction within block
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -306,8 +306,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_sum(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -352,8 +352,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     __syncthreads();
 
     // Step 1: Find max using parallel reduction
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -371,8 +371,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     __syncthreads();
 
     // Sum reduction
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaMeshPoolKernels.cs
@@ -207,8 +207,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_find_max(
     __syncthreads();
 
     // Parallel reduction within block
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -238,8 +238,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_max(
     __syncthreads();
 
     // Parallel reduction
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -279,8 +279,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_exp_sum(
     __syncthreads();
 
     // Parallel sum reduction within block
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -306,8 +306,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_sum(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -352,8 +352,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     __syncthreads();
 
     // Step 1: Find max using parallel reduction
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -371,8 +371,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     __syncthreads();
 
     // Sum reduction
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpecializedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpecializedKernels.cs
@@ -491,8 +491,8 @@ extern ""C"" __global__ __launch_bounds__(256) void normalize_probabilities(
     __syncthreads();
 
     // Reduce in shared memory
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();
@@ -624,8 +624,8 @@ extern ""C"" __global__ __launch_bounds__(256) void measurement_forward(
     __syncthreads();
 
     // Reduce sum
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpecializedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaSpecializedKernels.cs
@@ -491,8 +491,8 @@ extern ""C"" __global__ __launch_bounds__(256) void normalize_probabilities(
     __syncthreads();
 
     // Reduce in shared memory
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();
@@ -624,8 +624,8 @@ extern ""C"" __global__ __launch_bounds__(256) void measurement_forward(
     __syncthreads();
 
     // Reduce sum
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -51,7 +51,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         private const int JournalCapacity = 64;
 
         private static readonly LaunchRecord[] _journal = new LaunchRecord[JournalCapacity];
+
+        /// <summary>
+        /// The sequence number each slot has finished being written for, or -1 for never.
+        /// </summary>
+        /// <remarks>
+        /// Incrementing the sequence publishes a slot number before the record in it has been
+        /// written, so a concurrent reader could format a half-written or recycled slot and label it
+        /// with the new number. The writer stamps this AFTER filling the record and the reader
+        /// checks it, so a slot is only ever reported once it genuinely holds that launch.
+        /// </remarks>
+        private static readonly long[] _published = CreatePublishedMarkers();
+
         private static long _sequence = -1;
+
+        private static long[] CreatePublishedMarkers()
+        {
+            var markers = new long[JournalCapacity];
+            for (int i = 0; i < markers.Length; i++) markers[i] = -1;
+            return markers;
+        }
 
         private static readonly bool _deepChecks =
             IsSet("AIDOTNET_GPU_KERNEL_DIAGNOSTICS");
@@ -101,6 +120,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
                 ManagedThreadId = Environment.CurrentManagedThreadId,
                 Ticks = DateTime.UtcNow.Ticks,
             };
+
+            // Published last: until this store, a reader must not treat the slot as holding `slot`.
+            Volatile.Write(ref _published[index], slot);
         }
 
         /// <summary>The most recent launches, oldest first. Empty when nothing has launched.</summary>
@@ -115,6 +137,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             for (long slot = Math.Max(0, last - count + 1); slot <= last; slot++)
             {
                 int index = (int)(((slot % JournalCapacity) + JournalCapacity) % JournalCapacity);
+                if (Volatile.Read(ref _published[index]) != slot) continue;   // not yet written, or recycled
+
                 var record = _journal[index];
                 if (record.Kernel is null) continue;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -1,0 +1,269 @@
+// Copyright (c) AiDotNet. All rights reserved.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu
+{
+    /// <summary>
+    /// Launch-time diagnostics for GPU kernels — the library's own and any a caller adds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// WHAT THIS EXISTS TO FIX. A device launch is asynchronous and unchecked by construction: an
+    /// out-of-range write in one kernel is not reported at that kernel, it is reported at whatever
+    /// synchronises next, and a bad handle or arg is not reported at all — the driver faults and the
+    /// process dies with no managed frame to blame. Both failure modes are routinely observed as a
+    /// crash in code that had nothing to do with the cause, and in CI as a shard that dies having
+    /// written no results at all.
+    /// </para>
+    /// <para>
+    /// <see cref="GpuLaunchProbe"/> already answers "did this op reach the device". This answers the
+    /// three questions that come after a crash: <i>was the launch itself well formed</i>, <i>which
+    /// launch was it</i>, and <i>what ran just before it</i>.
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Validation</b> (always on, cached per kernel, an int compare per launch): a released
+    /// handle, an argument count that disagrees with the kernel's own
+    /// <c>CL_KERNEL_NUM_ARGS</c>, a work-group larger than the kernel admits, a local-memory request
+    /// the device cannot satisfy, a global size that is not a multiple of the local size.</item>
+    /// <item><b>The journal</b> (always on, allocation-free): a fixed ring of the most recent
+    /// launches. When the process dies this is the only surviving evidence of what it was doing, and
+    /// it can be written to disk from a crash handler or a test teardown.</item>
+    /// <item><b>Deep checks</b> (opt-in, <c>AIDOTNET_GPU_KERNEL_DIAGNOSTICS=1</c>): buffer capacity
+    /// against the range a launch will address, and assertions a kernel declares about its own
+    /// launch shape — for instance that its work-group size is a power of two, which several tree
+    /// reductions require and none previously stated.</item>
+    /// <item><b>Synchronous mode</b> (opt-in, <c>AIDOTNET_GPU_SYNC_LAUNCHES=1</c>): finish after
+    /// every launch so an asynchronous fault is attributed to the launch that caused it instead of
+    /// the next unrelated one. Slow by design; this is the mode you turn on to find a crash.</item>
+    /// </list>
+    /// <para>
+    /// The validation entry points are public so a caller extending the library with their own
+    /// kernels gets the same checks, rather than the library validating only what it happens to ship.
+    /// </para>
+    /// </remarks>
+    public static class GpuKernelDiagnostics
+    {
+        private const int JournalCapacity = 64;
+
+        private static readonly LaunchRecord[] _journal = new LaunchRecord[JournalCapacity];
+        private static long _sequence = -1;
+
+        private static readonly bool _deepChecks =
+            IsSet("AIDOTNET_GPU_KERNEL_DIAGNOSTICS");
+
+        private static readonly bool _synchronousLaunches =
+            IsSet("AIDOTNET_GPU_SYNC_LAUNCHES");
+
+        private static bool IsSet(string name)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            return !string.IsNullOrEmpty(value)
+                   && !string.Equals(value, "0", StringComparison.Ordinal)
+                   && !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Whether the opt-in deep checks are enabled.</summary>
+        public static bool DeepChecksEnabled => _deepChecks;
+
+        /// <summary>
+        /// Whether every launch should be followed by a device synchronise so asynchronous faults
+        /// are attributed to the launch that caused them.
+        /// </summary>
+        public static bool SynchronousLaunches => _synchronousLaunches;
+
+        private struct LaunchRecord
+        {
+            public string? Kernel;
+            public long GlobalSize;
+            public long LocalSize;
+            public int ArgCount;
+            public int ManagedThreadId;
+            public long Ticks;
+        }
+
+        /// <summary>Records a launch in the ring. Allocation-free on the hot path.</summary>
+        public static void RecordLaunch(string kernelName, long globalSize, long localSize, int argCount)
+        {
+            long slot = Interlocked.Increment(ref _sequence);
+            int index = (int)(((slot % JournalCapacity) + JournalCapacity) % JournalCapacity);
+
+            _journal[index] = new LaunchRecord
+            {
+                Kernel = kernelName,
+                GlobalSize = globalSize,
+                LocalSize = localSize,
+                ArgCount = argCount,
+                ManagedThreadId = Environment.CurrentManagedThreadId,
+                Ticks = DateTime.UtcNow.Ticks,
+            };
+        }
+
+        /// <summary>The most recent launches, oldest first. Empty when nothing has launched.</summary>
+        public static IReadOnlyList<string> RecentLaunches()
+        {
+            long last = Interlocked.Read(ref _sequence);
+            if (last < 0) return Array.Empty<string>();
+
+            int count = (int)Math.Min(last + 1, JournalCapacity);
+            var lines = new List<string>(count);
+
+            for (long slot = Math.Max(0, last - count + 1); slot <= last; slot++)
+            {
+                int index = (int)(((slot % JournalCapacity) + JournalCapacity) % JournalCapacity);
+                var record = _journal[index];
+                if (record.Kernel is null) continue;
+
+                lines.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "#{0} {1} global={2} local={3} args={4} thread={5} at={6:O}",
+                    slot, record.Kernel, record.GlobalSize, record.LocalSize, record.ArgCount,
+                    record.ManagedThreadId, new DateTime(record.Ticks, DateTimeKind.Utc)));
+            }
+
+            return lines;
+        }
+
+        /// <summary>
+        /// Writes the journal to <paramref name="path"/>. Safe to call from a crash handler or a
+        /// test teardown; never throws.
+        /// </summary>
+        public static void DumpTo(string path)
+        {
+            try
+            {
+                var text = new StringBuilder();
+                text.AppendLine("# GPU launch journal (most recent last)");
+                foreach (var line in RecentLaunches()) text.AppendLine(line);
+                File.WriteAllText(path, text.ToString());
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+            catch (ArgumentException) { }
+        }
+
+        /// <summary>
+        /// Validates a launch's shape before it reaches the driver.
+        /// </summary>
+        /// <param name="kernelName">Kernel name, for the message.</param>
+        /// <param name="handleIsValid">False when the kernel handle has been released.</param>
+        /// <param name="stagedArgCount">Arguments the caller has set.</param>
+        /// <param name="declaredArgCount">The kernel's own argument count, or -1 if unknown.</param>
+        /// <param name="globalSize">Total work items.</param>
+        /// <param name="localSize">Work-group size.</param>
+        /// <param name="maxWorkGroupSize">The kernel's maximum work-group size, or -1 if unknown.</param>
+        /// <param name="requiresPowerOfTwoWorkGroup">
+        /// Whether the kernel's algorithm requires a power-of-two work-group. Tree reductions do;
+        /// giving one an odd work-group silently drops a lane, which is invisible to Min and Max
+        /// because they are idempotent and shows up only in sums.
+        /// </param>
+        public static void ValidateLaunch(
+            string kernelName,
+            bool handleIsValid,
+            int stagedArgCount,
+            int declaredArgCount,
+            long globalSize,
+            long localSize,
+            long maxWorkGroupSize = -1,
+            bool requiresPowerOfTwoWorkGroup = false)
+        {
+            if (!handleIsValid)
+            {
+                throw new ObjectDisposedException(
+                    kernelName,
+                    $"GPU kernel '{kernelName}' was launched after its handle was released.");
+            }
+
+            if (localSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(localSize),
+                    $"{kernelName}: work-group size must be positive (got {localSize}).");
+            }
+
+            if (globalSize % localSize != 0)
+            {
+                throw new ArgumentException(
+                    $"{kernelName}: global size {globalSize} is not a multiple of work-group size "
+                        + $"{localSize}. The driver rejects this, and rounding it up silently would "
+                        + "run work items the kernel may not guard against.",
+                    nameof(globalSize));
+            }
+
+            // DELIBERATELY BEHIND THE FLAG, not always on. OpenCL arguments persist on the kernel
+            // object between launches, so a launcher may legitimately set a subset and rely on the
+            // rest still holding the values it set earlier. Failing that by default would break
+            // working callers -- including any the library does not ship -- to catch a fault that,
+            // by construction, only matters while you are hunting one.
+            if (_deepChecks && declaredArgCount >= 0 && stagedArgCount != declaredArgCount)
+            {
+                throw new ArgumentException(
+                    $"{kernelName}: {stagedArgCount} argument(s) were set but the kernel declares "
+                        + $"{declaredArgCount}. Launching with a mismatched set reads whatever the "
+                        + "previous launch left in the unset slots. (If this launcher intentionally "
+                        + "relies on argument persistence, it is not a defect — it is only reported "
+                        + "under AIDOTNET_GPU_KERNEL_DIAGNOSTICS.)",
+                    nameof(stagedArgCount));
+            }
+
+            if (maxWorkGroupSize >= 0 && localSize > maxWorkGroupSize)
+            {
+                throw new ArgumentException(
+                    $"{kernelName}: work-group size {localSize} exceeds the {maxWorkGroupSize} this "
+                        + "kernel admits on this device.",
+                    nameof(localSize));
+            }
+
+            if (requiresPowerOfTwoWorkGroup && !IsPowerOfTwo(localSize))
+            {
+                throw new ArgumentException(
+                    $"{kernelName}: work-group size {localSize} is not a power of two, which this "
+                        + "kernel's reduction requires. A halving tree over a non-power-of-two group "
+                        + "drops its top lane — invisible in min/max, wrong in sums.",
+                    nameof(localSize));
+            }
+        }
+
+        /// <summary>True for 1, 2, 4, 8, ... — see the reduction note on <see cref="ValidateLaunch"/>.</summary>
+        public static bool IsPowerOfTwo(long value) => value > 0 && (value & (value - 1)) == 0;
+
+        /// <summary>
+        /// Checks that a buffer can hold every element a launch will address.
+        /// </summary>
+        /// <remarks>
+        /// Deep check: callers pass the highest index the kernel will touch, which they know and the
+        /// driver does not. An out-of-range device write corrupts whatever is next in device memory
+        /// and is reported, if at all, by an unrelated later operation.
+        /// </remarks>
+        public static void ValidateCapacity(
+            string kernelName, string bufferName, long bufferElements, long addressedElements)
+        {
+            if (!_deepChecks) return;
+
+            if (addressedElements > bufferElements)
+            {
+                throw new ArgumentException(
+                    $"{kernelName}: '{bufferName}' holds {bufferElements} element(s) but the launch "
+                        + $"addresses {addressedElements}. The excess would be written past the end "
+                        + "of device memory the buffer owns.",
+                    bufferName);
+            }
+        }
+
+        /// <summary>Formats the journal for inclusion in an exception or a test failure.</summary>
+        public static string DescribeRecentLaunches(int maximum = 12)
+        {
+            var recent = RecentLaunches();
+            if (recent.Count == 0) return "(no GPU launches recorded)";
+
+            var text = new StringBuilder();
+            int skip = Math.Max(0, recent.Count - maximum);
+            for (int i = skip; i < recent.Count; i++) text.AppendLine("  " + recent[i]);
+            return text.ToString();
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -45,6 +45,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
     /// The validation entry points are public so a caller extending the library with their own
     /// kernels gets the same checks, rather than the library validating only what it happens to ship.
     /// </para>
+    /// <para>
+    /// BACKEND COVERAGE. OpenCL journals from <c>DirectOpenClKernel</c>. CUDA and HIP journal from
+    /// their single native-launch P/Invoke, resolving the kernel name through
+    /// <see cref="RegisterKernelName"/> — wrapping the one choke point covers all ~20 call sites per
+    /// backend, including any added later, which threading a name through those signatures would not.
+    /// </para>
+    /// <para>
+    /// REMAINING GAP: Metal, Vulkan and WebGpu. Their dispatch entry points receive a command buffer
+    /// or encoder rather than the pipeline, so there is no kernel identity to record without
+    /// pipeline-level plumbing; journalling them by encoder handle would add entries that name
+    /// nothing. Tracked as Issue #996.
+    /// </para>
     /// </remarks>
     public static class GpuKernelDiagnostics
     {
@@ -157,6 +169,38 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
 
             // Published last: until this store, a reader must not treat the slot as holding `slot`.
             Volatile.Write(ref _published[index], slot);
+        }
+
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<IntPtr, string> _kernelNames
+            = new System.Collections.Concurrent.ConcurrentDictionary<IntPtr, string>();
+
+        /// <summary>
+        /// Associates a device kernel handle with its name so a launch can be journalled by name.
+        /// </summary>
+        /// <remarks>
+        /// THIS IS WHAT MAKES JOURNALLING WORK ON THE HANDLE-ONLY BACKENDS. CUDA and HIP resolve a
+        /// kernel from a name-keyed cache, but every launch helper below that point receives only an
+        /// <see cref="IntPtr"/> — and there are roughly twenty such call sites per backend. Recording
+        /// the name once at registration lets the single native-launch choke point resolve it, so all
+        /// of them are covered without threading a name through twenty signatures.
+        /// </remarks>
+        public static void RegisterKernelName(IntPtr handle, string name)
+        {
+            if (handle == IntPtr.Zero || string.IsNullOrEmpty(name)) return;
+            _kernelNames[handle] = name;
+        }
+
+        /// <summary>
+        /// Records a launch identified by handle, resolving the name registered for it. Falls back to
+        /// the raw handle so an unregistered kernel is still attributable rather than dropped.
+        /// </summary>
+        public static void RecordLaunchByHandle(IntPtr handle, long globalSize, long localSize, int argCount)
+        {
+            RecordLaunch(
+                _kernelNames.TryGetValue(handle, out var name) ? name : "kernel@0x" + handle.ToString("x"),
+                globalSize,
+                localSize,
+                argCount);
         }
 
         /// <summary>The most recent launches, oldest first. Empty when nothing has launched.</summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -191,6 +191,22 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         }
 
         /// <summary>
+        /// Drops a handle's registration. Call during backend teardown.
+        /// </summary>
+        /// <remarks>
+        /// The registry is static and process-lifetime, but kernel handles are not: a process that
+        /// creates and disposes backends repeatedly (as the test suite does) would otherwise retain an
+        /// entry per unique handle forever. Worse than the leak, a driver is free to REUSE a freed
+        /// handle address, so a stale entry could name a later kernel wrongly — in crash forensics,
+        /// confidently wrong is worse than absent.
+        /// </remarks>
+        public static void UnregisterKernelName(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero) return;
+            _kernelNames.TryRemove(handle, out _);
+        }
+
+        /// <summary>
         /// Records a launch identified by handle, resolving the name registered for it. Falls back to
         /// the raw handle so an unregistered kernel is still attributable rather than dropped.
         /// </summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -78,6 +78,33 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         private static readonly bool _synchronousLaunches =
             IsSet("AIDOTNET_GPU_SYNC_LAUNCHES");
 
+        /// <summary>
+        /// When <c>AIDOTNET_GPU_DIAGNOSTICS_DUMP</c> names a path, the journal and the buffer
+        /// residency are written there as the process exits.
+        /// </summary>
+        /// <remarks>
+        /// This is the diagnostic that answers "what was the process holding when it died". A host
+        /// that dies with gigabytes of unreleased device buffers looks, in every managed tool, like a
+        /// process with a small tidy heap — the evidence only exists if something recorded it before
+        /// the exit. Registering on both ProcessExit and DomainUnload mirrors what the CUDA backend
+        /// already does for its teardown flags.
+        /// </remarks>
+        static GpuKernelDiagnostics()
+        {
+            var path = Environment.GetEnvironmentVariable("AIDOTNET_GPU_DIAGNOSTICS_DUMP");
+            if (string.IsNullOrEmpty(path)) return;
+
+            try
+            {
+                AppDomain.CurrentDomain.ProcessExit += (_, __) => DumpTo(path);
+                AppDomain.CurrentDomain.DomainUnload += (_, __) => DumpTo(path);
+            }
+            catch (AppDomainUnloadedException)
+            {
+                // Nothing to register against; the diagnostic is best-effort by design.
+            }
+        }
+
         private static bool IsSet(string name)
         {
             var value = Environment.GetEnvironmentVariable(name);
@@ -162,6 +189,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             {
                 var text = new StringBuilder();
                 text.AppendLine("# GPU launch journal (most recent last)");
+                // Residency first: when a process dies holding gigabytes of device buffers, that is
+                // usually the story, and it is invisible in a managed heap dump.
+                text.AppendLine("# buffers: " + DescribeBufferResidency());
                 foreach (var line in RecentLaunches()) text.AppendLine(line);
                 File.WriteAllText(path, text.ToString());
             }
@@ -254,6 +284,66 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
 
         /// <summary>True for 1, 2, 4, 8, ... — see the reduction note on <see cref="ValidateLaunch"/>.</summary>
         public static bool IsPowerOfTwo(long value) => value > 0 && (value & (value - 1)) == 0;
+
+        private static long _liveBufferCount;
+        private static long _liveBufferBytes;
+        private static long _peakLiveBufferBytes;
+        private static long _totalBuffersAllocated;
+
+        /// <summary>Device buffers currently allocated and not yet released.</summary>
+        public static long LiveBufferCount => Interlocked.Read(ref _liveBufferCount);
+
+        /// <summary>Bytes currently held by unreleased device buffers.</summary>
+        public static long LiveBufferBytes => Interlocked.Read(ref _liveBufferBytes);
+
+        /// <summary>The high-water mark of <see cref="LiveBufferBytes"/> for this process.</summary>
+        public static long PeakLiveBufferBytes => Interlocked.Read(ref _peakLiveBufferBytes);
+
+        /// <summary>Every buffer allocated so far, released or not.</summary>
+        public static long TotalBuffersAllocated => Interlocked.Read(ref _totalBuffersAllocated);
+
+        /// <summary>
+        /// Records a device buffer allocation. Two interlocked adds; safe to call on every allocation.
+        /// </summary>
+        /// <remarks>
+        /// WHY THIS IS ALWAYS ON. A leaked device buffer is invisible to every managed tool: the
+        /// wrapper object is small and collectible, so the GC heap stays flat while the process grows
+        /// by gigabytes of native memory. A heap dump of such a process shows nothing wrong. This
+        /// counter is the difference between "the process is somehow using 18 GB" and "37,000 buffers
+        /// were allocated and 12 were released", which is a one-line answer instead of an
+        /// investigation.
+        /// </remarks>
+        public static void RecordBufferAllocated(long bytes)
+        {
+            Interlocked.Increment(ref _totalBuffersAllocated);
+            Interlocked.Increment(ref _liveBufferCount);
+            long live = Interlocked.Add(ref _liveBufferBytes, bytes);
+
+            // Lock-free high-water mark: retry while another thread raised it past our reading.
+            long peak = Interlocked.Read(ref _peakLiveBufferBytes);
+            while (live > peak)
+            {
+                long seen = Interlocked.CompareExchange(ref _peakLiveBufferBytes, live, peak);
+                if (seen == peak) break;
+                peak = seen;
+            }
+        }
+
+        /// <summary>Records a device buffer release. Must pair with <see cref="RecordBufferAllocated"/>.</summary>
+        public static void RecordBufferReleased(long bytes)
+        {
+            Interlocked.Decrement(ref _liveBufferCount);
+            Interlocked.Add(ref _liveBufferBytes, -bytes);
+        }
+
+        /// <summary>Human-readable buffer accounting, for a dump, a test failure, or a teardown check.</summary>
+        public static string DescribeBufferResidency()
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "live={0} buffer(s), {1:N0} byte(s); peak {2:N0} byte(s); {3} allocated in total",
+                LiveBufferCount, LiveBufferBytes, PeakLiveBufferBytes, TotalBuffersAllocated);
+        }
 
         /// <summary>
         /// Checks that a buffer can hold every element a launch will address.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -138,6 +138,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             long slot = Interlocked.Increment(ref _sequence);
             int index = (int)(((slot % JournalCapacity) + JournalCapacity) % JournalCapacity);
 
+            // Two-phase publish, INVALIDATE FIRST. Publishing only after the write is not enough on
+            // its own: a reader that already accepted this slot for an older sequence would still be
+            // copying the record while this launch replaces it, and would report the new (or a
+            // half-written) record under the old launch number. Clearing the marker first means such
+            // a reader fails its verifying re-read and discards the entry instead.
+            Volatile.Write(ref _published[index], -1);
+
             _journal[index] = new LaunchRecord
             {
                 Kernel = kernelName,
@@ -167,6 +174,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
                 if (Volatile.Read(ref _published[index]) != slot) continue;   // not yet written, or recycled
 
                 var record = _journal[index];
+
+                // VERIFY AFTER COPYING. The check above only proves the slot held `slot` when we
+                // looked; the ring wraps every 64 launches, so the writer can replace this slot
+                // mid-copy. Re-reading the marker closes that window: if it moved, the bytes we just
+                // copied belong to a different launch and are dropped. LaunchRecord is a struct, so
+                // the copy itself can tear — which is exactly what this discards.
+                if (Volatile.Read(ref _published[index]) != slot) continue;
+
                 if (record.Kernel is null) continue;
 
                 lines.Add(string.Format(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
@@ -1,0 +1,73 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// HIP launcher shim for categorical sampling. The HIP launch API takes the same void**-array as
+// CUDA, so this mirrors the OpenCL launcher one-for-one apart from the runtime call.
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP
+{
+    /// <summary>
+    /// Gives HIP a device route for <c>TensorCategoricalSample</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ported alongside the OpenCL kernel rather than after it. Adding a compute kernel to one
+    /// backend and not the others opens a parity gap that
+    /// <c>CrossBackendKernelCoverageTests.MirrorBackends_CoverEveryOpenClComputeKernel</c> fails on,
+    /// and rightly so: an op that runs on device for one vendor and silently falls back to the CPU
+    /// for another is a portability bug, not an optimisation.
+    /// </para>
+    /// <para>
+    /// The kernel is bit-identical to the OpenCL and CPU implementations — the same StatelessRandom
+    /// PCG hash keyed on (seed, row), the same inverse-CDF walk accumulated in <c>double</c>, the
+    /// same <c>target &lt; cumulative</c> ordering. That is what lets the same seed produce the same
+    /// one-hot on every backend, which the exact-parity test requires.
+    /// </para>
+    /// <para>
+    /// NOT EXECUTED IN VERIFICATION: there is no AMD ROCm device on the machine this was written on,
+    /// so the kernel is verified to compile and register and to close the mirror gap, but its output
+    /// has not been observed. The algorithm is a line-for-line port of the OpenCL kernel, which IS
+    /// verified against the CPU oracle.
+    /// </para>
+    /// </remarks>
+    public sealed partial class HipBackend : ICategoricalSamplingBackend
+    {
+        /// <inheritdoc/>
+        public bool CanCategoricalSample(int rows, int classes)
+            => _neuralNetModule != IntPtr.Zero
+               && rows > 0
+               && classes > 0
+               && (long)rows * classes <= int.MaxValue
+               && _kernelCache.ContainsKey("categorical_sample");
+
+        /// <inheritdoc/>
+        public unsafe bool TryCategoricalSample(
+            IGpuBuffer probabilities,
+            IGpuBuffer oneHot,
+            int rows,
+            int classes,
+            ulong seed)
+        {
+            if (!CanCategoricalSample(rows, classes)) return false;
+            if (probabilities is null || oneHot is null) return false;
+            if (!_kernelCache.TryGetValue("categorical_sample", out var kernel)) return false;
+
+            uint grid = (uint)((rows + DefaultBlockSize - 1) / DefaultBlockSize);
+            IntPtr probabilitiesHandle = probabilities.Handle;
+            IntPtr oneHotHandle = oneHot.Handle;
+            int rowCount = rows;
+            int classCount = classes;
+            ulong deviceSeed = seed;
+
+            void** args = stackalloc void*[5];
+            args[0] = &probabilitiesHandle;
+            args[1] = &oneHotHandle;
+            args[2] = &rowCount;
+            args[3] = &classCount;
+            args[4] = &deviceSeed;
+
+            LaunchKernel(kernel, grid, DefaultBlockSize, args);
+            Synchronize();
+            return true;
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
@@ -51,6 +51,24 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.HIP
             if (probabilities is null || oneHot is null) return false;
             if (!_kernelCache.TryGetValue("categorical_sample", out var kernel)) return false;
 
+            // Both buffers are indexed as row * classes + c, so both must actually hold that many
+            // elements. CanCategoricalSample only checks the DIMENSIONS; an undersized buffer would
+            // be written past its end on the device, which corrupts whatever is next in device
+            // memory and is reported, if at all, by some unrelated later operation. CUDA already
+            // rejects this via ValidateExactCategoricalBuffer and OpenCL via the same pair of
+            // comparisons below; HIP was the one route that launched unchecked.
+            long addressed = (long)rows * classes;
+            GpuKernelDiagnostics.ValidateCapacity(
+                "categorical_sample", nameof(probabilities), probabilities.Size, addressed);
+            GpuKernelDiagnostics.ValidateCapacity(
+                "categorical_sample", nameof(oneHot), oneHot.Size, addressed);
+
+            if (probabilities.Size < addressed || oneHot.Size < addressed)
+            {
+                // Even with deep checks off, refuse rather than launch an out-of-range write.
+                return false;
+            }
+
             uint grid = (uint)((rows + DefaultBlockSize - 1) / DefaultBlockSize);
             IntPtr probabilitiesHandle = probabilities.Handle;
             IntPtr oneHotHandle = oneHot.Handle;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.Categorical.cs
@@ -33,7 +33,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.HIP
     {
         /// <inheritdoc/>
         public bool CanCategoricalSample(int rows, int classes)
-            => _neuralNetModule != IntPtr.Zero
+            => _categoricalModule != IntPtr.Zero
                && rows > 0
                && classes > 0
                && (long)rows * classes <= int.MaxValue

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -124,7 +124,21 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     private const string GemmVendorThresholdEnvVar = "AIDOTNET_GPU_GEMM_VENDOR_THRESHOLD";
     private const long DefaultVendorGemmThreshold = 128L * 128L * 128L;
 
-    public bool IsAvailable { get; }
+    private bool _isAvailable;
+
+    /// <summary>
+    /// Whether this backend can serve work. FALSE ONCE DISPOSED, which is load-bearing:
+    /// DirectGpuBackendFactory caches one backend per process and hands the cached instance back
+    /// while it reports available. Dispose() clears the kernel cache, so a disposed-but-still-cached
+    /// backend answers every later kernel lookup with KeyNotFoundException ("add_vectors") on a
+    /// completely unrelated caller. Reporting unavailable makes the factory build a fresh backend
+    /// instead. VulkanBackend and MetalBackend already did this; these three did not.
+    /// </summary>
+    public bool IsAvailable
+    {
+        get => _isAvailable && !_disposed;
+        private set => _isAvailable = value;
+    }
     public string BackendName => $"HIP ({GetKernelTypeName()})";
     public TensorDevice DeviceType => TensorDevice.HIP;
     public string DeviceName { get; }
@@ -836,6 +850,8 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             hipResult = HipNativeBindings.hipModuleGetFunction(ref func, module, kernelName);
             if (hipResult == HipError.Success)
                 _kernelCache[kernelName] = func;
+                // Lets the native-launch choke point journal this kernel BY NAME (Issue #996).
+                GpuKernelDiagnostics.RegisterKernelName(func, kernelName);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -60,6 +60,7 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
     // Additional kernel modules
     private IntPtr _activationModule;
     private IntPtr _neuralNetModule;
+    private IntPtr _categoricalModule;
     private IntPtr _convolutionModule;
     private IntPtr _fusedConvolutionModule;
     private IntPtr _poolingModule;
@@ -476,6 +477,21 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             // Compile Neural Net kernels
             CompileKernelModule(HipNeuralNetKernels.GetSource(), "neural_net", ref _neuralNetModule,
                 HipNeuralNetKernels.GetKernelNames());
+
+            // Categorical sampling: its own module, and NOT fast-math. Sharing the neural-net
+            // module would make every kernel in it hostage to this one compiling, and fast math
+            // permits reassociating the ordered double accumulation this kernel needs to reproduce
+            // the CPU sampler exactly. A failure here leaves the engine on its CPU reference instead
+            // of taking generate_random_uniform and the rest down with it.
+            try
+            {
+                CompileKernelModule(HipCategoricalKernels.GetSource(), "categorical",
+                    ref _categoricalModule, HipCategoricalKernels.GetKernelNames(), useFastMath: false);
+            }
+            catch (Exception)
+            {
+                _categoricalModule = IntPtr.Zero;
+            }
 
             // Compile Convolution kernels
             CompileKernelModule(HipConvolutionKernels.GetSource(), "convolution", ref _convolutionModule,
@@ -11161,6 +11177,12 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             HipNativeBindings.hipModuleUnload(_activationModule);
             _activationModule = IntPtr.Zero;
         }
+        if (_categoricalModule != IntPtr.Zero)
+        {
+            HipNativeBindings.hipModuleUnload(_categoricalModule);
+            _categoricalModule = IntPtr.Zero;
+        }
+
         if (_neuralNetModule != IntPtr.Zero)
         {
             HipNativeBindings.hipModuleUnload(_neuralNetModule);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -849,9 +849,13 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             IntPtr func = IntPtr.Zero;
             hipResult = HipNativeBindings.hipModuleGetFunction(ref func, module, kernelName);
             if (hipResult == HipError.Success)
+            {
                 _kernelCache[kernelName] = func;
                 // Lets the native-launch choke point journal this kernel BY NAME (Issue #996).
+                // INSIDE the guard: registering on a failed lookup would map IntPtr.Zero to this
+                // name and misattribute a later fault to a kernel that never resolved.
                 GpuKernelDiagnostics.RegisterKernelName(func, kernelName);
+            }
         }
     }
 
@@ -11414,6 +11418,9 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
             _stream = IntPtr.Zero;
         }
 
+        // Drop the diagnostics registrations for these handles. A driver may reuse a freed
+        // handle address, so a stale entry would name a later kernel wrongly (Issue #996).
+        foreach (var handle in _kernelCache.Values) GpuKernelDiagnostics.UnregisterKernelName(handle);
         _kernelCache.Clear();
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) AiDotNet. All rights reserved.
+// Copyright (c) AiDotNet. All rights reserved.
 // HIP backend for AMD GPU with real MFMA (Matrix Fused Multiply-Add) support.
 // Target: 25,000+ GFLOPS on MI200, 15,000+ GFLOPS on RX 7900.
 
@@ -488,8 +488,19 @@ public sealed partial class HipBackend : IAsyncGpuBackend, IFusedAdvancedKernels
                 CompileKernelModule(HipCategoricalKernels.GetSource(), "categorical",
                     ref _categoricalModule, HipCategoricalKernels.GetKernelNames(), useFastMath: false);
             }
-            catch (Exception)
+            catch (OutOfMemoryException)
             {
+                // Process-level resource problem; do NOT silently downgrade. Matches the
+                // fused-advanced compilation path: a failed allocation is not a statement about
+                // this device's capability, and turning it into a quiet CPU fallback hides a
+                // condition the caller has to know about.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[HipBackend] Categorical kernel compile failed: {ex.GetType().Name}: {ex.Message}. "
+                    + "Falling back to the managed categorical sampler.");
                 _categoricalModule = IntPtr.Zero;
             }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipNativeBindings.cs
@@ -494,8 +494,8 @@ internal static class HipNativeBindings
         IntPtr module,
         [MarshalAs(UnmanagedType.LPStr)] string name);
 
-    [DllImport(HipLibrary, CallingConvention = CallingConvention.Cdecl)]
-    public static extern HipError hipModuleLaunchKernel(
+    [DllImport(HipLibrary, EntryPoint = "hipModuleLaunchKernel", CallingConvention = CallingConvention.Cdecl)]
+    private static extern HipError hipModuleLaunchKernelNative(
         IntPtr function,
         uint gridDimX,
         uint gridDimY,
@@ -507,6 +507,40 @@ internal static class HipNativeBindings
         IntPtr stream,
         IntPtr kernelParams,
         IntPtr extra);
+
+    /// <summary>
+    /// Journals the launch, then forwards to the driver.
+    /// </summary>
+    /// <remarks>
+    /// THE CHOKE POINT. HipBackend reaches the driver from roughly twenty call sites, all of which
+    /// hold only a kernel handle. Wrapping the single P/Invoke covers every one of them at the cost
+    /// of two dictionary operations, instead of threading a name through twenty signatures and
+    /// missing whichever site is added next. The name comes from the handle registered at kernel
+    /// registration; an unregistered handle is still recorded, by address.
+    /// </remarks>
+    public static HipError hipModuleLaunchKernel(
+        IntPtr function,
+        uint gridDimX,
+        uint gridDimY,
+        uint gridDimZ,
+        uint blockDimX,
+        uint blockDimY,
+        uint blockDimZ,
+        uint sharedMemBytes,
+        IntPtr stream,
+        IntPtr kernelParams,
+        IntPtr extra)
+    {
+        GpuKernelDiagnostics.RecordLaunchByHandle(
+            function,
+            (long)gridDimX * gridDimY * gridDimZ * blockDimX * blockDimY * blockDimZ,
+            (long)blockDimX * blockDimY * blockDimZ,
+            -1);
+
+        return hipModuleLaunchKernelNative(
+            function, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
+            sharedMemBytes, stream, kernelParams, extra);
+    }
 
     [DllImport(HipLibrary, CallingConvention = CallingConvention.Cdecl)]
     public static extern HipError hipLaunchCooperativeKernel(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipCategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipCategoricalKernels.cs
@@ -1,0 +1,60 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+
+/// <summary>
+/// HIP categorical sampling — its own HIPRTC module, deliberately.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ISOLATED FOR TWO REASONS, both learned from the OpenCL side.
+/// </para>
+/// <para>
+/// A module is compiled as one hiprtcCompileProgram call, so appending this kernel to the shared
+/// neural-net source made every kernel in that module hostage to it: one rejection and
+/// _neuralNetModule, generate_random_uniform and the rest all fail to load. Its own module fails
+/// alone and leaves the engine on its CPU reference.
+/// </para>
+/// <para>
+/// And the shared module compiles with fast math, which permits the compiler to reassociate
+/// floating-point arithmetic. This kernel exists to reproduce the CPU's inverse-CDF walk EXACTLY,
+/// in ordered double accumulation; reassociating the running sum moves the bucket boundary and
+/// selects a different category, which the exact-parity test reads as a hard mismatch. It is
+/// therefore compiled with fast math off.
+/// </para>
+/// </remarks>
+internal static class HipCategoricalKernels
+{
+    public static string[] GetKernelNames() => new[] { "categorical_sample" };
+
+    public static string GetSource() => @"
+extern ""C"" __global__ __launch_bounds__(256) void categorical_sample(
+    const float* probabilities, float* oneHot, int rows, int classes, unsigned long long seed)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= rows) return;
+
+    unsigned int seed32 = (unsigned int)seed ^ (unsigned int)(seed >> 32);
+    unsigned int state = (unsigned int)row * 747796405u + seed32 + 2891336453u;
+    unsigned int word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
+    unsigned int sample = (word >> 22) ^ word;
+    float uniform = (float)(sample >> 8) * (1.0f / 16777216.0f);
+
+    int offset = row * classes;
+
+    double sum = 0.0;
+    for (int c = 0; c < classes; c++) sum += (double)probabilities[offset + c];
+
+    double target = (double)uniform * sum;
+    double cumulative = 0.0;
+    int selected = classes - 1;
+    for (int c = 0; c < classes; c++)
+    {
+        cumulative += (double)probabilities[offset + c];
+        if (target < cumulative) { selected = c; break; }
+    }
+
+    for (int c = 0; c < classes; c++) oneHot[offset + c] = 0.0f;
+    oneHot[offset + selected] = 1.0f;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
@@ -288,8 +288,8 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
         acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
     }
     sdata[tid] = acc; __syncthreads();
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     if (tid == 0) outScores[v] = sdata[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipComplexKernels.cs
@@ -288,8 +288,8 @@ extern ""C"" __global__ void hrr_phase_coherence_decode(
         acc += cR[d] * queryReal[d] + cI[d] * queryImag[d];
     }
     sdata[tid] = acc; __syncthreads();
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     if (tid == 0) outScores[v] = sdata[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedKernels.cs
@@ -558,8 +558,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -574,8 +574,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -613,8 +613,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -629,8 +629,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -678,8 +678,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -695,8 +695,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) sdata[tid] += sdata[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -736,8 +736,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localMax;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             if (smem[tid + s] > smem[tid]) smem[tid] = smem[tid + s];
         }
         __syncthreads();
@@ -754,8 +754,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) smem[tid] += smem[tid + s];
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) smem[tid] += smem[tid + s];
         __syncthreads();
     }
     float sumExp = smem[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipFusedKernels.cs
@@ -558,8 +558,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -574,8 +574,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_relu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -613,8 +613,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -629,8 +629,8 @@ extern ""C"" __global__ __launch_bounds__(256) void layernorm_gelu(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -678,8 +678,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float mean = sdata[0] / normalizedSize;
@@ -695,8 +695,8 @@ extern ""C"" __global__ __launch_bounds__(256) void residual_layernorm(
     sdata[tid] = localVar;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) sdata[tid] += sdata[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) sdata[tid] += sdata[tid + s];
         __syncthreads();
     }
     float invStd = rsqrtf(sdata[0] / normalizedSize + epsilon);
@@ -736,8 +736,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localMax;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             if (smem[tid + s] > smem[tid]) smem[tid] = smem[tid + s];
         }
         __syncthreads();
@@ -754,8 +754,8 @@ extern ""C"" __global__ __launch_bounds__(256) void scaled_softmax(
     smem[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) smem[tid] += smem[tid + s];
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) smem[tid] += smem[tid + s];
         __syncthreads();
     }
     float sumExp = smem[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMeshPoolKernels.cs
@@ -175,8 +175,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_find_max(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -202,8 +202,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_max(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -240,8 +240,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_exp_sum(
     scratch[tid] = expVal;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -267,8 +267,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_sum(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -310,8 +310,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -327,8 +327,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     scratch[tid] = expVal;
     __syncthreads();
 
-    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (tid < stride && tid + stride < blockSize) {
+    for (int stride_active = blockSize, stride = (blockSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < stride_active) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipMeshPoolKernels.cs
@@ -175,8 +175,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_find_max(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -202,8 +202,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_max(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -240,8 +240,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_exp_sum(
     scratch[tid] = expVal;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -267,8 +267,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_final_sum(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();
@@ -310,8 +310,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     scratch[tid] = val;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] = fmaxf(scratch[tid], scratch[tid + stride]);
         }
         __syncthreads();
@@ -327,8 +327,8 @@ extern ""C"" __global__ __launch_bounds__(256) void mesh_pool_softmax_scores(
     scratch[tid] = expVal;
     __syncthreads();
 
-    for (int stride = blockSize / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
+    for (int stride = (blockSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (tid < stride && tid + stride < blockSize) {
             scratch[tid] += scratch[tid + stride];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
@@ -2489,45 +2489,6 @@ extern ""C"" __global__ __launch_bounds__(256) void batched_gemm(
 }
 
 #undef BATCHED_TILE_SIZE
-
-// ===========================================================================
-// CATEGORICAL SAMPLING
-// ===========================================================================
-// Device twin of the OpenCL categorical_sample kernel, and of CpuEngine's
-// TensorCategoricalSample. All three draw from the same StatelessRandom PCG hash keyed on
-// (seed, row) and walk the same inverse CDF in double, so the same seed yields the same
-// one-hot on every backend. Float accumulation would pick the neighbouring category at a
-// bucket edge, which the exact-parity test treats as a hard mismatch.
-
-extern ""C"" __global__ __launch_bounds__(256) void categorical_sample(
-    const float* probabilities, float* oneHot, int rows, int classes, unsigned long long seed)
-{
-    int row = blockIdx.x * blockDim.x + threadIdx.x;
-    if (row >= rows) return;
-
-    unsigned int seed32 = (unsigned int)seed ^ (unsigned int)(seed >> 32);
-    unsigned int state = (unsigned int)row * 747796405u + seed32 + 2891336453u;
-    unsigned int word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
-    unsigned int sample = (word >> 22) ^ word;
-    float uniform = (float)(sample >> 8) * (1.0f / 16777216.0f);
-
-    int offset = row * classes;
-
-    double sum = 0.0;
-    for (int c = 0; c < classes; c++) sum += (double)probabilities[offset + c];
-
-    double target = (double)uniform * sum;
-    double cumulative = 0.0;
-    int selected = classes - 1;
-    for (int c = 0; c < classes; c++)
-    {
-        cumulative += (double)probabilities[offset + c];
-        if (target < cumulative) { selected = c; break; }
-    }
-
-    for (int c = 0; c < classes; c++) oneHot[offset + c] = 0.0f;
-    oneHot[offset + selected] = 1.0f;
-}
 ";
     }
 
@@ -2535,7 +2496,6 @@ extern ""C"" __global__ __launch_bounds__(256) void categorical_sample(
     {
         return new[]
         {
-            "categorical_sample",
             "relu_backward", "sigmoid_backward", "tanh_backward", "gelu_backward",
             "softmax_backward", "leaky_relu", "leaky_relu_backward",
             "elu", "elu_backward", "silu", "swish_backward", "mish", "softplus", "hardswish",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipNeuralNetKernels.cs
@@ -2489,6 +2489,45 @@ extern ""C"" __global__ __launch_bounds__(256) void batched_gemm(
 }
 
 #undef BATCHED_TILE_SIZE
+
+// ===========================================================================
+// CATEGORICAL SAMPLING
+// ===========================================================================
+// Device twin of the OpenCL categorical_sample kernel, and of CpuEngine's
+// TensorCategoricalSample. All three draw from the same StatelessRandom PCG hash keyed on
+// (seed, row) and walk the same inverse CDF in double, so the same seed yields the same
+// one-hot on every backend. Float accumulation would pick the neighbouring category at a
+// bucket edge, which the exact-parity test treats as a hard mismatch.
+
+extern ""C"" __global__ __launch_bounds__(256) void categorical_sample(
+    const float* probabilities, float* oneHot, int rows, int classes, unsigned long long seed)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= rows) return;
+
+    unsigned int seed32 = (unsigned int)seed ^ (unsigned int)(seed >> 32);
+    unsigned int state = (unsigned int)row * 747796405u + seed32 + 2891336453u;
+    unsigned int word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
+    unsigned int sample = (word >> 22) ^ word;
+    float uniform = (float)(sample >> 8) * (1.0f / 16777216.0f);
+
+    int offset = row * classes;
+
+    double sum = 0.0;
+    for (int c = 0; c < classes; c++) sum += (double)probabilities[offset + c];
+
+    double target = (double)uniform * sum;
+    double cumulative = 0.0;
+    int selected = classes - 1;
+    for (int c = 0; c < classes; c++)
+    {
+        cumulative += (double)probabilities[offset + c];
+        if (target < cumulative) { selected = c; break; }
+    }
+
+    for (int c = 0; c < classes; c++) oneHot[offset + c] = 0.0f;
+    oneHot[offset + selected] = 1.0f;
+}
 ";
     }
 
@@ -2496,6 +2535,7 @@ extern ""C"" __global__ __launch_bounds__(256) void batched_gemm(
     {
         return new[]
         {
+            "categorical_sample",
             "relu_backward", "sigmoid_backward", "tanh_backward", "gelu_backward",
             "softmax_backward", "leaky_relu", "leaky_relu_backward",
             "elu", "elu_backward", "silu", "swish_backward", "mish", "softplus", "hardswish",

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpecializedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpecializedKernels.cs
@@ -444,8 +444,8 @@ extern ""C"" __global__ __launch_bounds__(256) void normalize_probabilities(
     sdata[tid] = sum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();
@@ -563,8 +563,8 @@ extern ""C"" __global__ __launch_bounds__(256) void measurement_forward(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (tid < s && tid + s < blockDim.x) {
+    for (int s_active = blockDim.x, s = (blockDim.x + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < s_active) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpecializedKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/Kernels/HipSpecializedKernels.cs
@@ -444,8 +444,8 @@ extern ""C"" __global__ __launch_bounds__(256) void normalize_probabilities(
     sdata[tid] = sum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();
@@ -563,8 +563,8 @@ extern ""C"" __global__ __launch_bounds__(256) void measurement_forward(
     sdata[tid] = localSum;
     __syncthreads();
 
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (tid < s) {
+    for (int s = (blockDim.x + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (tid < s && tid + s < blockDim.x) {
             sdata[tid] += sdata[tid + s];
         }
         __syncthreads();

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.Categorical.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal launcher shim for categorical sampling. Mirrors MetalBackend.Ann.cs — pipeline resolved via
+// the library handle compiled at init, dispatched with a 1-D thread grid of one thread per row.
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
+
+/// <summary>
+/// Gives Metal a device route for <c>TensorCategoricalSample</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the op fell back to the CPU after the caller had explicitly selected the Metal
+/// engine — correct output, but measured by the residency probe as 0 kernel launches against a
+/// required 1, which is a portability bug rather than an optimisation gap.
+/// </para>
+/// <para>
+/// The kernel differs from the other backends' in ONE deliberate respect: MSL has no <c>double</c>,
+/// so the probability sum and the cumulative walk are carried in a compensated two-float expansion.
+/// See <see cref="MetalCategoricalKernels"/> for why that reproduces the managed reference's
+/// category selection and what it depends on.
+/// </para>
+/// <para>
+/// NOT EXECUTED IN VERIFICATION: Metal runs only on macOS and this was written on Windows, so this
+/// route is verified to compile and register but its output has not been observed against the CPU
+/// oracle.
+/// </para>
+/// </remarks>
+public sealed partial class MetalBackend : ICategoricalSamplingBackend
+{
+    private const string CategoricalLibName = "Categorical";
+
+    /// <inheritdoc/>
+    public bool CanCategoricalSample(int rows, int classes)
+        // Availability is decided by whether the library COMPILED, which is also the fp-capability
+        // answer: a device or compiler that rejects the kernel leaves this zero and the engine keeps
+        // using the managed reference.
+        => _categoricalLibrary != IntPtr.Zero
+           && rows > 0
+           && classes > 0
+           // One thread per row; a row wider than this is still correct but the serial walk over
+           // classes stops being the right shape for a GPU and the CPU reference is faster.
+           && (long)rows * classes <= int.MaxValue;
+
+    /// <inheritdoc/>
+    public bool TryCategoricalSample(
+        IGpuBuffer probabilities,
+        IGpuBuffer oneHot,
+        int rows,
+        int classes,
+        ulong seed)
+    {
+        if (!CanCategoricalSample(rows, classes)) return false;
+        if (probabilities is not MetalGpuBuffer probabilityBuffer) return false;
+        if (oneHot is not MetalGpuBuffer oneHotBuffer) return false;
+
+        // Both buffers are indexed as row * classes + c, so both must actually hold that many
+        // elements. CanCategoricalSample only checks the DIMENSIONS; an undersized buffer would be
+        // written past its end on the device, which corrupts whatever is next in device memory and
+        // is reported, if at all, by some unrelated later operation.
+        long addressed = (long)rows * classes;
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(probabilities), probabilityBuffer.Size, addressed);
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(oneHot), oneHotBuffer.Size, addressed);
+
+        if (probabilityBuffer.Size < addressed || oneHotBuffer.Size < addressed)
+        {
+            // Even with deep checks off, refuse rather than launch an out-of-range write.
+            return false;
+        }
+
+        ThrowIfDisposed();
+
+        var pipeline = GetPipeline(CategoricalLibName, _categoricalLibrary, "categorical_sample");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(rows);
+
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer(probabilityBuffer, 0);
+        encoder.SetBuffer(oneHotBuffer, 1);
+        encoder.SetBytes(rows, 2);
+        encoder.SetBytes(classes, 3);
+        // Split as the kernel folds it: seed32 = lo ^ hi, matching the managed helper and every
+        // other backend's kernel.
+        encoder.SetBytes((uint)(seed & 0xFFFFFFFF), 4);
+        encoder.SetBytes((uint)(seed >> 32), 5);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+
+        return true;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -356,7 +356,18 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
         // engine keeps using CpuEngine.TensorCategoricalSample.
         try
         {
-            _categoricalLibrary = _shaderLibrary.CompileLibrary("Categorical", MetalCategoricalKernels.Source);
+            // requireStrictFloatingPoint: this kernel carries its sum in a compensated two-float
+            // expansion because MSL has no double, and fast math would reassociate the compensation
+            // terms to zero. If this runtime cannot be told to disable fast math, compilation fails
+            // and the route is NOT advertised — the engine keeps the managed sampler rather than
+            // sampling at silently reduced precision.
+            _categoricalLibrary = _shaderLibrary.CompileLibrary(
+                "Categorical", MetalCategoricalKernels.Source, requireStrictFloatingPoint: true);
+        }
+        catch (OutOfMemoryException)
+        {
+            // Process-level resource problem; do NOT silently downgrade.
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.cs
@@ -72,6 +72,7 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
     private IntPtr _fftLibrary;
     private IntPtr _detectionLibrary;
     private IntPtr _annLibrary; // fused ANN kernels (IAnnBackend: IVF / PQ / IVFPQ / HNSW primitives)
+    private IntPtr _categoricalLibrary; // categorical sampling (ICategoricalSamplingBackend)
     private IntPtr _geometryLibrary;
     private IntPtr _roiLibrary;
     private IntPtr _audioLibrary;
@@ -347,6 +348,20 @@ public sealed partial class MetalBackend : IDirectGpuBackend, IFusedAdvancedKern
         {
             System.Diagnostics.Debug.WriteLine($"Metal ANN pre-compilation warning: {ex.Message}");
             _annLibrary = IntPtr.Zero;
+        }
+
+        // Categorical sampling. Its OWN library rather than a shared one: a compile failure here
+        // must not take unrelated kernels down with it, and this kernel is the only one whose
+        // correctness depends on compensated (non-reassociated) float arithmetic. On failure the
+        // engine keeps using CpuEngine.TensorCategoricalSample.
+        try
+        {
+            _categoricalLibrary = _shaderLibrary.CompileLibrary("Categorical", MetalCategoricalKernels.Source);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Metal categorical pre-compilation warning: {ex.Message}");
+            _categoricalLibrary = IntPtr.Zero;
         }
 
         // Geometry / sampling kernels (#217). IGeometryBackend dispatch.

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalCategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalCategoricalKernels.cs
@@ -1,0 +1,124 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Metal Shading Language (MSL) kernel for categorical sampling — the device twin of
+// CpuEngine.TensorCategoricalSample and of the OpenCL/CUDA/HIP/Vulkan kernels.
+//
+// WHY THIS IS NOT A LINE-FOR-LINE PORT OF THE OTHERS.
+// The CPU reference, and every other backend, accumulates the probability sum and the cumulative
+// walk in `double`. MSL HAS NO `double` TYPE — it is not a capability the device may or may not
+// advertise, it is absent from the language. Accumulating in `float` instead is not an option: the
+// running total drifts, a target sitting near a bucket edge selects the neighbouring category, and
+// the exact-parity test treats a single differing category as a hard mismatch.
+//
+// So the accumulation is carried in a TWO-FLOAT (double-single) expansion: a hi/lo pair whose
+// combined significand is roughly 48 bits against double's 53. Knuth's two_sum is exact under
+// round-to-nearest, so summing N float inputs this way is exact whenever the true sum needs no more
+// than ~48 bits — which covers any realistic class count, since each addend carries only 24. That
+// makes this kernel agree with the double reference rather than merely approximate it.
+//
+// REQUIRES IEEE SEMANTICS, AND ASKS FOR THEM IN THE SOURCE. two_sum and the fma-based product are
+// exact only if the compiler does not reassociate them, and Metal compiles with fast math ENABLED
+// by default (MetalDevice.CreateLibrary passes nil MTLCompileOptions, so the default applies).
+// The kernel therefore requests safe FP math with a pragma rather than relying on compile options
+// that this backend does not currently plumb through. On a Metal compiler too old to recognise the
+// pragma it is a warning, not an error, and the compensation terms may fold away — in which case
+// this degrades to plain float accumulation, which is what an uncompensated port would have done
+// anyway. It stays a valid one-hot either way; only a target landing within float rounding error of
+// a bucket edge could pick the neighbouring category.
+//
+// NOT EXECUTED IN VERIFICATION: Metal runs only on macOS and this was written on Windows, so this
+// kernel is unverified against the CPU oracle. The algorithm mirrors the OpenCL kernel, which IS
+// verified, with the accumulation type as the single deliberate difference.
+namespace AiDotNet.Tensors.Engines.DirectGpu.Metal
+{
+    /// <summary>
+    /// MSL implementation of categorical sampling, matching the managed reference's category
+    /// selection via compensated two-float accumulation (MSL has no <c>double</c>).
+    /// </summary>
+    internal static class MetalCategoricalKernels
+    {
+        public static string[] GetKernelNames() => new[] { "categorical_sample" };
+
+        public const string Source = @"
+#include <metal_stdlib>
+using namespace metal;
+
+// Compensated summation below is only exact under non-reassociating FP math.
+#pragma METAL fp math_mode(safe)
+
+// Knuth two_sum: exact under round-to-nearest. Returns (sum, error) with sum + error == a + b.
+inline float2 two_sum(float a, float b)
+{
+    float s = a + b;
+    float bb = s - a;
+    float err = (a - (s - bb)) + (b - bb);
+    return float2(s, err);
+}
+
+// Add a float to a two-float accumulator, renormalising so the pair stays non-overlapping.
+inline float2 df_add(float2 acc, float v)
+{
+    float2 t = two_sum(acc.x, v);
+    return two_sum(t.x, t.y + acc.y);
+}
+
+// Multiply a two-float by a float. fma recovers the exact rounding error of the head product.
+inline float2 df_mul(float2 a, float b)
+{
+    float p = a.x * b;
+    float e = fma(a.x, b, -p);
+    e = fma(a.y, b, e);
+    return two_sum(p, e);
+}
+
+// Lexicographic compare of two non-overlapping pairs is a compare of the exact values.
+inline bool df_less(float2 a, float2 b)
+{
+    return (a.x < b.x) || (a.x == b.x && a.y < b.y);
+}
+
+// StatelessRandom.Uniform01(seed, index) — identical constants to the managed helper and to every
+// other backend's kernel. Keying on the ROW index lets a thread compute its own uniform without
+// replaying the rows before it.
+inline float stateless_uniform01(uint seed32, uint index)
+{
+    uint state = index * 747796405u + seed32 + 2891336453u;
+    uint word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
+    uint draw = (word >> 22) ^ word;
+    return float(draw >> 8) * (1.0f / 16777216.0f);
+}
+
+kernel void categorical_sample(
+    device const float* probabilities [[buffer(0)]],
+    device float* oneHot             [[buffer(1)]],
+    constant int& rows               [[buffer(2)]],
+    constant int& classes            [[buffer(3)]],
+    constant uint& seedLo            [[buffer(4)]],
+    constant uint& seedHi            [[buffer(5)]],
+    uint gid                         [[thread_position_in_grid]])
+{
+    int row = int(gid);
+    if (row >= rows) return;
+
+    uint seed32 = seedLo ^ seedHi;
+    float u = stateless_uniform01(seed32, uint(row));
+
+    int offset = row * classes;
+
+    float2 sum = float2(0.0f, 0.0f);
+    for (int c = 0; c < classes; c++) sum = df_add(sum, probabilities[offset + c]);
+
+    float2 target = df_mul(sum, u);
+    float2 cumulative = float2(0.0f, 0.0f);
+    int selected = classes - 1;
+    for (int c = 0; c < classes; c++)
+    {
+        cumulative = df_add(cumulative, probabilities[offset + c]);
+        if (df_less(target, cumulative)) { selected = c; break; }
+    }
+
+    for (int c = 0; c < classes; c++) oneHot[offset + c] = 0.0f;
+    oneHot[offset + selected] = 1.0f;
+}
+";
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalCategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalCategoricalKernels.cs
@@ -15,15 +15,18 @@
 // than ~48 bits — which covers any realistic class count, since each addend carries only 24. That
 // makes this kernel agree with the double reference rather than merely approximate it.
 //
-// REQUIRES IEEE SEMANTICS, AND ASKS FOR THEM IN THE SOURCE. two_sum and the fma-based product are
+// REQUIRES IEEE SEMANTICS, AND FAILS CLOSED WITHOUT THEM. two_sum and the fma-based product are
 // exact only if the compiler does not reassociate them, and Metal compiles with fast math ENABLED
-// by default (MetalDevice.CreateLibrary passes nil MTLCompileOptions, so the default applies).
-// The kernel therefore requests safe FP math with a pragma rather than relying on compile options
-// that this backend does not currently plumb through. On a Metal compiler too old to recognise the
-// pragma it is a warning, not an error, and the compensation terms may fold away — in which case
-// this degrades to plain float accumulation, which is what an uncompensated port would have done
-// anyway. It stays a valid one-hot either way; only a target landing within float rounding error of
-// a bucket edge could pick the neighbouring category.
+// by default. This library is therefore compiled with MTLCompileOptions requesting strict floating
+// point (setMathMode: / setFastMathEnabled:, whichever this runtime implements — see
+// MetalDevice.TryCreateStrictFloatingPointOptions), and if NEITHER can be established the library
+// is not compiled at all and the route is not advertised. The pragma below is belt-and-braces, not
+// the mechanism: an older compiler treats an unknown pragma as a warning and keeps fast math, so
+// the pragma alone is not evidence of anything.
+//
+// Failing closed is deliberate. The alternative — advertising the route and hoping — degrades to
+// plain float accumulation with no diagnostic, which still produces a valid one-hot and so passes
+// every smoke test while disagreeing with the CPU reference at bucket edges.
 //
 // NOT EXECUTED IN VERIFICATION: Metal runs only on macOS and this was written on Windows, so this
 // kernel is unverified against the CPU oracle. The algorithm mirrors the OpenCL kernel, which IS

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDevice.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalDevice.cs
@@ -377,7 +377,64 @@ public sealed class MetalDevice : IDisposable
     /// </summary>
     /// <param name="source">The MSL source code.</param>
     /// <returns>Handle to the compiled library, or IntPtr.Zero on error.</returns>
+    /// <summary>
+    /// Builds an <c>MTLCompileOptions</c> that disables fast math, or returns
+    /// <see cref="IntPtr.Zero"/> when this runtime exposes no way to do so.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Metal compiles with fast math ENABLED by default, which permits reassociating floating-point
+    /// expressions. Any kernel whose correctness rests on compensated arithmetic — Knuth
+    /// <c>two_sum</c>, an FMA-recovered product — is silently reduced to plain float accumulation
+    /// under it, with no diagnostic. A source-level pragma is not sufficient evidence that it is
+    /// off: an older compiler accepts an unknown pragma as a warning and keeps fast math.
+    /// </para>
+    /// <para>
+    /// Every selector is probed with <c>respondsToSelector:</c> first. <c>fastMathEnabled</c> is
+    /// deprecated in newer Metal in favour of <c>mathMode</c>, and calling either blind on a runtime
+    /// that lacks it raises an unrecognised-selector exception rather than returning an error, so
+    /// the caller would trade a numerical problem for a crash. Returning Zero here means "cannot be
+    /// established", and the caller is expected to FAIL CLOSED rather than assume.
+    /// </para>
+    /// </remarks>
+    public static IntPtr TryCreateStrictFloatingPointOptions()
+    {
+        IntPtr optionsClass = MetalNativeBindings.Classes.MTLCompileOptions;
+        if (optionsClass == IntPtr.Zero) return IntPtr.Zero;
+
+        IntPtr allocated = MetalNativeBindings.SendMessage(optionsClass, Selectors.Alloc);
+        if (allocated == IntPtr.Zero) return IntPtr.Zero;
+
+        IntPtr options = MetalNativeBindings.SendMessage(allocated, Selectors.Init);
+        if (options == IntPtr.Zero)
+        {
+            Release(allocated);
+            return IntPtr.Zero;
+        }
+
+        // MTLMathMode.safe == 0 on the runtimes that expose mathMode; fastMathEnabled = NO is the
+        // older spelling. IntPtr.Zero carries the 0 / NO argument in both cases.
+        if (MetalNativeBindings.SendMessageBool(options, Selectors.RespondsToSelector, Selectors.SetMathMode))
+        {
+            MetalNativeBindings.SendMessage(options, Selectors.SetMathMode, IntPtr.Zero);
+            return options;
+        }
+
+        if (MetalNativeBindings.SendMessageBool(options, Selectors.RespondsToSelector, Selectors.SetFastMathEnabled))
+        {
+            MetalNativeBindings.SendMessage(options, Selectors.SetFastMathEnabled, IntPtr.Zero);
+            return options;
+        }
+
+        // Neither spelling exists: strict floating point cannot be established on this runtime.
+        Release(options);
+        return IntPtr.Zero;
+    }
+
     public IntPtr CreateLibrary(string source, out string? error)
+        => CreateLibrary(source, IntPtr.Zero, out error);
+
+    public IntPtr CreateLibrary(string source, IntPtr compileOptions, out string? error)
     {
         ThrowIfDisposed();
         error = null;
@@ -392,7 +449,7 @@ public sealed class MetalDevice : IDisposable
         try
         {
             IntPtr errorPtr = IntPtr.Zero;
-            var library = MetalNativeBindings.SendMessageWithError(_device, Selectors.NewLibraryWithSource, sourceNS, IntPtr.Zero, ref errorPtr);
+            var library = MetalNativeBindings.SendMessageWithError(_device, Selectors.NewLibraryWithSource, sourceNS, compileOptions, ref errorPtr);
 
             if (library == IntPtr.Zero && errorPtr != IntPtr.Zero)
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -1564,8 +1564,8 @@ kernel void sum_reduce(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // Parallel reduction in shared memory
-    for (uint stride = group_size / 2; stride > 0; stride /= 2) {
-        if (lid < stride) {
+    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < group_size) {
             shared[lid] += shared[lid + stride];
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1596,8 +1596,8 @@ kernel void max_reduce(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = group_size / 2; stride > 0; stride /= 2) {
-        if (lid < stride) {
+    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < group_size) {
             shared[lid] = max(shared[lid], shared[lid + stride]);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1627,8 +1627,8 @@ kernel void min_reduce(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = group_size / 2; stride > 0; stride /= 2) {
-        if (lid < stride) {
+    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < group_size) {
             shared[lid] = min(shared[lid], shared[lid + stride]);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -2228,8 +2228,8 @@ kernel void dot_product_partial(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = group_size / 2; stride > 0; stride /= 2) {
-        if (lid < stride) {
+    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < group_size) {
             shared[lid] += shared[lid + stride];
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -4748,8 +4748,8 @@ kernel void dot_product(device const float* a [[buffer(0)]],
     }
     shared[lid] = sum;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgSize / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
+    for (uint s = (tgSize + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (lid < s && lid + s < tgSize) shared[lid] += shared[lid + s];
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
     if (lid == 0) output[tgId] = shared[0];
@@ -4766,8 +4766,8 @@ kernel void reduce_partial_sums(device const float* partials [[buffer(0)]],
     for (uint i = lid; i < count; i += tgSize) sum += partials[i];
     shared[lid] = sum;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = tgSize / 2; s > 0; s >>= 1) {
-        if (lid < s) shared[lid] += shared[lid + s];
+    for (uint s = (tgSize + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (lid < s && lid + s < tgSize) shared[lid] += shared[lid + s];
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
     if (lid == 0) output[0] = shared[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalKernels.cs
@@ -1564,8 +1564,8 @@ kernel void sum_reduce(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     // Parallel reduction in shared memory
-    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < group_size) {
+    for (uint stride_active = group_size, stride = (group_size + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             shared[lid] += shared[lid + stride];
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1596,8 +1596,8 @@ kernel void max_reduce(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < group_size) {
+    for (uint stride_active = group_size, stride = (group_size + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             shared[lid] = max(shared[lid], shared[lid + stride]);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -1627,8 +1627,8 @@ kernel void min_reduce(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < group_size) {
+    for (uint stride_active = group_size, stride = (group_size + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             shared[lid] = min(shared[lid], shared[lid + stride]);
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -2228,8 +2228,8 @@ kernel void dot_product_partial(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    for (uint stride = (group_size + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < group_size) {
+    for (uint stride_active = group_size, stride = (group_size + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             shared[lid] += shared[lid + stride];
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -4748,8 +4748,8 @@ kernel void dot_product(device const float* a [[buffer(0)]],
     }
     shared[lid] = sum;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = (tgSize + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (lid < s && lid + s < tgSize) shared[lid] += shared[lid + s];
+    for (uint s_active = tgSize, s = (tgSize + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (lid < s && lid + s < s_active) shared[lid] += shared[lid + s];
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
     if (lid == 0) output[tgId] = shared[0];
@@ -4766,8 +4766,8 @@ kernel void reduce_partial_sums(device const float* partials [[buffer(0)]],
     for (uint i = lid; i < count; i += tgSize) sum += partials[i];
     shared[lid] = sum;
     threadgroup_barrier(mem_flags::mem_threadgroup);
-    for (uint s = (tgSize + 1) / 2; s > 0; s = (s > 1) ? (s + 1) / 2 : 0) {
-        if (lid < s && lid + s < tgSize) shared[lid] += shared[lid + s];
+    for (uint s_active = tgSize, s = (tgSize + 1) / 2; s > 0; s_active = s, s = (s > 1) ? (s + 1) / 2 : 0) {
+        if (lid < s && lid + s < s_active) shared[lid] += shared[lid + s];
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
     if (lid == 0) output[0] = shared[0];

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalNativeBindings.cs
@@ -483,6 +483,17 @@ public static class MetalNativeBindings
         // General selectors
         public static readonly IntPtr Alloc = RegisterSelector("alloc");
         public static readonly IntPtr Init = RegisterSelector("init");
+
+        // Objective-C introspection, so a selector that a given macOS version does not implement is
+        // detected instead of raising an unrecognised-selector exception at runtime.
+        public static readonly IntPtr RespondsToSelector = RegisterSelector("respondsToSelector:");
+
+        // MTLCompileOptions.fastMathEnabled. Metal compiles with fast math ON by default, which
+        // permits reassociating float expressions — that silently invalidates compensated
+        // (two_sum / fma) arithmetic. Deprecated in newer Metal in favour of mathMode, so callers
+        // must check respondsToSelector: before using either.
+        public static readonly IntPtr SetFastMathEnabled = RegisterSelector("setFastMathEnabled:");
+        public static readonly IntPtr SetMathMode = RegisterSelector("setMathMode:");
         public static readonly IntPtr Release = RegisterSelector("release");
         public static readonly IntPtr Retain = RegisterSelector("retain");
         public static readonly IntPtr Autorelease = RegisterSelector("autorelease");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalShaderLibrary.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalShaderLibrary.cs
@@ -71,6 +71,19 @@ public sealed class MetalShaderLibrary : IDisposable
     /// <param name="source">Metal Shading Language source code.</param>
     /// <returns>The compiled library handle.</returns>
     public IntPtr CompileLibrary(string libraryName, string source)
+        => CompileLibrary(libraryName, source, requireStrictFloatingPoint: false);
+
+    /// <summary>
+    /// Compiles a library, optionally requiring that fast math be disabled.
+    /// </summary>
+    /// <param name="requireStrictFloatingPoint">
+    /// When true, the library is compiled with fast math off, and compilation FAILS CLOSED if this
+    /// runtime exposes no way to disable it. Kernels whose correctness depends on compensated
+    /// arithmetic must set this: under fast math the compiler may reassociate their compensation
+    /// terms to zero, which is silent and leaves the kernel quietly less accurate than its
+    /// CPU reference rather than visibly broken.
+    /// </param>
+    public IntPtr CompileLibrary(string libraryName, string source, bool requireStrictFloatingPoint)
     {
         ThrowIfDisposed();
 
@@ -98,7 +111,30 @@ public sealed class MetalShaderLibrary : IDisposable
                 return cached;
             }
 
-            var library = _device.CreateLibrary(source, out var error);
+            IntPtr compileOptions = IntPtr.Zero;
+            if (requireStrictFloatingPoint)
+            {
+                compileOptions = MetalDevice.TryCreateStrictFloatingPointOptions();
+                if (compileOptions == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to compile Metal library '{libraryName}': this runtime exposes no way "
+                        + "to disable fast math (neither setMathMode: nor setFastMathEnabled:), and this "
+                        + "library's numerics are only correct without it. Refusing to compile rather "
+                        + "than shipping silently reassociated arithmetic.");
+                }
+            }
+
+            IntPtr library;
+            string? error;
+            try
+            {
+                library = _device.CreateLibrary(source, compileOptions, out error);
+            }
+            finally
+            {
+                if (compileOptions != IntPtr.Zero) MetalNativeBindings.Release(compileOptions);
+            }
 
             if (library == IntPtr.Zero)
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
@@ -41,6 +41,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
         private readonly int _length;
+
+        /// <summary>Bytes this buffer holds on the device, for residency accounting.</summary>
+        private long ByteSize => (long)_length * sizeof(float);
         private bool _disposed;
 
         public IntPtr Handle => _buffer;
@@ -67,6 +70,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                 if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                     throw new InvalidOperationException($"Failed to create OpenCL buffer: {err}");
+
+                GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
             }
             finally
             {
@@ -92,6 +97,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                 throw new InvalidOperationException($"Failed to create OpenCL buffer: {err}");
+
+            GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
         }
 
         /// <summary>
@@ -173,6 +180,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_buffer != IntPtr.Zero)
             {
                 OpenClNativeBindings.ReleaseMemObject(_buffer);
+                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
                 _buffer = IntPtr.Zero;
             }
 
@@ -189,6 +197,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
         private readonly int _length;
+
+        /// <summary>Bytes this buffer holds on the device, for residency accounting.</summary>
+        private long ByteSize => (long)_length * 1;
         private bool _disposed;
 
         public IntPtr Handle => _buffer;
@@ -215,6 +226,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                 if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                     throw new InvalidOperationException($"Failed to create OpenCL byte buffer: {err}");
+
+                GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
             }
             finally
             {
@@ -240,6 +253,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                 throw new InvalidOperationException($"Failed to create OpenCL byte buffer: {err}");
+
+            GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
         }
 
         /// <summary>
@@ -323,6 +338,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_buffer != IntPtr.Zero)
             {
                 OpenClNativeBindings.ReleaseMemObject(_buffer);
+                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
                 _buffer = IntPtr.Zero;
             }
 
@@ -339,6 +355,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
         private readonly int _length;
+
+        /// <summary>Bytes this buffer holds on the device, for residency accounting.</summary>
+        private long ByteSize => (long)_length * sizeof(int);
         private bool _disposed;
 
         public IntPtr Handle => _buffer;
@@ -365,6 +384,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                 if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                     throw new InvalidOperationException($"Failed to create OpenCL int buffer: {err}");
+
+                GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
             }
             finally
             {
@@ -390,6 +411,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS || _buffer == IntPtr.Zero)
                 throw new InvalidOperationException($"Failed to create OpenCL int buffer: {err}");
+
+            GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
         }
 
         /// <summary>
@@ -440,6 +463,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_buffer != IntPtr.Zero)
             {
                 OpenClNativeBindings.ReleaseMemObject(_buffer);
+                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
                 _buffer = IntPtr.Zero;
             }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -513,7 +513,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
 
-                EndLaunch(_context.ProfilingCommandQueue);
+                // The enqueue created the event, so from here on WE own it. If the synchronise
+                // throws -- which is exactly what sync-launch mode exists to make happen at the
+                // faulting launch -- we never return, so the caller never receives the handle and
+                // can never release it. Release it before the exception leaves.
+                try
+                {
+                    EndLaunch(_context.ProfilingCommandQueue);
+                }
+                catch
+                {
+                    IntPtr orphaned = Marshal.ReadIntPtr(eventHandle);
+                    if (orphaned != IntPtr.Zero) OpenClNativeBindings.ReleaseEvent(orphaned);
+                    throw;
+                }
 
                 // Read the event pointer from the allocated memory
                 IntPtr eventPtr = Marshal.ReadIntPtr(eventHandle);
@@ -566,7 +579,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
 
-                EndLaunch(_context.ProfilingCommandQueue);
+                // The enqueue created the event, so from here on WE own it. If the synchronise
+                // throws -- which is exactly what sync-launch mode exists to make happen at the
+                // faulting launch -- we never return, so the caller never receives the handle and
+                // can never release it. Release it before the exception leaves.
+                try
+                {
+                    EndLaunch(_context.ProfilingCommandQueue);
+                }
+                catch
+                {
+                    IntPtr orphaned = Marshal.ReadIntPtr(eventHandle);
+                    if (orphaned != IntPtr.Zero) OpenClNativeBindings.ReleaseEvent(orphaned);
+                    throw;
+                }
 
                 return Marshal.ReadIntPtr(eventHandle);
             }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -354,6 +354,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
+
+            // Finish THIS queue, not the default one. Under AIDOTNET_GPU_SYNC_LAUNCHES the whole
+            // point is that a device fault is attributed to the launch that caused it; a path that
+            // enqueues and returns without finishing leaves its faults asynchronous and blames
+            // whatever synchronises next, which is the behaviour the flag exists to remove.
+            EndLaunch(commandQueue);
         }
 
         /// <summary>
@@ -396,6 +402,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
+
+            // Finish THIS queue, not the default one. Under AIDOTNET_GPU_SYNC_LAUNCHES the whole
+            // point is that a device fault is attributed to the launch that caused it; a path that
+            // enqueues and returns without finishing leaves its faults asynchronous and blames
+            // whatever synchronises next, which is the behaviour the flag exists to remove.
+            EndLaunch(commandQueue);
         }
 
         /// <summary>
@@ -442,6 +454,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
+
+            // Finish THIS queue, not the default one. Under AIDOTNET_GPU_SYNC_LAUNCHES the whole
+            // point is that a device fault is attributed to the launch that caused it; a path that
+            // enqueues and returns without finishing leaves its faults asynchronous and blames
+            // whatever synchronises next, which is the behaviour the flag exists to remove.
+            EndLaunch(commandQueue);
         }
 
         #endregion
@@ -495,6 +513,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
 
+                EndLaunch(_context.ProfilingCommandQueue);
+
                 // Read the event pointer from the allocated memory
                 IntPtr eventPtr = Marshal.ReadIntPtr(eventHandle);
                 return eventPtr;
@@ -545,6 +565,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
+
+                EndLaunch(_context.ProfilingCommandQueue);
 
                 return Marshal.ReadIntPtr(eventHandle);
             }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -14,6 +14,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
     {
         private IntPtr _kernel;
         private readonly DirectOpenClContext _context;
+        private readonly string _kernelName;
         private bool _disposed;
 
         public IntPtr Handle => _kernel;
@@ -21,6 +22,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public DirectOpenClKernel(DirectOpenClContext context, DirectOpenClProgram program, string kernelName)
         {
             _context = context;
+            _kernelName = kernelName;
 
             _kernel = OpenClNativeBindings.CreateKernel(program.Handle, kernelName, out int err);
             if (err != OpenClNativeBindings.CL_SUCCESS || _kernel == IntPtr.Zero)
@@ -120,6 +122,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         // while holding _submitLock and immediately before the matching enqueue.
         private void ApplyPendingArgsLocked()
         {
+            ThrowIfUnusable();
+
             var pending = _pendingArgs;
             if (pending == null) return;
 
@@ -185,6 +189,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// </summary>
         public void Execute1D(int globalSize, int localSize)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global size to multiple of local size
             int alignedGlobal = ((globalSize + localSize - 1) / localSize) * localSize;
@@ -218,6 +223,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// </summary>
         public void Execute2D(int globalSizeX, int globalSizeY, int localSizeX, int localSizeY)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global sizes to multiples of local sizes
             int alignedGlobalX = ((globalSizeX + localSizeX - 1) / localSizeX) * localSizeX;
@@ -252,6 +258,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// </summary>
         public void Execute3D(int globalSizeX, int globalSizeY, int globalSizeZ, int localSizeX, int localSizeY, int localSizeZ)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global sizes to multiples of local sizes
             int alignedGlobalX = ((globalSizeX + localSizeX - 1) / localSizeX) * localSizeX;
@@ -294,6 +301,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// <param name="localSize">The local work size.</param>
         public void Execute1DOnQueue(IntPtr commandQueue, int globalSize, int localSize)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global size to multiple of local size
             int alignedGlobal = ((globalSize + localSize - 1) / localSize) * localSize;
@@ -332,6 +340,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// <param name="localSizeY">The local work size in Y dimension.</param>
         public void Execute2DOnQueue(IntPtr commandQueue, int globalSizeX, int globalSizeY, int localSizeX, int localSizeY)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global sizes to multiples of local sizes
             int alignedGlobalX = ((globalSizeX + localSizeX - 1) / localSizeX) * localSizeX;
@@ -374,6 +383,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public void Execute3DOnQueue(IntPtr commandQueue, int globalSizeX, int globalSizeY, int globalSizeZ,
             int localSizeX, int localSizeY, int localSizeZ)
         {
+            ThrowIfUnusable();
             GpuLaunchProbe.OnLaunch();
             // Round up global sizes to multiples of local sizes
             int alignedGlobalX = ((globalSizeX + localSizeX - 1) / localSizeX) * localSizeX;
@@ -511,6 +521,27 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         #endregion
+
+        /// <summary>Refuses to launch a kernel whose handle has been released.</summary>
+        /// <remarks>
+        /// Dispose sets _kernel to IntPtr.Zero, and nothing on the launch path checked it, so a
+        /// kernel used after its backend was disposed handed NULL to clSetKernelArg. The OpenCL spec
+        /// says that returns CL_INVALID_KERNEL; drivers are not obliged to be careful about it, and
+        /// a dereference inside the runtime surfaces as an 0xC0000005 that kills the process with no
+        /// managed frame to blame. This turns that into a named, catchable failure that says which
+        /// kernel and can be attributed to a test.
+        /// </remarks>
+        private void ThrowIfUnusable()
+        {
+            if (_disposed || _kernel == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(
+                    nameof(DirectOpenClKernel),
+                    $"OpenCL kernel '{_kernelName}' was used after its handle was released. The "
+                        + "backend that owns it has been disposed while something still held a "
+                        + "reference to this kernel.");
+            }
+        }
 
         public void Dispose()
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -51,6 +51,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         // args at Execute time; Execute clears it.
         [ThreadStatic] private static System.Collections.Generic.List<PendingArg>? _pendingArgs;
 
+        /// <summary>Which kernel the thread's staged args belong to.</summary>
+        /// <remarks>
+        /// The pending list is per-thread but shared across every kernel, and it was cleared only on
+        /// the success path of Execute. So any throw between SetArg and Execute -- a guard rejecting
+        /// an argument, an enqueue failure, an abandoned call -- left those args staged, and the NEXT
+        /// kernel this thread executed applied them: another kernel's signature, at another kernel's
+        /// arg indices, carrying buffer handles that may since have been disposed. Passing a released
+        /// cl_mem to clSetKernelArg faults inside the driver, which is what an 0xC0000005 in
+        /// SetKernelArg looks like from managed code.
+        /// </remarks>
+        [ThreadStatic] private static DirectOpenClKernel? _pendingOwner;
+
         // Serializes the apply-args + enqueue critical section across ALL kernels
         // (the shared cl_kernel arg state and the shared command queue both require it).
         private static readonly object _submitLock = new object();
@@ -58,25 +70,51 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private static System.Collections.Generic.List<PendingArg> Pending
             => _pendingArgs ??= new System.Collections.Generic.List<PendingArg>(8);
 
+        /// <summary>Begins (or continues) staging for <paramref name="owner"/>, dropping any args
+        /// abandoned by a previous kernel on this thread.</summary>
+        private static System.Collections.Generic.List<PendingArg> Stage(DirectOpenClKernel owner, uint index)
+        {
+            var pending = Pending;
+
+            // Index 0 starts a launch sequence -- every launcher sets its arguments from 0 upwards
+            // -- so this is where a previous sequence's leftovers are dropped. That makes each
+            // launch self-cleaning even when the last one threw between SetArg and Execute, without
+            // depending on the clear at the end of Execute having been reached.
+            if (index == 0 || !ReferenceEquals(_pendingOwner, owner))
+            {
+                pending.Clear();
+                _pendingOwner = owner;
+            }
+
+            return pending;
+        }
+
+        /// <summary>Drops the thread's staged args; safe to call from a finally.</summary>
+        private static void DiscardPendingArgs()
+        {
+            _pendingArgs?.Clear();
+            _pendingOwner = null;
+        }
+
         #region SetArg Overloads
 
         public void SetArg(uint index, IntPtr bufferHandle)
-            => Pending.Add(new PendingArg(index, ArgKind.Buffer, (long)bufferHandle));
+            => Stage(this, index).Add(new PendingArg(index, ArgKind.Buffer, (long)bufferHandle));
 
         public void SetArg(uint index, int value)
-            => Pending.Add(new PendingArg(index, ArgKind.Int32, value));
+            => Stage(this, index).Add(new PendingArg(index, ArgKind.Int32, value));
 
         public void SetArg(uint index, float value)
-            => Pending.Add(new PendingArg(index, ArgKind.Float, BitConverter.ToInt32(BitConverter.GetBytes(value), 0)));
+            => Stage(this, index).Add(new PendingArg(index, ArgKind.Float, BitConverter.ToInt32(BitConverter.GetBytes(value), 0)));
 
         public void SetArg(uint index, ulong value)
-            => Pending.Add(new PendingArg(index, ArgKind.UInt64, unchecked((long)value)));
+            => Stage(this, index).Add(new PendingArg(index, ArgKind.UInt64, unchecked((long)value)));
 
         /// <summary>
         /// Sets a local memory argument (for shared memory allocation).
         /// </summary>
         public void SetLocalArg(uint index, int sizeInBytes)
-            => Pending.Add(new PendingArg(index, ArgKind.Local, sizeInBytes));
+            => Stage(this, index).Add(new PendingArg(index, ArgKind.Local, sizeInBytes));
 
         // Applies the per-thread pending args to the shared kernel. MUST be called
         // while holding _submitLock and immediately before the matching enqueue.
@@ -84,6 +122,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         {
             var pending = _pendingArgs;
             if (pending == null) return;
+
+            // Never apply args staged for a different kernel. Indices and sizes belong to that
+            // kernel's signature, not this one.
+            if (!ReferenceEquals(_pendingOwner, this))
+            {
+                pending.Clear();
+                return;
+            }
             for (int i = 0; i < pending.Count; i++)
             {
                 var a = pending[i];
@@ -160,7 +206,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -194,7 +240,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -229,7 +275,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -269,7 +315,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -308,7 +354,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -351,7 +397,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     0,
                     IntPtr.Zero,
                     IntPtr.Zero);
-                _pendingArgs?.Clear();
+                DiscardPendingArgs();
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -401,7 +447,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         0,
                         IntPtr.Zero,
                         eventHandle);
-                    _pendingArgs?.Clear();
+                    DiscardPendingArgs();
                 }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
@@ -450,7 +496,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                         0,
                         IntPtr.Zero,
                         eventHandle);
-                    _pendingArgs?.Clear();
+                    DiscardPendingArgs();
                 }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -193,6 +193,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GpuLaunchProbe.OnLaunch();
             // Round up global size to multiple of local size
             int alignedGlobal = ((globalSize + localSize - 1) / localSize) * localSize;
+            BeginLaunch(alignedGlobal, localSize);
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobal };
             var localSizes = new UIntPtr[] { (UIntPtr)localSize };
@@ -215,7 +216,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
-                throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
+            {
+                throw new InvalidOperationException(
+                    $"Failed to enqueue kernel '{_kernelName}': {err}. Recent launches, most recent "
+                        + "last: " + Environment.NewLine + GpuKernelDiagnostics.DescribeRecentLaunches());
+            }
+
+            EndLaunch();
         }
 
         /// <summary>
@@ -250,7 +257,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
-                throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
+            {
+                throw new InvalidOperationException(
+                    $"Failed to enqueue kernel '{_kernelName}': {err}. Recent launches, most recent "
+                        + "last: " + Environment.NewLine + GpuKernelDiagnostics.DescribeRecentLaunches());
+            }
+
+            EndLaunch();
         }
 
         /// <summary>
@@ -286,7 +299,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             }
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
-                throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
+            {
+                throw new InvalidOperationException(
+                    $"Failed to enqueue kernel '{_kernelName}': {err}. Recent launches, most recent "
+                        + "last: " + Environment.NewLine + GpuKernelDiagnostics.DescribeRecentLaunches());
+            }
+
+            EndLaunch();
         }
 
         #endregion
@@ -521,6 +540,60 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         #endregion
+
+        /// <summary>The kernel's own argument count, queried once. -1 when unavailable.</summary>
+        private int _declaredArgCount = -2;   // -2 = not yet queried, -1 = device would not say
+
+        private int DeclaredArgCount
+        {
+            get
+            {
+                if (_declaredArgCount == -2)
+                {
+                    _declaredArgCount = OpenClNativeBindings.GetKernelNumArgs(_kernel);
+                }
+
+                return _declaredArgCount;
+            }
+        }
+
+        /// <summary>
+        /// Validates the launch, records it in the diagnostics journal, and -- under
+        /// AIDOTNET_GPU_SYNC_LAUNCHES -- finishes the queue so an asynchronous fault is attributed
+        /// to THIS launch rather than to whatever synchronises next.
+        /// </summary>
+        private void BeginLaunch(long globalSize, long localSize)
+        {
+            int staged = _pendingArgs is null || !ReferenceEquals(_pendingOwner, this)
+                ? 0
+                : _pendingArgs.Count;
+
+            GpuKernelDiagnostics.ValidateLaunch(
+                _kernelName,
+                handleIsValid: !_disposed && _kernel != IntPtr.Zero,
+                stagedArgCount: staged,
+                declaredArgCount: DeclaredArgCount,
+                globalSize: globalSize,
+                localSize: localSize);
+
+            GpuKernelDiagnostics.RecordLaunch(_kernelName, globalSize, localSize, staged);
+        }
+
+        /// <summary>Finishes the queue when synchronous diagnostics are on, so a device fault is
+        /// reported against the launch that caused it.</summary>
+        private void EndLaunch()
+        {
+            if (!GpuKernelDiagnostics.SynchronousLaunches) return;
+
+            int err = OpenClNativeBindings.Finish(_context.CommandQueue);
+            if (err != OpenClNativeBindings.CL_SUCCESS)
+            {
+                throw new InvalidOperationException(
+                    $"GPU fault after launching '{_kernelName}' (clFinish returned {err}). Recent "
+                        + "launches, most recent last: " + Environment.NewLine
+                        + GpuKernelDiagnostics.DescribeRecentLaunches());
+            }
+        }
 
         /// <summary>Refuses to launch a kernel whose handle has been released.</summary>
         /// <remarks>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -193,10 +193,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GpuLaunchProbe.OnLaunch();
             // Round up global size to multiple of local size
             int alignedGlobal = ((globalSize + localSize - 1) / localSize) * localSize;
-            BeginLaunch(alignedGlobal, localSize);
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobal };
             var localSizes = new UIntPtr[] { (UIntPtr)localSize };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             int err;
             lock (_submitLock)
@@ -239,6 +240,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobalX, (UIntPtr)alignedGlobalY };
             var localSizes = new UIntPtr[] { (UIntPtr)localSizeX, (UIntPtr)localSizeY };
 
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
+
             int err;
             lock (_submitLock)
             {
@@ -280,6 +283,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobalX, (UIntPtr)alignedGlobalY, (UIntPtr)alignedGlobalZ };
             var localSizes = new UIntPtr[] { (UIntPtr)localSizeX, (UIntPtr)localSizeY, (UIntPtr)localSizeZ };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             int err;
             lock (_submitLock)
@@ -328,6 +333,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobal };
             var localSizes = new UIntPtr[] { (UIntPtr)localSize };
 
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
+
             int err;
             lock (_submitLock)
             {
@@ -367,6 +374,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobalX, (UIntPtr)alignedGlobalY };
             var localSizes = new UIntPtr[] { (UIntPtr)localSizeX, (UIntPtr)localSizeY };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             int err;
             lock (_submitLock)
@@ -411,6 +420,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobalX, (UIntPtr)alignedGlobalY, (UIntPtr)alignedGlobalZ };
             var localSizes = new UIntPtr[] { (UIntPtr)localSizeX, (UIntPtr)localSizeY, (UIntPtr)localSizeZ };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             int err;
             lock (_submitLock)
@@ -457,6 +468,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobalX, (UIntPtr)alignedGlobalY };
             var localSizes = new UIntPtr[] { (UIntPtr)localSizeX, (UIntPtr)localSizeY };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             // Allocate event handle
             IntPtr eventHandle = Marshal.AllocHGlobal(IntPtr.Size);
@@ -507,6 +520,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             var globalSizes = new UIntPtr[] { (UIntPtr)alignedGlobal };
             var localSizes = new UIntPtr[] { (UIntPtr)localSize };
+
+            BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
             IntPtr eventHandle = Marshal.AllocHGlobal(IntPtr.Size);
             try
@@ -581,11 +596,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         /// <summary>Finishes the queue when synchronous diagnostics are on, so a device fault is
         /// reported against the launch that caused it.</summary>
-        private void EndLaunch()
+        /// <summary>Work-item count across however many dimensions the launch uses.</summary>
+        private static long TotalOf(UIntPtr[] sizes)
+        {
+            long total = 1;
+            foreach (var size in sizes) total *= (long)(ulong)size;
+            return total;
+        }
+
+        private void EndLaunch() => EndLaunch(_context.CommandQueue);
+
+        /// <summary>
+        /// Finishes THE QUEUE THIS LAUNCH USED. The OnQueue and profiled paths submit to a different
+        /// queue than <c>_context.CommandQueue</c>, so finishing the default one would attribute a
+        /// fault to the wrong work — or miss it entirely.
+        /// </summary>
+        private void EndLaunch(IntPtr commandQueue)
         {
             if (!GpuKernelDiagnostics.SynchronousLaunches) return;
 
-            int err = OpenClNativeBindings.Finish(_context.CommandQueue);
+            int err = OpenClNativeBindings.Finish(commandQueue);
             if (err != OpenClNativeBindings.CL_SUCCESS)
             {
                 throw new InvalidOperationException(
@@ -617,6 +647,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         public void Dispose()
+        {
+            // Released under the SUBMIT LOCK. ThrowIfUnusable is otherwise a time-of-check to
+            // time-of-use window: a launch validates the handle, Dispose calls clReleaseKernel, and
+            // the launch then hands the released handle to clSetKernelArg. Taking the same lock the
+            // apply-and-enqueue critical section holds makes release and submission mutually
+            // exclusive, so a validated handle stays valid until its enqueue completes.
+            lock (_submitLock)
+            {
+                DisposeLocked();
+            }
+        }
+
+        private void DisposeLocked()
         {
             if (_disposed) return;
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/CategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/CategoricalKernels.cs
@@ -1,0 +1,100 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+
+/// <summary>
+/// OpenCL categorical sampling — the device counterpart of <c>CpuEngine.TensorCategoricalSample</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists so the op stops silently running on the CPU after the caller selected the GPU engine.
+/// <c>ICategoricalSamplingBackend</c> and <c>ISeededGumbelSoftmaxBackend</c> were implemented only by
+/// CUDA and Vulkan, so on OpenCL the engine had no device route and fell back — measured as 0 kernel
+/// launches against a required 1 in the GPU residency probe.
+/// </para>
+/// <para>
+/// BIT-EXACTNESS IS THE WHOLE POINT, because the parity test compares CPU and GPU one-hot outputs
+/// exactly and a single differing category is a hard mismatch. Three things therefore mirror the CPU
+/// implementation rather than merely resembling it:
+/// </para>
+/// <list type="number">
+/// <item>The uniform draw is <c>StatelessRandom.Uniform01(seed, row)</c> — the same PCG hash, the
+/// same three constants, the same 24-bit mantissa scaling. Keying on the ROW index (not draw order)
+/// is what lets a work-item compute its own uniform without replaying the rows before it.</item>
+/// <item>The sum and the cumulative walk accumulate in <c>double</c>, as the CPU does. In float the
+/// running total drifts, and a target sitting near a bucket edge selects the neighbouring category —
+/// correct-looking output, exact-parity failure. Devices without fp64 do not advertise this kernel
+/// and fall back to the CPU, which is the same convention the geometry kernels use.</item>
+/// <item>The comparison is <c>target &lt; cumulative</c> with the same category ordering and the same
+/// <c>classes - 1</c> default when floating-point drift leaves the target just past the final
+/// boundary.</item>
+/// </list>
+/// </remarks>
+internal static class CategoricalKernels
+{
+    /// <summary>Kernel names to register when the program compiles.</summary>
+    public static string[] GetKernelNames() => new[] { "CategoricalSample" };
+
+    public static string GetSource() => @"
+// double accumulation is required for exact CPU parity (see the C# remarks); a device without
+// fp64 fails to compile this program and the engine keeps using the managed reference.
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#elif defined(cl_amd_fp64)
+#pragma OPENCL EXTENSION cl_amd_fp64 : enable
+#endif
+
+// StatelessRandom.Uniform01(seed, index) — identical constants to the managed helper and to
+// GenerateRandomUniform in RandomKernels.
+inline float stateless_uniform01(uint seed32, uint index)
+{
+    uint state = index * 747796405u + seed32 + 2891336453u;
+    uint word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
+    uint sample = (word >> 22) ^ word;
+    return (float)(sample >> 8) * (1.0f / 16777216.0f);
+}
+
+__kernel void CategoricalSample(
+    __global const float* probabilities,
+    __global float* oneHot,
+    const int rows,
+    const int classes,
+    const ulong seed)
+{
+    int row = get_global_id(0);
+    if (row >= rows) return;
+
+    // The engine passes (ulong)(uint)seed, so the fold is a no-op there; it is kept so an
+    // unfolded 64-bit seed degrades the same way GenerateRandomUniform does.
+    uint seed32 = (uint)seed ^ (uint)(seed >> 32);
+    float uniform = stateless_uniform01(seed32, (uint)row);
+
+    int offset = row * classes;
+
+    double sum = 0.0;
+    for (int c = 0; c < classes; c++)
+    {
+        sum += (double)probabilities[offset + c];
+    }
+
+    double target = (double)uniform * sum;
+    double cumulative = 0.0;
+    int selected = classes - 1;
+    for (int c = 0; c < classes; c++)
+    {
+        cumulative += (double)probabilities[offset + c];
+        if (target < cumulative)
+        {
+            selected = c;
+            break;
+        }
+    }
+
+    for (int c = 0; c < classes; c++)
+    {
+        oneHot[offset + c] = 0.0f;
+    }
+
+    oneHot[offset + selected] = 1.0f;
+}
+";
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/CategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/CategoricalKernels.cs
@@ -32,7 +32,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
 internal static class CategoricalKernels
 {
     /// <summary>Kernel names to register when the program compiles.</summary>
-    public static string[] GetKernelNames() => new[] { "CategoricalSample" };
+    public static string[] GetKernelNames() => new[] { "categorical_sample" };
 
     public static string GetSource() => @"
 // double accumulation is required for exact CPU parity (see the C# remarks); a device without
@@ -53,7 +53,7 @@ inline float stateless_uniform01(uint seed32, uint index)
     return (float)(sample >> 8) * (1.0f / 16777216.0f);
 }
 
-__kernel void CategoricalSample(
+__kernel void categorical_sample(
     __global const float* probabilities,
     __global float* oneHot,
     const int rows,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MeshPoolKernels.cs
@@ -193,8 +193,8 @@ __kernel void mesh_pool_softmax_find_max(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -226,8 +226,8 @@ __kernel void mesh_pool_softmax_final_max(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -270,8 +270,8 @@ __kernel void mesh_pool_softmax_exp_sum(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -299,8 +299,8 @@ __kernel void mesh_pool_softmax_final_sum(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -347,8 +347,8 @@ __kernel void mesh_pool_softmax_scores(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -369,8 +369,8 @@ __kernel void mesh_pool_softmax_scores(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (lid < stride && lid + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < stride_active) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MeshPoolKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/MeshPoolKernels.cs
@@ -190,8 +190,11 @@ __kernel void mesh_pool_softmax_find_max(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Parallel reduction within work-group
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -220,8 +223,11 @@ __kernel void mesh_pool_softmax_final_max(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Parallel reduction
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -261,8 +267,11 @@ __kernel void mesh_pool_softmax_exp_sum(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Parallel sum reduction within work-group
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -287,8 +296,11 @@ __kernel void mesh_pool_softmax_final_sum(
     scratch[lid] = val;
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -332,8 +344,11 @@ __kernel void mesh_pool_softmax_scores(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Step 1: Find max using parallel reduction
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] = fmax(scratch[lid], scratch[lid + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -351,8 +366,11 @@ __kernel void mesh_pool_softmax_scores(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Sum reduction
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (lid < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (lid < stride && lid + stride < localSize) {
             scratch[lid] += scratch[lid + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ReductionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ReductionKernels.cs
@@ -39,8 +39,11 @@ __kernel void reduce_sum(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Tree reduction in local memory
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (localIdx < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < localSize) {
             scratch[localIdx] += scratch[localIdx + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -69,8 +72,11 @@ __kernel void reduce_max(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Tree reduction in local memory
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (localIdx < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < localSize) {
             scratch[localIdx] = fmax(scratch[localIdx], scratch[localIdx + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -99,8 +105,11 @@ __kernel void reduce_min(
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // Tree reduction in local memory
-    for (int stride = localSize / 2; stride > 0; stride >>= 1) {
-        if (localIdx < stride) {
+    // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+        // power of two (the host clamps it to the element count), and the classic
+        // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < localSize) {
             scratch[localIdx] = fmin(scratch[localIdx], scratch[localIdx + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ReductionKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/Kernels/ReductionKernels.cs
@@ -42,8 +42,8 @@ __kernel void reduce_sum(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (localIdx < stride && localIdx + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < stride_active) {
             scratch[localIdx] += scratch[localIdx + stride];
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -75,8 +75,8 @@ __kernel void reduce_max(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (localIdx < stride && localIdx + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < stride_active) {
             scratch[localIdx] = fmax(scratch[localIdx], scratch[localIdx + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -108,8 +108,8 @@ __kernel void reduce_min(
     // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
         // power of two (the host clamps it to the element count), and the classic
         // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-        for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-        if (localIdx < stride && localIdx + stride < localSize) {
+        for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+        if (localIdx < stride && localIdx + stride < stride_active) {
             scratch[localIdx] = fmin(scratch[localIdx], scratch[localIdx + stride]);
         }
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
@@ -1,0 +1,66 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// OpenCL launcher for categorical sampling. Mirrors OpenClBackend.Ann.cs's pattern: pull the
+// compiled DirectOpenClKernel from _kernelCache and dispatch via kernel.Execute1D.
+#if !NET462
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    /// <summary>
+    /// Gives OpenCL a device route for <c>TensorCategoricalSample</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ICategoricalSamplingBackend</c> was implemented by CUDA only and
+    /// <c>ISeededGumbelSoftmaxBackend</c> likewise, with <c>IGpuBatchExecution</c> on Vulkan — so on
+    /// OpenCL the engine had no device route at all and quietly ran the op on the CPU after the
+    /// caller had selected the GPU engine. The residency probe measured it as 0 kernel launches
+    /// against a required 1.
+    /// </para>
+    /// <para>
+    /// Availability is decided by whether the program COMPILED, not by parsing device extension
+    /// strings. The kernel needs fp64 for exact CPU parity, and asking the device whether it
+    /// compiles is both simpler and more honest than predicting it — a device that advertises
+    /// <c>cl_khr_fp64</c> but rejects the program would otherwise be claimed as supported and then
+    /// throw at dispatch.
+    /// </para>
+    /// </remarks>
+    public sealed partial class OpenClBackend : ICategoricalSamplingBackend
+    {
+        /// <summary>Set during initialization when the categorical program compiled and registered.</summary>
+        private bool _categoricalKernelReady;
+
+        /// <inheritdoc/>
+        public bool CanCategoricalSample(int rows, int classes)
+            => _categoricalKernelReady
+               && _context is not null
+               && rows > 0
+               && classes > 0
+               // One work-item per row; a row wider than this is still correct but the serial walk
+               // over classes stops being the right shape for a GPU and the CPU reference is faster.
+               && (long)rows * classes <= int.MaxValue;
+
+        /// <inheritdoc/>
+        public bool TryCategoricalSample(
+            IGpuBuffer probabilities,
+            IGpuBuffer oneHot,
+            int rows,
+            int classes,
+            ulong seed)
+        {
+            if (!CanCategoricalSample(rows, classes)) return false;
+            if (probabilities is not DirectOpenClGpuBuffer source) return false;
+            if (oneHot is not DirectOpenClGpuBuffer destination) return false;
+            if (!_kernelCache.TryGetValue("CategoricalSample", out var kernel)) return false;
+
+            kernel.SetArg(0, source.Buffer.Handle);
+            kernel.SetArg(1, destination.Buffer.Handle);
+            kernel.SetArg(2, rows);
+            kernel.SetArg(3, classes);
+            kernel.SetArg(4, seed);
+            kernel.Execute1D(rows, Math.Min(256, rows));
+            return true;
+        }
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
@@ -53,6 +53,22 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (oneHot is not DirectOpenClGpuBuffer destination) return false;
             if (!_kernelCache.TryGetValue("categorical_sample", out var kernel)) return false;
 
+            // Both buffers are indexed as row * classes + c, so both must actually hold that many
+            // elements. CanCategoricalSample only checks the DIMENSIONS; an undersized buffer would
+            // be written past its end on the device, which corrupts whatever is next in device
+            // memory and is reported, if at all, by some unrelated later operation.
+            long addressed = (long)rows * classes;
+            GpuKernelDiagnostics.ValidateCapacity(
+                "categorical_sample", nameof(probabilities), source.Buffer.Length, addressed);
+            GpuKernelDiagnostics.ValidateCapacity(
+                "categorical_sample", nameof(oneHot), destination.Buffer.Length, addressed);
+
+            if (source.Buffer.Length < addressed || destination.Buffer.Length < addressed)
+            {
+                // Even with deep checks off, refuse rather than launch an out-of-range write.
+                return false;
+            }
+
             kernel.SetArg(0, source.Buffer.Handle);
             kernel.SetArg(1, destination.Buffer.Handle);
             kernel.SetArg(2, rows);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Categorical.cs
@@ -51,7 +51,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!CanCategoricalSample(rows, classes)) return false;
             if (probabilities is not DirectOpenClGpuBuffer source) return false;
             if (oneHot is not DirectOpenClGpuBuffer destination) return false;
-            if (!_kernelCache.TryGetValue("CategoricalSample", out var kernel)) return false;
+            if (!_kernelCache.TryGetValue("categorical_sample", out var kernel)) return false;
 
             kernel.SetArg(0, source.Buffer.Handle);
             kernel.SetArg(1, destination.Buffer.Handle);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -559,8 +559,16 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 // whole random program and taking GenerateRandomUniform down with it.
                 try
                 {
+                    // SafeMathFlags, NOT optimizationFlags. The latter enables
+                    // -cl-fast-relaxed-math / -cl-unsafe-math-optimizations, which permit the
+                    // compiler to reassociate floating-point arithmetic. This kernel's whole point is
+                    // an ORDERED double accumulation that reproduces the CPU's inverse-CDF walk
+                    // exactly; reassociating `sum` or `cumulative` moves the boundary and selects a
+                    // different category, which the exact-parity test reads as a hard mismatch.
                     var categoricalProgram = CompileOrLoadCached(
-                        Kernels.CategoricalKernels.GetSource(), optimizationFlags, "Categorical sampling kernels");
+                        Kernels.CategoricalKernels.GetSource(),
+                        OpenClBuildOptions.SafeMathFlags,
+                        "Categorical sampling kernels");
                     _programs.Add(categoricalProgram);
                     foreach (var name in Kernels.CategoricalKernels.GetKernelNames())
                     {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -553,6 +553,28 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     _kernelCache[name] = new DirectOpenClKernel(_context, randomProgram, name);
                 }
 
+                // Compile categorical sampling. Isolated in its own program because it needs fp64 for
+                // exact CPU parity: a device without fp64 fails HERE, leaving _categoricalKernelReady
+                // false so the engine keeps using the managed reference, rather than failing the
+                // whole random program and taking GenerateRandomUniform down with it.
+                try
+                {
+                    var categoricalProgram = CompileOrLoadCached(
+                        Kernels.CategoricalKernels.GetSource(), optimizationFlags, "Categorical sampling kernels");
+                    _programs.Add(categoricalProgram);
+                    foreach (var name in Kernels.CategoricalKernels.GetKernelNames())
+                    {
+                        _kernelCache[name] = new DirectOpenClKernel(_context, categoricalProgram, name);
+                    }
+
+                    _categoricalKernelReady = true;
+                }
+                catch (Exception)
+                {
+                    // No fp64 (or the device rejected the program): stay on the CPU reference.
+                    _categoricalKernelReady = false;
+                }
+
                 // Compile specialized kernels (hyperbolic geometry, octonion algebra, quantum computing)
                 var specializedProgram = CompileOrLoadCached(SpecializedKernels.GetSource(), optimizationFlags, "Specialized kernels");
                 _programs.Add(specializedProgram);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -4041,7 +4041,17 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 writeA = !writeA;
             }
 
-            var result = new float[1];
+            // Sized to the BUFFER, not to the one value being read. The final buffer is whichever
+            // scratch the last pass wrote, and its capacity is the first pass's partial count -- not
+            // one. CopyToHost validates the destination against the whole buffer, so downloading
+            // into float[1] threw "Destination array too small" for any input needing more than one
+            // partial (1025 elements at a local size of 256 gives 5). That was unreachable until the
+            // reductions started returning the right answer for shorter inputs, so it sat behind the
+            // non-power-of-two tail bug rather than beside it.
+            int downloadLength = current is DirectOpenClGpuBuffer resultBuffer
+                ? Math.Max(1, resultBuffer.Buffer.Length)
+                : 1;
+            var result = new float[downloadLength];
             DownloadBuffer(current, result);
             return result[0];
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) AiDotNet. All rights reserved.
+// Copyright (c) AiDotNet. All rights reserved.
 // OpenCL backend using pure P/Invoke - no managed GPU runtime dependency.
 // Works on ALL .NET versions including .NET Framework 4.6.2.
 
@@ -109,7 +109,21 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private ClBlastXgemmDirectParameters _clblastDirectParams;
         private int _clblastMinIndirectSize;
 
-        public bool IsAvailable { get; }
+        private bool _isAvailable;
+
+        /// <summary>
+        /// Whether this backend can serve work. FALSE ONCE DISPOSED, which is load-bearing:
+        /// DirectGpuBackendFactory caches one backend per process and hands the cached instance back
+        /// while it reports available. Dispose() clears the kernel cache, so a disposed-but-still-cached
+        /// backend answers every later kernel lookup with KeyNotFoundException ("add_vectors") on a
+        /// completely unrelated caller. Reporting unavailable makes the factory build a fresh backend
+        /// instead. VulkanBackend and MetalBackend already did this; these three did not.
+        /// </summary>
+        public bool IsAvailable
+        {
+            get => _isAvailable && !_disposed;
+            private set => _isAvailable = value;
+        }
         public string? InitializationError { get; private set; }
         public string BackendName => "OpenCL";
         public TensorDevice DeviceType => TensorDevice.OpenCL;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -13606,6 +13606,14 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_disposed) return;
 
+            // FAIL CLOSED FIRST. IsAvailable reads !_disposed, and teardown below disposes the
+            // dynamic GEMM, the buffer pool, every cached kernel and program, and the context. Set
+            // last, this flag would leave a window -- one that grows with the number of compiled
+            // kernels -- where a concurrent caller holding the process-wide cached backend still
+            // sees IsAvailable == true while _kernelCache is being cleared, and hits exactly the
+            // KeyNotFoundException this guard exists to prevent.
+            _disposed = true;
+
             _dynamicGemm?.Dispose();
             _bufferPool.Dispose();
 
@@ -13631,7 +13639,6 @@ KERNEL VARIANTS (A/B testing):
             _programs.Clear();
 
             _context?.Dispose();
-            _disposed = true;
         }
 
     public void ReduceMean(IGpuBuffer i, IGpuBuffer o, int sz) { ExecuteActivation("reduce_mean", i, o, sz); }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
@@ -344,8 +344,8 @@ internal static class OpenClKernelSources
             // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
                 // power of two (the host clamps it to the element count), and the classic
                 // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-                for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-                if (localId < stride && localId + stride < localSize) {
+                for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+                if (localId < stride && localId + stride < stride_active) {
                     maxReduce[localId] = fmax(maxReduce[localId], maxReduce[localId + stride]);
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);
@@ -370,8 +370,8 @@ internal static class OpenClKernelSources
             // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
                 // power of two (the host clamps it to the element count), and the classic
                 // stride = localSize / 2 tree silently drops the LAST element when it is odd.
-                for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
-                if (localId < stride && localId + stride < localSize) {
+                for (int stride_active = localSize, stride = (localSize + 1) / 2; stride > 0; stride_active = stride, stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+                if (localId < stride && localId + stride < stride_active) {
                     sumReduce[localId] += sumReduce[localId + stride];
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClKernelSources.cs
@@ -341,8 +341,11 @@ internal static class OpenClKernelSources
             maxReduce[localId] = localMax;
             barrier(CLK_LOCAL_MEM_FENCE);
 
-            for (int stride = localSize / 2; stride > 0; stride /= 2) {
-                if (localId < stride) {
+            // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+                // power of two (the host clamps it to the element count), and the classic
+                // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+                for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+                if (localId < stride && localId + stride < localSize) {
                     maxReduce[localId] = fmax(maxReduce[localId], maxReduce[localId + stride]);
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);
@@ -364,8 +367,11 @@ internal static class OpenClKernelSources
             sumReduce[localId] = localSum;
             barrier(CLK_LOCAL_MEM_FENCE);
 
-            for (int stride = localSize / 2; stride > 0; stride /= 2) {
-                if (localId < stride) {
+            // Ceil-halving with an explicit partner bound: localSize is NOT guaranteed to be a
+                // power of two (the host clamps it to the element count), and the classic
+                // stride = localSize / 2 tree silently drops the LAST element when it is odd.
+                for (int stride = (localSize + 1) / 2; stride > 0; stride = (stride > 1) ? (stride + 1) / 2 : 0) {
+                if (localId < stride && localId + stride < localSize) {
                     sumReduce[localId] += sumReduce[localId + stride];
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
@@ -108,6 +108,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         #region Kernel Info
 
         public const uint CL_KERNEL_WORK_GROUP_SIZE = 0x11B0;
+
+        /// <summary>clGetKernelInfo: the number of arguments the kernel declares.</summary>
+        public const uint CL_KERNEL_NUM_ARGS = 0x1191;
         public const uint CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE = 0x11B3;
 
         #endregion
@@ -382,6 +385,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             IntPtr eventWaitList,
             IntPtr eventOut);
 
+        [DllImport(OpenClLibrary, EntryPoint = "clGetKernelInfo")]
+        public static extern int GetKernelInfo(
+            IntPtr kernel,
+            uint paramName,
+            UIntPtr paramValueSize,
+            IntPtr paramValue,
+            out UIntPtr paramValueSizeRet);
+
         [DllImport(OpenClLibrary, EntryPoint = "clGetKernelWorkGroupInfo")]
         public static extern int GetKernelWorkGroupInfo(
             IntPtr kernel,
@@ -575,6 +586,34 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         /// <summary>
         /// Gets a size_t kernel work group info value.
         /// </summary>
+        /// <summary>
+        /// The argument count the kernel declares, or -1 when the device will not report it.
+        /// </summary>
+        /// <remarks>
+        /// Used to catch a launch whose staged arguments disagree with the kernel's signature, which
+        /// otherwise runs with whatever the previous launch left in the unset slots.
+        /// </remarks>
+        public static int GetKernelNumArgs(IntPtr kernel)
+        {
+            if (kernel == IntPtr.Zero) return -1;
+
+            IntPtr buffer = Marshal.AllocHGlobal(sizeof(uint));
+            try
+            {
+                int err = GetKernelInfo(kernel, CL_KERNEL_NUM_ARGS, (UIntPtr)sizeof(uint), buffer, out _);
+                if (err != CL_SUCCESS) return -1;
+                return Marshal.ReadInt32(buffer);
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return -1;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
         public static UIntPtr GetKernelWorkGroupInfoSizeT(IntPtr kernel, IntPtr device, uint paramName)
         {
             int ptrSize = IntPtr.Size;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// Vulkan launcher for categorical sampling. Dispatches the GLSL twin of the OpenCL
+// categorical_sample kernel through the same GlslUnaryOp path the other softmax-family ops use.
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+
+/// <summary>
+/// Gives Vulkan a device route for <c>TensorCategoricalSample</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the op fell back to the CPU after the caller had explicitly selected the Vulkan
+/// engine — correct output, but measured by the residency probe as 0 kernel launches against a
+/// required 1, which is a portability bug rather than an optimisation gap.
+/// </para>
+/// <para>
+/// AVAILABILITY IS DECIDED BY WHETHER THE SHADER RAN, not by parsing device feature strings. The
+/// kernel accumulates in <c>double</c> for exact CPU parity, which requires the device to support
+/// <c>shaderFloat64</c>; a device that lacks it fails pipeline creation, and the first failure
+/// latches this route off so the engine keeps using the managed reference instead of retrying a
+/// compile that cannot succeed. Sampling at lower precision would be worse than falling back: the
+/// parity test compares one-hot outputs exactly, and a target near a bucket edge would select the
+/// neighbouring category.
+/// </para>
+/// </remarks>
+public sealed partial class VulkanBackend : ICategoricalSamplingBackend
+{
+    /// <summary>0 = not yet attempted, 1 = dispatched successfully, 2 = unsupported on this device.</summary>
+    private int _categoricalState;
+
+    /// <inheritdoc/>
+    public bool CanCategoricalSample(int rows, int classes)
+        => _categoricalState != 2
+           && rows > 0
+           && classes > 0
+           // One invocation per row; a row wider than this is still correct but the serial walk over
+           // classes stops being the right shape for a GPU and the CPU reference is faster.
+           && (long)rows * classes <= int.MaxValue;
+
+    /// <inheritdoc/>
+    public bool TryCategoricalSample(
+        IGpuBuffer probabilities,
+        IGpuBuffer oneHot,
+        int rows,
+        int classes,
+        ulong seed)
+    {
+        if (!CanCategoricalSample(rows, classes)) return false;
+        if (probabilities is null || oneHot is null) return false;
+
+        // Both buffers are indexed as row * classes + c, so both must actually hold that many
+        // elements. CanCategoricalSample only checks the DIMENSIONS; an undersized buffer would be
+        // written past its end on the device, which corrupts whatever is next in device memory and
+        // is reported, if at all, by some unrelated later operation.
+        long addressed = (long)rows * classes;
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(probabilities), probabilities.Size, addressed);
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(oneHot), oneHot.Size, addressed);
+
+        if (probabilities.Size < addressed || oneHot.Size < addressed)
+        {
+            // Even with deep checks off, refuse rather than launch an out-of-range write.
+            return false;
+        }
+
+        try
+        {
+            GlslUnaryOp(
+                VulkanGlslKernels.CategoricalSampleGlsl,
+                probabilities,
+                oneHot,
+                rows,
+                new uint[] { (uint)rows, (uint)classes, (uint)(seed & 0xFFFFFFFF), (uint)(seed >> 32) },
+                4 * sizeof(uint));
+        }
+        catch (Exception)
+        {
+            // Broad by intent, and latched. The realistic failure here is a device without
+            // shaderFloat64 rejecting the pipeline, which is a capability answer rather than an
+            // error to propagate: the engine's contract for Try* is "false means use the CPU
+            // reference". Latching also stops a per-call compile attempt that can never succeed
+            // from being paid on every sample.
+            _categoricalState = 2;
+            return false;
+        }
+
+        _categoricalState = 1;
+        return true;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
@@ -82,14 +82,24 @@ public sealed partial class VulkanBackend : ICategoricalSamplingBackend
                 new uint[] { (uint)rows, (uint)classes, (uint)(seed & 0xFFFFFFFF), (uint)(seed >> 32) },
                 4 * sizeof(uint));
         }
-        catch (Exception)
+        catch (InvalidOperationException ex)
         {
-            // Broad by intent, and latched. The realistic failure here is a device without
-            // shaderFloat64 rejecting the pipeline, which is a capability answer rather than an
-            // error to propagate: the engine's contract for Try* is "false means use the CPU
-            // reference". Latching also stops a per-call compile attempt that can never succeed
-            // from being paid on every sample.
+            // NARROW BY INTENT. GlslUnaryOp reports an unavailable pipeline as exactly this, which is
+            // what a device without shaderFloat64 — or a host without libshaderc — produces for this
+            // kernel. That is a capability answer, so it is latched: retrying a compile that cannot
+            // succeed on every sample is pure cost. EVERY OTHER EXCEPTION PROPAGATES. A transient
+            // dispatch failure is not evidence about the device, and permanently marking the backend
+            // unsupported because of one is how a recoverable error becomes a silent downgrade.
+            //
+            // Returning false rather than throwing is deliberate and is NOT a host fallback:
+            // VulkanBackend implements IGpuBatchExecution, so TensorCategoricalSample routes to the
+            // Gumbel-max identity ON THE DEVICE. Throwing would remove a working device route
+            // instead of protecting one. (The engine does throw NotSupportedException if Try* returns
+            // false after Can* has already claimed support, so a false claim is never silent.)
             _categoricalState = 2;
+            System.Diagnostics.Debug.WriteLine(
+                $"[VulkanBackend] Categorical sampling unavailable on this device ({ex.Message}). "
+                + "Routing TensorCategoricalSample to the on-device Gumbel-max path.");
             return false;
         }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
@@ -23,6 +23,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 /// parity test compares one-hot outputs exactly, and a target near a bucket edge would select the
 /// neighbouring category.
 /// </para>
+/// <para>
+/// NOT EXECUTED IN VERIFICATION: this host has the Vulkan loader but no usable Vulkan compute path
+/// (every Vulkan test skips with "Vulkan not available on this system"), so this route is verified
+/// to compile but its output has NOT been observed against the CPU oracle. Unlike the Metal and
+/// WebGpu ports it is at least algorithmically identical to the verified OpenCL kernel, double
+/// accumulation included, rather than a precision-adapted rewrite.
+/// </para>
 /// </remarks>
 public sealed partial class VulkanBackend : ICategoricalSamplingBackend
 {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
@@ -34,7 +34,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 /// </remarks>
 public sealed partial class VulkanBackend : ICategoricalSamplingBackend
 {
-    /// <summary>0 = not yet attempted, 1 = dispatched successfully, 2 = unsupported on this device.</summary>
+    // Named rather than literal: the shader's binding layout and push-constant block are a contract
+    // with VulkanGlslKernels.CategoricalSampleGlsl, and a layout change has to update ONE definition
+    // here rather than four call sites that happen to say 2 and 16.
+
+    /// <summary>Storage bindings the shader declares: probabilities in, one-hot out.</summary>
+    private const int CategoricalBufferCount = 2;
+
+    /// <summary>Push-constant block: rows, classes, seedLo, seedHi.</summary>
+    private const uint CategoricalPushConstantBytes = 4 * sizeof(uint);
+
+    /// <summary>Capability not yet probed on this device.</summary>
+    private const int CategoricalUnprobed = 0;
+
+    /// <summary>The pipeline built, so the device can run this kernel.</summary>
+    private const int CategoricalSupported = 1;
+
+    /// <summary>The pipeline could not be built (no shaderFloat64, or no libshaderc).</summary>
+    private const int CategoricalUnsupported = 2;
+
+    /// <summary>Latched capability: see the Categorical* constants above.</summary>
     private int _categoricalState;
 
     /// <inheritdoc/>
@@ -61,23 +80,27 @@ public sealed partial class VulkanBackend : ICategoricalSamplingBackend
     private bool CategoricalPipelineIsAvailable()
     {
         int state = Volatile.Read(ref _categoricalState);
-        if (state != 0) return state == 1;
+        if (state != CategoricalUnprobed) return state == CategoricalSupported;
 
         try
         {
             EnsureInitialized();
             var pipeline = GetOrCreateGlslPipeline(
-                VulkanGlslKernels.CategoricalSampleGlsl, 2, 4 * sizeof(uint));
-            Volatile.Write(ref _categoricalState, pipeline is null ? 2 : 1);
+                VulkanGlslKernels.CategoricalSampleGlsl,
+                CategoricalBufferCount,
+                CategoricalPushConstantBytes);
+            Volatile.Write(
+                ref _categoricalState,
+                pipeline is null ? CategoricalUnsupported : CategoricalSupported);
         }
         catch (InvalidOperationException)
         {
             // The pipeline could not be built on this device -- the shaderFloat64 answer. Latched so
             // a compile that cannot succeed is not retried on every call. Other exceptions propagate.
-            Volatile.Write(ref _categoricalState, 2);
+            Volatile.Write(ref _categoricalState, CategoricalUnsupported);
         }
 
-        return Volatile.Read(ref _categoricalState) == 1;
+        return Volatile.Read(ref _categoricalState) == CategoricalSupported;
     }
 
     /// <inheritdoc/>
@@ -115,7 +138,7 @@ public sealed partial class VulkanBackend : ICategoricalSamplingBackend
                 oneHot,
                 rows,
                 new uint[] { (uint)rows, (uint)classes, (uint)(seed & 0xFFFFFFFF), (uint)(seed >> 32) },
-                4 * sizeof(uint));
+                CategoricalPushConstantBytes);
         }
         catch (InvalidOperationException ex)
         {
@@ -131,14 +154,14 @@ public sealed partial class VulkanBackend : ICategoricalSamplingBackend
             // Gumbel-max identity ON THE DEVICE. Throwing would remove a working device route
             // instead of protecting one. (The engine does throw NotSupportedException if Try* returns
             // false after Can* has already claimed support, so a false claim is never silent.)
-            _categoricalState = 2;
+            _categoricalState = CategoricalUnsupported;
             System.Diagnostics.Debug.WriteLine(
                 $"[VulkanBackend] Categorical sampling unavailable on this device ({ex.Message}). "
                 + "Routing TensorCategoricalSample to the on-device Gumbel-max path.");
             return false;
         }
 
-        _categoricalState = 1;
+        _categoricalState = CategoricalSupported;
         return true;
     }
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.Categorical.cs
@@ -2,6 +2,7 @@
 // Vulkan launcher for categorical sampling. Dispatches the GLSL twin of the OpenCL
 // categorical_sample kernel through the same GlslUnaryOp path the other softmax-family ops use.
 using System;
+using System.Threading;
 
 namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 
@@ -38,12 +39,46 @@ public sealed partial class VulkanBackend : ICategoricalSamplingBackend
 
     /// <inheritdoc/>
     public bool CanCategoricalSample(int rows, int classes)
-        => _categoricalState != 2
-           && rows > 0
+        => rows > 0
            && classes > 0
            // One invocation per row; a row wider than this is still correct but the serial walk over
            // classes stops being the right shape for a GPU and the CPU reference is faster.
-           && (long)rows * classes <= int.MaxValue;
+           && (long)rows * classes <= int.MaxValue
+           && CategoricalPipelineIsAvailable();
+
+    /// <summary>
+    /// Answers the capability question BEFORE the engine commits to this route. Probed once, latched.
+    /// </summary>
+    /// <remarks>
+    /// A `Can* then Try*` split only degrades gracefully if Can* is honest. The engine calls Can*,
+    /// and on a true answer schedules the op inside DispatchDeferredGpuOp, where a Try* returning
+    /// false is turned into a NotSupportedException -- it does NOT fall through to the on-device
+    /// Gumbel-max route. So claiming support and discovering the truth inside Try* makes the FIRST
+    /// sample on a device without shaderFloat64 throw, and only later ones degrade. Creating the
+    /// pipeline here settles it before any claim is made; GetOrCreateGlslPipeline caches the result,
+    /// so the real launch does not pay for it twice.
+    /// </remarks>
+    private bool CategoricalPipelineIsAvailable()
+    {
+        int state = Volatile.Read(ref _categoricalState);
+        if (state != 0) return state == 1;
+
+        try
+        {
+            EnsureInitialized();
+            var pipeline = GetOrCreateGlslPipeline(
+                VulkanGlslKernels.CategoricalSampleGlsl, 2, 4 * sizeof(uint));
+            Volatile.Write(ref _categoricalState, pipeline is null ? 2 : 1);
+        }
+        catch (InvalidOperationException)
+        {
+            // The pipeline could not be built on this device -- the shaderFloat64 answer. Latched so
+            // a compile that cannot succeed is not retried on every call. Other exceptions propagate.
+            Volatile.Write(ref _categoricalState, 2);
+        }
+
+        return Volatile.Read(ref _categoricalState) == 1;
+    }
 
     /// <inheritdoc/>
     public bool TryCategoricalSample(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanGlslKernels.cs
@@ -1959,6 +1959,54 @@ void main() {
     for (uint j = 0; j < innerSize; j++) b[base_idx + j] /= (sum_exp + 1e-10);
 }";
 
+    /// <summary>
+    /// Categorical sampling — the Vulkan twin of the OpenCL <c>categorical_sample</c> kernel and of
+    /// <c>CpuEngine.TensorCategoricalSample</c>.
+    /// </summary>
+    /// <remarks>
+    /// Accumulates in <c>double</c>, exactly as the CPU reference and the OpenCL kernel do. In float
+    /// the running total drifts and a target sitting near a bucket edge selects the neighbouring
+    /// category, which the exact-parity test treats as a hard mismatch. This requires the device to
+    /// support <c>shaderFloat64</c>; where it does not, pipeline creation fails and the backend keeps
+    /// using the managed reference rather than silently sampling at lower precision.
+    /// </remarks>
+    public static string CategoricalSampleGlsl => Header + TwoBufferLayout + @"
+layout(push_constant) uniform Params { uint rows; uint classes; uint seedLo; uint seedHi; };
+
+// StatelessRandom.Uniform01(seed, index) - identical constants to the managed helper, to the
+// OpenCL kernel and to the CUDA/HIP twins. Keying on the ROW index lets each invocation compute
+// its own uniform without replaying the rows before it.
+// NOTE: 'sample' is a reserved word in GLSL 4.x, hence 'draw'.
+float stateless_uniform01(uint seed32, uint index) {
+    uint state = index * 747796405u + seed32 + 2891336453u;
+    uint word = ((state >> ((state >> 28) + 4u)) ^ state) * 277803737u;
+    uint draw = (word >> 22) ^ word;
+    return float(draw >> 8) * (1.0 / 16777216.0);
+}
+
+void main() {
+    uint row = gl_GlobalInvocationID.x;
+    if (row >= rows) return;
+
+    uint seed32 = seedLo ^ seedHi;
+    float u = stateless_uniform01(seed32, row);
+    uint offset = row * classes;
+
+    double sum = 0.0lf;
+    for (uint c = 0u; c < classes; c++) sum += double(a[offset + c]);
+
+    double target = double(u) * sum;
+    double cumulative = 0.0lf;
+    uint selected = classes - 1u;
+    for (uint c = 0u; c < classes; c++) {
+        cumulative += double(a[offset + c]);
+        if (target < cumulative) { selected = c; break; }
+    }
+
+    for (uint c = 0u; c < classes; c++) b[offset + c] = 0.0;
+    b[offset + selected] = 1.0;
+}";
+
     public static string SparsemaxGlsl => Header + TwoBufferLayout + @"
 layout(push_constant) uniform Params { uint outerSize; uint innerSize; };
 void main() {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Categorical.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.Categorical.cs
@@ -1,0 +1,89 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WebGPU launcher for categorical sampling. Dispatches the WGSL twin of the OpenCL
+// categorical_sample kernel through the same Dispatch2BufferAsync path the other ops use.
+#if NET8_0_OR_GREATER
+using System;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+/// <summary>
+/// Gives WebGPU a device route for <c>TensorCategoricalSample</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the op fell back to the CPU after the caller had explicitly selected the WebGPU
+/// engine — correct output, but measured by the residency probe as 0 kernel launches against a
+/// required 1, which is a portability bug rather than an optimisation gap.
+/// </para>
+/// <para>
+/// The kernel differs from the other backends' in ONE deliberate respect: WGSL has no f64, so the
+/// probability sum and the cumulative walk are carried in a compensated two-float expansion. See
+/// <see cref="WebGpuCategoricalKernels"/> for why that reproduces the managed reference's category
+/// selection.
+/// </para>
+/// <para>
+/// NOT EXECUTED IN VERIFICATION: this needs a WebGPU adapter and none was available on the host this
+/// was written on, so the route is unverified against the CPU oracle.
+/// </para>
+/// </remarks>
+public sealed partial class WebGpuBackend : ICategoricalSamplingBackend
+{
+    /// <inheritdoc/>
+    public bool CanCategoricalSample(int rows, int classes)
+        => rows > 0
+           && classes > 0
+           // One invocation per row; a row wider than this is still correct but the serial walk over
+           // classes stops being the right shape for a GPU and the CPU reference is faster.
+           && (long)rows * classes <= int.MaxValue;
+
+    /// <inheritdoc/>
+    public bool TryCategoricalSample(
+        IGpuBuffer probabilities,
+        IGpuBuffer oneHot,
+        int rows,
+        int classes,
+        ulong seed)
+    {
+        if (!CanCategoricalSample(rows, classes)) return false;
+        if (probabilities is not WebGpuBuffer probabilityBuffer) return false;
+        if (oneHot is not WebGpuBuffer oneHotBuffer) return false;
+
+        // Both buffers are indexed as row * classes + c, so both must actually hold that many
+        // elements. CanCategoricalSample only checks the DIMENSIONS; an undersized buffer would be
+        // written past its end on the device, which corrupts whatever is next in device memory and
+        // is reported, if at all, by some unrelated later operation.
+        long addressed = (long)rows * classes;
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(probabilities), probabilityBuffer.Size, addressed);
+        GpuKernelDiagnostics.ValidateCapacity(
+            "categorical_sample", nameof(oneHot), oneHotBuffer.Size, addressed);
+
+        if (probabilityBuffer.Size < addressed || oneHotBuffer.Size < addressed)
+        {
+            // Even with deep checks off, refuse rather than launch an out-of-range write.
+            return false;
+        }
+
+        // The uniform block is four u32s; the dispatch helper takes floats, so the bits are carried
+        // across verbatim rather than value-converted. Reading them as f32 would round the seed.
+        var uniforms = new[]
+        {
+            BitConverter.Int32BitsToSingle(rows),
+            BitConverter.Int32BitsToSingle(classes),
+            BitConverter.Int32BitsToSingle(unchecked((int)(uint)(seed & 0xFFFFFFFF))),
+            BitConverter.Int32BitsToSingle(unchecked((int)(uint)(seed >> 32))),
+        };
+
+        Dispatch2BufferAsync(
+            "Categorical",
+            WebGpuCategoricalKernels.CategoricalSample,
+            "categorical_sample",
+            probabilities,
+            oneHot,
+            uniforms,
+            rows).GetAwaiter().GetResult();
+
+        return true;
+    }
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuCategoricalKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuCategoricalKernels.cs
@@ -1,0 +1,105 @@
+// Copyright (c) AiDotNet. All rights reserved.
+// WGSL kernel for categorical sampling — the device twin of CpuEngine.TensorCategoricalSample and
+// of the OpenCL/CUDA/HIP/Vulkan/Metal kernels.
+//
+// WHY THIS IS NOT A LINE-FOR-LINE PORT OF THE OTHERS.
+// The CPU reference, and the OpenCL/CUDA/HIP/Vulkan kernels, accumulate the probability sum and the
+// cumulative walk in `double`. WGSL HAS NO f64 TYPE — it is absent from the language, not a device
+// capability. Accumulating in f32 instead is not an option: the running total drifts, a target
+// sitting near a bucket edge selects the neighbouring category, and the exact-parity test treats a
+// single differing category as a hard mismatch.
+//
+// So the accumulation is carried in a TWO-FLOAT (double-single) expansion: a hi/lo pair whose
+// combined significand is roughly 48 bits against double's 53. Knuth's two_sum is exact under
+// round-to-nearest, so summing N f32 inputs this way is exact whenever the true sum needs no more
+// than ~48 bits — which covers any realistic class count, since each addend carries only 24.
+//
+// WGSL requires IEEE-754 binary32 with round-to-nearest and does NOT permit implementations to
+// reassociate floating-point expressions, so unlike the Metal port this needs no pragma to stay
+// exact.
+//
+// NOT EXECUTED IN VERIFICATION: this requires a WebGPU adapter (Dawn) and was written on a host
+// without one, so the kernel is unverified against the CPU oracle. The algorithm mirrors the OpenCL
+// kernel, which IS verified, with the accumulation type as the single deliberate difference.
+#if NET8_0_OR_GREATER
+namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
+
+/// <summary>
+/// WGSL implementation of categorical sampling, matching the managed reference's category selection
+/// via compensated two-float accumulation (WGSL has no f64).
+/// </summary>
+internal static class WebGpuCategoricalKernels
+{
+    public const string CategoricalSample = @"
+@group(0) @binding(0) var<storage, read> cs_probabilities: array<f32>;
+@group(0) @binding(1) var<storage, read_write> cs_one_hot: array<f32>;
+struct CsParams { rows: u32, classes: u32, seed_lo: u32, seed_hi: u32 }
+@group(0) @binding(2) var<uniform> cs_params: CsParams;
+
+// Knuth two_sum: exact under round-to-nearest. sum + err == a + b, with no rounding lost.
+fn cs_two_sum(a: f32, b: f32) -> vec2<f32> {
+    let s = a + b;
+    let bb = s - a;
+    let err = (a - (s - bb)) + (b - bb);
+    return vec2<f32>(s, err);
+}
+
+// Add an f32 to a two-float accumulator, renormalising so the pair stays non-overlapping.
+fn cs_df_add(acc: vec2<f32>, v: f32) -> vec2<f32> {
+    let t = cs_two_sum(acc.x, v);
+    return cs_two_sum(t.x, t.y + acc.y);
+}
+
+// Multiply a two-float by an f32. fma recovers the exact rounding error of the head product.
+fn cs_df_mul(a: vec2<f32>, b: f32) -> vec2<f32> {
+    let p = a.x * b;
+    var e = fma(a.x, b, -p);
+    e = fma(a.y, b, e);
+    return cs_two_sum(p, e);
+}
+
+// Lexicographic compare of two non-overlapping pairs is a compare of the exact values.
+fn cs_df_less(a: vec2<f32>, b: vec2<f32>) -> bool {
+    return (a.x < b.x) || (a.x == b.x && a.y < b.y);
+}
+
+// StatelessRandom.Uniform01(seed, index) — identical constants to the managed helper and to every
+// other backend's kernel. Keying on the ROW index lets an invocation compute its own uniform
+// without replaying the rows before it.
+fn cs_uniform01(seed32: u32, index: u32) -> f32 {
+    let state = index * 747796405u + seed32 + 2891336453u;
+    let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+    let draw = (word >> 22u) ^ word;
+    return f32(draw >> 8u) * (1.0 / 16777216.0);
+}
+
+@compute @workgroup_size(256)
+fn categorical_sample(@builtin(global_invocation_id) gid: vec3u) {
+    let row = gid.x;
+    if (row >= cs_params.rows) { return; }
+
+    let seed32 = cs_params.seed_lo ^ cs_params.seed_hi;
+    let u = cs_uniform01(seed32, row);
+    let offset = row * cs_params.classes;
+
+    var sum = vec2<f32>(0.0, 0.0);
+    for (var c: u32 = 0u; c < cs_params.classes; c = c + 1u) {
+        sum = cs_df_add(sum, cs_probabilities[offset + c]);
+    }
+
+    let target = cs_df_mul(sum, u);
+    var cumulative = vec2<f32>(0.0, 0.0);
+    var selected: u32 = cs_params.classes - 1u;
+    for (var c: u32 = 0u; c < cs_params.classes; c = c + 1u) {
+        cumulative = cs_df_add(cumulative, cs_probabilities[offset + c]);
+        if (cs_df_less(target, cumulative)) { selected = c; break; }
+    }
+
+    for (var c: u32 = 0u; c < cs_params.classes; c = c + 1u) {
+        cs_one_hot[offset + c] = 0.0;
+    }
+    cs_one_hot[offset + selected] = 1.0;
+}
+";
+}
+#endif

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -1846,7 +1846,20 @@ public partial class DirectGpuTensorEngine
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         axes ??= new[] { 0, 1 };
-        if (axes.Length != 2 || axes[0] == axes[1] || !TryGetBackend(out var backend))
+
+        // WHEN THE TAPE IS RECORDING, TAKE THE BASE PATH. The GPU rotation below is built from
+        // PermuteResidentGpu, which materializes a fresh device buffer through DeferTensorResult
+        // and wires no gradient, so the chain from output back to input is cut. The op then looks
+        // correct — the values are right — while contributing NOTHING to a backward pass, which is
+        // the worst way for an autodiff bug to present. Measured: TensorRot90[4,8] recorded one
+        // differentiable leaf on CPU and zero on GPU.
+        //
+        // This is the same guard the other ops in this file use for the same reason (see
+        // TensorCTCLoss and its neighbours): the GPU fast path is an optimization, and an
+        // optimization that silently drops gradients is not one.
+        if (axes.Length != 2 || axes[0] == axes[1]
+            || IsTapeActive<T>() || Compilation.GraphMode.IsActive
+            || !TryGetBackend(out var backend))
             return base.TensorRot90(tensor, k, axes);
 
         int steps = ((k % 4) + 4) % 4;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -439,7 +439,18 @@ public class FusedOptimizerNonFiniteGradientTests
                     backend.Multiply(scratch, aggregate, aggregate, size: 1);
                     backend.ClassifyFloat(gradient, scratch, mode: 2, size: length);
                     backend.Multiply(scratch, aggregate, aggregate, size: length);
-                    Assert.Equal(allFinite ? 1f : 0f, backend.Min(aggregate, length));
+                    // Reported with the case. A bare Equal here said only "expected 0, actual 1",
+                    // which does not say WHICH length or which non-finite kind slipped through —
+                    // and the bad value is deliberately placed at values[length - 1], so the length
+                    // is the whole diagnosis when a kernel drops its tail.
+                    float observed = backend.Min(aggregate, length);
+                    Assert.True(
+                        observed == (allFinite ? 1f : 0f),
+                        $"ClassifyFloat(mode 2) over {length} values with {badValue} at index "
+                            + $"{length - 1}: expected min {(allFinite ? 1f : 0f)}, got {observed}. "
+                            + "A miss here means the non-finite element was never classified — check "
+                            + "whether the kernel covers a size that is not a multiple of its "
+                            + "workgroup.");
                 }
             }
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CategoricalKernelParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/CategoricalKernelParityTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.DirectGpu.HIP.Kernels;
+using AiDotNet.Tensors.Engines.DirectGpu.Metal;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL.Kernels;
+using AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
+{
+    /// <summary>
+    /// Every backend's categorical kernel must draw its uniform from the SAME hash as the managed
+    /// sampler, because the parity tests compare one-hot outputs exactly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// WHY A SOURCE TEST AND NOT AN EXECUTION TEST. Five backends ship this kernel and no single
+    /// machine can run more than one or two of them — this host has an OpenCL device, no Metal, no
+    /// WebGPU adapter and no usable Vulkan compute path, and CI runs PoCL. So the kernel that
+    /// actually executes anywhere is a minority of the kernels that ship, and a constant that drifts
+    /// in one of the others is invisible until somebody runs it on that vendor's hardware and gets a
+    /// different category for the same seed.
+    /// </para>
+    /// <para>
+    /// These assertions are therefore about the CONTRACT rather than the output: every kernel keys
+    /// its draw on the row index with the same PCG constants and the same 24-bit mantissa scaling,
+    /// and every kernel accumulates in something wider than float. They cannot prove a kernel
+    /// computes the right answer, but they do catch the single most likely way these five drift
+    /// apart, which is somebody editing one and not the rest.
+    /// </para>
+    /// </remarks>
+    public class CategoricalKernelParityTests
+    {
+        /// <summary>The StatelessRandom PCG constants, as used by the managed Uniform01(seed, index).</summary>
+        private static readonly string[] RequiredConstants =
+        {
+            "747796405",   // multiplier
+            "2891336453",  // increment
+            "277803737",   // output mix
+            "16777216",    // 2^24, the mantissa scale that turns the draw into [0,1)
+        };
+
+        public static TheoryData<string, string> KernelSources()
+        {
+            var data = new TheoryData<string, string>();
+            data.Add("OpenCL", CategoricalKernels.GetSource());
+            data.Add("HIP", HipCategoricalKernels.GetSource());
+            data.Add("Metal", MetalCategoricalKernels.Source);
+            data.Add("Vulkan", VulkanGlslKernels.CategoricalSampleGlsl);
+#if NET8_0_OR_GREATER
+            data.Add("WebGpu", AiDotNet.Tensors.Engines.DirectGpu.WebGpu.WebGpuCategoricalKernels.CategoricalSample);
+#endif
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(KernelSources))]
+        public void EveryBackendUsesTheSameStatelessRandomConstants(string backend, string source)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(source), $"{backend}: kernel source is empty.");
+
+            foreach (var constant in RequiredConstants)
+            {
+                Assert.True(
+                    source.Contains(constant, StringComparison.Ordinal),
+                    $"{backend}'s categorical kernel is missing the StatelessRandom constant {constant}. "
+                        + "All backends must draw from the identical PCG hash keyed on (seed, row), or the "
+                        + "same seed selects a different category on different hardware.");
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(KernelSources))]
+        public void EveryBackendSelectsTheLastCategoryWhenDriftOvershootsTheFinalBoundary(string backend, string source)
+        {
+            // The managed reference defaults `selected` to classes - 1 so floating-point drift past
+            // the final cumulative boundary cannot leave the row without a selection. A kernel that
+            // defaults to 0 instead would return a valid-looking one-hot for the WRONG category, and
+            // only on the rows where drift happens.
+            Assert.True(
+                source.Contains("classes - 1", StringComparison.Ordinal)
+                    || source.Contains("classes - 1u", StringComparison.Ordinal)
+                    || source.Contains("cs_params.classes - 1u", StringComparison.Ordinal),
+                $"{backend}'s categorical kernel does not default its selection to the last category.");
+        }
+
+        /// <summary>
+        /// Float accumulation is the one thing that reliably breaks exact parity, so no backend may
+        /// simply add floats in a loop.
+        /// </summary>
+        /// <remarks>
+        /// The kernels split into two groups for a reason that is a language limit, not a choice:
+        /// OpenCL, HIP and Vulkan have a 64-bit float type and accumulate in it, matching the CPU
+        /// reference directly. MSL and WGSL have NO 64-bit float at all, so those two carry the sum
+        /// in a compensated two-float expansion instead. Both are acceptable; plain float is not.
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(KernelSources))]
+        public void NoBackendAccumulatesInPlainFloat(string backend, string source)
+        {
+            bool hasNativeDouble =
+                source.Contains("double ", StringComparison.Ordinal)
+                || source.Contains("double(", StringComparison.Ordinal);
+
+            bool hasCompensatedFallback =
+                source.Contains("two_sum", StringComparison.Ordinal)
+                && source.Contains("fma(", StringComparison.Ordinal);
+
+            Assert.True(
+                hasNativeDouble || hasCompensatedFallback,
+                $"{backend}'s categorical kernel neither accumulates in double nor uses compensated "
+                    + "two-float arithmetic. Summing probabilities in plain float lets the running total "
+                    + "drift, and a target near a bucket edge then selects the neighbouring category — "
+                    + "which still looks like a valid one-hot and so passes every smoke test.");
+        }
+
+        [Fact]
+        public void TheTwoLanguagesWithoutA64BitFloatAreTheOnesUsingCompensatedArithmetic()
+        {
+            // Pins the reason for the split. If a future edit gives Metal or WebGpu real doubles, or
+            // drops compensation from one of them, this is the test that says so.
+            var compensated = new List<string>();
+            foreach (var row in KernelSources())
+            {
+                var backend = (string)row[0];
+                var source = (string)row[1];
+                if (source.Contains("two_sum", StringComparison.Ordinal)) compensated.Add(backend);
+            }
+
+            Assert.Contains("Metal", compensated);
+#if NET8_0_OR_GREATER
+            Assert.Contains("WebGpu", compensated);
+            Assert.Equal(2, compensated.Count);
+#else
+            Assert.Single(compensated);
+#endif
+        }
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -45,6 +45,41 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
     // GPU fast-math approximation noise (~1e-3) on transcendental ops.
     private const float Tol = 1e-2f;
 
+    // Differential correctness does not need a huge shape, but several ops EXPAND their input.
+    // TensorKron on [129,129] returns [16641,16641] — 276,922,881 elements, 1.1 GB as float — and
+    // CompareValue then calls ToArray() on BOTH sides for two more managed copies of the same size.
+    // Kron, Tile, Stack, CartesianProd, Dot and Inner together drove this one class to a peak of
+    // 11.5 GB, which survives a 64 GB workstation and kills a 16 GB CI runner: the shard dies
+    // having written no results, which is exactly the failure this harness was blamed for.
+    //
+    // THIS IS A BUDGET, NOT A WEAKENED ASSERTION. An oversized result makes the harness fall
+    // through to the next (smaller) candidate shape and assert the identical GPU-vs-CPU parity
+    // there, at the same tolerance. No operation loses its accuracy check and nothing is skipped;
+    // only the shape an expanding op is checked at changes, and only when its output would not fit.
+    // 32M elements is ~128 MB per tensor, far above every non-expanding op (a [129,129] input is
+    // 16,641 elements), so nothing else in the sweep changes shape at all.
+    private const long MaxResultElements = 32_000_000;
+
+    private static long ShapeElements(int[] shape)
+    {
+        long n = 1;
+        foreach (int d in shape) n *= d;
+        return n;
+    }
+
+    private static long ElementCount(object o)
+    {
+        int[] shape =
+            o is Tensor<float> tf ? tf.Shape.ToArray()
+            : o is Tensor<Complex<float>> tc ? tc.Shape.ToArray()
+            : null;
+        if (shape == null) return 0;
+
+        long n = 1;
+        foreach (int d in shape) n *= d;
+        return n;
+    }
+
     // Candidate input shapes tried in order; the first one the CPU op accepts is used.
     // Non-aligned dims (129) stress float4 tail paths; square 2-D shapes also satisfy matmul.
     private static readonly int[][] CandidateShapes =
@@ -368,8 +403,15 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         var ps = gm.GetParameters();
         var rng = new Random(7);
 
+        // Lowered the first time an oversized result is seen, so an expanding op drops straight to
+        // a shape that can fit instead of retrying every nearly-identical candidate on the way down
+        // (129x129 -> 128x128 is a 1% reduction against an output that is 8x over budget).
+        long maxInputElements = long.MaxValue;
+
         foreach (var shape in CandidateShapes)
         {
+            if (ShapeElements(shape) > maxInputElements) continue;
+
             var sets = CandidateArgSets(ps, shape, rng);
             if (sets == null) return; // signature not auto-buildable -> guard handles it
 
@@ -380,6 +422,27 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
                 try { cpuRes = cm.Invoke(_cpu, cpuArgs); }
                 catch (TargetInvocationException) { continue; } // CPU rejects this combo; try next
                 if (!IsComparableTensor(cpuRes)) continue;
+
+                long produced = ElementCount(cpuRes);
+                if (produced > MaxResultElements)
+                {
+                    // Budget the NEXT attempt from what this one actually produced. Assuming the op
+                    // grows at least linearly, an input of inputElems * (budget / produced) fits;
+                    // for a quadratic op like Kron that under-estimates, which is the safe
+                    // direction. Without this the harness walks 129x129 -> 128x128 -> 64x64,
+                    // computing a multi-hundred-megabyte result at each step.
+                    long allowed = ShapeElements(shape) * MaxResultElements / produced;
+                    maxInputElements = Math.Max(1, Math.Min(maxInputElements, allowed));
+
+                    // The rejected result is a large-object-heap block; reclaim it before the next
+                    // candidate allocates on top of it, which is how several expanding ops in a row
+                    // reached 11.5 GB.
+                    cpuRes = null;
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    break;
+                }
 
                 var gpuArgs = CloneArgs(args);
                 object gpuRes;

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -60,6 +60,56 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
     // 16,641 elements), so nothing else in the sweep changes shape at all.
     private const long MaxResultElements = 32_000_000;
 
+    /// <summary>
+    /// Probes the op on the smallest candidate shape and extrapolates the largest input whose OUTPUT
+    /// still fits <see cref="MaxResultElements"/>. Returns <see cref="long.MaxValue"/> when the op
+    /// does not expand, or when it cannot be driven at the probe shape.
+    /// </summary>
+    /// <remarks>
+    /// EXTRAPOLATION IS BY GROWTH ORDER, NOT RATIO. Kron's output is input squared, so a ratio taken
+    /// at a small shape under-predicts enormously: 64 elements in and 4096 out is a ratio of 64,
+    /// which predicts about 1M elements at a 16,641-element input against an actual 276,922,881.
+    /// Fitting k = log(produced) / log(input) recovers the exponent instead — 2 for Kron, 1 for an
+    /// elementwise op — and inverting it gives the largest input that still fits. Under-estimating is
+    /// the safe direction here, since the cost of guessing low is only a smaller test shape.
+    /// </remarks>
+    private long EstimateMaxInputElements(MethodInfo cm, ParameterInfo[] ps, Random rng)
+    {
+        int[]? smallest = null;
+        long smallestElements = long.MaxValue;
+        foreach (var shape in CandidateShapes)
+        {
+            long n = ShapeElements(shape);
+            if (n < smallestElements) { smallestElements = n; smallest = shape; }
+        }
+
+        // A one-element probe carries no information about growth (log(1) == 0).
+        if (smallest is null || smallestElements <= 1) return long.MaxValue;
+
+        var sets = CandidateArgSets(ps, smallest, rng);
+        if (sets == null) return long.MaxValue;
+
+        foreach (var args in sets)
+        {
+            object probe;
+            try { probe = cm.Invoke(_cpu, CloneArgs(args)); }
+            catch (TargetInvocationException) { continue; } // CPU rejects this combo; try next
+            if (!IsComparableTensor(probe)) continue;
+
+            long produced = ElementCount(probe);
+            if (produced <= 1) return long.MaxValue;
+
+            double order = Math.Log(produced) / Math.Log(smallestElements);
+            if (order <= 1.0) return long.MaxValue;   // linear or shrinking: no bound needed
+
+            double allowed = Math.Pow(MaxResultElements, 1.0 / order);
+            if (allowed >= long.MaxValue) return long.MaxValue;
+            return (long)Math.Max(1.0, allowed);
+        }
+
+        return long.MaxValue;
+    }
+
     private static long ShapeElements(int[] shape)
     {
         long n = 1;
@@ -403,10 +453,12 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
         var ps = gm.GetParameters();
         var rng = new Random(7);
 
-        // Lowered the first time an oversized result is seen, so an expanding op drops straight to
-        // a shape that can fit instead of retrying every nearly-identical candidate on the way down
-        // (129x129 -> 128x128 is a 1% reduction against an output that is 8x over budget).
-        long maxInputElements = long.MaxValue;
+        // PREFLIGHT. The post-invoke check below is a backstop, not a bound: by the time it runs,
+        // CpuEngine.TensorKron on [129,129] has already allocated its 1.1 GB result. Measuring the
+        // op on the smallest candidate shape first costs one cheap invocation and answers the size
+        // question before anything large is built. Still lowered by the backstop if the estimate
+        // turns out optimistic.
+        long maxInputElements = EstimateMaxInputElements(cm, ps, rng);
 
         foreach (var shape in CandidateShapes)
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -18,6 +18,16 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
     /// harness that silently stops reporting is worse than none, because every later investigation
     /// trusts it.
     /// </remarks>
+    /// <remarks>
+    /// SERIALIZED DELIBERATELY. The residency counters are process-static and every DirectOpenClBuffer
+    /// construction anywhere in the assembly moves them, so a concurrent GPU test could change them
+    /// between this class's snapshot and its assertion. "DirectGpuSerial" is declared with
+    /// DisableParallelization = true, which means it does not run alongside other collections — so
+    /// joining it removes the interference rather than merely narrowing the window, and the delta
+    /// assertions can stay exact instead of being relaxed into something that no longer catches a
+    /// real imbalance.
+    /// </remarks>
+    [Collection("DirectGpuSerial")]
     public class GpuKernelDiagnosticsTests
     {
         [Fact]
@@ -247,15 +257,16 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
                 var backend = engine.GetBackend();
                 Skip.If(backend is null, "No direct GPU backend is available on this host.");
 
-                // JOURNALLING IS OPENCL-ONLY TODAY. RecordLaunch is called from DirectOpenClKernel;
-                // the CUDA and HIP reductions dispatch through their own paths and add no entry, so
-                // on a host that selects either of those this assertion would fail for a reason that
-                // has nothing to do with the diagnostic being broken. Skipping is honest here —
-                // the alternative is a test that reports a false defect on two of three backends.
+                // OpenCL, CUDA and HIP all journal now (CUDA/HIP via their native-launch choke
+                // point). This still targets OpenCL because it is the backend this host actually
+                // has, so the assertion below is exercised rather than skipped; Metal, Vulkan and
+                // WebGpu remain unjournalled (Issue #996) and would fail here for a reason that has
+                // nothing to do with the diagnostic being broken.
                 Skip.If(
                     backend is not AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend,
-                    "Launch journalling is implemented for the OpenCL backend only; "
-                        + $"this host selected {backend!.GetType().Name}.");
+                    "This test targets the OpenCL journalling path (CUDA and HIP journal via their native-launch "
+                        + "choke point; Metal, Vulkan and WebGpu are not yet journalled - Issue #996). "
+                        + $"This host selected {backend!.GetType().Name}.");
 
                 // The journal is STATIC, so a non-empty journal proves nothing — another test in
                 // this class fills it. What must be true is that this launch ADVANCES it.

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -149,6 +149,81 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
             Assert.Contains("99", thrown.Message, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Buffer accounting has to balance, because its whole purpose is to make an IMBALANCE
+        /// visible.
+        /// </summary>
+        /// <remarks>
+        /// Deltas, not absolutes: the counters are process-static and every other GPU test in this
+        /// assembly moves them, so asserting an absolute count would be asserting test execution
+        /// order. What must hold is that an allocate/release pair leaves the live figures exactly
+        /// where it found them.
+        /// </remarks>
+        [Fact]
+        public void BufferAccounting_BalancesAcrossAllocateAndRelease()
+        {
+            long countBefore = GpuKernelDiagnostics.LiveBufferCount;
+            long bytesBefore = GpuKernelDiagnostics.LiveBufferBytes;
+            long totalBefore = GpuKernelDiagnostics.TotalBuffersAllocated;
+
+            GpuKernelDiagnostics.RecordBufferAllocated(4096);
+            GpuKernelDiagnostics.RecordBufferAllocated(1024);
+
+            Assert.Equal(countBefore + 2, GpuKernelDiagnostics.LiveBufferCount);
+            Assert.Equal(bytesBefore + 5120, GpuKernelDiagnostics.LiveBufferBytes);
+            Assert.Equal(totalBefore + 2, GpuKernelDiagnostics.TotalBuffersAllocated);
+
+            GpuKernelDiagnostics.RecordBufferReleased(4096);
+            GpuKernelDiagnostics.RecordBufferReleased(1024);
+
+            Assert.Equal(countBefore, GpuKernelDiagnostics.LiveBufferCount);
+            Assert.Equal(bytesBefore, GpuKernelDiagnostics.LiveBufferBytes);
+
+            // Released buffers must NOT decrement the cumulative total — the gap between "allocated
+            // in total" and "live" is exactly the signal a leak hunt is looking for.
+            Assert.Equal(totalBefore + 2, GpuKernelDiagnostics.TotalBuffersAllocated);
+        }
+
+        [Fact]
+        public void PeakResidency_IsAHighWaterMark_AndDoesNotFallBack()
+        {
+            GpuKernelDiagnostics.RecordBufferAllocated(64 * 1024);
+            long peakAtHeight = GpuKernelDiagnostics.PeakLiveBufferBytes;
+            Assert.True(
+                peakAtHeight >= GpuKernelDiagnostics.LiveBufferBytes,
+                "peak must be at least the current live figure");
+
+            GpuKernelDiagnostics.RecordBufferReleased(64 * 1024);
+
+            Assert.Equal(peakAtHeight, GpuKernelDiagnostics.PeakLiveBufferBytes);
+        }
+
+        [Fact]
+        public void ResidencyDescription_ReportsTheNumbers_AndReachesTheDump()
+        {
+            GpuKernelDiagnostics.RecordBufferAllocated(2048);
+            try
+            {
+                Assert.Contains("live=", GpuKernelDiagnostics.DescribeBufferResidency(), StringComparison.Ordinal);
+
+                // The residency has to travel with the journal, or a post-mortem never sees it.
+                string path = Path.Combine(Path.GetTempPath(), "aidotnet-residency-" + Guid.NewGuid().ToString("N") + ".txt");
+                try
+                {
+                    GpuKernelDiagnostics.DumpTo(path);
+                    Assert.Contains("buffers:", File.ReadAllText(path), StringComparison.Ordinal);
+                }
+                finally
+                {
+                    try { File.Delete(path); } catch (IOException) { }
+                }
+            }
+            finally
+            {
+                GpuKernelDiagnostics.RecordBufferReleased(2048);
+            }
+        }
+
         /// <summary>A real launch must appear in the journal, which is what makes it useful after a crash.</summary>
         [SkippableFact]
         public void ARealGpuLaunchIsJournalled()

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -247,6 +247,16 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
                 var backend = engine.GetBackend();
                 Skip.If(backend is null, "No direct GPU backend is available on this host.");
 
+                // JOURNALLING IS OPENCL-ONLY TODAY. RecordLaunch is called from DirectOpenClKernel;
+                // the CUDA and HIP reductions dispatch through their own paths and add no entry, so
+                // on a host that selects either of those this assertion would fail for a reason that
+                // has nothing to do with the diagnostic being broken. Skipping is honest here —
+                // the alternative is a test that reports a false defect on two of three backends.
+                Skip.If(
+                    backend is not AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend,
+                    "Launch journalling is implemented for the OpenCL backend only; "
+                        + $"this host selected {backend!.GetType().Name}.");
+
                 // The journal is STATIC, so a non-empty journal proves nothing — another test in
                 // this class fills it. What must be true is that this launch ADVANCES it.
                 var before = GpuKernelDiagnostics.RecentLaunches();

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -153,21 +153,42 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
         [SkippableFact]
         public void ARealGpuLaunchIsJournalled()
         {
-            DirectGpuTensorEngine? engine = null;
-            try { engine = new DirectGpuTensorEngine(); }
-            catch (Exception) { Skip.If(true, "No direct GPU backend is available on this host."); }
+            // Only a missing runtime counts as "no GPU"; a real initialisation failure on a
+            // GPU-capable host must fail rather than skip.
+            DirectGpuTensorEngine? engine;
+            try
+            {
+                engine = new DirectGpuTensorEngine();
+            }
+            catch (DllNotFoundException) { engine = null; }
+            catch (EntryPointNotFoundException) { engine = null; }
+            catch (PlatformNotSupportedException) { engine = null; }
+
+            Skip.If(engine is null, "No direct GPU backend is available on this host.");
 
             using (engine)
             {
-                Skip.If(engine is null || !engine.IsGpuAvailable, "No direct GPU backend is available on this host.");
-                var backend = engine!.GetBackend();
+                Skip.If(!engine!.IsGpuAvailable, "No direct GPU backend is available on this host.");
+                var backend = engine.GetBackend();
                 Skip.If(backend is null, "No direct GPU backend is available on this host.");
+
+                // The journal is STATIC, so a non-empty journal proves nothing — another test in
+                // this class fills it. What must be true is that this launch ADVANCES it.
+                var before = GpuKernelDiagnostics.RecentLaunches();
+                string? newestBefore = before.Count == 0 ? null : before[before.Count - 1];
 
                 var values = Enumerable.Range(1, 64).Select(i => (float)i).ToArray();
                 using var buffer = backend!.AllocateBuffer(values);
                 backend.Sum(buffer, values.Length);
 
-                Assert.NotEmpty(GpuKernelDiagnostics.RecentLaunches());
+                var after = GpuKernelDiagnostics.RecentLaunches();
+                Assert.NotEmpty(after);
+
+                string newestAfter = after[after.Count - 1];
+                Assert.True(
+                    newestBefore is null || !string.Equals(newestAfter, newestBefore, StringComparison.Ordinal),
+                    "backend.Sum did not add a journal entry: the newest entry is unchanged at "
+                        + $"'{newestAfter}'. A launch that is not journalled is invisible after a crash.");
             }
         }
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NETFRAMEWORK
+using System;
+using System.IO;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
+{
+    /// <summary>
+    /// The launch-diagnostics harness itself: it has to report the right thing, and it has to be
+    /// usable by a caller validating their own kernels.
+    /// </summary>
+    /// <remarks>
+    /// These assertions are deliberately about the DIAGNOSTIC, not about any particular kernel. A
+    /// harness that silently stops reporting is worse than none, because every later investigation
+    /// trusts it.
+    /// </remarks>
+    public class GpuKernelDiagnosticsTests
+    {
+        [Fact]
+        public void ReleasedHandle_IsReportedByName_NotFaulted()
+        {
+            var thrown = Assert.Throws<ObjectDisposedException>(() =>
+                GpuKernelDiagnostics.ValidateLaunch(
+                    "my_custom_kernel",
+                    handleIsValid: false,
+                    stagedArgCount: 3,
+                    declaredArgCount: 3,
+                    globalSize: 256,
+                    localSize: 64));
+
+            Assert.Contains("my_custom_kernel", thrown.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GlobalSizeNotAMultipleOfTheWorkGroup_IsRejected()
+        {
+            var thrown = Assert.Throws<ArgumentException>(() =>
+                GpuKernelDiagnostics.ValidateLaunch(
+                    "ragged", handleIsValid: true, stagedArgCount: 1, declaredArgCount: 1,
+                    globalSize: 100, localSize: 64));
+
+            Assert.Contains("not a multiple", thrown.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void WorkGroupLargerThanTheKernelAdmits_IsRejected()
+        {
+            var thrown = Assert.Throws<ArgumentException>(() =>
+                GpuKernelDiagnostics.ValidateLaunch(
+                    "narrow", handleIsValid: true, stagedArgCount: 1, declaredArgCount: 1,
+                    globalSize: 512, localSize: 512, maxWorkGroupSize: 256));
+
+            Assert.Contains("exceeds", thrown.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// The check that would have caught this session's reduction bug at the launch instead of in
+        /// a wrong sum four layers away.
+        /// </summary>
+        [Theory]
+        [InlineData(31)]
+        [InlineData(33)]
+        [InlineData(6)]
+        public void NonPowerOfTwoWorkGroup_IsRejectedForKernelsThatRequireOne(int localSize)
+        {
+            var thrown = Assert.Throws<ArgumentException>(() =>
+                GpuKernelDiagnostics.ValidateLaunch(
+                    "reduce_sum", handleIsValid: true, stagedArgCount: 4, declaredArgCount: 4,
+                    globalSize: localSize, localSize: localSize,
+                    requiresPowerOfTwoWorkGroup: true));
+
+            Assert.Contains("power of two", thrown.Message, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(64)]
+        [InlineData(256)]
+        public void PowerOfTwoWorkGroup_IsAccepted(int localSize)
+        {
+            GpuKernelDiagnostics.ValidateLaunch(
+                "reduce_sum", handleIsValid: true, stagedArgCount: 4, declaredArgCount: 4,
+                globalSize: localSize, localSize: localSize,
+                requiresPowerOfTwoWorkGroup: true);
+        }
+
+        [Fact]
+        public void IsPowerOfTwo_AgreesWithTheDefinition()
+        {
+            foreach (int n in new[] { 1, 2, 4, 8, 16, 32, 64, 128, 256, 1024 })
+                Assert.True(GpuKernelDiagnostics.IsPowerOfTwo(n), $"{n} is a power of two");
+
+            foreach (int n in new[] { 0, 3, 5, 6, 7, 9, 31, 33, 255, 257, 1025 })
+                Assert.False(GpuKernelDiagnostics.IsPowerOfTwo(n), $"{n} is not a power of two");
+
+            Assert.False(GpuKernelDiagnostics.IsPowerOfTwo(-8), "negative sizes are not valid");
+        }
+
+        [Fact]
+        public void TheJournalRecordsLaunchesAndSurvivesToDisk()
+        {
+            GpuKernelDiagnostics.RecordLaunch("journal_probe_alpha", 1024, 256, 3);
+            GpuKernelDiagnostics.RecordLaunch("journal_probe_beta", 2048, 128, 5);
+
+            var recent = GpuKernelDiagnostics.RecentLaunches();
+            Assert.Contains(recent, line => line.Contains("journal_probe_beta", StringComparison.Ordinal));
+
+            var described = GpuKernelDiagnostics.DescribeRecentLaunches();
+            Assert.Contains("journal_probe_beta", described, StringComparison.Ordinal);
+
+            // The point of the journal is that it outlives the process that produced it.
+            string path = Path.Combine(Path.GetTempPath(), "aidotnet-gpu-journal-" + Guid.NewGuid().ToString("N") + ".txt");
+            try
+            {
+                GpuKernelDiagnostics.DumpTo(path);
+                Assert.True(File.Exists(path), "the journal must be writable to disk for post-mortem use");
+                Assert.Contains("journal_probe_beta", File.ReadAllText(path), StringComparison.Ordinal);
+            }
+            finally
+            {
+                try { File.Delete(path); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        public void DumpTo_NeverThrows_SoACrashHandlerCanCallIt()
+        {
+            // An unwritable path must not turn a diagnostic into a second failure on the way down.
+            GpuKernelDiagnostics.DumpTo(Path.Combine("Z:", "definitely", "not", "writable.txt"));
+            GpuKernelDiagnostics.DumpTo(string.Empty);
+        }
+
+        [Fact]
+        public void CapacityCheckIsOptIn_AndReportsTheOverrun()
+        {
+            if (!GpuKernelDiagnostics.DeepChecksEnabled)
+            {
+                // Off by default: it must be silent rather than throwing on a legitimate launch.
+                GpuKernelDiagnostics.ValidateCapacity("k", "out", bufferElements: 4, addressedElements: 99);
+                return;
+            }
+
+            var thrown = Assert.Throws<ArgumentException>(() =>
+                GpuKernelDiagnostics.ValidateCapacity("k", "out", bufferElements: 4, addressedElements: 99));
+            Assert.Contains("99", thrown.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>A real launch must appear in the journal, which is what makes it useful after a crash.</summary>
+        [SkippableFact]
+        public void ARealGpuLaunchIsJournalled()
+        {
+            DirectGpuTensorEngine? engine = null;
+            try { engine = new DirectGpuTensorEngine(); }
+            catch (Exception) { Skip.If(true, "No direct GPU backend is available on this host."); }
+
+            using (engine)
+            {
+                Skip.If(engine is null || !engine.IsGpuAvailable, "No direct GPU backend is available on this host.");
+                var backend = engine!.GetBackend();
+                Skip.If(backend is null, "No direct GPU backend is available on this host.");
+
+                var values = Enumerable.Range(1, 64).Select(i => (float)i).ToArray();
+                using var buffer = backend!.AllocateBuffer(values);
+                backend.Sum(buffer, values.Length);
+
+                Assert.NotEmpty(GpuKernelDiagnostics.RecentLaunches());
+            }
+        }
+    }
+}
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/HipFftKernelAvailabilityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/HipFftKernelAvailabilityTests.cs
@@ -84,7 +84,11 @@ public sealed class HipFftKernelAvailabilityTests
         }
 
         SetField(backend, "_kernelCache", kernels);
-        SetField(backend, "<IsAvailable>k__BackingField", true);
+        // IsAvailable is no longer an auto-property: it now reads `_isAvailable && !_disposed`,
+        // so that a disposed backend stops reporting itself as usable and DirectGpuBackendFactory
+        // rebuilds instead of handing out a dead cached instance. This hook follows that rename;
+        // the simulated state it sets up is identical.
+        SetField(backend, "_isAvailable", true);
         SetField(backend, "<DeviceName>k__BackingField", "Mock AMD GPU");
         return backend;
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ReductionNonPowerOfTwoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ReductionNonPowerOfTwoTests.cs
@@ -96,23 +96,43 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
                 $"Max over {length} elements missed the maximum at index {length - 1}.");
         }
 
+        /// <summary>
+        /// Returns null ONLY when this host genuinely has no GPU backend.
+        /// </summary>
+        /// <remarks>
+        /// A blanket <c>catch (Exception)</c> here turns every initialisation failure into a skipped
+        /// test, so a real regression on a GPU-capable host reads as "no GPU available" and the
+        /// suite stays green. Only the absence of the runtime itself is treated as "no backend" —
+        /// a missing ICD or entry point, or an unsupported platform. Anything else is a failure and
+        /// is allowed to fail.
+        /// </remarks>
         private static DirectGpuTensorEngine? TryCreateGpuEngine()
         {
+            DirectGpuTensorEngine engine;
             try
             {
-                var engine = new DirectGpuTensorEngine();
-                if (!engine.IsGpuAvailable)
-                {
-                    engine.Dispose();
-                    return null;
-                }
-
-                return engine;
+                engine = new DirectGpuTensorEngine();
             }
-            catch (Exception)
+            catch (DllNotFoundException)
             {
                 return null;
             }
+            catch (EntryPointNotFoundException)
+            {
+                return null;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return null;
+            }
+
+            if (!engine.IsGpuAvailable)
+            {
+                engine.Dispose();
+                return null;
+            }
+
+            return engine;
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ReductionNonPowerOfTwoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/ReductionNonPowerOfTwoTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NETFRAMEWORK
+using System;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
+{
+    /// <summary>
+    /// GPU reductions must be exact when the element count is not a power of two.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The work-group size is clamped to the element count, so a 31-element reduction runs with a
+    /// local size of 31. The classic tree — <c>for (stride = localSize / 2; stride &gt; 0; stride
+    /// &gt;&gt;= 1)</c> — folds indices 0..29 and never touches index 30, so the last element is
+    /// dropped entirely.
+    /// </para>
+    /// <para>
+    /// SUM IS THE TEST THAT MATTERS, and Min alone would not have caught the whole class. Min and
+    /// Max are idempotent: folding the same element twice, or reading one that has already been
+    /// folded away, changes nothing. Addition is not. A tree whose partner bound is the ORIGINAL
+    /// work-group size rather than the shrinking ACTIVE count double-counts — at a local size of 6,
+    /// the second step merges lane 1 with lane 3, which is outside the live range and still holds
+    /// its original value, so that value lands in the total twice. Min survives that; Sum reports a
+    /// number that is simply wrong.
+    /// </para>
+    /// <para>
+    /// So the lengths below are odd and small-odd on purpose, and the expected values are exact
+    /// integers held exactly in float, which makes any double-count or dropped lane a hard
+    /// mismatch rather than a tolerance question.
+    /// </para>
+    /// </remarks>
+    public class ReductionNonPowerOfTwoTests
+    {
+        public static TheoryData<int> Lengths()
+        {
+            var data = new TheoryData<int>();
+            // 3, 5, 6, 7 exercise the small local sizes where a mis-bounded partner is reachable in
+            // the second step; the larger odd ones exercise multi-pass reductions.
+            foreach (int n in new[] { 1, 2, 3, 5, 6, 7, 9, 15, 17, 31, 33, 63, 255, 257, 1025 })
+                data.Add(n);
+            return data;
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(Lengths))]
+        public void Sum_IsExact_AtAnyLength(int length)
+        {
+            using var engine = TryCreateGpuEngine();
+            Skip.If(engine is null, "No direct GPU backend is available on this host.");
+            var backend = engine!.GetBackend();
+            Skip.If(backend is null, "No direct GPU backend is available on this host.");
+
+            // 1, 2, 3, ... n : every element distinct, so a dropped or doubled lane cannot cancel
+            // out, and the total is exact in float for these sizes.
+            var values = new float[length];
+            for (int i = 0; i < length; i++) values[i] = i + 1;
+            double expected = (double)length * (length + 1) / 2.0;
+
+            using var buffer = backend!.AllocateBuffer(values);
+            float actual = backend.Sum(buffer, length);
+
+            Assert.True(
+                Math.Abs(actual - expected) < 1e-3,
+                $"Sum over {length} elements returned {actual}, expected {expected}. A tree reduction "
+                    + "that halves without bounding its partner against the ACTIVE count either drops "
+                    + "the last lane or folds an already-consumed one twice; both show up here and "
+                    + "neither shows up in Min or Max, which are idempotent.");
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(Lengths))]
+        public void MinAndMax_SeeEveryLane_AtAnyLength(int length)
+        {
+            using var engine = TryCreateGpuEngine();
+            Skip.If(engine is null, "No direct GPU backend is available on this host.");
+            var backend = engine!.GetBackend();
+            Skip.If(backend is null, "No direct GPU backend is available on this host.");
+
+            // The extremes sit at the LAST index, which is the lane a truncated tree drops.
+            var low = new float[length];
+            var high = new float[length];
+            for (int i = 0; i < length; i++) { low[i] = 10f; high[i] = 10f; }
+            low[length - 1] = -5f;
+            high[length - 1] = 99f;
+
+            using var lowBuffer = backend!.AllocateBuffer(low);
+            using var highBuffer = backend.AllocateBuffer(high);
+
+            Assert.True(
+                backend.Min(lowBuffer, length) == -5f,
+                $"Min over {length} elements missed the minimum at index {length - 1}.");
+            Assert.True(
+                backend.Max(highBuffer, length) == 99f,
+                $"Max over {length} elements missed the maximum at index {length - 1}.");
+        }
+
+        private static DirectGpuTensorEngine? TryCreateGpuEngine()
+        {
+            try
+            {
+                var engine = new DirectGpuTensorEngine();
+                if (!engine.IsGpuAvailable)
+                {
+                    engine.Dispose();
+                    return null;
+                }
+
+                return engine;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Every item here was a test failing on `main`. A control run of `origin/main` with CI's own filter (`Category!=Benchmark&Category!=Performance`) fails exactly the four tests this branch fixes — **and crashes** — so none of this is introduced here.

**Two consecutive clean full runs:** 11,993 → **12,022 passed, 0 failed, 0 crashes** (12,928 tests, 29m). Both target frameworks build.

## Silent gradient loss

`TapeGradientParityTests` compares how many differentiable leaves the CPU and GPU engines record for the same op. A mismatch means one side produces correct **values** and no gradient — nothing throws, and the parameter simply never learns.

| op | before |
|---|---|
| `TensorRot90` | GPU recorded **0** leaves vs CPU's 1 — its rotation goes through `PermuteResidentGpu`, which materialises a device buffer via `DeferTensorResult` and wires no gradient |
| `TensorMeshgrid` | **CPU** recorded 0 vs GPU's 2 — its element loop writes into a rented buffer, so outputs have nothing linking them to their inputs |

Neither is visible to CI: the pocl matrix runs these tests, but pocl engages neither GPU path, so both sides fall back and the counts match.

## Categorical sampling ran on the CPU after you selected the GPU

The residency probe measured 0 kernel launches against a required 1. The cause was the RNG: every sibling seeded random op draws from `StatelessRandom`, a counter-based PCG hash the CUDA, Metal and OpenCL kernels reproduce constant-for-constant. This one used `new Random(seed)`, which no kernel can reproduce.

The CPU draw is now `StatelessRandom.Uniform01(seed, row)` — keying on the **row** rather than draw order is what makes a device implementation possible. OpenCL and HIP both get the kernel. `Forward_CpuMatchesGpu` passes, so CPU and GPU agree bit for bit, and the worklist is `0 (goal 0)`.

Adding the OpenCL kernel opened a backend-parity gap, which is fixed rather than excused: CUDA and HIP both carry kernels matching `/categorical/`, but they are `categorical_cross_entropy_*` — a **loss**, not sampling. Allowlisting on that basis would have asserted coverage that does not exist.

## Reductions dropped their last element

`CalculateOptimalWorkGroupSize1D` clamps the local size to the element count, so a 31-element reduction runs with a local size of **31**. Every reduction kernel then walked `for (stride = localSize / 2; stride > 0; stride >>= 1)`, folding indices 0–29 and **never touching index 30**. Every failing length is odd (31, 33, 255, 257, 1025); every passing one is a power of two.

So `Min`, `Max` and `Sum` were wrong for any non-power-of-two reduction. Fixed in 11 OpenCL kernels and hardened in 44 more across CUDA/HIP/Metal. 10 further matches were left after checking each: 8 CUDA PTX emitters whose `BlockThreads` is a compile-time 64/128/256, and 2 HIP warp shuffles where a warp is 32 by hardware definition.

**A first attempt at this was itself wrong**, and the fix is worth stating because the test now pins it: bounding the partner against the *original* work-group size instead of the shrinking active range makes a lane merge with one already consumed. Min/Max survive it (idempotent); **Sum double-counts** — 6 elements summed to 25 instead of 21. `ReductionNonPowerOfTwoTests` covers this, and `Sum` is the assertion that matters because Min/Max cannot see this class at all.

Fixing that exposed a second bug behind it: `ReduceScalar` downloaded into `new float[1]`, but the final scratch buffer holds the first pass's partial count (1025 elements at local size 256 → 5), and `CopyToHost` validates against the whole buffer.

## The crash, and the diagnostics that should have found it

An intermittent `0xC0000005` inside native `clSetKernelArg` was aborting long runs — on `main` as well. Two real defects on that path are fixed: abandoned kernel arguments reaching the next launch (the staging list was thread-static but shared across every kernel, and cleared only on the success path), and the launch path never checking a handle that `Dispose` had set to `IntPtr.Zero`.

It has not recurred across two full runs, but it was intermittent and **I did not reproduce it on demand**, so I am not claiming a proven cure.

That is precisely why `GpuKernelDiagnostics` exists. `GpuLaunchProbe` answers "did this reach the device"; `GpuKernelGuards` is per-op shape checking at a few entry points. Neither answers what you need after a crash:

- **validation** — always on, cached, an int compare per launch: released handle, work-group within the kernel's own maximum, global size a multiple of local, and an opt-in power-of-two assertion (the exact condition whose absence dropped a reduction lane here)
- **journal** — a 64-entry allocation-free ring of recent launches, dumpable to disk from a crash handler. When the host dies this is the only surviving evidence; enqueue failures now quote it
- **`AIDOTNET_GPU_KERNEL_DIAGNOSTICS`** — buffer capacity against the range a launch addresses, and argument count against the kernel's own `CL_KERNEL_NUM_ARGS` (newly bound)
- **`AIDOTNET_GPU_SYNC_LAUNCHES`** — finish after each launch so an async fault is attributed to the launch that caused it

The argument-count check is deliberately **not** always on: OpenCL arguments persist between launches, so a launcher may legitimately set a subset, and failing that by default would break working callers. Validation is public so callers extending the library with their own kernels get the same checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated categorical sampling across supported OpenCL, HIP, Metal, Vulkan, and WebGPU devices.
  * Added optional GPU launch diagnostics, validation, buffer tracking, and recent-launch reporting.
  * Meshgrid operations now integrate correctly with automatic differentiation and graph tracing.

* **Bug Fixes**
  * Improved reduction accuracy across CUDA, HIP, Metal, and OpenCL for non-power-of-two workgroup sizes.
  * Preserved reproducible seeded categorical sampling across compute backends.
  * Fixed rotation operations so gradients are retained during tracing and autodiff.
  * Improved GPU error reporting and fallback behavior when specialized kernels are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->