### PR TITLE
fix(cpu): preserve Conv2D parity without Windows regression

### DIFF
--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9495,42 +9495,38 @@ public partial class CpuEngine : ITensorLevelEngine
 
         var result = TensorAllocator.Rent<T>(new[] { batch, outChannels, outputHeight, outputWidth });
 
-        // SAME KERNEL AS Conv2DInto. These two entry points used to dispatch differently for
-        // float -- this one to Conv2DWithIm2ColFloat (the SIMD-direct / Winograd cascade), and
-        // Conv2DInto to Conv2DIm2colGemm -- on the stated grounds that the results are
-        // "numerically equivalent (im2col-GEMM vs direct differ only by FP summation order)".
-        //
-        // At float32 they are not. Measured on a 3x3 stride-1 conv, 8 output channels over a
-        // [1,3,16,16] input: 1658 of 2048 outputs differed, by up to 2.3e-4 RELATIVE, and against a
-        // float64 reference the two land at rms 5.13e-08 and 6.77e-08 -- either side of the float
-        // epsilon, so the disagreement is not confined to the last bits.
-        //
-        // Callers cannot see which entry point they reached. AiDotNet's ConvolutionalLayer picks
-        // between them by whether a GradientTape is recording, since the in-place variant bypasses
-        // the tape, so the SAME layer with the SAME weights computed a different function in
-        // training than at inference -- and its serialize-replay test failed intermittently in CI
-        // depending on whether a tape happened to be active. That is a dispatch bug here, not a
-        // layer bug there: PyTorch selects a convolution algorithm from shape and hardware, never
-        // from grad mode, and torch.no_grad() changes whether a graph is built rather than the
-        // values flowing through it.
-        //
-        // Routing both to Conv2DIm2colGemm also makes THIS path faster: the cascade is roughly 15x
-        // slower for the small 3x3 stride-1 convolutions that dominate CNN inference, which is the
-        // measurement that moved Conv2DInto onto the GEMM path in the first place.
+        // Every float/NCHW entry point must select the same numeric kernel for a given
+        // platform and geometry. Overload choice and gradient recording are deliberately
+        // absent from the selector because neither may change the computed function.
         if (typeof(T) == typeof(float))
         {
             // GetReadOnlyDataArray for the two INPUTS: GetDataArray privatizes a copy-on-write
             // tensor, and a read must not. TensorCowInferenceReadPathTests.Conv2D_DoesNotPrivatizeCowKernel
             // asserts exactly that the kernel stays COW-shared across a convolution. The output is a
             // tensor this method just rented, so it is written through GetDataArray as normal.
-            Conv2DIm2colGemm(
-                (float[])(object)input.GetReadOnlyDataArray(),
-                (float[])(object)kernel.GetReadOnlyDataArray(),
-                (float[])(object)result.GetDataArray(),
-                batch, inChannels, height, width,
-                outChannels, kernelHeight, kernelWidth,
-                outputHeight, outputWidth,
-                stride, stride, padding, padding, dilation, dilation);
+            if (ShouldUseAdaptiveFloatConv2D(
+                input.Layout, stride, stride, padding, padding, dilation, dilation))
+            {
+                Conv2DWithIm2ColFloat(
+                    (Tensor<float>)(object)input,
+                    (Tensor<float>)(object)kernel,
+                    (Tensor<float>)(object)result,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    stride, padding, dilation,
+                    outputHeight, outputWidth);
+            }
+            else
+            {
+                Conv2DIm2colGemm(
+                    (float[])(object)input.GetReadOnlyDataArray(),
+                    (float[])(object)kernel.GetReadOnlyDataArray(),
+                    (float[])(object)result.GetDataArray(),
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    outputHeight, outputWidth,
+                    stride, stride, padding, padding, dilation, dilation);
+            }
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                 BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
             if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => eng.Conv2D(inputOrig, kernel, stride, padding, dilation));
@@ -9748,25 +9744,33 @@ public partial class CpuEngine : ITensorLevelEngine
                 $"Output tensor shape [{string.Join(", ", output._shape)}] doesn't match expected shape [{batch}, {outChannels}, {outputHeight}, {outputWidth}].");
         }
 
-        // Use im2col + GEMM for float. Route through Conv2DIm2colGemm — the same
-        // maintained fast path the int[] Conv2DInto / allocating Conv2D(int[])
-        // overloads use — rather than Conv2DWithIm2ColFloat (the SIMD-direct /
-        // Winograd cascade). For the small 3×3 stride-1 convs that dominate CNN
-        // inference the direct cascade is ~15× slower than im2col-GEMM (measured:
-        // a 16→32 @14×14 conv at 1967 µs via this overload vs 117 µs via the int[]
-        // overload), so the int and int[] overloads were silently making opposite
-        // kernel choices. Output is numerically equivalent (im2col-GEMM vs direct
-        // differ only by FP summation order).
+        // Use the same platform/geometry selector as both allocating overloads so
+        // a preallocated destination changes allocation behavior only, never arithmetic.
         if (typeof(T) == typeof(float))
         {
-            Conv2DIm2colGemm(
-                (float[])(object)input.GetDataArray(),
-                (float[])(object)kernel.GetDataArray(),
-                (float[])(object)output.GetDataArray(),
-                batch, inChannels, height, width,
-                outChannels, kernelHeight, kernelWidth,
-                outputHeight, outputWidth,
-                stride, stride, padding, padding, dilation, dilation);
+            if (ShouldUseAdaptiveFloatConv2D(
+                input.Layout, stride, stride, padding, padding, dilation, dilation))
+            {
+                Conv2DWithIm2ColFloat(
+                    (Tensor<float>)(object)input,
+                    (Tensor<float>)(object)kernel,
+                    (Tensor<float>)(object)output,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    stride, padding, dilation,
+                    outputHeight, outputWidth);
+            }
+            else
+            {
+                Conv2DIm2colGemm(
+                    (float[])(object)input.GetReadOnlyDataArray(),
+                    (float[])(object)kernel.GetReadOnlyDataArray(),
+                    (float[])(object)output.GetDataArray(),
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    outputHeight, outputWidth,
+                    stride, stride, padding, padding, dilation, dilation);
+            }
             return;
         }
 
@@ -9848,6 +9852,29 @@ public partial class CpuEngine : ITensorLevelEngine
             outChannels, kernelHeight, kernelWidth,
             stride, padding, dilation,
             outputHeight, outputWidth);
+    }
+
+    /// <summary>
+    /// Selects one float convolution family for every public CPU entry point.
+    /// The adaptive cascade is materially faster on Windows, while im2col-GEMM is the
+    /// measured winner on Linux. Geometry and layout, never overload or gradient mode,
+    /// determine the family so equivalent calls remain bit-identical.
+    /// </summary>
+    private static bool ShouldUseAdaptiveFloatConv2D(
+        LinearAlgebra.TensorLayout inputLayout,
+        int strideH,
+        int strideW,
+        int padH,
+        int padW,
+        int dilationH,
+        int dilationW)
+    {
+        return inputLayout == LinearAlgebra.TensorLayout.Nchw
+            && strideH == strideW
+            && padH == padW
+            && dilationH == dilationW
+            && System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.Windows);
     }
 
     /// <summary>
@@ -13787,14 +13814,29 @@ public partial class CpuEngine : ITensorLevelEngine
                     batch, inChannels, height, width, cBlock);
                 inputData = (T[])(object)unpackedData;
             }
-            Conv2DIm2colGemm(
-                (float[])(object)inputData,
-                (float[])(object)kernelData,
-                (float[])(object)outputData,
-                batch, inChannels, height, width,
-                outChannels, kernelHeight, kernelWidth,
-                outputHeight, outputWidth,
-                strideH, strideW, padH, padW, dilationH, dilationW);
+            if (ShouldUseAdaptiveFloatConv2D(
+                input.Layout, strideH, strideW, padH, padW, dilationH, dilationW))
+            {
+                Conv2DWithIm2ColFloat(
+                    (Tensor<float>)(object)input,
+                    (Tensor<float>)(object)kernel,
+                    (Tensor<float>)(object)result,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    strideH, padH, dilationH,
+                    outputHeight, outputWidth);
+            }
+            else
+            {
+                Conv2DIm2colGemm(
+                    (float[])(object)inputData,
+                    (float[])(object)kernelData,
+                    (float[])(object)outputData,
+                    batch, inChannels, height, width,
+                    outChannels, kernelHeight, kernelWidth,
+                    outputHeight, outputWidth,
+                    strideH, strideW, padH, padW, dilationH, dilationW);
+            }
         }
         else if (typeof(T) == typeof(double))
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -9500,33 +9500,19 @@ public partial class CpuEngine : ITensorLevelEngine
         // absent from the selector because neither may change the computed function.
         if (typeof(T) == typeof(float))
         {
-            // GetReadOnlyDataArray for the two INPUTS: GetDataArray privatizes a copy-on-write
-            // tensor, and a read must not. TensorCowInferenceReadPathTests.Conv2D_DoesNotPrivatizeCowKernel
-            // asserts exactly that the kernel stays COW-shared across a convolution. The output is a
-            // tensor this method just rented, so it is written through GetDataArray as normal.
-            if (ShouldUseAdaptiveFloatConv2D(
-                input.Layout, stride, stride, padding, padding, dilation, dilation))
-            {
-                Conv2DWithIm2ColFloat(
-                    (Tensor<float>)(object)input,
-                    (Tensor<float>)(object)kernel,
-                    (Tensor<float>)(object)result,
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    stride, padding, dilation,
-                    outputHeight, outputWidth);
-            }
-            else
-            {
-                Conv2DIm2colGemm(
-                    (float[])(object)input.GetReadOnlyDataArray(),
-                    (float[])(object)kernel.GetReadOnlyDataArray(),
-                    (float[])(object)result.GetDataArray(),
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    outputHeight, outputWidth,
-                    stride, stride, padding, padding, dilation, dilation);
-            }
+            // The dispatcher obtains backing arrays only if it selects im2col-GEMM. Keeping that
+            // lookup lazy matters for offset views on the Windows adaptive route: a read-only array
+            // request would materialize an otherwise-unneeded full copy. When arrays are needed,
+            // GetReadOnlyDataArray preserves COW sharing for both inputs.
+            DispatchFloatConv2D(
+                (Tensor<float>)(object)input,
+                (Tensor<float>)(object)kernel,
+                (Tensor<float>)(object)result,
+                null, null, null,
+                batch, inChannels, height, width,
+                outChannels, kernelHeight, kernelWidth,
+                stride, stride, padding, padding, dilation, dilation,
+                outputHeight, outputWidth);
             DifferentiableOps.RecordBinary("Conv2D", result, inputOrig, kernel,
                 BackwardFunctions<T>.Conv2DBackward, new object[] { new[] { stride, stride }, new[] { padding, padding }, new[] { dilation, dilation } });
             if (AutoTracer.ShouldRecord) AutoTracer.RecordOp("Conv2D", result, eng => eng.Conv2D(inputOrig, kernel, stride, padding, dilation));
@@ -9744,33 +9730,19 @@ public partial class CpuEngine : ITensorLevelEngine
                 $"Output tensor shape [{string.Join(", ", output._shape)}] doesn't match expected shape [{batch}, {outChannels}, {outputHeight}, {outputWidth}].");
         }
 
