### PR TITLE
fix: create the diagnostics dump directory instead of failing silently

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -329,6 +329,17 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
         {
             try
             {
+                // CREATE THE DIRECTORY FIRST. The caller's path is frequently RELATIVE (a CI step
+                // building it from a results folder), and a test host does not run with the
+                // workspace as its working directory -- so the target folder often does not exist
+                // from where this process is standing. File.WriteAllText then throws
+                // DirectoryNotFoundException, which is an IOException, which the catch below
+                // swallows. The result was a diagnostic that failed in total silence: the env var
+                // set on every shard of a full CI matrix, and not one file produced anywhere.
+                var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
+
                 var text = new StringBuilder();
                 text.AppendLine("# GPU launch journal (most recent last)");
                 // Residency first: when a process dies holding gigabytes of device buffers, that is

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -129,6 +129,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             var path = Environment.GetEnvironmentVariable("AIDOTNET_GPU_DIAGNOSTICS_DUMP");
             if (string.IsNullOrEmpty(path)) return;
 
+            // Pin the location NOW. A relative dump path resolves against the working directory at the
+            // time of each write, and this process may change directory later (test hosts do). The
+            // periodic flush, both exit hooks and the immediate write must all target the one file the
+            // operator named, not wherever the process happens to be standing when each fires.
+            try
+            {
+                path = Path.GetFullPath(path);
+            }
+            catch (ArgumentException) { return; }        // an unusable path: the diagnostic is best-effort
+            catch (IOException) { return; }              // PathTooLongException
+            catch (NotSupportedException) { return; }
+
             try
             {
                 // EXIT HOOKS ARE NOT ENOUGH, AND THIS IS THE WHOLE POINT OF THE DIAGNOSTIC.
@@ -336,7 +348,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
                 // DirectoryNotFoundException, which is an IOException, which the catch below
                 // swallows. The result was a diagnostic that failed in total silence: the env var
                 // set on every shard of a full CI matrix, and not one file produced anywhere.
-                var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+                //
+                // Resolve the path ONCE and use that same absolute path for both the directory and the
+                // write. Path.GetFullPath resolves a relative path against the working directory at the
+                // moment it is called; letting File.WriteAllText re-resolve the original relative path
+                // would let a chdir in between send the write to a directory this method never created,
+                // and the IOException handler below would swallow that too.
+                string fullPath = Path.GetFullPath(path);
+                var directory = Path.GetDirectoryName(fullPath);
                 if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                     Directory.CreateDirectory(directory);
 
@@ -346,7 +365,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
                 // usually the story, and it is invisible in a managed heap dump.
                 text.AppendLine("# buffers: " + DescribeBufferResidency());
                 foreach (var line in RecentLaunches()) text.AppendLine(line);
-                File.WriteAllText(path, text.ToString());
+                File.WriteAllText(fullPath, text.ToString());
             }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuKernelDiagnostics.cs
@@ -140,6 +140,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             catch (ArgumentException) { return; }        // an unusable path: the diagnostic is best-effort
             catch (IOException) { return; }              // PathTooLongException
             catch (NotSupportedException) { return; }
+            catch (System.Security.SecurityException) { return; }   // restricted .NET Framework hosts
 
             try
             {
@@ -370,6 +371,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
             catch (ArgumentException) { }
+            catch (NotSupportedException) { }                 // colon in a non-volume position (.NET Framework)
+            catch (System.Security.SecurityException) { }     // restricted hosts; this method must never throw
         }
 
         /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuKernelDiagnosticsTests.cs
@@ -144,6 +144,49 @@ namespace AiDotNet.Tensors.Tests.Engines.DirectGpu
             GpuKernelDiagnostics.DumpTo(string.Empty);
         }
 
+        /// <summary>
+        /// The dump must land even when its directory does not exist yet. Callers build the path from a
+        /// results folder that a fresh CI runner has never created, and the process does not run with
+        /// the workspace as its working directory. Before this was fixed the write threw
+        /// DirectoryNotFoundException -- an IOException -- straight into the swallow-everything catch:
+        /// the env var was set on every shard of a full matrix and not one file was produced.
+        /// </summary>
+        [Fact]
+        public void DumpTo_CreatesTheMissingDirectory_ForAbsoluteAndRelativePaths()
+        {
+            string absoluteRoot = Path.Combine(Path.GetTempPath(), "aidotnet-dump-abs-" + Guid.NewGuid().ToString("N"));
+            string relativeRoot = "aidotnet-dump-rel-" + Guid.NewGuid().ToString("N");
+            try
+            {
+                string nested = Path.Combine(absoluteRoot, "results", "gpu", "gpu-diagnostics.txt");
+                Assert.False(Directory.Exists(absoluteRoot), "precondition: the target directory must not exist yet");
+
+                GpuKernelDiagnostics.DumpTo(nested);
+
+                Assert.True(File.Exists(nested), "an absolute path into a directory that does not exist yet must still be written");
+                Assert.Contains("# GPU launch journal", File.ReadAllText(nested), StringComparison.Ordinal);
+
+                // A RELATIVE path resolves against the process working directory -- which is where a
+                // test host's CI step will NOT find it, but that is the caller's problem (pass an
+                // absolute path); this method's promise is that the file exists at the resolved location.
+                string relative = Path.Combine(relativeRoot, "sub", "gpu-diagnostics.txt");
+                string resolved = Path.GetFullPath(relative);
+
+                GpuKernelDiagnostics.DumpTo(relative);
+
+                Assert.True(File.Exists(resolved), $"a relative path must be written at its resolved location {resolved}");
+            }
+            finally
+            {
+                foreach (string root in new[] { absoluteRoot, Path.GetFullPath(relativeRoot) })
+                {
+                    try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); }
+                    catch (IOException) { }
+                    catch (UnauthorizedAccessException) { }
+                }
+            }
+        }
+
         [Fact]
         public void CapacityCheckIsOptIn_AndReportsTheOverrun()
         {


### PR DESCRIPTION
The exit-time dump never appeared in CI despite `AIDOTNET_GPU_DIAGNOSTICS_DUMP` being set on **every shard of a full matrix**. The cause is a silent failure in `DumpTo`.

Callers naturally pass a **relative** path built from a results folder. A test host does not run with the workspace as its working directory, so that folder does not exist from where the process is standing. `File.WriteAllText` throws `DirectoryNotFoundException` — an `IOException` — which the catch here swallowed. No file, no error, no clue. For a diagnostic, failing silently is the worst available behaviour.

`DumpTo` now creates the directory first.

**Verified.** A relative path that previously produced nothing now writes the journal and residency totals. It landed at `tests/.../bin/Debug/net10.0/RelTest/sub/gpu-diagnostics.txt` — confirming the second half of the problem: the path resolves against the **test host's** working directory, so a CI step wanting the file at a workspace-relative location must pass an absolute path. That is fixed separately in ooples/AiDotNet#2056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GomYPttAfrJzkoFBJx7nv4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU diagnostics journals can now be written to destinations whose directories do not yet exist, including relative paths.
  * Diagnostic dump paths remain consistent even if the application’s working directory changes.
  * Existing handling for directory-creation failures remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->