### PR TITLE
fix(gpu): avoid COW detach during cache maintenance

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12115,8 +12115,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return;
 
-        // Invalidation reads host data and cache identity; it must not request writable storage.
-        // A real host mutation has already passed through a write gate and detached its COW family.
+        // Cache identity is a read-only concern: key by the backing array WITHOUT requesting writable
+        // storage, which would detach a copy-on-write alias and copy the whole tensor as a side effect
+        // of cache maintenance. A real host mutation has already passed through a write gate.
         var key = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (key is null)
             return;
@@ -12124,13 +12125,21 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!_persistentBufferCache.TryGetValue(key, out var entry))
             return;
 
+        // The UPLOAD SOURCE is a different question from the cache key. The identity accessor never
+        // fires a pending deferred GPU->CPU download (DeferredArrayMaterializer), so a tensor whose
+        // latest value still lives on the device would re-upload its STALE host bytes. The read-only
+        // data accessor materialises that download without privatising a COW clone, and for the simple
+        // CPU layout the cache can hit on it hands back the very array used as the key. Resolve it
+        // BEFORE disposing the old buffer, so a failed materialisation leaves the cache entry intact.
+        T[] hostData = tensor.GetReadOnlyDataArray();
+
         try
         {
             // Dispose old buffer
             entry.Buffer.Dispose();
 
             // Upload new data
-            float[] floatData = DirectGpuEngine.ToFloatArray(key);
+            float[] floatData = DirectGpuEngine.ToFloatArray(hostData);
             IGpuBuffer newBuffer = backend.AllocateBuffer(floatData);
             backend.Synchronize();
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12079,7 +12079,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         base.UnregisterPersistentTensor(tensor);
 
-        object key = tensor.GetDataArray();
+        // Cache identity is a read-only concern. GetDataArray() advertises writable access and
+        // therefore detaches copy-on-write aliases, turning cleanup into an O(tensor size)
+        // allocation. The cache itself is keyed by the same backing-array identity accessor.
+        object? key = tensor.GetBackingArrayForCacheLookupUnsafe();
+        if (key is null)
+            return;
 
         lock (_persistentBufferLock)
         {

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12115,7 +12115,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!TryGetBackend(out var backend))
             return;
 
-        object key = tensor.GetDataArray();
+        // Invalidation reads host data and cache identity; it must not request writable storage.
+        // A real host mutation has already passed through a write gate and detached its COW family.
+        var key = tensor.GetBackingArrayForCacheLookupUnsafe();
+        if (key is null)
+            return;
 
         if (!_persistentBufferCache.TryGetValue(key, out var entry))
             return;
@@ -12126,7 +12130,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             entry.Buffer.Dispose();
 
             // Upload new data
-            float[] floatData = DirectGpuEngine.ToFloatArray(tensor.GetDataArray());
+            float[] floatData = DirectGpuEngine.ToFloatArray(key);
             IGpuBuffer newBuffer = backend.AllocateBuffer(floatData);
             backend.Synchronize();
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
@@ -1,46 +1,107 @@
 using System;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
 
 /// <summary>
-/// Registering a persistent tensor must not upload it.
+/// Registering, unregistering and invalidating a persistent tensor must not copy it.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Registration used to convert the tensor to float and allocate a GPU buffer immediately, which
 /// made cloning quadratic in memory: a cloned layer re-registers every parameter, so each clone
 /// re-uploaded a whole model. On a 31.5M-parameter decoder that was ~120 MB of float conversion per
 /// clone, and it exhausted memory across ten large models in one test process.
-///
-/// The read path already allocates on a cache miss and re-uploads when the host Version moves, so
-/// the upload belongs there and nowhere else. This test states that as an invariant rather than
-/// leaving it to be re-broken: it measures managed allocation across a registration, which is where
-/// the float conversion showed up.
+/// </para>
+/// <para>
+/// Cleanup had the same shape of defect: unregistering or invalidating a copy-on-write alias went
+/// through the writable <c>GetDataArray</c> escape purely to obtain a cache key, which detached the
+/// alias and copied the full tensor. BLIP and VideoCLIP reproduced it under a 1 GiB managed-heap cap.
+/// </para>
+/// <para>
+/// These tests state the invariants rather than leaving them to be re-broken. Two kinds of evidence
+/// are used: storage identity (a COW alias must still share its source's backing array afterwards),
+/// which holds on every target framework, and managed allocation across the call, which needs the
+/// per-thread allocation counter that net471 does not have. On net471 every scenario still runs and
+/// asserts identity and values; only the byte count is unavailable.
+/// </para>
 /// </remarks>
 public class PersistentTensorRegistrationTests
 {
+    private const int Side = 1024;
+    private const int Elements = Side * Side;   // 4 MiB of float: a detach is unmistakable in the allocation figure
+
+    /// <summary>
+    /// A [1, Side] input whose only non-zero is a 1 in column 0, so a linear pass through a
+    /// [Side, Side] weight returns the weight's first ROW verbatim: output[j] == weight[0, j].
+    /// </summary>
+    private static Tensor<float> UnitRowProbe()
+    {
+        var probe = new Tensor<float>(new[] { 1, Side });
+        probe[0] = 1.0f;
+        return probe;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> and returns the managed bytes it allocated on this thread, or
+    /// <see langword="null"/> where the runtime has no per-thread allocation counter (net471).
+    /// </summary>
+    /// <remarks>
+    /// THREAD-LOCAL, not process-wide: GetTotalAllocatedBytes counts every thread, so an unrelated
+    /// test running concurrently could push a measurement over its threshold and fail it.
+    /// </remarks>
+    private static long? MeasureAllocatedBytes(Action action)
+    {
 #if NET6_0_OR_GREATER   // GetAllocatedBytesForCurrentThread is .NET Core 3.0+; this project also targets net471.
+        long before = System.GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return System.GC.GetAllocatedBytesForCurrentThread() - before;
+#else
+        action();
+        return null;
+#endif
+    }
+
+    private static void AssertDidNotCopyTheTensor(long? allocated, string operation, Tensor<float> tensor)
+    {
+        if (allocated is not long bytes)
+            return;   // net471: the identity and value assertions carry the test
+
+        Assert.True(
+            bytes < 256 * 1024,
+            $"{operation} allocated {bytes:N0} bytes; it must not detach the "
+                + $"{(long)tensor.Length * sizeof(float):N0}-byte tensor.");
+    }
+
+    private static void AssertStillSharesStorage(Tensor<float> source, Tensor<float> alias)
+    {
+        float[]? sourceArray = source.GetBackingArrayForCacheLookupUnsafe();
+        float[]? aliasArray = alias.GetBackingArrayForCacheLookupUnsafe();
+        Assert.NotNull(sourceArray);
+        Assert.True(
+            ReferenceEquals(sourceArray, aliasArray),
+            "the copy-on-write alias was detached from its source: cache maintenance requested writable storage.");
+    }
+
     [Fact]
     public void UnregisterPersistentTensor_DoesNotDetachCopyOnWriteAlias()
     {
         using var engine = new DirectGpuTensorEngine();
-        using var source = new Tensor<float>(new[] { 1_048_576 });
+        using var source = new Tensor<float>(new[] { Elements });
         source[0] = 17.25f;
         using var clone = (Tensor<float>)source.CloneShared();
+        AssertStillSharesStorage(source, clone);
 
         engine.RegisterPersistentTensor(source, PersistentTensorRole.Weights);
         engine.RegisterPersistentTensor(clone, PersistentTensorRole.Weights);
 
-        long before = System.GC.GetAllocatedBytesForCurrentThread();
-        engine.UnregisterPersistentTensor(clone);
-        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+        long? allocated = MeasureAllocatedBytes(() => engine.UnregisterPersistentTensor(clone));
 
-        Assert.True(
-            allocated < 256 * 1024,
-            $"Unregistering a COW alias allocated {allocated:N0} bytes; cleanup must not detach " +
-            $"the {clone.Length * sizeof(float):N0}-byte tensor.");
+        AssertDidNotCopyTheTensor(allocated, "Unregistering a COW alias", clone);
+        AssertStillSharesStorage(source, clone);
         Assert.Equal(17.25f, source[0]);
         Assert.Equal(17.25f, clone[0]);
 
@@ -52,28 +113,90 @@ public class PersistentTensorRegistrationTests
     {
         using var engine = new DirectGpuTensorEngine();
         if (!engine.IsGpuAvailable)
-            return;
+            return;   // without a backend the invalidation path returns before it touches the tensor
 
-        using var source = new Tensor<float>(new[] { 1_048_576 });
+        using var source = new Tensor<float>(new[] { Side, Side });
         source[0] = -8.5f;
         using var clone = (Tensor<float>)source.CloneShared();
 
         engine.RegisterPersistentTensor(source, PersistentTensorRole.Weights);
         engine.RegisterPersistentTensor(clone, PersistentTensorRole.Weights);
 
-        long before = System.GC.GetAllocatedBytesForCurrentThread();
-        engine.InvalidatePersistentTensor(clone);
-        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+        // Registration no longer uploads, so an invalidation of a never-read tensor finds no cache
+        // entry and returns early -- it would pass here without exercising anything. Read the alias
+        // as a WEIGHT through a GPU op first so the persistent cache holds a buffer keyed by the
+        // SHARED array.
+        float[]? shared = clone.GetBackingArrayForCacheLookupUnsafe();
+        Assert.NotNull(shared);
+        using var probe = UnitRowProbe();
+        using (var warm = engine.FusedLinear(probe, clone, null, FusedActivationType.None))
+            Assert.Equal(-8.5f, warm[0]);   // row 0 of the weight, i.e. element [0,0]
+        Assert.NotNull(engine.TryGetCachedBuffer(shared));
 
-        Assert.True(
-            allocated < 256 * 1024,
-            $"Invalidating a COW alias allocated {allocated:N0} bytes; cache maintenance must not detach " +
-            $"the {clone.Length * sizeof(float):N0}-byte tensor.");
+        long? allocated = MeasureAllocatedBytes(() => engine.InvalidatePersistentTensor(clone));
+
+        AssertDidNotCopyTheTensor(allocated, "Invalidating a COW alias", clone);
+        AssertStillSharesStorage(source, clone);
         Assert.Equal(-8.5f, source[0]);
         Assert.Equal(-8.5f, clone[0]);
+        Assert.NotNull(engine.TryGetCachedBuffer(shared));   // re-uploaded under the same identity, not evicted
 
         engine.UnregisterPersistentTensor(clone);
         engine.UnregisterPersistentTensor(source);
+    }
+
+    /// <summary>
+    /// The cache key and the upload source are different questions. The identity accessor used for
+    /// the key never triggers a pending deferred GPU-to-CPU download, so if invalidation uploaded
+    /// from it, a tensor whose newest value still lived on the device would push its STALE host
+    /// bytes back to the GPU. The upload must read through an accessor that materialises first.
+    /// </summary>
+    [Fact]
+    public void InvalidatePersistentTensor_UploadsTheMaterialisedValue_WhenADownloadIsPending()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        if (!engine.IsGpuAvailable)
+            return;
+
+        using var weight = new Tensor<float>(new[] { Side, Side });
+        for (int i = 0; i < Elements; i++) weight[i] = 1.0f;
+        float[]? array = weight.GetBackingArrayForCacheLookupUnsafe();
+        Assert.NotNull(array);
+
+        engine.RegisterPersistentTensor(weight, PersistentTensorRole.Weights);
+        using var probe = UnitRowProbe();
+        using (var warm = engine.FusedLinear(probe, weight, null, FusedActivationType.None))
+            Assert.Equal(1.0f, warm[0]);
+        Assert.NotNull(engine.TryGetCachedBuffer(array));
+
+        // Stand in for FinishGpuOp: the host array is stale and a download that would fill it with the
+        // device's current value (3.0) is registered but has not run yet.
+        DeferredArrayMaterializer.Register(array, pending =>
+        {
+            var target = (float[])pending;
+            for (int i = 0; i < target.Length; i++) target[i] = 3.0f;
+        });
+        try
+        {
+            Assert.True(DeferredArrayMaterializer.IsPending(array));
+
+            engine.InvalidatePersistentTensor(weight);
+
+            Assert.False(
+                DeferredArrayMaterializer.IsPending(array),
+                "invalidation uploaded without materialising the pending download; the GPU now holds stale data.");
+
+            // Read the weight back THROUGH the cache: the weight path serves the buffer invalidation
+            // just uploaded (its host Version stamp was refreshed), so this is the device-side value.
+            using var readback = engine.FusedLinear(probe, weight, null, FusedActivationType.None);
+            Assert.Equal(3.0f, readback[0]);
+            Assert.Equal(3.0f, readback[Side - 1]);
+        }
+        finally
+        {
+            DeferredArrayMaterializer.Remove(array);
+            engine.UnregisterPersistentTensor(weight);
+        }
     }
 
     [Fact]
@@ -98,22 +221,20 @@ public class PersistentTensorRegistrationTests
         engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
         engine.UnregisterPersistentTensor(tensor);
 
-        // THREAD-LOCAL, not process-wide: GetTotalAllocatedBytes counts every thread, so an
-        // unrelated test running concurrently could push this over the threshold and fail it.
-        long before = System.GC.GetAllocatedBytesForCurrentThread();
-        engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights);
-        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+        long? allocated = MeasureAllocatedBytes(() => engine.RegisterPersistentTensor(tensor, PersistentTensorRole.Weights));
 
         engine.UnregisterPersistentTensor(tensor);
+
+        if (allocated is not long bytes)
+            return;   // net471: no per-thread counter; the registration round-trip above still ran
 
         // A float copy of the payload would be half its size; anything approaching that means the
         // eager upload is back. Bookkeeping is allowed to allocate a little.
         long floatCopy = payload / 2;
         Assert.True(
-            allocated < floatCopy / 4,
-            $"registration allocated {allocated:N0} bytes for a {payload:N0}-byte tensor. A float "
+            bytes < floatCopy / 4,
+            $"registration allocated {bytes:N0} bytes for a {payload:N0}-byte tensor. A float "
                 + $"copy would be about {floatCopy:N0}; the upload belongs on the read path, which "
                 + "allocates on a cache miss and re-uploads when the host Version moves.");
     }
-#endif
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
@@ -48,6 +48,35 @@ public class PersistentTensorRegistrationTests
     }
 
     [Fact]