-        // Use the same platform/geometry selector as both allocating overloads so
+        // Use the same platform/geometry dispatcher as both allocating overloads so
         // a preallocated destination changes allocation behavior only, never arithmetic.
         if (typeof(T) == typeof(float))
         {
-            if (ShouldUseAdaptiveFloatConv2D(
-                input.Layout, stride, stride, padding, padding, dilation, dilation))
-            {
-                Conv2DWithIm2ColFloat(
-                    (Tensor<float>)(object)input,
-                    (Tensor<float>)(object)kernel,
-                    (Tensor<float>)(object)output,
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    stride, padding, dilation,
-                    outputHeight, outputWidth);
-            }
-            else
-            {
-                Conv2DIm2colGemm(
-                    (float[])(object)input.GetReadOnlyDataArray(),
-                    (float[])(object)kernel.GetReadOnlyDataArray(),
-                    (float[])(object)output.GetDataArray(),
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    outputHeight, outputWidth,
-                    stride, stride, padding, padding, dilation, dilation);
-            }
+            DispatchFloatConv2D(
+                (Tensor<float>)(object)input,
+                (Tensor<float>)(object)kernel,
+                (Tensor<float>)(object)output,
+                null, null, null,
+                batch, inChannels, height, width,
+                outChannels, kernelHeight, kernelWidth,
+                stride, stride, padding, padding, dilation, dilation,
+                outputHeight, outputWidth);
             return;
         }
 
@@ -9854,6 +9826,10 @@ public partial class CpuEngine : ITensorLevelEngine
             outputHeight, outputWidth);
     }
 
+    private static readonly bool IsWindowsPlatform =
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows);
+
     /// <summary>
     /// Selects one float convolution family for every public CPU entry point.
     /// The adaptive cascade is materially faster on Windows, while im2col-GEMM is the
@@ -9869,12 +9845,79 @@ public partial class CpuEngine : ITensorLevelEngine
         int dilationH,
         int dilationW)
     {
-        return inputLayout == LinearAlgebra.TensorLayout.Nchw
+        return ShouldUseAdaptiveFloatConv2DForPlatform(
+            IsWindowsPlatform, inputLayout, strideH, strideW, padH, padW, dilationH, dilationW);
+    }
+
+    /// <summary>
+    /// Applies the platform and geometry policy separately from runtime OS detection so every
+    /// decision branch can be tested deterministically on every CI host.
+    /// </summary>
+    internal static bool ShouldUseAdaptiveFloatConv2DForPlatform(
+        bool isWindows,
+        LinearAlgebra.TensorLayout inputLayout,
+        int strideH,
+        int strideW,
+        int padH,
+        int padW,
+        int dilationH,
+        int dilationW)
+    {
+        return isWindows
+            && inputLayout == LinearAlgebra.TensorLayout.Nchw
             && strideH == strideW
             && padH == padW
-            && dilationH == dilationW
-            && System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                System.Runtime.InteropServices.OSPlatform.Windows);
+            && dilationH == dilationW;
+    }
+
+    /// <summary>
+    /// Dispatches every float Conv2D entry point through the same platform/geometry policy.
+    /// The supplied arrays may already be unpacked for a packed-layout fallback.
+    /// </summary>
+    private void DispatchFloatConv2D(
+        Tensor<float> input,
+        Tensor<float> kernel,
+        Tensor<float> output,
+        float[]? inputData,
+        float[]? kernelData,
+        float[]? outputData,
+        int batch,
+        int inChannels,
+        int height,
+        int width,
+        int outChannels,
+        int kernelHeight,
+        int kernelWidth,
+        int strideH,
+        int strideW,
+        int padH,
+        int padW,
+        int dilationH,
+        int dilationW,
+        int outputHeight,
+        int outputWidth)
+    {
+        if (ShouldUseAdaptiveFloatConv2D(
+            input.Layout, strideH, strideW, padH, padW, dilationH, dilationW))
+        {
+            Conv2DWithIm2ColFloat(
+                input, kernel, output,
+                batch, inChannels, height, width,
+                outChannels, kernelHeight, kernelWidth,
+                strideH, padH, dilationH,
+                outputHeight, outputWidth);
+            return;
+        }
+
+        inputData ??= input.GetReadOnlyDataArray();
+        kernelData ??= kernel.GetReadOnlyDataArray();
+        outputData ??= output.GetDataArray();
+        Conv2DIm2colGemm(
+            inputData, kernelData, outputData,
+            batch, inChannels, height, width,
+            outChannels, kernelHeight, kernelWidth,
+            outputHeight, outputWidth,
+            strideH, strideW, padH, padW, dilationH, dilationW);
     }
 
     /// <summary>
@@ -13814,29 +13857,17 @@ public partial class CpuEngine : ITensorLevelEngine
                     batch, inChannels, height, width, cBlock);
                 inputData = (T[])(object)unpackedData;
             }
-            if (ShouldUseAdaptiveFloatConv2D(
-                input.Layout, strideH, strideW, padH, padW, dilationH, dilationW))
-            {
-                Conv2DWithIm2ColFloat(
-                    (Tensor<float>)(object)input,
-                    (Tensor<float>)(object)kernel,
-                    (Tensor<float>)(object)result,
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    strideH, padH, dilationH,
-                    outputHeight, outputWidth);
-            }
-            else
-            {
-                Conv2DIm2colGemm(
-                    (float[])(object)inputData,
-                    (float[])(object)kernelData,
-                    (float[])(object)outputData,
-                    batch, inChannels, height, width,
-                    outChannels, kernelHeight, kernelWidth,
-                    outputHeight, outputWidth,
-                    strideH, strideW, padH, padW, dilationH, dilationW);
-            }
+            DispatchFloatConv2D(
+                (Tensor<float>)(object)input,
+                (Tensor<float>)(object)kernel,
+                (Tensor<float>)(object)result,
+                (float[])(object)inputData,
+                (float[])(object)kernelData,
+                (float[])(object)outputData,
+                batch, inChannels, height, width,
+                outChannels, kernelHeight, kernelWidth,
+                strideH, strideW, padH, padW, dilationH, dilationW,
+                outputHeight, outputWidth);
         }
         else if (typeof(T) == typeof(double))
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.DirectPtx.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.DirectPtx.cs
@@ -5185,7 +5185,6 @@ public sealed partial class CudaBackend
             _directPtxGumbelBackwardKernels.Dispose();
             _directPtxFusedRreluKernels.Dispose();
             _directPtxRreluKernels.Dispose();
-            _directPtxRuntime?.Dispose();
             lock (GpuDispatchLock)
             {
                 Array.Clear(
@@ -5198,6 +5197,7 @@ public sealed partial class CudaBackend
                 _directPtxCholesky4x4Plans.Clear();
             }
             DisposeDirectPtxSolver4x4Kernels();
+            _directPtxRuntime?.Dispose();
             _directPtxRuntime = null;
         }
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaOffloadAllocator.cs
@@ -53,47 +53,79 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
         _ownsContext = sharedContext == IntPtr.Zero; // zero -> behave like the default ctor (create our own)
     }
 
-    public bool IsAvailable => CudaNativeBindings.IsAvailable;
+    internal static bool IsCudaUsable(bool driverAvailable, bool circuitBroken)
+        => driverAvailable && !circuitBroken;
+
+    internal static bool ShouldPopContext(bool pushed, bool circuitBroken)
+        => pushed && !circuitBroken;
+
+    public bool IsAvailable
+    {
+        get
+        {
+            if (!IsCudaUsable(CudaNativeBindings.IsAvailable, AiDotNetEngine.GpuCircuitBroken))
+                return false;
+
+            lock (_lifecycleLock)
+            {
+                if (_disposed) return false;
+                lock (CudaBackend.ContextLifecycleLock)
+                    return IsContextUsableUnderLifecycleLock();
+            }
+        }
+    }
+
+    // Caller must hold CudaBackend.ContextLifecycleLock. For a shared backend context, membership
+    // is the authoritative lifetime signal: CudaBackend removes it under the same lock immediately
+    // before cuCtxDestroy. Owned primary contexts are protected by this allocator's lifecycle lock.
+    private bool IsContextUsableUnderLifecycleLock()
+        => _ownsContext || (_context != IntPtr.Zero && CudaBackend.LiveContexts.ContainsKey(_context));
 
     public GpuOffloadHandle Allocate(long bytes, OffloadScheme scheme)
     {
-        // Hold _lifecycleLock across the entire allocate+register so a
-        // concurrent Dispose cannot snapshot _live, clear it, and let this
-        // allocation slip in afterwards (which would leak the device handle
-        // since Dispose has already returned).
+        // Hold _lifecycleLock across the entire allocate+register so a concurrent Dispose cannot
+        // let this allocation escape its snapshot. ContextLifecycleLock is nested inside it and held
+        // across {live check + push + native call + pop}, making backend context destruction mutually
+        // exclusive with shared-context use.
         lock (_lifecycleLock)
         {
             if (_disposed) throw new ObjectDisposedException(nameof(CudaOffloadAllocator));
-            if (!IsAvailable)
-                throw new NotSupportedException("CUDA driver is not loadable on this host.");
+            if (!IsCudaUsable(CudaNativeBindings.IsAvailable, AiDotNetEngine.GpuCircuitBroken))
+                throw new NotSupportedException("CUDA offload is unavailable on this host.");
             if (bytes <= 0) throw new ArgumentOutOfRangeException(nameof(bytes));
 
-            EnsureContext();
-            using (PushContextScope())
+            lock (CudaBackend.ContextLifecycleLock)
             {
-                IntPtr ptr;
-                OffloadScheme effective = scheme == OffloadScheme.Auto ? OffloadScheme.Pinned : scheme;
-                switch (effective)
+                if (!IsContextUsableUnderLifecycleLock())
+                    throw new NotSupportedException("The CUDA context backing this offload allocator is no longer live.");
+
+                EnsureContext();
+                using (PushContextScope())
                 {
-                    case OffloadScheme.Pinned:
-                        {
-                            var rc = CuBlasNative.cuMemAllocHost(out ptr, (ulong)bytes);
-                            CuBlasNative.CheckCudaResult(rc, "cuMemAllocHost(offload)");
-                            break;
-                        }
-                    case OffloadScheme.Managed:
-                        {
-                            var rc = CudaNativeBindings.cuMemAllocManaged(out ptr, (ulong)bytes, CudaNativeBindings.CU_MEM_ATTACH_GLOBAL);
-                            if (rc != CudaResult.Success)
-                                throw new InvalidOperationException($"cuMemAllocManaged returned {rc}");
-                            break;
-                        }
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(scheme), scheme, "Unknown offload scheme.");
+                    IntPtr ptr;
+                    OffloadScheme effective = scheme == OffloadScheme.Auto ? OffloadScheme.Pinned : scheme;
+                    switch (effective)
+                    {
+                        case OffloadScheme.Pinned:
+                            {
+                                var rc = CuBlasNative.cuMemAllocHost(out ptr, (ulong)bytes);
+                                CuBlasNative.CheckCudaResult(rc, "cuMemAllocHost(offload)");
+                                break;
+                            }
+                        case OffloadScheme.Managed:
+                            {
+                                var rc = CudaNativeBindings.cuMemAllocManaged(
+                                    out ptr, (ulong)bytes, CudaNativeBindings.CU_MEM_ATTACH_GLOBAL);
+                                CuBlasNative.CheckCudaResult(rc, "cuMemAllocManaged(offload)");
+                                break;
+                            }
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(scheme), scheme, "Unknown offload scheme.");
+                    }
+                    var handle = new GpuOffloadHandle(ptr, ptr, bytes, effective);
+                    _live[ptr] = handle;
+                    return handle;
                 }
-                var h = new GpuOffloadHandle(ptr, ptr, bytes, effective);
-                _live[ptr] = h;
-                return h;
             }
         }
     }
