### PR TITLE
fix: register the crash diagnostics dump at assembly load, not first use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,10 @@ jobs:
 
     # If --blame-hang-timeout (a test made no progress for 300s) or --blame-crash (test host
     # native-crashed, e.g. a CUDA-finalizer 0xC0000005) fired, the hang/crash dump + the
-    # Sequence.xml naming the culprit test land under ./coverage. Upload them so the
+    # Sequence file naming the culprit test land under ./coverage. NOTE the glob is Sequence*.xml:
+    # vstest writes Sequence.xml for a HANG but Sequence_<guid>.xml for a CRASH, verified by
+    # forcing a FailFast under --blame-crash. Matching only one of the two silently drops the
+    # case you care about. Upload them so the
     # intermittent deadlock can be diagnosed instead of the run silently stalling for hours.
     - name: Upload hang/crash dumps
       uses: actions/upload-artifact@v4
@@ -99,7 +102,7 @@ jobs:
         name: blame-dumps
         path: |
           ./coverage/**/*.dmp
-          ./coverage/**/Sequence.xml
+          ./coverage/**/Sequence*.xml
           ./coverage/gpu-diagnostics.txt
         if-no-files-found: ignore
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -62,6 +62,17 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
     {
         private const int JournalCapacity = 64;
 
+        /// <summary>How often the journal is flushed to disk while the process is alive.</summary>
+        /// <remarks>
+        /// Two seconds bounds what a hard crash can lose. Shorter buys little (the residency totals
+        /// move slowly and the journal is a fixed 64-entry ring); longer starts losing the launches
+        /// immediately before the fault, which are the ones worth having.
+        /// </remarks>
+        private static readonly TimeSpan FlushInterval = TimeSpan.FromSeconds(2);
+
+        /// <summary>Held so the timer is not collected; never disposed, it lives as long as the process.</summary>
+        private static Timer? _periodicFlush;
+
         private static readonly LaunchRecord[] _journal = new LaunchRecord[JournalCapacity];
 
         /// <summary>
@@ -120,8 +131,24 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
 
             try
             {
+                // EXIT HOOKS ARE NOT ENOUGH, AND THIS IS THE WHOLE POINT OF THE DIAGNOSTIC.
+                // ProcessExit and DomainUnload run only on an ORDERLY shutdown. They do not run for
+                // the deaths this exists to explain: an access violation, a stack overflow, an
+                // OOM-kill, Environment.FailFast. Verified directly -- a FailFast under
+                // --blame-crash produced the crash dump and the Sequence file and NO journal at all,
+                // because nothing got the chance to write one.
+                //
+                // So the journal is also flushed PERIODICALLY, which means a hard kill loses at most
+                // one interval instead of everything. The cost is one small text write every two
+                // seconds, and only when the caller has explicitly named a dump path.
+                _periodicFlush = new Timer(_ => DumpTo(path), null, FlushInterval, FlushInterval);
+
                 AppDomain.CurrentDomain.ProcessExit += (_, __) => DumpTo(path);
                 AppDomain.CurrentDomain.DomainUnload += (_, __) => DumpTo(path);
+
+                // One immediate write, so the file exists even if the process dies inside the first
+                // interval -- which is exactly when a startup crash happens.
+                DumpTo(path);
             }
             catch (AppDomainUnloadedException)
             {
@@ -130,10 +157,24 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         }
 
         /// <summary>
-        /// Forces the exit-dump handler to be installed at assembly load, rather than whenever some
-        /// caller first happens to touch this type. Idempotent; running the static constructor is
-        /// the entire point, so the body can stay empty.
+        /// Forces the diagnostics handler to be installed at assembly load, rather than whenever some
+        /// caller first happens to touch this type. Idempotent.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// TARGET-FRAMEWORK QUALIFIED. The module initializer that calls this is
+        /// <c>NET6_0_OR_GREATER</c> only, so on <b>net471</b> registration still happens on first
+        /// use of this type. A net471 consumer that wants the journal written for a process which
+        /// might never touch GPU code must call <see cref="EnsureRegistered"/> itself during startup.
+        /// </para>
+        /// <para>
+        /// ENVIRONMENT VARIABLES ARE READ ONCE, HERE. <c>AIDOTNET_GPU_DIAGNOSTICS_DUMP</c>,
+        /// <c>AIDOTNET_GPU_KERNEL_DIAGNOSTICS</c> and <c>AIDOTNET_GPU_SYNC_LAUNCHES</c> are read by
+        /// the type initializer this triggers, and there is no runtime reconfiguration API. Setting
+        /// any of them AFTER assembly load has no effect — they must be set before the process
+        /// starts (or, on net471, before the first use of this type).
+        /// </para>
+        /// </remarks>
         public static void EnsureRegistered()
         {
             // Referencing any static member is enough to run the static constructor. Kept explicit

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -95,11 +95,23 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         /// residency are written there as the process exits.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This is the diagnostic that answers "what was the process holding when it died". A host
         /// that dies with gigabytes of unreleased device buffers looks, in every managed tool, like a
         /// process with a small tidy heap — the evidence only exists if something recorded it before
         /// the exit. Registering on both ProcessExit and DomainUnload mirrors what the CUDA backend
         /// already does for its teardown flags.
+        /// </para>
+        /// <para>
+        /// A STATIC CONSTRUCTOR IS NOT ENOUGH ON ITS OWN, which is why <see cref="EnsureRegistered"/>
+        /// exists and is called from a module initializer. A static constructor runs on FIRST USE of
+        /// the type, so on a run where nothing happens to touch this class — a CPU-only CI shard, for
+        /// instance — the handler is never installed and no journal is written. The diagnostic would
+        /// then only work for processes that were already using it, which is backwards for crash
+        /// forensics: the runs you most need evidence from are the ones that died before reaching any
+        /// GPU code. Observed exactly that way: AIDOTNET_GPU_DIAGNOSTICS_DUMP was set on every shard
+        /// and not one file was produced.
+        /// </para>
         /// </remarks>
         static GpuKernelDiagnostics()
         {
@@ -115,6 +127,20 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             {
                 // Nothing to register against; the diagnostic is best-effort by design.
             }
+        }
+
+        /// <summary>
+        /// Forces the exit-dump handler to be installed at assembly load, rather than whenever some
+        /// caller first happens to touch this type. Idempotent; running the static constructor is
+        /// the entire point, so the body can stay empty.
+        /// </summary>
+        public static void EnsureRegistered()
+        {
+            // Referencing any static member is enough to run the static constructor. Kept explicit
+            // (rather than relying on a field read a future edit might delete as "unused") so the
+            // reason this call exists survives.
+            System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(
+                typeof(GpuKernelDiagnostics).TypeHandle);
         }
 
         private static bool IsSet(string name)

--- a/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
+++ b/src/AiDotNet.Tensors/Engines/GpuAutoDetectModuleInit.cs
@@ -45,6 +45,22 @@ internal static class GpuAutoDetectModuleInit
     {
         try
         {
+            // BEFORE the opt-out gate, deliberately. This installs the crash-time diagnostics dump
+            // (AIDOTNET_GPU_DIAGNOSTICS_DUMP) and costs nothing when that variable is unset.
+            //
+            // It cannot live in GpuKernelDiagnostics's static constructor alone: a static
+            // constructor runs on FIRST USE of the type, so a process that never touches the class
+            // -- a CPU-only CI shard, or a run that dies before reaching any GPU code -- never
+            // installs the handler and writes no journal. That is backwards for crash forensics,
+            // where the runs you most need evidence from are exactly the ones that got nowhere.
+            // Observed: the variable was set on every shard of a full CI matrix and not one file
+            // was produced.
+            //
+            // Registered even when AIDOTNET_DISABLE_GPU is set, because the buffer-residency
+            // counters and the launch journal are diagnostics about the process, not GPU work being
+            // requested, and a host dying with GPU disabled is still worth attributing.
+            DirectGpu.GpuKernelDiagnostics.EnsureRegistered();
+
             // Opt-out gate: AIDOTNET_DISABLE_GPU set to any non-empty
             // value skips auto-detection. Mirrors BlasEnvDefault's
             // env-var pattern on the consumer side. Users who explicitly

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -234,6 +234,49 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
             }
         }
 
+        /// <summary>
+        /// The diagnostics env vars are read ONCE, at type initialization. Setting them later must
+        /// not appear to work.
+        /// </summary>
+        /// <remarks>
+        /// This pins a contract rather than an implementation detail. Registration now happens at
+        /// assembly load (module initializer), so by the time any caller could call
+        /// SetEnvironmentVariable the values have already been latched. Without this test, a future
+        /// reader could reasonably assume a mid-process toggle takes effect and spend a debugging
+        /// session wondering why their flag did nothing.
+        /// </remarks>
+        [Fact]
+        public void DiagnosticsEnvironmentVariables_AreLatchedAtInitialization_NotReadPerCall()
+        {
+            bool before = GpuKernelDiagnostics.DeepChecksEnabled;
+
+            string? original = Environment.GetEnvironmentVariable("AIDOTNET_GPU_KERNEL_DIAGNOSTICS");
+            try
+            {
+                // Flip it to whatever it currently is not.
+                Environment.SetEnvironmentVariable(
+                    "AIDOTNET_GPU_KERNEL_DIAGNOSTICS", before ? "0" : "1");
+
+                Assert.Equal(before, GpuKernelDiagnostics.DeepChecksEnabled);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIDOTNET_GPU_KERNEL_DIAGNOSTICS", original);
+            }
+        }
+
+        /// <summary>EnsureRegistered is called from a module initializer, so it must be safe to repeat.</summary>
+        [Fact]
+        public void EnsureRegistered_IsIdempotentAndDoesNotThrow()
+        {
+            // A throw here would propagate out of the module initializer and take down the AppDomain,
+            // which is the hazard GpuAutoDetectModuleInit's own comments warn about.
+            GpuKernelDiagnostics.EnsureRegistered();
+            GpuKernelDiagnostics.EnsureRegistered();
+
+            Assert.Contains("live=", GpuKernelDiagnostics.DescribeBufferResidency(), StringComparison.Ordinal);
+        }
+
         /// <summary>A real launch must appear in the journal, which is what makes it useful after a crash.</summary>
         [SkippableFact]
         public void ARealGpuLaunchIsJournalled()


### PR DESCRIPTION
## The bug

The exit-time diagnostics dump **never fired in CI**. A full AiDotNet matrix ran with `AIDOTNET_GPU_DIAGNOSTICS_DUMP` set on every shard and produced not one file:

```
No files were found with the provided path: TestResults/**/Sequence.xml
TestResults/**/gpu-diagnostics.txt. No artifacts will be uploaded.
```

The env var was set correctly and the upload step ran. The handler simply was never installed.

## Why

I registered it in `GpuKernelDiagnostics`'s **static constructor**, and a static constructor runs on *first use of the type*. A process that never touches the class — a CPU-only shard, or a run that dies before reaching any GPU code — never installs the handler and writes nothing.

That is backwards for crash forensics: the runs you most need evidence from are exactly the ones that got nowhere. The diagnostic only worked for processes that were already using it.

## The fix

`EnsureRegistered()`, called from the existing `GpuAutoDetectModuleInit` module initializer so the handler is installed at assembly load.

It is called **before** the `AIDOTNET_DISABLE_GPU` opt-out, deliberately: the residency counters and launch journal are diagnostics about the process, not GPU work being requested, and a host dying with GPU disabled is still worth attributing.

## Verification

Run against `RoundOperatorTests` — a pure-CPU shard that never mentions the class, i.e. precisely the case that produced nothing before:

```
Passed! - Failed: 0, Passed: 30
# GPU launch journal (most recent last)
# buffers: live=3 buffer(s), 48 byte(s); peak 48 byte(s); 3 allocated in total
#0 XgemmDirectTN global=128 local=128 args=17 thread=15 at=...
```

Builds clean on net10.0, net8.0 and net471.

## Note

The module initializer is `#if NET6_0_OR_GREATER`, so net471 consumers keep the old first-use behaviour. CI runs net10.0, so the shard case this fixes is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic registration of GPU diagnostics when the application loads.
  * Crash-time GPU diagnostics are now available even when GPU auto-detection is disabled or GPU functionality is not otherwise used.

* **Documentation**
  * Expanded diagnostic documentation to clarify registration behavior and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->