+    public void InvalidatePersistentTensor_DoesNotDetachCopyOnWriteAlias()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        if (!engine.IsGpuAvailable)
+            return;
+
+        using var source = new Tensor<float>(new[] { 1_048_576 });
+        source[0] = -8.5f;
+        using var clone = (Tensor<float>)source.CloneShared();
+
+        engine.RegisterPersistentTensor(source, PersistentTensorRole.Weights);
+        engine.RegisterPersistentTensor(clone, PersistentTensorRole.Weights);
+
+        long before = System.GC.GetAllocatedBytesForCurrentThread();
+        engine.InvalidatePersistentTensor(clone);
+        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(
+            allocated < 256 * 1024,
+            $"Invalidating a COW alias allocated {allocated:N0} bytes; cache maintenance must not detach " +
+            $"the {clone.Length * sizeof(float):N0}-byte tensor.");
+        Assert.Equal(-8.5f, source[0]);
+        Assert.Equal(-8.5f, clone[0]);
+
+        engine.UnregisterPersistentTensor(clone);
+        engine.UnregisterPersistentTensor(source);
+    }
+
+    [Fact]
     public void RegisterPersistentTensor_DoesNotMaterialiseTheTensor()
     {
         // The engine under test must be the GPU one. AiDotNetEngine.Current starts as CpuEngine and

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentTensorRegistrationTests.cs
@@ -23,6 +23,31 @@ public class PersistentTensorRegistrationTests
 {
 #if NET6_0_OR_GREATER   // GetAllocatedBytesForCurrentThread is .NET Core 3.0+; this project also targets net471.
     [Fact]
+    public void UnregisterPersistentTensor_DoesNotDetachCopyOnWriteAlias()
+    {
+        using var engine = new DirectGpuTensorEngine();
+        using var source = new Tensor<float>(new[] { 1_048_576 });
+        source[0] = 17.25f;
+        using var clone = (Tensor<float>)source.CloneShared();
+
+        engine.RegisterPersistentTensor(source, PersistentTensorRole.Weights);
+        engine.RegisterPersistentTensor(clone, PersistentTensorRole.Weights);
+
+        long before = System.GC.GetAllocatedBytesForCurrentThread();
+        engine.UnregisterPersistentTensor(clone);
+        long allocated = System.GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(
+            allocated < 256 * 1024,
+            $"Unregistering a COW alias allocated {allocated:N0} bytes; cleanup must not detach " +
+            $"the {clone.Length * sizeof(float):N0}-byte tensor.");
+        Assert.Equal(17.25f, source[0]);
+        Assert.Equal(17.25f, clone[0]);
+
+        engine.UnregisterPersistentTensor(source);
+    }
+
+    [Fact]
     public void RegisterPersistentTensor_DoesNotMaterialiseTheTensor()
     {
         // The engine under test must be the GPU one. AiDotNetEngine.Current starts as CpuEngine and


### PR DESCRIPTION
## Root cause

`DirectGpuTensorEngine` used the writable `GetDataArray` escape solely for cache identity and readback in `UnregisterPersistentTensor` and `InvalidatePersistentTensor`. For copy-on-write aliases those calls detach and copy the full tensor during cleanup. BLIP and VideoCLIP reproduced this under a 1 GiB managed-heap cap in `CowAliasFamily.DetachForWrite`.

## Fix

- Cache identity comes from the read-only backing-array accessor (`GetBackingArrayForCacheLookupUnsafe`) in both paths, so cleanup never detaches an alias. Base bookkeeping still runs and direct cache cleanup uses the same identity as the other invalidation paths.
- The invalidation **upload source** is a separate concern (Copilot review): the identity accessor never fires a pending `DeferredArrayMaterializer` download, so a tensor whose newest value still lived on the device would have re-uploaded stale host bytes. The upload now reads through `GetReadOnlyDataArray`, which materialises without privatising a COW clone and returns the very array used as the key for the simple CPU layout the cache can hit on. It is resolved before the old buffer is disposed, so a failed materialisation leaves the cache entry intact.

## Proof

- `UnregisterPersistentTensor_DoesNotDetachCopyOnWriteAlias`: 4 MiB COW alias; asserts the alias still shares its source's backing array, values intact, and (on .NET 6+) under 256 KiB allocated.
- `InvalidatePersistentTensor_DoesNotDetachCopyOnWriteAlias`: first reads the alias as a weight through `FusedLinear` so the persistent cache actually holds an entry (registration no longer uploads, so without this the invalidation returned before touching anything), then asserts identity, values, allocation, and that the entry was re-uploaded rather than evicted.
- `InvalidatePersistentTensor_UploadsTheMaterialisedValue_WhenADownloadIsPending`: registers a pending download that fills the array with 3.0, invalidates, and reads the weight back through the cache expecting 3.0. Control arm: with the previous upload source (the identity accessor) this test fails; with the fix it passes.
- Every scenario also runs on net471 (CodeRabbit review): only the per-thread allocation count is guarded by `NET6_0_OR_GREATER`, via a `MeasureAllocatedBytes` helper that returns null where the counter does not exist. Storage identity and values are asserted on every target.
- `PersistentTensorRegistrationTests`: 4/4 passed on net10.0 against a live OpenCL backend; test project builds on net471 with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mDPCQdPAGq5pHLuTBvyxC