@@ -101,19 +133,21 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
     public void Free(GpuOffloadHandle handle)
     {
         if (handle.HostPointer == IntPtr.Zero) return;
-        // Only call native free for handles WE own — a foreign handle or
-        // double-free would corrupt the heap on the second native release.
-        // Lock TryRemove against Dispose's snapshot+clear so a concurrent
-        // Dispose can't free the same pointer twice.
+        // Only call native free for handles WE own. Serialize the live-context check and CUDA
+        // cleanup against CudaBackend's {deregister + destroy} critical section.
         lock (_lifecycleLock)
         {
             if (!_live.TryRemove(handle.HostPointer, out _)) return;
-            // Native free needs our context current; push before, pop
-            // after so the thread's context stack is restored to its
-            // prior state.
-            using (PushContextScope())
+            if (!IsCudaUsable(CudaNativeBindings.IsAvailable, AiDotNetEngine.GpuCircuitBroken))
+                return;
+
+            lock (CudaBackend.ContextLifecycleLock)
             {
-                FreeNative(handle);
+                if (!IsContextUsableUnderLifecycleLock()) return;
+                using (PushContextScope())
+                {
+                    FreeNative(handle);
+                }
             }
         }
     }
@@ -165,7 +199,7 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
 
         public void Dispose()
         {
-            if (_pushed)
+            if (ShouldPopContext(_pushed, AiDotNetEngine.GpuCircuitBroken))
             {
                 // Best-effort pop on failure: a throwing pop here would
                 // mask the original native error and leave the stack
@@ -227,10 +261,14 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
         switch (handle.Scheme)
         {
             case OffloadScheme.Pinned:
-                CuBlasNative.cuMemFreeHost(handle.HostPointer);
+                CuBlasNative.CheckCudaResult(
+                    CuBlasNative.cuMemFreeHost(handle.HostPointer),
+                    "cuMemFreeHost(offload)");
                 break;
             case OffloadScheme.Managed:
-                CudaNativeBindings.cuMemFree(handle.DevicePointer);
+                CuBlasNative.CheckCudaResult(
+                    CudaNativeBindings.cuMemFree(handle.DevicePointer),
+                    "cuMemFree(offload)");
                 break;
         }
     }
@@ -252,6 +290,14 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
             ctxToDestroy = _context;
             _context = IntPtr.Zero;
 
+            if (AiDotNetEngine.GpuCircuitBroken)
+            {
+                // CUDA 700/709/719 can invalidate the context and even make a nominal cleanup call
+                // fault natively. The circuit breaker is process-lifetime, so abandon native teardown;
+                // the OS reclaims these resources when the process exits.
+                return;
+            }
+
             if (ctxToDestroy != IntPtr.Zero && _ownsContext)
             {
                 // WE retained the device primary context, so it is guaranteed valid here. Push it to free
@@ -270,20 +316,20 @@ public sealed class CudaOffloadAllocator : IGpuOffloadAllocator, IGpuDevicePoint
             }
             else if (ctxToDestroy != IntPtr.Zero)
             {
-                // SHARED (non-owning) context: its lifetime is the CudaBackend's,
-                // NOT ours. The backend may ALREADY have destroyed it before this
-                // allocator is disposed — e.g. AiDotNetEngine.ResetToCpu tears the
-                // backend (and its context) down first, then WeightRegistry.Reset
-                // disposes this allocator. Issuing cuCtxPushCurrent / cuMemFree /
-                // cuCtxPopCurrent against a destroyed context is a use-after-free
-                // that faults the process with an UNCATCHABLE native access
-                // violation (observed as "Test host process crashed" in
-                // WeightRegistry.Reset -> CudaOffloadAllocator.Dispose ->
-                // cuCtxPopCurrent). So do NOT touch the shared context here:
-                // cuCtxDestroy by its owner reclaims EVERY allocation made in the
-                // context (device + pinned host), so dropping the per-handle frees
-                // forgoes only a redundant free, never leaks past the context's own
-                // lifetime. (The owned-context branch above still frees+destroys.)
+                // SHARED (non-owning) context: free our outstanding allocations while its owner
+                // still has it live, but serialize the live check + push/free/pop against the
+                // backend's deregister + cuCtxDestroy critical section. If the backend already
+                // destroyed the context (for example ResetToCpu demoted it first), touching the raw
+                // handle is a use-after-free that can fault the process natively; skip cleanup in
+                // that case because cuCtxDestroy has already reclaimed the context's resources.
+                lock (CudaBackend.ContextLifecycleLock)
+                {
+                    if (CudaBackend.LiveContexts.ContainsKey(ctxToDestroy))
+                    {
+                        using var scope = new CudaContextPushScope(ctxToDestroy);
+                        foreach (var h in snapshot) FreeNative(h);
+                    }
+                }
             }
             else
             {

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxFeatureGate.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxFeatureGate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using AiDotNet.Tensors.Engines.DirectGpu;
 
 namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
@@ -95,8 +96,18 @@ internal static class DirectPtxFeatureGate
         !string.Equals(Environment.GetEnvironmentVariable(AutotuneEnvironmentVariable), "0", StringComparison.Ordinal);
     private static readonly int EnvironmentCacheCapacity = ReadCacheCapacity();
 
-    /// <summary>Test-only override. Null restores environment-based behavior.</summary>
-    internal static bool? TestOverride { get; set; }
+    private static readonly AsyncLocal<bool?> s_testOverride = new();
+
+    /// <summary>
+    /// Test-only override for the current logical call context. Null restores
+    /// environment-based behavior. Logical-context isolation prevents parallel
+    /// tests from changing one another's feature-gate decision.
+    /// </summary>
+    internal static bool? TestOverride
+    {
+        get => s_testOverride.Value;
+        set => s_testOverride.Value = value;
+    }
     /// <summary>Benchmark-only access to reduction cells that have not passed promotion.</summary>
     internal static bool ReductionExperimentOverride { get; set; }
     /// <summary>Benchmark-only access to mean/max/min/sum-of-squares row cells that have not passed promotion.</summary>

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxRuntime.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/DirectPtxRuntime.cs
@@ -644,6 +644,7 @@ internal sealed class DirectPtxModule : IDisposable
     private readonly DirectPtxRuntime _runtime;
     private readonly object _dynamicSharedMemoryLock = new();
     private readonly Dictionary<IntPtr, int> _dynamicSharedMemoryLimits = new();
+    private readonly HashSet<IntPtr> _registeredFunctions = new();
     private IntPtr _module;
     internal string JitInfoLog { get; }
     internal DirectPtxModuleImageKind ImageKind { get; }
@@ -680,24 +681,34 @@ internal sealed class DirectPtxModule : IDisposable
 
     internal IntPtr GetFunction(string name, out DirectPtxFunctionInfo info)
     {
-        using var _ = _runtime.Enter();
-        DirectPtxRuntime.Check(
-            CudaNativeBindings.cuModuleGetFunction(out IntPtr function, _module, name),
-            $"cuModuleGetFunction({name})");
-        // Carry this device's register-file capacity alongside the per-function JIT
-        // attributes so the resource budget can scale its register ceiling to the real
-        // GPU instead of a hardcoded literal.
-        info = DirectPtxFunctionInfo.Query(function) with
+        // Keep one lock order everywhere this module needs both locks:
+        // module metadata -> runtime context. SetMaxDynamicSharedMemory already uses this
+        // order; taking runtime -> metadata here would deadlock with it under concurrent
+        // first-use dispatch.
+        lock (_dynamicSharedMemoryLock)
         {
-            MaxRegistersPerMultiprocessor = _runtime.MaxRegistersPerMultiprocessor,
-            MaxRegistersPerBlock = _runtime.MaxRegistersPerBlock
-        };
-        if (info.LocalBytesPerThread != 0)
-            throw new InvalidOperationException(
-                $"Direct PTX kernel '{name}' was rejected: CUDA JIT allocated " +
-                $"{info.LocalBytesPerThread} local bytes/thread (register spill or local stack). " +
-                "The direct-kernel contract requires zero local memory.");
-        return function;
+            PtxCompat.ThrowIfDisposed(_module == IntPtr.Zero, this);
+            using var _ = _runtime.Enter();
+            DirectPtxRuntime.Check(
+                CudaNativeBindings.cuModuleGetFunction(out IntPtr function, _module, name),
+                $"cuModuleGetFunction({name})");
+            // Carry this device's register-file capacity alongside the per-function JIT
+            // attributes so the resource budget can scale its register ceiling to the real
+            // GPU instead of a hardcoded literal.
+            info = DirectPtxFunctionInfo.Query(function) with
+            {
+                MaxRegistersPerMultiprocessor = _runtime.MaxRegistersPerMultiprocessor,
+                MaxRegistersPerBlock = _runtime.MaxRegistersPerBlock
+            };
+            if (info.LocalBytesPerThread != 0)
+                throw new InvalidOperationException(
+                    $"Direct PTX kernel '{name}' was rejected: CUDA JIT allocated " +
+                    $"{info.LocalBytesPerThread} local bytes/thread (register spill or local stack). " +
+                    "The direct-kernel contract requires zero local memory.");
+            if (_registeredFunctions.Add(function))
+                GpuKernelDiagnostics.RegisterKernelName(function, name);
+            return function;
+        }
     }
 
     internal unsafe void Launch(
@@ -778,10 +789,19 @@ internal sealed class DirectPtxModule : IDisposable
 
     public void Dispose()
     {
-        if (_module == IntPtr.Zero) return;
-        using var _ = _runtime.Enter();
-        DirectPtxRuntime.Check(CudaNativeBindings.cuModuleUnload(_module), "cuModuleUnload");
-        _module = IntPtr.Zero;
+        lock (_dynamicSharedMemoryLock)
+        {
+            if (_module == IntPtr.Zero) return;
+            using var _ = _runtime.Enter();
+            // Remove diagnostics before unload: CUDA may reuse an invalidated function-handle
+            // address for a newly loaded module in another context, and unregistering afterward
+            // could erase that successor's correct name.
+            foreach (IntPtr function in _registeredFunctions)
+                GpuKernelDiagnostics.UnregisterKernelName(function);
+            _registeredFunctions.Clear();
+            DirectPtxRuntime.Check(CudaNativeBindings.cuModuleUnload(_module), "cuModuleUnload");
+            _module = IntPtr.Zero;
+        }
     }
 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxSplitComplexPhaseF32Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxSplitComplexPhaseF32Kernel.cs
@@ -17,6 +17,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
 /// </summary>
 internal sealed class PtxSplitComplexPhaseF32Kernel : IDisposable
 {
+    private const int MaxRegistersPerThreadLimit = 24;
+
     internal const int DefaultBlockThreads = 256;
     internal const string EntryPoint = "aidotnet_split_complex_phase_f32";
 
@@ -105,7 +107,7 @@ internal sealed class PtxSplitComplexPhaseF32Kernel : IDisposable
         ptx.AppendLine("    .param .u64 out_ptr");
         ptx.AppendLine(")");
         ptx.AppendLine($".maxntid {blockThreads}, 1, 1");
-        ptx.AppendLine(".maxnreg 24");
+        ptx.AppendLine($".maxnreg {MaxRegistersPerThreadLimit}");
         ptx.AppendLine("{");
         ptx.AppendLine("    .reg .pred %p<3>;");
         ptx.AppendLine("    .reg .b32 %r<2>;");
@@ -183,7 +185,7 @@ internal sealed class PtxSplitComplexPhaseF32Kernel : IDisposable
                     extent, extent, 16, DirectPtxTensorAccess.Write, DirectPtxExtentMode.Exact)
             ],
             ResourceBudget: new DirectPtxResourceBudget(
-                MaxRegistersPerThread: 24,
+                MaxRegistersPerThread: MaxRegistersPerThreadLimit,
                 MaxStaticSharedBytes: 0,
                 MaxLocalBytesPerThread: 0,
                 MinBlocksPerMultiprocessor: 1536 / blockThreads),

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxSplitComplexPhaseF32Kernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Ptx/PtxSplitComplexPhaseF32Kernel.cs
@@ -105,55 +105,60 @@ internal sealed class PtxSplitComplexPhaseF32Kernel : IDisposable
         ptx.AppendLine("    .param .u64 out_ptr");
         ptx.AppendLine(")");
         ptx.AppendLine($".maxntid {blockThreads}, 1, 1");
+        ptx.AppendLine(".maxnreg 24");
         ptx.AppendLine("{");
-        ptx.AppendLine("    .reg .pred %p<6>;");
-        ptx.AppendLine("    .reg .b32 %r<3>;");
-        ptx.AppendLine("    .reg .b64 %rd<10>;");
-        ptx.AppendLine("    .reg .f32 %f<24>;");
-        ptx.AppendLine("    ld.param.u64 %rd0, [in_real_ptr];");
-        ptx.AppendLine("    ld.param.u64 %rd1, [in_imag_ptr];");
-        ptx.AppendLine("    ld.param.u64 %rd2, [out_ptr];");
+        ptx.AppendLine("    .reg .pred %p<3>;");
+        ptx.AppendLine("    .reg .b32 %r<2>;");
+        ptx.AppendLine("    .reg .b64 %rd<2>;");
+        ptx.AppendLine("    .reg .f32 %f<6>;");
         ptx.AppendLine("    mov.u32 %r0, %tid.x;");
         ptx.AppendLine("    mov.u32 %r1, %ctaid.x;");
-        ptx.AppendLine($"    mad.lo.u32 %r2, %r1, {blockThreads}, %r0;");
-        ptx.AppendLine("    mul.wide.u32 %rd3, %r2, 4;");
-        ptx.AppendLine("    add.u64 %rd4, %rd0, %rd3;");
-        ptx.AppendLine("    add.u64 %rd5, %rd1, %rd3;");
-        ptx.AppendLine("    ld.global.nc.f32 %f0, [%rd4];");   // re
-        ptx.AppendLine("    ld.global.nc.f32 %f1, [%rd5];");   // im
+        ptx.AppendLine($"    mad.lo.u32 %r0, %r1, {blockThreads}, %r0;");
+        ptx.AppendLine("    mul.wide.u32 %rd1, %r0, 4;");
+        // Load each pointer only when it is needed and reuse the address
+        // register. Keeping three pointers plus three derived addresses live
+        // made the SM86 JIT allocate 26 registers/thread for a 24-register
+        // design budget.
+        ptx.AppendLine("    ld.param.u64 %rd0, [in_real_ptr];");
+        ptx.AppendLine("    add.u64 %rd0, %rd0, %rd1;");
+        ptx.AppendLine("    ld.global.nc.f32 %f0, [%rd0];");    // re
+        ptx.AppendLine("    ld.param.u64 %rd0, [in_imag_ptr];");
+        ptx.AppendLine("    add.u64 %rd0, %rd0, %rd1;");
+        ptx.AppendLine("    ld.global.nc.f32 %f1, [%rd0];");    // im
         ptx.AppendLine("    abs.f32 %f2, %f0;");               // ax
         ptx.AppendLine("    abs.f32 %f3, %f1;");               // ay
         ptx.AppendLine("    max.f32 %f4, %f2, %f3;");          // mx
         ptx.AppendLine("    min.f32 %f5, %f2, %f3;");          // mn
         ptx.AppendLine($"    setp.lt.f32 %p0, %f4, {tiny};");
-        ptx.AppendLine("    rcp.rn.f32 %f6, %f4;");
-        ptx.AppendLine("    mul.rn.f32 %f7, %f5, %f6;");        // a = mn/mx
-        ptx.AppendLine("    mul.rn.f32 %f8, %f7, %f7;");        // t = a^2
-        ptx.AppendLine($"    mov.f32 %f9, {c4};");
-        ptx.AppendLine($"    fma.rn.f32 %f9, %f9, %f8, {c3};");
-        ptx.AppendLine($"    fma.rn.f32 %f9, %f9, %f8, {c2};");
-        ptx.AppendLine($"    fma.rn.f32 %f9, %f9, %f8, {c1};");
-        ptx.AppendLine($"    fma.rn.f32 %f9, %f9, %f8, {c0};");
-        ptx.AppendLine("    mul.rn.f32 %f10, %f7, %f9;");       // r = atan(a) in [0,pi/4]
-        ptx.AppendLine($"    mul.rn.f32 %f11, %f10, {negOne};");
-        ptx.AppendLine($"    add.rn.f32 %f11, %f11, {halfPi};");
-        ptx.AppendLine("    setp.gt.f32 %p1, %f3, %f2;");        // ay > ax
-        ptx.AppendLine("    selp.f32 %f12, %f11, %f10, %p1;");
-        ptx.AppendLine($"    mul.rn.f32 %f13, %f12, {negOne};");
-        ptx.AppendLine($"    add.rn.f32 %f13, %f13, {pi};");
+        ptx.AppendLine("    setp.gt.f32 %p1, %f3, %f2;");       // ay > ax
+        ptx.AppendLine("    rcp.rn.f32 %f4, %f4;");
+        ptx.AppendLine("    mul.rn.f32 %f5, %f5, %f4;");        // a = mn/mx
+        ptx.AppendLine("    mul.rn.f32 %f2, %f5, %f5;");        // t = a^2
+        ptx.AppendLine($"    mov.f32 %f3, {c4};");
+        ptx.AppendLine($"    fma.rn.f32 %f3, %f3, %f2, {c3};");
+        ptx.AppendLine($"    fma.rn.f32 %f3, %f3, %f2, {c2};");
+        ptx.AppendLine($"    fma.rn.f32 %f3, %f3, %f2, {c1};");
+        ptx.AppendLine($"    fma.rn.f32 %f3, %f3, %f2, {c0};");
+        ptx.AppendLine("    mul.rn.f32 %f5, %f5, %f3;");        // r = atan(a) in [0,pi/4]
+        ptx.AppendLine($"    mul.rn.f32 %f2, %f5, {negOne};");
+        ptx.AppendLine($"    add.rn.f32 %f2, %f2, {halfPi};");
+        ptx.AppendLine("    selp.f32 %f5, %f2, %f5, %p1;");
+        ptx.AppendLine($"    mul.rn.f32 %f2, %f5, {negOne};");
+        ptx.AppendLine($"    add.rn.f32 %f2, %f2, {pi};");
         ptx.AppendLine("    setp.lt.f32 %p2, %f0, 0f00000000;");  // re < 0
-        ptx.AppendLine("    selp.f32 %f14, %f13, %f12, %p2;");
-        ptx.AppendLine("    neg.f32 %f15, %f14;");
-        ptx.AppendLine("    setp.lt.f32 %p3, %f1, 0f00000000;");  // im < 0
-        ptx.AppendLine("    selp.f32 %f14, %f15, %f14, %p3;");
+        ptx.AppendLine("    selp.f32 %f5, %f2, %f5, %p2;");
+        ptx.AppendLine("    neg.f32 %f2, %f5;");
+        ptx.AppendLine("    setp.lt.f32 %p1, %f1, 0f00000000;");  // im < 0
+        ptx.AppendLine("    selp.f32 %f5, %f2, %f5, %p1;");
         // Degenerate magnitude. atan2f(+-0, re) is pi for a negative real and 0
         // otherwise, so the guard cannot force 0 unconditionally: it also fires
         // for a small-but-nonzero negative real, where the reference returns pi.
         // %p2 already holds re < 0.
-        ptx.AppendLine($"    selp.f32 %f16, {pi}, 0f00000000, %p2;");
-        ptx.AppendLine("    selp.f32 %f14, %f16, %f14, %p0;");
-        ptx.AppendLine("    add.u64 %rd6, %rd2, %rd3;");
-        ptx.AppendLine("    st.global.f32 [%rd6], %f14;");
+        ptx.AppendLine($"    selp.f32 %f2, {pi}, 0f00000000, %p2;");
+        ptx.AppendLine("    selp.f32 %f5, %f2, %f5, %p0;");
+        ptx.AppendLine("    ld.param.u64 %rd0, [out_ptr];");
+        ptx.AppendLine("    add.u64 %rd0, %rd0, %rd1;");
+        ptx.AppendLine("    st.global.f32 [%rd0], %f5;");
         ptx.AppendLine("    ret;");
         ptx.AppendLine("}");
         return ptx.ToString();

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -139,7 +139,7 @@ public static class PersistenceGuard
         var previousPath = _trialFilePathOverride.Value;
         bool previousConfiguredSourcesSuppressed = _testConfiguredLicenseSourcesSuppressed.Value;
         _trialFilePathOverride.Value = path;
-        _testConfiguredLicenseSourcesSuppressed.Value = true;
+        _testConfiguredLicenseSourcesSuppressed.Value = path is not null;
         return new TrialPathScope(previousPath, previousConfiguredSourcesSuppressed);
     }
 

--- a/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
+++ b/src/AiDotNet.Tensors/Licensing/PersistenceGuard.cs
@@ -59,6 +59,7 @@ public static class PersistenceGuard
     // ─── Active license key ────────────────────────────────────────
 
     private static readonly AsyncLocal<AiDotNetTensorsLicenseKey?> _activeKey = new();
+    private static readonly AsyncLocal<bool> _testConfiguredLicenseSourcesSuppressed = new();
 
     /// <summary>
     /// Sets the active license key for the current logical call
@@ -120,8 +121,11 @@ public static class PersistenceGuard
     /// <summary>
     /// Test hook — overrides the trial-state file path for the
     /// current logical call context so test runs don't mutate the
-    /// developer's <c>~/.aidotnet/tensors-trial.json</c>. Pass
-    /// <c>null</c> to clear an existing override.
+    /// developer's <c>~/.aidotnet/tensors-trial.json</c>. Configured
+    /// environment/file license sources are suppressed for the same scope so
+    /// the requested trial path is actually exercised; an explicit key from
+    /// <see cref="SetActiveLicenseKey"/> still takes precedence. Pass
+    /// <c>null</c> to clear an existing path override.
     /// </summary>
     /// <remarks>
     /// <c>internal</c> on purpose — exposed only via the test project's
@@ -132,16 +136,32 @@ public static class PersistenceGuard
     /// </remarks>
     internal static IDisposable SetTestTrialFilePathOverride(string? path)
     {
-        var prev = _trialFilePathOverride.Value;
+        var previousPath = _trialFilePathOverride.Value;
+        bool previousConfiguredSourcesSuppressed = _testConfiguredLicenseSourcesSuppressed.Value;
         _trialFilePathOverride.Value = path;
-        return new TrialPathScope(prev);
+        _testConfiguredLicenseSourcesSuppressed.Value = true;
+        return new TrialPathScope(previousPath, previousConfiguredSourcesSuppressed);
     }
 
     private sealed class TrialPathScope : IDisposable
     {
-        private readonly string? _previous;
-        public TrialPathScope(string? prev) { _previous = prev; }
-        public void Dispose() => _trialFilePathOverride.Value = _previous;
+        private readonly string? _previousPath;
+        private readonly bool _previousConfiguredSourcesSuppressed;
+        private bool _disposed;
+
+        public TrialPathScope(string? previousPath, bool previousConfiguredSourcesSuppressed)
+        {
+            _previousPath = previousPath;
+            _previousConfiguredSourcesSuppressed = previousConfiguredSourcesSuppressed;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _trialFilePathOverride.Value = _previousPath;
+            _testConfiguredLicenseSourcesSuppressed.Value = _previousConfiguredSourcesSuppressed;
+        }
     }
 
     // ─── Shared validator cache ────────────────────────────────────
@@ -215,6 +235,7 @@ public static class PersistenceGuard
 
         // No explicit key selected → resolve from the configured env/disk sources (re-read + re-verified
         // each call so expiry/revocation and freshly-minted tokens take effect immediately).
+        if (_testConfiguredLicenseSourcesSuppressed.Value) return null;
         return AsymmetricEntitlementVerifier.TryVerifyConfigured();
     }
 
@@ -319,7 +340,7 @@ public static class PersistenceGuard
         // hard failure: we must NOT silently fall through to the trial path,
         // or a tampered/forged token would just degrade to free trial ops.
         // Absent (the default) → null → fall through unchanged.
-        var entitlement = GetCachedEntitlement();
+        var entitlement = _testConfiguredLicenseSourcesSuppressed.Value ? null : GetCachedEntitlement();
         if (entitlement is not null)
         {
             if (entitlement.IsValid && entitlement.HasCapability(requiredCapability))
@@ -438,6 +459,7 @@ public static class PersistenceGuard
     private static AiDotNetTensorsLicenseKey? ResolveActiveKey()
     {
         if (_activeKey.Value is { } explicitKey) return explicitKey;
+        if (_testConfiguredLicenseSourcesSuppressed.Value) return null;
 
         // Env var: AIDOTNET_LICENSE_KEY (same name upstream uses, so
         // setting it once configures both packages).

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GemvBypassTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/GemvBypassTest.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines.BlasManaged;
 using Xunit;
+using Xunit.Abstractions;
 using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
 #if NET6_0_OR_GREATER
 using System.Runtime.Intrinsics.X86;
@@ -12,8 +14,13 @@ namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
 /// Sub-R (#408): verify the GEMV bypass produces correct output for the M=1,
 /// N=1, and K=1 cases, and matches the scalar reference within FP32/FP64 bounds.
 /// </summary>
+[Collection("BlasManaged-Perf-Serial")]
 public class GemvBypassTest
 {
+    private readonly ITestOutputHelper _output;
+
+    public GemvBypassTest(ITestOutputHelper output) => _output = output;
+
     private static void NaiveGemmFp32(
         ReadOnlySpan<float> a, int lda, bool transA,
         ReadOnlySpan<float> b, int ldb, bool transB,
@@ -196,8 +203,11 @@ public class GemvBypassTest
     }
 
     [SkippableFact]
-    public void N1_AVX2_Path_Beats_Scalar_Reference_BySignificantMargin()
+    [Trait("Category", "Performance")]
+    public async Task N1_AVX2_Path_Beats_Scalar_Reference_BySignificantMargin()
     {
+        await Task.Yield();
+
         // Sub-R (#408) perf gate: the N=1 case used to be scalar-only —
         // single-multiply-per-cycle for the dot product. The new AVX2 FMA
         // path does 8 multiplies per cycle, so on long-K shapes
@@ -260,6 +270,9 @@ public class GemvBypassTest
         swScalar.Stop();
 
         double speedup = swScalar.Elapsed.TotalMilliseconds / swAvx2.Elapsed.TotalMilliseconds;
+        _output.WriteLine(
+            $"N=1 AVX2 speedup: {speedup:F2}× (AVX2 {swAvx2.Elapsed.TotalMilliseconds:F1} ms; " +
+            $"scalar {swScalar.Elapsed.TotalMilliseconds:F1} ms; required ≥3.0×).");
         Assert.True(speedup >= 3.0,
             $"N=1 AVX2 speedup over scalar reference is {speedup:F2}× — expected ≥3.0×. " +
             $"AVX2: {swAvx2.Elapsed.TotalMilliseconds:F1} ms, scalar: {swScalar.Elapsed.TotalMilliseconds:F1} ms.");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Codegen/GeneratedDepthwiseDispatchTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Codegen/GeneratedDepthwiseDispatchTests.cs
@@ -12,6 +12,7 @@
 // differ in the last fp32 place.
 
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
@@ -19,33 +20,34 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Codegen;
 
+[Collection("DirectGpuSerial")]
 public class GeneratedDepthwiseDispatchTests
 {
-    private static bool TryOpenBackend(out CudaBackend? backend)
+    private static CudaBackend OpenBackendOrSkip()
     {
-        backend = null;
-        try
+        Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver is unavailable.");
+
+        var backend = new CudaBackend();
+        if (!backend.IsAvailable)
         {
-            var candidate = new CudaBackend();
-            if (!candidate.IsAvailable) { candidate.Dispose(); return false; }
-            backend = candidate;
-            return true;
+            backend.Dispose();
+            throw new InvalidOperationException(
+                "CUDA driver was detected, but the CUDA backend failed to initialize.");
         }
-        catch (Exception)
-        {
-            return false;
-        }
+
+        return backend;
     }
 
     /// <summary>
     /// With the family promoted and the flag on, a depthwise 3x3 call must take the
     /// generated kernel AND agree with the established one.
     /// </summary>
-    [Fact]
-    public void GeneratedDepthwise_DispatchesAndAgreesWithTheEstablishedKernel()
+    [SkippableFact]
+    public async Task GeneratedDepthwise_DispatchesAndAgreesWithTheEstablishedKernel()
     {
-        if (!TryOpenBackend(out var backend)) return;          // no device: nothing to assert
-        using var _ = backend!;
+        await Task.Yield();
+
+        using var backend = OpenBackendOrSkip();
 
         const int N = 2, C = 16, H = 28, W = 28;
         long elements = (long)N * C * H * W;
@@ -118,15 +120,16 @@ public class GeneratedDepthwiseDispatchTests
     /// Geometry outside the measured set must DECLINE. A 5x5 or a strided depthwise has no
     /// evidence behind it, so it has to keep taking the established path.
     /// </summary>
-    [Theory]
+    [SkippableTheory]
     [InlineData(5, 5, 1, 1, 2, 2)]   // 5x5 taps
     [InlineData(3, 3, 2, 2, 1, 1)]   // stride 2
     [InlineData(3, 3, 1, 1, 0, 0)]   // no padding: output extent changes
-    public void GeometryOutsideTheMeasuredSet_Declines(
+    public async Task GeometryOutsideTheMeasuredSet_Declines(
         int kh, int kw, int sh, int sw, int ph, int pw)
     {
-        if (!TryOpenBackend(out var backend)) return;
-        using var _ = backend!;
+        await Task.Yield();
+
+        using var backend = OpenBackendOrSkip();
 
         const int N = 1, C = 8, H = 16, W = 16;
         long elements = (long)N * C * H * W;
@@ -149,11 +152,12 @@ public class GeneratedDepthwiseDispatchTests
     }
 
     /// <summary>With the feature flag off, nothing dispatches — opt-in stays opt-in.</summary>
-    [Fact]
-    public void FeatureFlagOff_Declines()
+    [SkippableFact]
+    public async Task FeatureFlagOff_Declines()
     {
-        if (!TryOpenBackend(out var backend)) return;
-        using var _ = backend!;
+        await Task.Yield();
+
+        using var backend = OpenBackendOrSkip();
 
         const int N = 1, C = 8, H = 16, W = 16;
         long elements = (long)N * C * H * W;
@@ -175,17 +179,52 @@ public class GeneratedDepthwiseDispatchTests
         }
     }
 
+    [Fact]
+    public async Task TestOverride_IsIsolatedBetweenLogicalCallContexts()
+    {
+        await Task.Yield();
+
+        bool? prior = DirectPtxFeatureGate.TestOverride;
+        var falseFlowReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFalseFlow = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            DirectPtxFeatureGate.TestOverride = null;
+            Task<bool?> falseFlow = Task.Run(async () =>
+            {
+                DirectPtxFeatureGate.TestOverride = false;
+                falseFlowReady.SetResult(true);
+                await releaseFalseFlow.Task;
+                await Task.Yield();
+                return DirectPtxFeatureGate.TestOverride;
+            });
+
+            await falseFlowReady.Task;
+            DirectPtxFeatureGate.TestOverride = true;
+            releaseFalseFlow.SetResult(true);
+
+            Assert.Equal(false, await falseFlow);
+            Assert.Equal(true, DirectPtxFeatureGate.TestOverride);
+        }
+        finally
+        {
+            releaseFalseFlow.TrySetResult(true);
+            DirectPtxFeatureGate.TestOverride = prior;
+        }
+    }
+
     /// <summary>
     /// The generated max pool must agree with the established kernel on BOTH outputs. The
     /// indices matter more than the values: the backward pass routes every gradient by
     /// them, so a wrong convention corrupts training while the pooled values still look
     /// right.
     /// </summary>
-    [Fact]
-    public void GeneratedMaxPool_AgreesOnValuesAndIndices()
+    [SkippableFact]
+    public async Task GeneratedMaxPool_AgreesOnValuesAndIndices()
     {
-        if (!TryOpenBackend(out var backend)) return;
-        using var _ = backend!;
+        await Task.Yield();
+
+        using var backend = OpenBackendOrSkip();
 
         const int N = 2, C = 8, H = 16, W = 16;
         const int OutH = H / 2, OutW = W / 2;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
@@ -1,17 +1,22 @@
 // Copyright (c) AiDotNet. All rights reserved.
 
 using System.Diagnostics;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Compilation;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 
+[Collection("BlasManaged-Perf-Serial")]
 public sealed class LazyGraphCompilerPerformanceTests
 {
     [Fact]
-    public void Compile_WideFanInGraph_StaysBelowQuadraticRuntime()
+    [Trait("Category", "Performance")]
+    public async Task Compile_WideFanInGraph_StaysBelowQuadraticRuntime()
     {
+        await Task.Yield();
+
         const int producerCount = 50_000;
         var producers = new StubLazyNode[producerCount];
         var rawNodes = new List<ILazyNode>(producerCount + 1);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
@@ -53,6 +53,10 @@ namespace AiDotNet.Tensors.Tests.Engines
             yield return new object[] { 7, 1, 3, 3, 8, 16 };
         }
 
+        /// <summary>
+        /// Verifies that replaying float convolution and selecting any public parameter or
+        /// allocation form preserves both the output shape and every output bit.
+        /// </summary>
         [Theory]
         [MemberData(nameof(Shapes))]
         public async Task AllConv2DEntryPoints_ProduceStableIdenticalFloatResults(
@@ -93,6 +97,8 @@ namespace AiDotNet.Tensors.Tests.Engines
 
             foreach (var candidate in candidates)
             {
+                Assert.Equal(expected.Shape.ToArray(), candidate.Output.Shape.ToArray());
+
                 int differing = 0;
                 int firstIndex = -1;
                 for (int i = 0; i < expected.Length; i++)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -54,9 +55,11 @@ namespace AiDotNet.Tensors.Tests.Engines
 
         [Theory]
         [MemberData(nameof(Shapes))]
-        public void Conv2DAndConv2DInto_ProduceIdenticalFloatResults(
+        public async Task AllConv2DEntryPoints_ProduceStableIdenticalFloatResults(
             int kernelSize, int stride, int padding, int inChannels, int outChannels, int spatial)
         {
+            await Task.Yield();
+
             var engine = new CpuEngine();
             var rng = new Random(11);
 
@@ -66,32 +69,50 @@ namespace AiDotNet.Tensors.Tests.Engines
             var kernel = new Tensor<float>(new[] { outChannels, inChannels, kernelSize, kernelSize });
             for (int i = 0; i < kernel.Length; i++) kernel[i] = (float)(rng.NextDouble() * 2 - 1);
 
-            var allocating = engine.Conv2D(input, kernel, stride, padding, 1);
+            var expected = engine.Conv2D(input, kernel, stride, padding, 1);
+            var scalarReplay = engine.Conv2D(input, kernel, stride, padding, 1);
 
-            var inPlace = new Tensor<float>(allocating.Shape.ToArray());
-            engine.Conv2DInto(inPlace, input, kernel, stride, padding, 1);
+            var scalarInPlace = new Tensor<float>(expected.Shape.ToArray());
+            engine.Conv2DInto(scalarInPlace, input, kernel, stride, padding, 1);
 
-            int differing = 0;
-            int firstIndex = -1;
-            for (int i = 0; i < allocating.Length; i++)
+            int[] stride2D = [stride, stride];
+            int[] padding2D = [padding, padding];
+            int[] dilation2D = [1, 1];
+            var arrayAllocating = engine.Conv2D(input, kernel, stride2D, padding2D, dilation2D);
+
+            var arrayInPlace = new Tensor<float>(expected.Shape.ToArray());
+            engine.Conv2DInto(arrayInPlace, input, kernel, stride2D, padding2D, dilation2D);
+
+            var candidates = new (string Name, Tensor<float> Output)[]
             {
-                if (allocating[i] == inPlace[i]) continue;
-                differing++;
-                if (firstIndex < 0) firstIndex = i;
-            }
+                ("scalar replay", scalarReplay),
+                ("scalar in-place", scalarInPlace),
+                ("array allocating", arrayAllocating),
+                ("array in-place", arrayInPlace),
+            };
 
-            Assert.True(
-                differing == 0,
-                $"Conv2D and Conv2DInto disagree on {differing} of {allocating.Length} outputs for "
-                    + $"k{kernelSize} s{stride} p{padding} {inChannels}->{outChannels} @{spatial}x{spatial}. "
-                    + (firstIndex >= 0
-                        ? $"First at [{firstIndex}]: allocating={allocating[firstIndex]:G9}, "
-                          + $"inPlace={inPlace[firstIndex]:G9}. "
-                        : string.Empty)
-                    + "These entry points must select the same kernel: callers cannot observe which "
-                    + "one they reached, and choosing between them by whether a gradient tape is "
-                    + "recording would make a layer compute a different function in training than "
-                    + "at inference.");
+            foreach (var candidate in candidates)
+            {
+                int differing = 0;
+                int firstIndex = -1;
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    if (expected[i] == candidate.Output[i]) continue;
+                    differing++;
+                    if (firstIndex < 0) firstIndex = i;
+                }
+
+                Assert.True(
+                    differing == 0,
+                    $"Scalar Conv2D and {candidate.Name} disagree on {differing} of {expected.Length} outputs for "
+                        + $"k{kernelSize} s{stride} p{padding} {inChannels}->{outChannels} @{spatial}x{spatial}. "
+                        + (firstIndex >= 0
+                            ? $"First at [{firstIndex}]: expected={expected[firstIndex]:G9}, "
+                              + $"actual={candidate.Output[firstIndex]:G9}. "
+                            : string.Empty)
+                        + "Every public entry point must select the same kernel, and replaying one "
+                        + "entry point must not change its own output.");
+            }
         }
 
         [Theory]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DEntryPointParityTests.cs
@@ -36,6 +36,7 @@ namespace AiDotNet.Tensors.Tests.Engines
     /// two are supposed to be the same computation reaching two different destinations.
     /// </para>
     /// </remarks>
+    [Collection("BlasManaged-Stats-Serial")]
     public class Conv2DEntryPointParityTests
     {
         public static IEnumerable<object[]> Shapes()
@@ -51,6 +52,41 @@ namespace AiDotNet.Tensors.Tests.Engines
             yield return new object[] { 4, 2, 1, 16, 32, 14 };
             yield return new object[] { 5, 1, 2, 3, 8, 16 };
             yield return new object[] { 7, 1, 3, 3, 8, 16 };
+        }
+
+        public static IEnumerable<object[]> AdaptiveDispatchCases()
+        {
+            // isWindows, layout, strideH/W, padH/W, dilationH/W, expected
+            yield return new object[] { true, TensorLayout.Nchw, 1, 1, 1, 1, 1, 1, true };
+            yield return new object[] { false, TensorLayout.Nchw, 1, 1, 1, 1, 1, 1, false };
+            yield return new object[] { true, TensorLayout.Nchwc8, 1, 1, 1, 1, 1, 1, false };
+            yield return new object[] { true, TensorLayout.Nchw, 1, 2, 1, 1, 1, 1, false };
+            yield return new object[] { true, TensorLayout.Nchw, 1, 1, 1, 0, 1, 1, false };
+            yield return new object[] { true, TensorLayout.Nchw, 1, 1, 1, 1, 1, 2, false };
+        }
+
+        /// <summary>
+        /// Verifies the OS/layout/geometry dispatch policy without depending on the CI host OS.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AdaptiveDispatchCases))]
+        public async Task AdaptiveDispatchPolicy_SelectsOnlyWindowsSymmetricNchw(
+            bool isWindows,
+            TensorLayout layout,
+            int strideH,
+            int strideW,
+            int padH,
+            int padW,
+            int dilationH,
+            int dilationW,
+            bool expected)
+        {
+            await Task.Yield();
+
+            bool actual = CpuEngine.ShouldUseAdaptiveFloatConv2DForPlatform(
+                isWindows, layout, strideH, strideW, padH, padW, dilationH, dilationW);
+
+            Assert.Equal(expected, actual);
         }
 
         /// <summary>
@@ -118,6 +154,40 @@ namespace AiDotNet.Tensors.Tests.Engines
                             : string.Empty)
                         + "Every public entry point must select the same kernel, and replaying one "
                         + "entry point must not change its own output.");
+            }
+        }
+
+        /// <summary>
+        /// Exercises the im2col side of the shared dispatcher on Windows as well as Linux by using
+        /// geometry the adaptive kernel cannot represent.
+        /// </summary>
+        [Fact]
+        public async Task AsymmetricArrayEntryPoints_ProduceStableIdenticalFloatResults()
+        {
+            await Task.Yield();
+
+            var engine = new CpuEngine();
+            var rng = new Random(23);
+            var input = new Tensor<float>(new[] { 1, 3, 9, 11 });
+            var kernel = new Tensor<float>(new[] { 5, 3, 3, 2 });
+
+            for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+            for (int i = 0; i < kernel.Length; i++) kernel[i] = (float)(rng.NextDouble() * 2 - 1);
+
+            int[] stride = [2, 1];
+            int[] padding = [1, 0];
+            int[] dilation = [1, 2];
+            var expected = engine.Conv2D(input, kernel, stride, padding, dilation);
+            var replay = engine.Conv2D(input, kernel, stride, padding, dilation);
+            var inPlace = new Tensor<float>(expected.Shape.ToArray());
+            engine.Conv2DInto(inPlace, input, kernel, stride, padding, dilation);
+
+            Assert.Equal(expected.Shape.ToArray(), replay.Shape.ToArray());
+            Assert.Equal(expected.Shape.ToArray(), inPlace.Shape.ToArray());
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i], replay[i]);
+                Assert.Equal(expected[i], inPlace[i]);
             }
         }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -15,6 +16,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// im2col path. This guards that across stride / padding / dilation / batch / spatial-size
 /// variations — including deep-bottleneck shapes where the row-block clamps to a single row.
 /// </summary>
+[Collection("BlasManaged-Stats-Serial")]
 public class Conv2DImplicitGemmParityTests
 {
     private static Tensor<float> Rand(int[] shape, int seed)
@@ -37,9 +39,11 @@ public class Conv2DImplicitGemmParityTests
     [InlineData(1, 256, 256, 3, 16, 1, 2, 2)]   // dilation 2
     [InlineData(1, 512, 256, 1, 16, 1, 0, 1)]   // 1×1 high-channel (routes to full path)
     [InlineData(1, 256, 300, 5, 12, 1, 2, 1)]   // 5×5, non-power-of-two outC
-    public void FusedConv_IsBitIdentical_ToFullIm2Col(
+    public async Task FusedConv_IsBitIdentical_ToFullIm2Col(
         int batch, int inC, int outC, int k, int hw, int stride, int pad, int dilation)
     {
+        await Task.Yield();
+
         var e = new CpuEngine();
         var x = Rand(new[] { batch, inC, hw, hw }, 101);
         var kernel = Rand(new[] { outC, inC, k, k }, 202);

--- a/tests/AiDotNet.Tensors.Tests/Engines/ConvTranspose2DGemmCorrectnessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/ConvTranspose2DGemmCorrectnessTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -12,6 +13,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 // they produce numerically equivalent output. Shapes cover DCGAN's
 // generator stack (4×4 stride 2 padding 1, channels 512→256→128→64→3) and a
 // few small shapes to catch indexing edge cases.
+[Collection("BlasManaged-Perf-Serial")]
 public class ConvTranspose2DGemmCorrectnessTests
 {
     private static Tensor<double> MakeRandomTensor(int[] shape, int seed)
@@ -155,8 +157,10 @@ public class ConvTranspose2DGemmCorrectnessTests
     // tests in this same file (maxDiff < 1e-9); this test only asserts latency.
     [Trait("Category", "Performance")]
     [Fact]
-    public void DcganL2Shape_FatASmallNFastPath_BeatsOpenBlasBudget()
+    public async Task DcganL2Shape_FatASmallNFastPath_BeatsOpenBlasBudget()
     {
+        await Task.Yield();
+
         // Issue #358 phase-2 perf gate: the DCGAN L2 ConvTranspose2D shape
         // [B=1, Cin=512, 4, 4] → [Co=256, 8, 8] hits a documented MKL/OpenBLAS
         // perf cliff at M=4096, N=16, K=512, transA=true (215 ms OpenBLAS /

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BytecapEvictionRaceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/BytecapEvictionRaceTests.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -51,8 +52,10 @@ public class BytecapEvictionRaceTests
     /// </summary>
     [SkippableFact]
     [Trait("Category", "CudaRequired")]
-    public void EagerTraining_BelowCap_NoCudaError()
+    public async Task EagerTraining_BelowCap_NoCudaError()
     {
+        await Task.Yield();
+
         Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver not available");
         var eng = AiDotNetEngine.Current;
         Skip.IfNot(eng is DirectGpuTensorEngine, "active engine is not the GPU backend");
@@ -109,8 +112,10 @@ public class BytecapEvictionRaceTests
     /// </summary>
     [SkippableFact]
     [Trait("Category", "CudaRequired")]
-    public void EagerTraining_CacheAccounting_StaysConsistent()
+    public async Task EagerTraining_CacheAccounting_StaysConsistent()
     {
+        await Task.Yield();
+
         Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver not available");
         var eng = AiDotNetEngine.Current;
         Skip.IfNot(eng is DirectGpuTensorEngine, "active engine is not the GPU backend");
@@ -130,6 +135,10 @@ public class BytecapEvictionRaceTests
                 var c = eng.TensorMatMul(a, b);
                 _ = c.AsSpan()[0];
             }
+
+            // Attribute any asynchronous fault to this test instead of leaving a
+            // sticky CUDA error for the next DirectGpuSerial test to discover.
+            cudaBackend!.Synchronize();
 
             long running = ReadLong(dgte, "_currentActivationCacheBytes");
             Assert.True(running >= 0,

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxComplexMultiplyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectPtxComplexMultiplyTests.cs
@@ -610,14 +610,20 @@ public class DirectPtxComplexMultiplyTests
 
     [SkippableTheory]
     [InlineData(65536)]
-    public void DriverOnlySplitComplexPhase_MatchesAtan2WithinTolerance(int count)
+    public async Task DriverOnlySplitComplexPhase_MatchesAtan2WithinTolerance(int count)
     {
+        await Task.Yield();
+
         Skip.IfNot(DirectPtxRuntime.IsAvailable, "Requires an NVIDIA CUDA driver and GPU.");
         using var runtime = new DirectPtxRuntime();
         Skip.IfNot(DirectPtxArchitecture.HasValidatedComplexUnary(
                 runtime.ComputeCapabilityMajor, runtime.ComputeCapabilityMinor),
             "The candidate is admitted only on SM86.");
         using var kernel = new PtxSplitComplexPhaseF32Kernel(runtime, count);
+        Assert.True(
+            kernel.Audit.Function.RegistersPerThread <= kernel.Blueprint.ResourceBudget.MaxRegistersPerThread,
+            $"Split-phase kernel uses {kernel.Audit.Function.RegistersPerThread} registers/thread; " +
+            $"budget is {kernel.Blueprint.ResourceBudget.MaxRegistersPerThread}.");
         var re = new float[count]; var im = new float[count];
         var random = RandomHelper.CreateSeededRandom(20260910 + count);
         for (int i = 0; i < count; i++) { re[i] = (float)(random.NextDouble() * 2.0 - 1.0); im[i] = (float)(random.NextDouble() * 2.0 - 1.0); }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OffloadAllocatorTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OffloadAllocatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
 
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 using AiDotNet.Tensors.Engines.DirectGpu.HIP;
@@ -35,6 +36,75 @@ public class OffloadAllocatorTests
         new VulkanOffloadAllocator(),
         new WebGpuOffloadAllocator(),
     };
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public async Task CudaAvailability_FailsClosedAfterCircuitBreaker(
+        bool driverAvailable, bool circuitBroken, bool expected)
+    {
+        await Task.Yield();
+
+        Assert.Equal(expected, CudaOffloadAllocator.IsCudaUsable(driverAvailable, circuitBroken));
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public async Task CudaContextCleanup_NeverPopsAfterCircuitBreaker(
+        bool pushed, bool circuitBroken, bool expected)
+    {
+        await Task.Yield();
+
+        Assert.Equal(expected, CudaOffloadAllocator.ShouldPopContext(pushed, circuitBroken));
+    }
+
+    [SkippableFact]
+    public async Task SharedCudaAllocator_FailsClosedAfterBackendDestroysContext()
+    {
+        await Task.Yield();
+
+        Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver is unavailable.");
+        using var backend = new CudaBackend();
+        Skip.IfNot(backend.IsAvailable, "CUDA backend failed to initialize.");
+        using var allocator = new CudaOffloadAllocator(backend.CudaContextHandle);
+
+        Assert.True(allocator.IsAvailable);
+        backend.Dispose();
+
+        Assert.False(allocator.IsAvailable);
+        var error = Assert.Throws<NotSupportedException>(
+            () => allocator.Allocate(1024, OffloadScheme.Pinned));
+        Assert.Contains("no longer live", error.Message, StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public async Task SharedCudaAllocator_DisposeWithLiveBackend_FreesOutstandingAllocations()
+    {
+        await Task.Yield();
+
+        Skip.IfNot(CudaNativeBindings.IsAvailable, "CUDA driver is unavailable.");
+        using var backend = new CudaBackend();
+        Skip.IfNot(backend.IsAvailable, "CUDA backend failed to initialize.");
+        using var allocator = new CudaOffloadAllocator(backend.CudaContextHandle);
+
+        var pinned = allocator.Allocate(1024, OffloadScheme.Pinned);
+        var managed = allocator.Allocate(1024, OffloadScheme.Managed);
+        Assert.NotEqual(IntPtr.Zero, pinned.HostPointer);
+        Assert.NotEqual(IntPtr.Zero, managed.DevicePointer);
+
+        // Dispose owns both outstanding handles. Checked native frees make either cleanup failure
+        // surface here, while the probe below proves a shared allocator never tears down its owner.
+        allocator.Dispose();
+        Assert.False(allocator.IsAvailable);
+
+        using var probe = backend.AllocateBuffer(new[] { 1.25f, -2.5f, 4.75f });
+        Assert.Equal(new[] { 1.25f, -2.5f, 4.75f }, backend.DownloadBuffer(probe));
+    }
 
     [Fact]
     public void IsAvailable_ProbeNeverThrows_OnAnyBackend()

--- a/tests/AiDotNet.Tensors.Tests/Engines/Training/MultiSlotFusedStepTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Training/MultiSlotFusedStepTests.cs
@@ -14,6 +14,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Training;
 /// pattern; this test uses a simpler [input, target, aux] triple with a linear
 /// forward to isolate the multi-slot mechanism.
 /// </summary>
+[Collection("DirectGpuSerial")]
 public class MultiSlotFusedStepTests
 {
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Helpers/InferenceArenaForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/InferenceArenaForwardTests.cs
@@ -9,6 +9,7 @@
 // (arena, steady state) — a ~98% reduction.
 
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -78,8 +79,10 @@ public class InferenceArenaForwardTests
 
 #if NET5_0_OR_GREATER
     [Fact]
-    public void RepeatedForward_InArena_AllocatesFarLessThanNonArena()
+    public async Task RepeatedForward_InArena_AllocatesFarLessThanNonArena()
     {
+        await Task.Yield();
+
         const int S = 128, D = 256, N = 40;
         var x = Rand(new[] { S, D }, 11);
         var w = Rand(new[] { D, D }, 12);
@@ -90,20 +93,20 @@ public class InferenceArenaForwardTests
         float sink = 0;
         sink += Forward(x, w, gamma, beta)[0];
 
-        long a0 = GC.GetTotalAllocatedBytes(precise: true);
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < N; i++) sink += Forward(x, w, gamma, beta)[0];
-        long noArenaBytes = GC.GetTotalAllocatedBytes(precise: true) - a0;
+        long noArenaBytes = GC.GetAllocatedBytesForCurrentThread() - a0;
 
         using (var arena = TensorArena.Create())
         {
             sink += Forward(x, w, gamma, beta)[0]; // warm the arena (first forward fills it)
-            long a1 = GC.GetTotalAllocatedBytes(precise: true);
+            long a1 = GC.GetAllocatedBytesForCurrentThread();
             for (int i = 0; i < N; i++)
             {
                 arena.Reset();
                 sink += Forward(x, w, gamma, beta)[0];
             }
-            long arenaBytes = GC.GetTotalAllocatedBytes(precise: true) - a1;
+            long arenaBytes = GC.GetAllocatedBytesForCurrentThread() - a1;
 
             // Conservative gate (real ratio is ~0.05): the arena must cut forward allocation by
             // at least half. This guards the Rent->TensorArena.Current routing for the forward

--- a/tests/AiDotNet.Tensors.Tests/Helpers/NestedParallelismTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/NestedParallelismTests.cs
@@ -25,6 +25,7 @@ namespace AiDotNet.Tensors.Tests.Helpers;
 /// serial automatically.
 /// </para>
 /// </summary>
+[Collection("BlasManaged-Stats-Serial")]
 public class NestedParallelismTests
 {
     private readonly ITestOutputHelper _output;
@@ -37,8 +38,10 @@ public class NestedParallelismTests
     }
 
     [Fact]
-    public void NestedParallelLoop_RunsSerially_WhenInsideParallelRegion()
+    public async Task NestedParallelLoop_RunsSerially_WhenInsideParallelRegion()
     {
+        await Task.Yield();
+
         // Force the OUTER loop to dispatch in parallel: huge totalWork + many
         // iterations. On a multi-core box this runs the body on several workers,
         // each of which sets IsInParallelRegion. A NESTED parallel loop must then
@@ -100,8 +103,10 @@ public class NestedParallelismTests
     [InlineData(1, 8, 1024, 64)]
     [InlineData(2, 8, 512, 64)]
     [InlineData(1, 16, 256, 72)]
-    public void FloatSdpa_LargeShape_CompletesWithoutStarvation(int b, int h, int s, int d)
+    public async Task FloatSdpa_LargeShape_CompletesWithoutStarvation(int b, int h, int s, int d)
     {
+        await Task.Yield();
+
         var engine = new CpuEngine();
         var q = RandomFloat(new[] { b, h, s, d }, 1);
         var k = RandomFloat(new[] { b, h, s, d }, 2);
@@ -113,14 +118,15 @@ public class NestedParallelismTests
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var task = Task.Run(() =>
             engine.ScaledDotProductAttention(q, k, v, mask: null, scale: null, out _));
-        bool finished = task.Wait(TimeSpan.FromSeconds(60));
+        Task completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(60)));
         sw.Stop();
 
-        Assert.True(finished,
+        Assert.True(ReferenceEquals(task, completed),
             $"float SDPA [{b},{h},{s},{d}] did not finish within 60s — nested-parallelism starvation regressed.");
+        var output = await task;
         _output.WriteLine($"[{b},{h},{s},{d}] float SDPA completed in {sw.Elapsed.TotalMilliseconds:F0} ms");
 
-        var outSpan = task.Result.AsSpan();
+        var outSpan = output.AsSpan();
         for (int i = 0; i < outSpan.Length; i++)
             // float.IsFinite is unavailable on net471 — use the NaN/Inf primitives.
             Assert.True(!float.IsNaN(outSpan[i]) && !float.IsInfinity(outSpan[i]),

--- a/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/ThreadLocalTensorCacheBoundsTests.cs
@@ -9,15 +9,15 @@
 // this cache on the same thread. With retention bounded it completes inside the budget.
 
 using System;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Helpers;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Helpers;
 
-// Serialized with the arena tests: these poke [ThreadStatic] caches, and the allocation assertion
-// below reads GC.GetTotalAllocatedBytes, which is PROCESS-wide — a sibling collection allocating on
-// another thread lands in the same counter and makes the measurement meaningless. Same reason
-// TensorArenaPersistentPoolTests joins this collection.
+// Serialized with the arena tests because these tests poke [ThreadStatic] caches. The allocation
+// assertion below deliberately uses the current-thread counter so unrelated xUnit collections
+// cannot contaminate the measurement.
 [Collection(nameof(TensorArenaPinnedTests))]
 public class ThreadLocalTensorCacheBoundsTests
 {
@@ -109,8 +109,10 @@ public class ThreadLocalTensorCacheBoundsTests
     /// last buffer is rented — reintroduces a Bucket + Stack allocation on every cycle.
     /// </summary>
     [Fact]
-    public void HotSize_ReturnRentCycle_DoesNotAllocate()
+    public async Task HotSize_ReturnRentCycle_DoesNotAllocate()
     {
+        await Task.Yield();
+
         ThreadLocalTensorCache<float>.Clear();
         const int size = 4096;
 
@@ -123,23 +125,21 @@ public class ThreadLocalTensorCacheBoundsTests
         }
 
         const int cycles = 50_000;
-        long before = GC.GetTotalAllocatedBytes(precise: true);
+        long before = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < cycles; i++)
         {
             ThreadLocalTensorCache<float>.TryReturn(buffer);
             buffer = ThreadLocalTensorCache<float>.TryRent(size)!;
         }
-        long allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         Assert.NotNull(buffer);
 
         // The cache's own steady-state path allocates nothing here — a dictionary lookup and a
-        // Stack push/pop — so what this measures is ambient allocation on the test thread, which
-        // came in around 0.2 MB. Dropping the dictionary entry when its last buffer is rented
-        // instead costs a Bucket + Stack per cycle, measured at 1,212,984 bytes over 10,000 cycles
-        // (~121 B/cycle), i.e. ~6 MB at this iteration count. A 1 MB ceiling separates the two by
-        // several times over in both directions rather than sitting on top of the noise.
-        Assert.True(allocated < 1024 * 1024,
+        // Stack push/pop. Allow only instrumentation-scale slack. Dropping the dictionary entry
+        // when its last buffer is rented instead costs a Bucket + Stack per cycle, measured at
+        // 1,212,984 bytes over 10,000 cycles (~121 B/cycle), or roughly 6 MB here.
+        Assert.True(allocated < 128,
             $"steady-state return/rent cycle allocated {allocated} bytes over {cycles} iterations");
 
         ThreadLocalTensorCache<float>.Clear();

--- a/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Licensing/PersistenceGuardTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Licensing;
 using AiDotNet.Tensors.NumericOperations;
 using Xunit;
@@ -303,6 +304,33 @@ public class PersistenceGuardTests
         Assert.False(LicenseValidator.ValidateKeyFormat("not-a-valid-key"));
         Assert.False(LicenseValidator.ValidateKeyFormat(""));
         Assert.False(LicenseValidator.ValidateKeyFormat("aidn..."));  // empty id+sig
+    }
+
+    [Fact]
+    public async Task SetTestTrialFilePathOverride_IgnoresAmbientKeyAndExercisesTrial()
+    {
+        await Task.Yield();
+
+        string savedKey = Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY");
+        try
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY", "aidn.test.ambient.AAAAAAAA");
+            PersistenceGuard.ClearValidatorCacheForTesting();
+
+            using var trial = IsolatedTrial(out var path);
+
+            PersistenceGuard.EnforceBeforeLoad();
+
+            var state = TrialState.Load(path);
+            Assert.Equal(1, state.OperationsConsumed);
+            Assert.Equal("aidn.test.ambient.AAAAAAAA",
+                Environment.GetEnvironmentVariable("AIDOTNET_LICENSE_KEY"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_LICENSE_KEY", savedKey);
+            PersistenceGuard.ClearValidatorCacheForTesting();
+        }
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Sparse/SparseCompletenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/Sparse/SparseCompletenessTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -656,8 +657,9 @@ public class SparseCompletenessTests
     }
 
     [Fact]
-    public void Safetensors_RoundtripSparseTensor_PreservesValues()
+    public async Task Safetensors_RoundtripSparseTensor_PreservesValues()
     {
+        await Task.Yield();
         using var trial = IsolateTrial();
         var a = SmallA(); // CSR-form COO; round-trip through CSR for storage compactness.
         var path = Path.GetTempFileName();
@@ -680,8 +682,9 @@ public class SparseCompletenessTests
     }
 
     [Fact]
-    public void Safetensors_RoundtripBsrTensor_PreservesBlockShape()
+    public async Task Safetensors_RoundtripBsrTensor_PreservesBlockShape()
     {
+        await Task.Yield();
         using var trial = IsolateTrial();
         var a = SmallA().ToBsr(2, 2);
         var path = Path.GetTempFileName();
@@ -708,10 +711,10 @@ public class SparseCompletenessTests
     private static System.IDisposable IsolateTrial()
     {
         var trialPath = Path.Combine(Path.GetTempPath(), "aidotnet-test-trial-" + System.Guid.NewGuid().ToString("N") + ".json");
-        var scope = PersistenceGuard.SetTestTrialFilePathOverride(trialPath);
+        var trialScope = PersistenceGuard.SetTestTrialFilePathOverride(trialPath);
         return new ActionDisposable(() =>
         {
-            scope.Dispose();
+            trialScope.Dispose();
             try { if (File.Exists(trialPath)) File.Delete(trialPath); } catch { }
         });
     }


### PR DESCRIPTION
## Summary

- route all public float/NCHW Conv2D entrypoints through one platform-and-geometry selector
- preserve bitwise parity across scalar/array and allocating/in-place overloads
- keep the adaptive convolution cascade on Windows, where full-model measurement shows it is materially faster
- retain im2col-GEMM on non-Windows and for unsupported/asymmetric geometry
- expand regression coverage to scalar replay plus all four entrypoint forms across ten convolution shapes

## Root cause

PR #988 fixed entrypoint determinism by universally routing float Conv2D through im2col-GEMM. That makes equivalent overloads agree, but it also causes a severe Windows CNN performance regression. AiDotNet PR #2054 exposed both sides: PatchGAN serialization self-replay differed by one float ULP before parity was enforced, while MiDaS became several times slower after consuming the universal im2col route.

This change makes kernel selection depend only on platform, layout, and geometry—never overload choice, allocation style, or gradient recording.

## Validation

- Conv2D entrypoint parity/replay: 20/20 passed
- focused convolution, fused-operation, and COW tests: 57/57 passed
- exact AiDotNet PatchGAN CI regression: passed in five separate test processes
- library builds: net10.0, net8.0, and net471 all succeeded with 0 errors
- test-project net471 build succeeded with 0 errors
- git diff --check: clean

### Windows MiDaS full-model census

| Build | Steady median | Cold | Training |
|---|---:|---:|---:|
| stock 0.129.7 | 359.6 ms | 1841.6 ms | 5671.9 ms |
| patched 0.129.7 (3 runs) | 82.6-101.2 ms | 1214.0-1371.3 ms | 3614.6-5014.0 ms |
| 0.129.4 controls (2 runs) | 91.5-97.3 ms | 1642.1-1811.7 ms | 4859.8-6227.5 ms |

Measured allocation fell from 3,334,653,720 bytes on stock 0.129.7 to 2,805,119,208 bytes with the patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved floating-point convolution performance with optimized execution paths for compatible layouts and operation settings.
  - Preserved a reliable fallback for unsupported configurations.
  - Reduced resource usage in selected GPU operations.

- **Bug Fixes**
  - Improved consistency across all floating-point convolution entry points.
  - Strengthened GPU resource cleanup and fail-safe behavior after context failures.
  - Improved repeatability for repeated operations.

- **Tests**
  - Expanded coverage for convolution variants, GPU reliability, licensing scenarios, and performance-sensitive workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->