### PR TITLE
fix(compilation): correct graph capture and tensor lifetimes

### DIFF
--- a/src/AiDotNet.Tensors.Onnx/OnnxImporter.cs
+++ b/src/AiDotNet.Tensors.Onnx/OnnxImporter.cs
@@ -216,7 +216,7 @@ public static class OnnxImporter
         });
         try
         {
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             // Resolve the default-domain opset version from the model's
             // opset_import list. Softmax and a handful of other translators
             // need this to pick the correct per-opset attribute defaults.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/AutogradFunction.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/AutogradFunction.cs
@@ -76,7 +76,7 @@ public abstract class AutogradFunction<T>
 /// <summary>
 /// Context object for saving tensors between forward and backward passes.
 /// </summary>
-public sealed class AutogradContext
+public sealed class AutogradContext : ISavedStateTensorContainer
 {
     private readonly List<object> _saved = [];
 
@@ -100,4 +100,6 @@ public sealed class AutogradContext
 
     /// <summary>Gets the number of saved items.</summary>
     public int SavedCount => _saved.Count;
+
+    IReadOnlyList<object> ISavedStateTensorContainer.SavedStateValues => _saved;
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardStorageReleasePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardStorageReleasePlan.cs
@@ -1,0 +1,195 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Autodiff;
+
+/// <summary>
+/// Precomputed, storage-aware release schedule for progressive GPU activation reclamation.
+/// Tensor objects are not allocation identities: reshape/transpose/slice views can all share
+/// one storage, and a saved tensor can outlive an earlier alias's backward step. The schedule
+/// therefore releases an output storage only after its final declared backward use.
+/// </summary>
+internal sealed class BackwardStorageReleasePlan<T>
+{
+    private readonly struct ReleaseCandidate
+    {
+        internal readonly object StorageIdentity;
+        internal readonly Tensor<T> Tensor;
+
+        internal ReleaseCandidate(object storageIdentity, Tensor<T> tensor)
+        {
+            StorageIdentity = storageIdentity;
+            Tensor = tensor;
+        }
+    }
+
+    private sealed class StorageUsage
+    {
+        internal readonly object Identity;
+        internal Tensor<T>? ReleaseCandidate;
+        internal int LastUse;
+
+        internal StorageUsage(object identity, int lastUse)
+        {
+            Identity = identity;
+            LastUse = lastUse;
+        }
+    }
+
+    private sealed class Builder
+    {
+        private readonly Dictionary<object, StorageUsage> _usage =
+            new(ReferenceEqualityComparer<object>.Instance);
+
+        internal void Observe(Tensor<T>? tensor, int step, bool canRelease)
+        {
+            if (tensor is null) return;
+            object identity = tensor.StorageIdentity;
+            if (!_usage.TryGetValue(identity, out var usage))
+            {
+                usage = new StorageUsage(identity, step);
+                _usage.Add(identity, usage);
+            }
+            else if (step > usage.LastUse)
+            {
+                usage.LastUse = step;
+            }
+
+            // Only graph-produced outputs are owned by progressive activation reclamation.
+            // Inputs that are leaves must never become releasable merely because they were read.
+            if (canRelease && usage.ReleaseCandidate is null)
+                usage.ReleaseCandidate = tensor;
+        }
+
+        internal BackwardStorageReleasePlan<T> Build(int stepCount)
+        {
+            var counts = new int[stepCount];
+            foreach (var usage in _usage.Values)
+            {
+                if (usage.ReleaseCandidate is not null)
+                    counts[usage.LastUse]++;
+            }
+
+            var releases = new ReleaseCandidate[]?[stepCount];
+            for (int i = 0; i < stepCount; i++)
+            {
+                if (counts[i] != 0)
+                    releases[i] = new ReleaseCandidate[counts[i]];
+            }
+
+            Array.Clear(counts, 0, counts.Length);
+            foreach (var usage in _usage.Values)
+            {
+                if (usage.ReleaseCandidate is null) continue;
+                int step = usage.LastUse;
+                releases[step]![counts[step]++] =
+                    new ReleaseCandidate(usage.Identity, usage.ReleaseCandidate);
+            }
+
+            return new BackwardStorageReleasePlan<T>(releases);
+        }
+    }
+
+    private struct SavedUseVisitor : ISavedStateTensorVisitor
+    {
+        private readonly Builder _builder;
+        private readonly int _step;
+
+        internal SavedUseVisitor(Builder builder, int step)
+        {
+            _builder = builder;
+            _step = step;
+        }
+
+        public void Visit(ITensorStorageLeaseSource tensor)
+        {
+            if (tensor is Tensor<T> typed)
+                _builder.Observe(typed, _step, canRelease: false);
+        }
+    }
+
+    private readonly ReleaseCandidate[]?[] _releasesAfterStep;
+
+    private BackwardStorageReleasePlan(ReleaseCandidate[]?[] releasesAfterStep)
+        => _releasesAfterStep = releasesAfterStep;
+
+    internal static BackwardStorageReleasePlan<T> Create(BackwardStep<T>[] steps, int count)
+    {
+        var builder = new Builder();
+        for (int i = 0; i < count; i++)
+        {
+            ref var step = ref steps[i];
+            builder.Observe(step.Output, i, canRelease: true);
+            if (step.Inputs is not null)
+            {
+                for (int j = 0; j < step.Inputs.Length; j++)
+                    builder.Observe(step.Inputs[j], i, canRelease: false);
+            }
+
+            var visitor = new SavedUseVisitor(builder, i);
+            SavedStateTensorTraversal.Visit(step.SavedState, ref visitor);
+        }
+        return builder.Build(count);
+    }
+
+    internal static BackwardStorageReleasePlan<T> Create(
+        TapeEntryArena<T> entries,
+        int[] executionOrder)
+    {
+        var builder = new Builder();
+        for (int step = 0; step < executionOrder.Length; step++)
+        {
+            ref var entry = ref entries[executionOrder[step]];
+            builder.Observe(entry.Output, step, canRelease: true);
+            if (entry.InputsOverflow is not null)
+            {
+                for (int j = 0; j < entry.InputsOverflow.Length; j++)
+                    builder.Observe(entry.InputsOverflow[j], step, canRelease: false);
+            }
+            else
+            {
+                builder.Observe(entry.Input0, step, canRelease: false);
+                if (entry.InputCount >= 2)
+                    builder.Observe(entry.Input1, step, canRelease: false);
+                if (entry.InputCount >= 3)
+                    builder.Observe(entry.Input2, step, canRelease: false);
+            }
+
+            var visitor = new SavedUseVisitor(builder, step);
+            SavedStateTensorTraversal.Visit(entry.SavedState, ref visitor);
+        }
+        return builder.Build(executionOrder.Length);
+    }
+
+    /// <summary>
+    /// Invalidates storages whose final backward use is the completed step. A changed storage
+    /// identity means replay rebinding invalidated the precomputed proof; fail closed by retaining
+    /// that activation rather than risking premature release.
+    /// </summary>
+    internal void ReleaseAfterStep(
+        int step,
+        DirectGpuTensorEngine engine,
+        HashSet<object> protectedStorages)
+    {
+        var candidates = _releasesAfterStep[step];
+        if (candidates is null) return;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            var candidate = candidates[i];
+            if (protectedStorages.Contains(candidate.StorageIdentity)) continue;
+            if (!ReferenceEquals(candidate.Tensor.StorageIdentity, candidate.StorageIdentity)) continue;
+            engine.InvalidateGpuCacheForTensor(candidate.Tensor);
+        }
+    }
+
+    internal bool IsStorageScheduledAfterStep(Tensor<T> tensor, int step)
+    {
+        var candidates = _releasesAfterStep[step];
+        if (candidates is null) return false;
+        object identity = tensor.StorageIdentity;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            if (ReferenceEquals(candidates[i].StorageIdentity, identity)) return true;
+        }
+        return false;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -101,6 +101,7 @@ internal sealed class CompiledDelegateChain<T>
     // Logical step count. The backing array may be larger when rented
     // from BackwardScratch<T> — only indices [0, _count) hold live data.
     private readonly int _count;
+    private BackwardStorageReleasePlan<T>? _storageReleasePlan;
 
     internal CompiledDelegateChain(BackwardStep<T>[] steps)
         : this(steps, steps.Length)
@@ -111,6 +112,7 @@ internal sealed class CompiledDelegateChain<T>
     {
         _steps = steps;
         _count = count;
+        _storageReleasePlan = BackwardStorageReleasePlan<T>.Create(steps, count);
     }
 
     /// <summary>
@@ -151,6 +153,7 @@ internal sealed class CompiledDelegateChain<T>
             // Output, Inputs, Backward, SavedState.
             _steps[i] = default;
         }
+        _storageReleasePlan = null;
     }
 
     /// <summary>
@@ -167,7 +170,8 @@ internal sealed class CompiledDelegateChain<T>
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources,
         IEngine engine,
-        bool useScratch = false)
+        bool useScratch = false,
+        IReadOnlyCollection<Tensor<T>>? retainedTensors = null)
     {
         Dictionary<Tensor<T>, Tensor<T>> grads = useScratch
             ? BackwardScratch<T>.RentGrads(_count + 1)
@@ -203,26 +207,39 @@ internal sealed class CompiledDelegateChain<T>
         // Iterate only over the live range [0, _count).
         bool timing = BackwardTiming.Enabled;
 
-        // OOM fix: free each forward activation's GPU buffer on its LAST use — right after its step's backward; in
-        // reverse-topological order a step's output is fully consumed once its step runs (every consumer was an
-        // earlier step). Previously all forward activations stayed GPU-pinned for the whole backward, so the working
-        // set pegged at the card memory limit → OOM at scale (a tiny d256/L2 model OOM'd a 12 GB card past ~200K
-        // tokens). Skip the loss + sources (leaf params). Gated to the GPU engine; materialize-then-free is safe.
+        // Free graph-owned activation storages on their final declared backward use. This is storage-aware rather
+        // than tensor-object-aware because metadata views can alias a saved tensor needed by a later step. The
+        // release schedule is precomputed with the chain, preserving progressive reclamation without adding a
+        // per-replay graph scan. Loss/source/retain-grad storages remain caller-owned after backward.
         var gpuEngine = engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
-        HashSet<Tensor<T>>? freeSkip = null;
+        HashSet<object>? protectedStorages = null;
         if (gpuEngine is not null)
         {
-            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { loss };
-            if (sources is not null) foreach (var s in sources) freeSkip.Add(s);
+            protectedStorages = new HashSet<object>(ReferenceEqualityComparer<object>.Instance)
+            {
+                loss.StorageIdentity
+            };
+            if (sources is not null)
+                foreach (var source in sources) protectedStorages.Add(source.StorageIdentity);
+            if (retainedTensors is not null)
+                foreach (var retained in retainedTensors) protectedStorages.Add(retained.StorageIdentity);
         }
 
         for (int i = 0; i < _count; i++)
         {
             ref var step = ref _steps[i];
             if (!DifferentiableOps.IsGradientRequired(step.Output))
+            {
+                if (gpuEngine is not null)
+                    _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
                 continue;
+            }
             if (!grads.TryGetValue(step.Output, out var gradOutput))
+            {
+                if (gpuEngine is not null)
+                    _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
                 continue;
+            }
 
             long start = timing ? Stopwatch.GetTimestamp() : 0;
             var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
@@ -241,8 +258,8 @@ internal sealed class CompiledDelegateChain<T>
                 BackwardTiming.Record(step.Backward.Method.Name, ticks);
             }
 
-            if (gpuEngine is not null && !freeSkip!.Contains(step.Output))
-                gpuEngine.InvalidateGpuCacheForTensor(step.Output);
+            if (gpuEngine is not null)
+                _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
         }
 
         if (sources is not null)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -480,7 +480,7 @@ internal static class DifferentiableOps
     }
 
     /// <summary>
-    /// Issue #338 completion: pins every <see cref="Tensor{T}"/> stored in a recorded op's
+    /// Issue #338 completion: pins every tensor stored in a recorded op's
     /// saved state against pool/arena reuse, exactly as Record* pins the op's
     /// inputs. Many backward functions read tensors OUT of savedState rather than from the op's
     /// inputs — LayerNorm/BatchNorm/RMSNorm mean/variance/rms, attention weights and softmax
@@ -498,14 +498,9 @@ internal static class DifferentiableOps
         if (entry.SavedStatePinsHeld) return;
         var savedState = entry.SavedState;
         if (savedState is null) return;
-        bool pinnedAny = false;
-        for (int i = 0; i < savedState.Length; i++)
-            if (savedState[i] is Tensor<T> saved)
-            {
-                saved._pinnedByTape = true; // ref-counted increment (see TensorBase._pinnedByTape)
-                pinnedAny = true;
-            }
-        entry.SavedStatePinsHeld = pinnedAny;
+        var visitor = new SavedStatePinVisitor(pin: true);
+        SavedStateTensorTraversal.Visit(savedState, ref visitor);
+        entry.SavedStatePinsHeld = visitor.VisitedAny;
     }
 
     /// <summary>
@@ -523,10 +518,27 @@ internal static class DifferentiableOps
             entry.SavedStatePinsHeld = false;
             return;
         }
-        for (int i = 0; i < savedState.Length; i++)
-            if (savedState[i] is Tensor<T> saved)
-                saved._pinnedByTape = false; // ref-counted decrement, clamped at zero
+        var visitor = new SavedStatePinVisitor(pin: false);
+        SavedStateTensorTraversal.Visit(savedState, ref visitor);
         entry.SavedStatePinsHeld = false;
+    }
+
+    private struct SavedStatePinVisitor : ISavedStateTensorVisitor
+    {
+        private readonly bool _pin;
+        internal bool VisitedAny;
+
+        internal SavedStatePinVisitor(bool pin)
+        {
+            _pin = pin;
+            VisitedAny = false;
+        }
+
+        public void Visit(ITensorStorageLeaseSource tensor)
+        {
+            tensor.SetTapePinned(_pin);
+            VisitedAny = true;
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -1622,7 +1622,8 @@ public sealed class GradientTape<T> : IDisposable
             // returned grads dict carries the data either way.
             if (_cachedDelegateChain is not null)
             {
-                var cachedResult = _cachedDelegateChain.Execute(loss, sources, _engine, useScratch: acquiredScratch);
+                var cachedResult = _cachedDelegateChain.Execute(
+                    loss, sources, _engine, useScratch: acquiredScratch, retainedTensors: _retainGrad);
                 HashSet<Tensor<T>>? cachedSourceSet = null;
                 if (sources is not null)
                 {
@@ -1699,7 +1700,8 @@ public sealed class GradientTape<T> : IDisposable
                 _cachedDelegateChain = chain;
 
             // Execute the chain
-            var result = chain.Execute(loss, sources, engine, useScratch: acquiredScratch);
+            var result = chain.Execute(
+                loss, sources, engine, useScratch: acquiredScratch, retainedTensors: _retainGrad);
 
             // Build rebindable plan for fresh-tape callers (closes the
             // consumer fresh-tape gap from issue #327). MUST run AFTER

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -23,6 +23,7 @@ internal sealed class OptimizedBackwardPlan<T>
     private readonly Tensor<T> _loss;
     private readonly Tensor<T>[]? _sources;
     private readonly IEngine _engine;
+    private readonly BackwardStorageReleasePlan<T> _storageReleasePlan;
 
     /// <summary>
     /// Optional reference to the owning tape's RetainGrad set. Same parity rule
@@ -54,6 +55,7 @@ internal sealed class OptimizedBackwardPlan<T>
         _sources = sources;
         _engine = engine;
         _retainGrad = retainGrad;
+        _storageReleasePlan = BackwardStorageReleasePlan<T>.Create(entries, reachableIndices);
         _ = analysis; // Retained for future backward optimization passes
     }
 
@@ -109,38 +111,42 @@ internal sealed class OptimizedBackwardPlan<T>
         _inputsBuf2 = BackwardInputBuffers<T>.Get2();
         _inputsBuf3 = BackwardInputBuffers<T>.Get3();
 
-        // OOM fix: free each forward activation's GPU buffer as soon as it is DEAD — right after its entry's backward,
-        // in reverse-topological order its output is fully consumed (every consumer was processed earlier). Previously
-        // all forward activations stayed GPU-pinned for the whole backward, pegging the card at its memory limit →
-        // OOM at scale. Skip the loss + sources/retained tensors: the loss IS an entry.Output (the loss op's
-        // output), and the caller reads its value after backward, so it must never be freed mid-walk — same
-        // contract as CompiledDelegateChain.Execute. Sources and retain-grad tensors are likewise consumed by
-        // the caller after backward and must survive too. (Gated to GPU engine; materialize-then-free is
-        // correctness-safe.)
+        // Reclaim graph-owned activation storages progressively after their final declared backward use.
+        // Storage identity, not Tensor object identity, is the lifetime unit because metadata views alias their
+        // source. Loss/source/retain-grad storages remain protected for the caller.
         var gpuEngine = _engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
-        HashSet<Tensor<T>>? freeSkip = null;
+        HashSet<object>? protectedStorages = null;
         if (gpuEngine is not null)
         {
-            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { _loss };
-            if (_sources is not null) foreach (var s in _sources) freeSkip.Add(s);
-            if (_retainGrad is not null) foreach (var r in _retainGrad) freeSkip.Add(r);
-        }
-        void FreeDeadActivation(Tensor<T> t)
-        {
-            if (gpuEngine is not null && (freeSkip is null || !freeSkip.Contains(t)))
-                gpuEngine.InvalidateGpuCacheForTensor(t);
+            protectedStorages = new HashSet<object>(ReferenceEqualityComparer<object>.Instance)
+            {
+                _loss.StorageIdentity
+            };
+            if (_sources is not null)
+                foreach (var source in _sources) protectedStorages.Add(source.StorageIdentity);
+            if (_retainGrad is not null)
+                foreach (var retained in _retainGrad) protectedStorages.Add(retained.StorageIdentity);
         }
 
         try
         {
-            foreach (int i in _reachableIndices)
+            for (int executionStep = 0; executionStep < _reachableIndices.Length; executionStep++)
             {
+                int i = _reachableIndices[executionStep];
                 ref var entry = ref _entries[i];
 
                 if (!DifferentiableOps.IsGradientRequired(entry.Output))
+                {
+                    if (gpuEngine is not null)
+                        _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                     continue;
+                }
                 if (!grads.TryGetValue(entry.Output, out var gradOutput))
+                {
+                    if (gpuEngine is not null)
+                        _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                     continue;
+                }
 
                 entry.ValidateInputVersions();
 
@@ -150,7 +156,8 @@ internal sealed class OptimizedBackwardPlan<T>
                     // Try optimized path for MatMul operations
                     if (TryOptimizedMatMulBackward(ref entry, gradOutput, cse, grads))
                     {
-                        FreeDeadActivation(entry.Output);
+                        if (gpuEngine is not null)
+                            _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                         continue;
                     }
 
@@ -170,12 +177,14 @@ internal sealed class OptimizedBackwardPlan<T>
                     if (BackwardTiming.Enabled)
                         BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
 
-                    FreeDeadActivation(entry.Output);
                 }
                 finally
                 {
                     DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
+
+                if (gpuEngine is not null)
+                    _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
             }
         }
         finally

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Strategies/StreamingStrategy.cs
@@ -303,10 +303,22 @@ internal static class StreamingStrategy
                 int ldaLocal = lda, ldbLocal = ldb, ldcLocal = ldc;
                 bool taLocal = transA, tbLocal = transB;
 
+                // Partition complete SIMD column tiles, not arbitrary columns. Splitting raw N by
+                // integer division can put a globally vectorizable column into a worker's scalar
+                // tail (for example N=704 over 32 workers produced 22-column chunks). Besides
+                // wasting SIMD capacity at every boundary, FP32 then changes from explicit FMA to
+                // scalar multiply/add and violates deterministic mode's bit-identical partitioning
+                // contract. The Run caller guarantees at least two StreamingNr tiles per worker;
+                // distribute those whole tiles evenly and leave only the matrix's genuine N tail
+                // to the final worker.
+                int fullColumnTiles = nLocal / StreamingNr;
+
                 PersistentParallelExecutor.Instance.Execute(procsLocal, p =>
                 {
-                    int nStart = (int)(((long)p * nLocal) / procsLocal);
-                    int nEnd = (int)(((long)(p + 1) * nLocal) / procsLocal);
+                    int firstTile = (int)(((long)p * fullColumnTiles) / procsLocal);
+                    int tileEnd = (int)(((long)(p + 1) * fullColumnTiles) / procsLocal);
+                    int nStart = firstTile * StreamingNr;
+                    int nEnd = p == procsLocal - 1 ? nLocal : tileEnd * StreamingNr;
                     int nChunk = nEnd - nStart;
                     if (nChunk <= 0) return;
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/AutoTracer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/AutoTracer.cs
@@ -240,7 +240,7 @@ internal sealed class AutoTracerState
 
         try
         {
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             var engine = AiDotNetEngine.Current;
             if (engine is null) return;
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -36,6 +36,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     // Array is never null but may be empty (degenerate empty-plan case).
     private readonly Tensor<T>[] _compiledInputTensors;
     private readonly List<GCHandle> _pinnedHandles = new();
+    private TensorStorageLeaseSet? _storageLeases;
 
     // Source plans that were stitched to form this plan — empty for plans
     // constructed from a scope compile, length 2 for each ThenAsync result.
@@ -147,22 +148,21 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         List<GCHandle>? handles = null,
         CompiledInferencePlan<T>[]? sourcePlans = null,
         Tensor<T>[]? compiledInputTensors = null,
-        bool containsCrossEngineSteps = false)
+        bool containsCrossEngineSteps = false,
+        TensorStorageLeaseSet? storageLeases = null)
     {
         _steps = steps;
         _finalOutput = finalOutput;
         _engine = engine;
         _compiledInputShape = inputShape;
         _containsCrossEngineSteps = containsCrossEngineSteps;
-        // Compile() / CreateFromDeserialized currently capture one input,
-        // so the array has length 0 or 1 in practice. Storing it as an array
-        // lets SetInputs generalize cleanly when multi-input Compile lands.
         _compiledInputTensors = compiledInputTensors is not null
             ? compiledInputTensors
             : compiledInputTensor is null
             ? Array.Empty<Tensor<T>>()
             : new[] { compiledInputTensor };
         _sourcePlans = sourcePlans ?? Array.Empty<CompiledInferencePlan<T>>();
+        _storageLeases = storageLeases;
         if (handles is not null)
             _pinnedHandles.AddRange(handles);
     }
@@ -185,11 +185,8 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         if (_disposed) throw new ObjectDisposedException(nameof(CompiledInferencePlan<T>));
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Current on-disk format captures a single input tensor. When
-        // Compile() starts producing multi-input plans, bump the format
-        // version and extend the writer to emit every entry.
-        var firstInput = _compiledInputTensors.Length > 0 ? _compiledInputTensors[0] : null;
-        InferencePlanWriter.Write(stream, _steps, _finalOutput, _compiledInputShape, firstInput);
+        InferencePlanWriter.Write(
+            stream, _steps, _finalOutput, _compiledInputShape, _compiledInputTensors);
         return Task.CompletedTask;
     }
 
@@ -211,7 +208,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         Tensor<T> finalOutput,
         IEngine engine,
         int[] inputShape,
-        Tensor<T>? compiledInputTensor)
+        Tensor<T>[] compiledInputTensors)
     {
         // Run TryBuildSpecializedForward on the deserialized steps so the
         // loaded plan uses the same SIMD-tuned kernels as the original.
@@ -231,7 +228,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         for (int i = 0; i < steps.Length; i++)
         {
             var step = steps[i];
-            bool allowCachedB = !IsMutableSecondMatMulInput(step, compiledInputTensor);
+            bool allowCachedB = !IsMutableSecondMatMulInput(step, compiledInputTensors);
             MaybeRegisterFrozenMatMulWeight(step, allowCachedB);
             var spec = CompiledTrainingPlan<T>.TryBuildSpecializedForward(step, pinnedHandles, allowCachedB);
             if (spec != null)
@@ -255,13 +252,11 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         foreach (var step in specialized)
             step.OutputBuffer.LazySource = null;
 
-        var actualFinalOutput = specialized.Length > 0
-            ? specialized[specialized.Length - 1].OutputBuffer
-            : finalOutput;
-
         return new CompiledInferencePlan<T>(
-            specialized, actualFinalOutput, engine, inputShape,
-            handles: pinnedHandles, compiledInputTensor: compiledInputTensor);
+            specialized, finalOutput, engine, inputShape,
+            handles: pinnedHandles,
+            compiledInputTensor: compiledInputTensors.Length > 0 ? compiledInputTensors[0] : null,
+            compiledInputTensors: compiledInputTensors);
     }
 
     // ── Internal accessors for serialization ────────────────────────────
@@ -334,6 +329,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // below where the kernels DO run concurrently with the host.
         if (IsCpuEngine(_engine))
         {
+            using var recordingSuspension = GraphMode.SuspendRecording();
             var steps = _steps;
             for (int i = 0; i < steps.Length; i++)
             {
@@ -352,9 +348,10 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // infrastructure.
         var stream = GetOrCreateStream();
         var steps = _steps;
-        for (int i = 0; i < steps.Length; i++)
+        using (GraphMode.SuspendRecording())
         {
-            stream.Submit(steps[i], _engine);
+            for (int i = 0; i < steps.Length; i++)
+                stream.Submit(steps[i], _engine);
         }
         await stream.SyncAsync(cancellationToken).ConfigureAwait(false);
         return _finalOutput;
@@ -495,7 +492,11 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 "Reusing it with a new upstream would rebind its input storage and " +
                 "silently invalidate the earlier pipeline.");
         }
-        nextPlanInput.RebindStorageFrom(_finalOutput);
+        if (!nextPlanInput.SharesStorageWith(_finalOutput))
+        {
+            nextPlanInput.RebindStorageFrom(_finalOutput);
+            nextPlan.RefreshStorageLeasesAfterRebind();
+        }
         nextPlan._lastStitchUpstream = _finalOutput;
 
         // CPU fast path — same rationale as ExecuteAsync. Inline both
@@ -505,6 +506,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         bool crossEngine = !ReferenceEquals(_engine, nextPlan._engine);
         if (IsCpuEngine(_engine) && IsCpuEngine(nextPlan._engine))
         {
+            using var recordingSuspension = GraphMode.SuspendRecording();
             var thisSteps = _steps;
             for (int i = 0; i < thisSteps.Length; i++)
                 thisSteps[i].Execute(_engine, thisSteps[i].OutputBuffer);
@@ -533,8 +535,11 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // the queued kernels however the hardware allows.
         var stream = GetOrCreateStream();
         var thisSteps = _steps;
-        for (int i = 0; i < thisSteps.Length; i++)
-            stream.Submit(thisSteps[i], _engine);
+        using (GraphMode.SuspendRecording())
+        {
+            for (int i = 0; i < thisSteps.Length; i++)
+                stream.Submit(thisSteps[i], _engine);
+        }
 
         var nextSteps = nextPlan._steps;
         var nextEngine = nextPlan._engine;
@@ -549,7 +554,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             // upstream stream returns BEFORE next's kernels finish, and
             // ChainAsync's await would resume against a still-pending
             // GPU output. Sync the upstream first to flush this plan's
-            // work, then run next's steps on its OWN cached stream and
+        // work, then run next's steps on its OWN cached stream and
             // sync that one. On CPU this is the same fast-path the
             // single-engine case takes (just with two streams instead
             // of one); on GPU it's correctness, not just perf.
@@ -557,16 +562,22 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
             await stream.SyncAsync(cancellationToken).ConfigureAwait(false);
 
             var nextStream = nextPlan.GetOrCreateStream();
-            for (int i = 0; i < nextSteps.Length; i++)
-                nextStream.Submit(nextSteps[i], nextEngine);
+            using (GraphMode.SuspendRecording())
+            {
+                for (int i = 0; i < nextSteps.Length; i++)
+                    nextStream.Submit(nextSteps[i], nextEngine);
+            }
             await nextStream.SyncAsync(cancellationToken).ConfigureAwait(false);
             return nextPlan._finalOutput;
         }
 
         // Same-engine fast path: queue everything on the upstream
         // stream and sync once.
-        for (int i = 0; i < nextSteps.Length; i++)
-            stream.Submit(nextSteps[i], _engine);
+        using (GraphMode.SuspendRecording())
+        {
+            for (int i = 0; i < nextSteps.Length; i++)
+                stream.Submit(nextSteps[i], _engine);
+        }
 
         await stream.SyncAsync(cancellationToken).ConfigureAwait(false);
         return nextPlan._finalOutput;
@@ -649,7 +660,11 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // validates shape/contiguity/offset-zero and throws descriptively
         // if the invariants don't hold (pre-filtered above, so in practice
         // this is a belt-and-suspenders check).
-        nextPlanInput.RebindStorageFrom(_finalOutput);
+        if (!nextPlanInput.SharesStorageWith(_finalOutput))
+        {
+            nextPlanInput.RebindStorageFrom(_finalOutput);
+            nextPlan.RefreshStorageLeasesAfterRebind();
+        }
         nextPlan._lastStitchUpstream = _finalOutput;
 
         // Splice: [thisSteps..., nextSteps...]. No boundary step — the
@@ -752,6 +767,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     public Tensor<T> Execute()
     {
         if (_disposed) throw new ObjectDisposedException(nameof(CompiledInferencePlan<T>));
+        using var recordingSuspension = GraphMode.SuspendRecording();
 
         // Stitched-plan guard: the steps array holds references into each
         // source plan's pre-allocated buffers. If the caller disposed A or
@@ -1082,6 +1098,8 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 handle.Free();
         }
         _pinnedHandles.Clear();
+        _storageLeases?.Dispose();
+        _storageLeases = null;
     }
 
     /// <summary>
@@ -1104,6 +1122,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     internal (string OpName, double AvgMs)[] ProfilePerStep(int warmup, int iters)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(CompiledInferencePlan<T>));
+        using var recordingSuspension = GraphMode.SuspendRecording();
         if (warmup < 0) throw new ArgumentOutOfRangeException(nameof(warmup));
         if (iters <= 0) throw new ArgumentOutOfRangeException(nameof(iters));
 
@@ -1209,6 +1228,27 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         var compiler = new LazyGraphCompiler();
         var optimized = compiler.Compile(scope.Nodes);
 
+        // A compiled inference plan is homogeneous in T. Cross-type nodes cannot be represented
+        // by CompiledStep<T>, and silently ignoring them used to produce partial plans whose
+        // outputs were stale or uninitialized. Reject the graph until heterogeneous mutable-input
+        // rebinding and type-erased compiled steps are implemented as one coherent feature.
+        if (optimized.Count == 0)
+            throw new NotSupportedException(
+                "The captured inference graph contains no compilable tensor operations.");
+
+        if (optimized.Any(node => node is not LazyNode<T>))
+            throw new NotSupportedException(
+                "The captured inference graph crosses tensor element types. " +
+                "Heterogeneous compiled inference plans are not supported yet.");
+
+        if (explicitOutput is not null)
+        {
+            if (explicitOutput.LazySource is not ILazyNode outputNode || !optimized.Contains(outputNode))
+                throw new NotSupportedException(
+                    "The requested inference output is not rooted in the captured graph. " +
+                    "An eager operation escaped graph capture, so compiling would freeze stale data.");
+        }
+
         var steps = new List<CompiledStep<T>>();
         foreach (var node in optimized)
         {
@@ -1285,10 +1325,12 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // TensorAdd writes to the wrong buffer" failure that surfaced as
         // ONNX Erf / Gelu / MNIST returning an upstream intermediate's
         // value instead of the declared output.
-        steps = RunStepMutatingPasses(steps, engine);
+        steps = RunStepMutatingPasses(steps, engine, explicitOutput);
 
         // Build specialized forward actions (same optimization as CompiledTrainingPlan)
         var specializedSteps = new CompiledStep<T>[steps.Count];
+        var mutableInputs = compiledInputTensors ??
+            (inputTensor is null ? Array.Empty<Tensor<T>>() : new[] { inputTensor });
         for (int i = 0; i < steps.Count; i++)
         {
             var step = steps[i];
@@ -1342,7 +1384,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 continue;
             }
 
-            bool allowCachedB = !IsMutableSecondMatMulInput(step, inputTensor);
+            bool allowCachedB = !IsMutableSecondMatMulInput(step, mutableInputs);
             MaybeRegisterFrozenMatMulWeight(step, allowCachedB);
             var specialized = CompiledTrainingPlan<T>.TryBuildSpecializedForward(step, pinnedHandles, allowCachedB);
             if (specialized != null)
@@ -1404,9 +1446,52 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                 ? optimizedSteps[optimizedSteps.Length - 1].OutputBuffer
                 : new Tensor<T>(new int[] { 0 });
         }
-        return new CompiledInferencePlan<T>(
-            optimizedSteps, finalOutput, engine, inputShape, inputTensor, pinnedHandles,
-            compiledInputTensors: compiledInputTensors);
+        TensorStorageLeaseSet? storageLeases = CaptureStorageLeases(
+            optimizedSteps,
+            finalOutput,
+            compiledInputTensors ?? (inputTensor is null ? Array.Empty<Tensor<T>>() : new[] { inputTensor }));
+        try
+        {
+            var plan = new CompiledInferencePlan<T>(
+                optimizedSteps, finalOutput, engine, inputShape, inputTensor, pinnedHandles,
+                compiledInputTensors: compiledInputTensors,
+                storageLeases: storageLeases);
+            storageLeases = null;
+            scope.ReleaseStorageLeases();
+            return plan;
+        }
+        finally
+        {
+            storageLeases?.Dispose();
+        }
+    }
+
+    private static TensorStorageLeaseSet CaptureStorageLeases(
+        CompiledStep<T>[] steps,
+        Tensor<T> finalOutput,
+        Tensor<T>[] compiledInputs)
+    {
+        var leases = new TensorStorageLeaseSet();
+        try
+        {
+            for (int i = 0; i < steps.Length; i++) leases.Add(steps[i]);
+            leases.Add(finalOutput);
+            for (int i = 0; i < compiledInputs.Length; i++) leases.Add(compiledInputs[i]);
+            return leases;
+        }
+        catch
+        {
+            leases.Dispose();
+            throw;
+        }
+    }
+
+    private void RefreshStorageLeasesAfterRebind()
+    {
+        var replacement = CaptureStorageLeases(_steps, _finalOutput, _compiledInputTensors);
+        var previous = _storageLeases;
+        _storageLeases = replacement;
+        previous?.Dispose();
     }
 
     /// <summary>
@@ -1514,12 +1599,19 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         public int GetHashCode(TItem obj) => RuntimeHelpers.GetHashCode(obj);
     }
 
-    private static bool IsMutableSecondMatMulInput(CompiledStep<T> step, Tensor<T>? mutableInput)
+    private static bool IsMutableSecondMatMulInput(
+        CompiledStep<T> step, Tensor<T>[] mutableInputs)
     {
-        return mutableInput is not null
-            && step.OpType == OpType.TensorMatMul
-            && step.Inputs.Length >= 2
-            && ReferenceEquals(step.Inputs[1], mutableInput);
+        if (step.OpType != OpType.TensorMatMul || step.Inputs.Length < 2)
+            return false;
+
+        for (int i = 0; i < mutableInputs.Length; i++)
+        {
+            if (ReferenceEquals(step.Inputs[1], mutableInputs[i]))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1553,7 +1645,10 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
     /// DataflowFusion) to keep the specialization layer free of
     /// pre-fused opaque closures that would defeat subsequent pins.
     /// </summary>
-    private static List<CompiledStep<T>> RunStepMutatingPasses(List<CompiledStep<T>> steps, IEngine engine)
+    private static List<CompiledStep<T>> RunStepMutatingPasses(
+        List<CompiledStep<T>> steps,
+        IEngine engine,
+        Tensor<T>? explicitOutput)
     {
         if (steps.Count < 4) return steps;
 
@@ -1568,18 +1663,15 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // matmuls whose output buffer was aliased by MemoryPlanning) — see BlasBatchPass.HasAliasedOutput.
         // Verified eager-parity across the full attention/SDPA fan-out suite (MultiInputReplayAliasingTests).
         var arr = steps.ToArray();
-        AiDotNet.Tensors.Engines.Optimization.ICpuOptimizationPass[] passes =
-            new AiDotNet.Tensors.Engines.Optimization.ICpuOptimizationPass[]
-        {
-            new AiDotNet.Tensors.Engines.Optimization.OperatorReorderingPass(),
-            new AiDotNet.Tensors.Engines.Optimization.MemoryPlanningPass(),
-        };
-        foreach (var pass in passes)
-        {
-            if (!pass.IsEnabled) continue;
-            var optimized = pass.TryOptimize(arr, engine);
-            if (optimized is not null) arr = optimized;
-        }
+        var reordering = new AiDotNet.Tensors.Engines.Optimization.OperatorReorderingPass();
+        if (reordering.IsEnabled && reordering.TryOptimize(arr, engine) is { } reordered)
+            arr = reordered;
+
+        var memoryPlanning = new AiDotNet.Tensors.Engines.Optimization.MemoryPlanningPass();
+        if (memoryPlanning.IsEnabled &&
+            memoryPlanning.TryOptimize(arr, engine, explicitOutput) is { } memoryPlanned)
+            arr = memoryPlanned;
+
         return new List<CompiledStep<T>>(arr);
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledModelCache.cs
@@ -51,7 +51,7 @@ public sealed class CompiledModelCache<T> : IDisposable
             // Trace the forward pass under GraphMode and compile.
             // The forward function is called once to trace the graph — on subsequent calls
             // the caller must invoke plan.Execute() with current data in the input tensors.
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             var explicitOutput = forward();
             ThrowIfForwardRecordedNothing(scope, explicitOutput);
             var plan = scope.CompileInference<T>(explicitOutput, inputShape);
@@ -96,7 +96,7 @@ public sealed class CompiledModelCache<T> : IDisposable
                 return cached;
             }
 
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             var explicitOutput = forward();
             ThrowIfForwardRecordedNothing(scope, explicitOutput);
             var plan = scope.CompileInference<T>(explicitOutput, input);
@@ -148,7 +148,7 @@ public sealed class CompiledModelCache<T> : IDisposable
             // The trace runs the forward against the CURRENT input data, so the freshly
             // compiled plan already reflects this call — no SetInputs needed on the miss path
             // (mirrors the single-input Tensor<T> overload above).
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             var explicitOutput = forward();
             ThrowIfForwardRecordedNothing(scope, explicitOutput);
             var plan = scope.CompileInference<T>(explicitOutput, inputs);
@@ -253,7 +253,7 @@ public sealed class CompiledModelCache<T> : IDisposable
                 return cached;
 
             // Compile with the current concrete shape
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             var explicitOutput = forward();
             ThrowIfForwardRecordedNothing(scope, explicitOutput);
             var plan = scope.CompileInference<T>(explicitOutput, inputShape);

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -104,6 +104,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
     private readonly Tensor<T>[] _preAllocatedGrads;
     private readonly Tensor<T> _lossGradSeed;
     private readonly List<GCHandle> _pinnedHandles = new();
+    private TensorStorageLeaseSet? _storageLeases;
     // CodeRabbit #425 review: GPU optimizer state (gpuM/gpuV) is owned by the
     // plan once allocated via paramBackend.AllocateBuffer in
     // ConfigureOptimizerFloat / ConfigureOptimizerFloatGrouped, but pre-fix
@@ -204,7 +205,8 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         ILazyNode[]? fp16HeteroOrder = null,
         int[][]? gradPoolReZeroByStep = null,
         ForwardEmit[]? forwardEmitKinds = null,
-        Action<IEngine>?[]? forwardFixedActions = null)
+        Action<IEngine>?[]? forwardFixedActions = null,
+        TensorStorageLeaseSet? storageLeases = null)
     {
         _gradPoolReZeroByStep = gradPoolReZeroByStep;
         _forwardActions = forwardActions;
@@ -234,6 +236,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         _graphRefreshTensor = graphRefreshTensor ?? compiledInputTensor;
         _forwardEmitKinds = forwardEmitKinds;
         _forwardFixedActions = forwardFixedActions;
+        _storageLeases = storageLeases;
         _fusedStepIndices = fusedStepIndices;
         _fusedForwardActions = fusedForwardActions;
         _lossGradDest = lossGradDest;
@@ -273,6 +276,10 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
 
         // Free the captured training-step graph, if any.
         InvalidateCapturedStepGraph();
+        _fp16PagedPlan?.Dispose();
+        _fp16PagedPlan = null;
+        _storageLeases?.Dispose();
+        _storageLeases = null;
     }
 
     /// <summary>
@@ -6003,30 +6010,48 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             outputBuffer.AsWritableSpan();
         }
 
-        return new CompiledTrainingPlan<T>(
-            forwardActions,
-            backwardActions.ToArray(),
-            lossOutput,
-            engine,
-            parameters,
-            allGrads.ToArray(),
-            gradients,
-            lossGradSeed,
-            originalParameterToUnique,
-            genericGradIndices,
-            gradMap.ContainsKey(lossOutput) ? gradMap[lossOutput] : null,
-            pinnedHandles,
-            forwardSteps.ToArray(),
-            compiledInputShape,
-            compiledInputTensor,
-            graphRefreshTensor,
-            fusedStepIndices.Count > 0 ? fusedStepIndices.ToArray() : null,
-            fusedForwardActions.Count > 0 ? fusedForwardActions.ToArray() : null,
-            graphStepEligible,
-            fp16HeteroOrder,
-            gradPoolReZeroByStep,
-            forwardEmitKinds,
-            forwardFixedActions);
+        TensorStorageLeaseSet? storageLeases = new TensorStorageLeaseSet();
+        try
+        {
+            for (int i = 0; i < forwardSteps.Count; i++) storageLeases.Add(forwardSteps[i]);
+            if (fp16HeteroOrder is not null)
+                for (int i = 0; i < fp16HeteroOrder.Length; i++)
+                    fp16HeteroOrder[i].AddStorageLeases(storageLeases);
+            storageLeases.Add(lossOutput);
+
+            var plan = new CompiledTrainingPlan<T>(
+                forwardActions,
+                backwardActions.ToArray(),
+                lossOutput,
+                engine,
+                parameters,
+                allGrads.ToArray(),
+                gradients,
+                lossGradSeed,
+                originalParameterToUnique,
+                genericGradIndices,
+                gradMap.ContainsKey(lossOutput) ? gradMap[lossOutput] : null,
+                pinnedHandles,
+                forwardSteps.ToArray(),
+                compiledInputShape,
+                compiledInputTensor,
+                graphRefreshTensor,
+                fusedStepIndices.Count > 0 ? fusedStepIndices.ToArray() : null,
+                fusedForwardActions.Count > 0 ? fusedForwardActions.ToArray() : null,
+                graphStepEligible,
+                fp16HeteroOrder,
+                gradPoolReZeroByStep,
+                forwardEmitKinds,
+                forwardFixedActions,
+                storageLeases);
+            storageLeases = null;
+            scope.ReleaseStorageLeases();
+            return plan;
+        }
+        finally
+        {
+            storageLeases?.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/CrossTypeLazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CrossTypeLazyNode.cs
@@ -123,4 +123,11 @@ internal sealed class CrossTypeLazyNode<TIn, TOut> : ILazyNode
     {
         Output.LazySource = null;
     }
+
+    public void AddStorageLeases(TensorStorageLeaseSet leases)
+    {
+        leases.Add(Input);
+        leases.Add(Output);
+        leases.AddSavedState(SavedState);
+    }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/GpuCompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GpuCompiledPlan.cs
@@ -41,6 +41,8 @@ internal sealed class GpuCompiledPlan<T> : IDisposable
     /// </summary>
     internal Tensor<T> Execute()
     {
+        if (_disposed) throw new ObjectDisposedException(nameof(GpuCompiledPlan<T>));
+        using var recordingSuspension = GraphMode.SuspendRecording();
         if (_captured)
         {
             // Phase 5+: cuGraphLaunch replay here

--- a/src/AiDotNet.Tensors/Engines/Compilation/GradientCheckpointing.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GradientCheckpointing.cs
@@ -63,6 +63,7 @@ internal sealed class GradientCheckpointing<T>
     /// </summary>
     public Tensor<T> ForwardWithCheckpoints()
     {
+        using var recordingSuspension = GraphMode.SuspendRecording();
         for (int seg = 0; seg < _segmentCount; seg++)
         {
             int start = seg * _segmentSize;
@@ -89,6 +90,7 @@ internal sealed class GradientCheckpointing<T>
     /// <param name="segmentIndex">Which segment to recompute (0-based).</param>
     public void RecomputeSegment(int segmentIndex)
     {
+        using var recordingSuspension = GraphMode.SuspendRecording();
         if (segmentIndex < 0 || segmentIndex >= _segmentCount)
             throw new ArgumentOutOfRangeException(nameof(segmentIndex));
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
@@ -3,6 +3,27 @@ using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines.Compilation;
 
+internal enum GraphTraceKind : byte
+{
+    Compatibility,
+    Inference,
+    Training
+}
+
+/// <summary>
+/// Type-safe reasons an IEngine contract cannot currently be represented by a homogeneous,
+/// fixed-shape inference plan.
+/// </summary>
+internal enum GraphCaptureLimitation : byte
+{
+    DataDependentOutputShape,
+    HeterogeneousInput,
+    HeterogeneousOutput,
+    MixedElementTypes,
+    HostBoundary,
+    Stateful
+}
+
 /// <summary>
 /// Ambient context toggle for lazy tensor evaluation. When active, tensor operations
 /// record into a computation graph instead of executing immediately. The graph is then
@@ -34,12 +55,66 @@ internal static class GraphMode
     }
 
     /// <summary>
+    /// Whether the active scope was explicitly opened for inference. Composite kernels may retain
+    /// opaque fused nodes only in this mode. The compatibility scope deliberately returns false:
+    /// callers that choose whether to compile inference or training only after tracing must receive
+    /// a differentiable primitive graph rather than a silently non-differentiable training plan.
+    /// </summary>
+    internal static bool IsInferenceTrace
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _current?.TraceKind == GraphTraceKind.Inference;
+    }
+
+    /// <summary>
+    /// Fails before an inference trace can partially execute an operation whose public contract is
+    /// not representable by the current plan format. Compatibility and training traces are left
+    /// untouched so their existing eager/decomposed behavior remains available.
+    /// </summary>
+    internal static void ThrowIfInferenceUnsupported(GraphCaptureLimitation limitation)
+    {
+        if (!IsInferenceTrace) return;
+
+        string reason = limitation switch
+        {
+            GraphCaptureLimitation.DataDependentOutputShape =>
+                "its output shape depends on runtime tensor values",
+            GraphCaptureLimitation.HeterogeneousInput =>
+                "its tensor inputs use different element types",
+            GraphCaptureLimitation.HeterogeneousOutput =>
+                "it returns tensor outputs with different element types",
+            GraphCaptureLimitation.MixedElementTypes =>
+                "its graph crosses tensor element types",
+            GraphCaptureLimitation.HostBoundary =>
+                "it crosses a host-only data boundary",
+            GraphCaptureLimitation.Stateful =>
+                "it mutates state during execution",
+            _ => throw new ArgumentOutOfRangeException(nameof(limitation))
+        };
+
+        throw new NotSupportedException(
+            $"This operation cannot be captured in an inference graph because {reason}.");
+    }
+
+    /// <summary>
     /// Enables graph mode and returns a scope. All tensor operations on this thread
     /// will record into the scope's computation graph until it is disposed.
     /// </summary>
     internal static LazyTensorScope Enable()
     {
-        var scope = new LazyTensorScope(_current);
+        var scope = new LazyTensorScope(_current, GraphTraceKind.Compatibility);
+        _current = scope;
+        return scope;
+    }
+
+    /// <summary>
+    /// Enables a graph scope whose result will be compiled for inference. This explicit intent lets
+    /// inference-only composite kernels remain fused while <see cref="Enable"/> retains the safe,
+    /// differentiable compatibility behavior required by older training callers.
+    /// </summary>
+    internal static LazyTensorScope EnableInference()
+    {
+        var scope = new LazyTensorScope(_current, GraphTraceKind.Inference);
         _current = scope;
         return scope;
     }
@@ -60,7 +135,7 @@ internal static class GraphMode
             parameters[i].PrepareForInPlaceWrite();
         }
 
-        var scope = new LazyTensorScope(_current, trainingParametersPreparedBeforeTrace: true);
+        var scope = new LazyTensorScope(_current, GraphTraceKind.Training);
         _current = scope;
         return scope;
     }

--- a/src/AiDotNet.Tensors/Engines/Compilation/ILazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ILazyNode.cs
@@ -34,4 +34,7 @@ internal interface ILazyNode
 
     /// <summary>Clears the LazySource reference on the output tensor after realization.</summary>
     void ClearOutputLazySource();
+
+    /// <summary>Adds every tensor storage structurally retained by this node.</summary>
+    void AddStorageLeases(TensorStorageLeaseSet leases);
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
@@ -221,6 +221,17 @@ internal sealed class LazyNode<T> : ILazyNode
         Output.LazySource = null;
     }
 
+    public void AddStorageLeases(TensorStorageLeaseSet leases)
+    {
+        leases.Add(Input0);
+        if (Input1 is not null) leases.Add(Input1);
+        if (Input2 is not null) leases.Add(Input2);
+        if (InputsOverflow is not null)
+            for (int i = 0; i < InputsOverflow.Length; i++) leases.Add(InputsOverflow[i]);
+        leases.Add(Output);
+        leases.AddSavedState(SavedState);
+    }
+
     /// <summary>Get input tensors as array for backward compatibility.</summary>
     public Tensor<T>[] GetInputsArray()
     {

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyNodeType.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyNodeType.cs
@@ -93,5 +93,19 @@ internal enum LazyNodeType : byte
     // ordinals, and serialized compiled plans identify ops by that ordinal —
     // inserting Expand next to the Broadcast* group above would renumber every
     // member after it and silently misinterpret plans written by an older build.
-    Expand
+    Expand,
+
+    // Composite inference kernels. Appended to preserve serialized ordinals.
+    MultiHeadAttentionForward,
+    MlpForward,
+    LstmSequenceForward,
+    ScaledDotProductAttentionGqa,
+    FusedLinearMaxout,
+    FusedHierarchicalSoftmax,
+
+    // Serializable primitives required by decomposed attention graphs.
+    TensorRepeatInterleave,
+    TensorMaskedFill,
+    TensorPermute,
+    GroupedQueryAttention
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -17,16 +17,19 @@ internal sealed class LazyTensorScope : IDisposable
 {
     private readonly LazyTensorScope? _parent;
     private readonly List<ILazyNode> _nodes = new();
+    private readonly TensorStorageLeaseSet _storageLeases = new();
     private IEngine _engine;
     private bool _engineExplicitlyBound;
     private bool _disposed;
     private bool _realized;
-    private readonly bool _trainingParametersPreparedBeforeTrace;
+    private readonly GraphTraceKind _traceKind;
 
-    internal LazyTensorScope(LazyTensorScope? parent, bool trainingParametersPreparedBeforeTrace = false)
+    internal LazyTensorScope(
+        LazyTensorScope? parent,
+        GraphTraceKind traceKind = GraphTraceKind.Compatibility)
     {
         _parent = parent;
-        _trainingParametersPreparedBeforeTrace = trainingParametersPreparedBeforeTrace;
+        _traceKind = traceKind;
         // Default to AiDotNetEngine.Current; the first op recorded into the
         // scope will rebind via BindEngineIfUnset to the engine instance the
         // user actually invoked the op on. This matters because the global
@@ -61,6 +64,12 @@ internal sealed class LazyTensorScope : IDisposable
     internal int NodeCount => _nodes.Count;
 
     /// <summary>
+    /// The explicit purpose of this trace. Composite kernels use this to distinguish fused
+    /// inference replay from differentiable training/compatibility capture.
+    /// </summary>
+    internal GraphTraceKind TraceKind => _traceKind;
+
+    /// <summary>
     /// Records a unary operation as a lazy node. Returns a tensor whose data
     /// is not yet computed — it will be materialized during Realize().
     /// </summary>
@@ -78,7 +87,7 @@ internal sealed class LazyTensorScope : IDisposable
 
         var node = new LazyNode<T>(opType, opName, input, output, execute, backwardFn, savedState);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
 
         return output;
     }
@@ -91,10 +100,12 @@ internal sealed class LazyTensorScope : IDisposable
         int[] outputShape,
         Action<IEngine, Tensor<TOut>> execute)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         var output = TensorAllocator.RentUninitialized<TOut>(outputShape);
         var node = new CrossTypeLazyNode<TIn, TOut>(opType, opName, input, output, execute);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
         return output;
     }
 
@@ -116,7 +127,7 @@ internal sealed class LazyTensorScope : IDisposable
         var output = TensorAllocator.RentUninitialized<TOut>(outputShape);
         var node = new CrossTypeLazyNode<TIn, TOut>(opType, opName, input, output, execute, backwardFn, savedState);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
         return output;
     }
 
@@ -135,7 +146,7 @@ internal sealed class LazyTensorScope : IDisposable
 
         var node = new LazyNode<T>(opType, opName, input0, input1, output, execute, backwardFn, savedState);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
 
         return output;
     }
@@ -171,7 +182,7 @@ internal sealed class LazyTensorScope : IDisposable
             backwardFn,
             savedState);
         view.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
         return view;
     }
 
@@ -192,7 +203,33 @@ internal sealed class LazyTensorScope : IDisposable
         var node = new LazyNode<T>(
             opType, opName, input, output, execute, backwardFn, savedState);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
+        return output;
+    }
+
+    /// <summary>
+    /// Records an operation whose output was materialized once to establish its exact shape during
+    /// tracing, while retaining every public tensor operand as a graph dependency. This is the
+    /// variadic counterpart to <see cref="RecordMaterializedUnary{T}"/> and is used by opaque
+    /// inference nodes for kernels that do not have a primitive graph decomposition yet.
+    /// </summary>
+    internal Tensor<T> RecordMaterializedVariadic<T>(
+        LazyNodeType opType,
+        string opName,
+        Tensor<T>[] inputs,
+        Tensor<T> output,
+        Action<IEngine, Tensor<T>> execute,
+        BackwardFunction<T>? backwardFn = null,
+        object[]? savedState = null)
+    {
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (inputs.Length == 0)
+            throw new ArgumentException("A materialized graph operation must have at least one tensor input.", nameof(inputs));
+
+        var node = new LazyNode<T>(
+            opType, opName, inputs, output, execute, backwardFn, savedState);
+        output.LazySource = node;
+        AddNode(node);
         return output;
     }
 
@@ -271,7 +308,7 @@ internal sealed class LazyTensorScope : IDisposable
             savedState: savedState,
             externalPrerequisite: prevProducer);
         target.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
     }
 
     /// <summary>Records a variadic operation as a lazy node.</summary>
@@ -288,7 +325,7 @@ internal sealed class LazyTensorScope : IDisposable
 
         var node = new LazyNode<T>(opType, opName, inputs, output, execute, backwardFn, savedState);
         output.LazySource = node;
-        _nodes.Add(node);
+        AddNode(node);
 
         return output;
     }
@@ -332,6 +369,22 @@ internal sealed class LazyTensorScope : IDisposable
 
     /// <summary>Gets all recorded nodes (for graph compiler).</summary>
     internal IReadOnlyList<ILazyNode> Nodes => _nodes;
+
+    private void AddNode(ILazyNode node)
+    {
+        // Acquire ownership before publishing the node. A composite is free to dispose a
+        // temporary tensor immediately after its operation returns; the graph must therefore
+        // hold an independent storage reference from the moment the node becomes visible.
+        node.AddStorageLeases(_storageLeases);
+        _nodes.Add(node);
+    }
+
+    /// <summary>
+    /// Releases the trace-time lease snapshot after a successfully compiled plan has acquired
+    /// its own post-optimization snapshot. This also releases storages abandoned by memory
+    /// planning rebinds instead of retaining them for the plan's lifetime.
+    /// </summary>
+    internal void ReleaseStorageLeases() => _storageLeases.Dispose();
 
     /// <summary>
     /// Compiles the lazy graph into an inference plan for zero-overhead replay.
@@ -438,7 +491,7 @@ internal sealed class LazyTensorScope : IDisposable
             // existing internal tests). A COW parameter, however, must have
             // detached before tracing: doing it here is too late because graph
             // nodes may already retain parameter-derived storage views.
-            if (!_trainingParametersPreparedBeforeTrace && parameters[i].IsCowShared)
+            if (_traceKind != GraphTraceKind.Training && parameters[i].IsCowShared)
             {
                 throw new InvalidOperationException(
                     "Copy-on-write parameters must be prepared before a training graph is traced. " +
@@ -459,6 +512,13 @@ internal sealed class LazyTensorScope : IDisposable
     internal void MarkCompiled()
     {
         _realized = true;
+
+        // Compilation is a terminal transition for this trace. Leaving the compiled scope
+        // ambient until the lexical using statement unwinds lets plan replay (or an optimizer
+        // call made immediately after compilation) append nodes to a scope whose storage
+        // leases have already been transferred and released.
+        if (ReferenceEquals(GraphMode.Current, this))
+            GraphMode.SetCurrent(_parent);
     }
 
     public void Dispose()
@@ -474,8 +534,11 @@ internal sealed class LazyTensorScope : IDisposable
         }
         finally
         {
-            // Always restore parent scope, even if Realize() throws
-            GraphMode.SetCurrent(_parent);
+            // MarkCompiled may already have restored the parent. Only unwind this scope when
+            // it is still current; otherwise a later nested scope must remain untouched.
+            if (ReferenceEquals(GraphMode.Current, this))
+                GraphMode.SetCurrent(_parent);
+            _storageLeases.Dispose();
         }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/MixedPrecisionCompiledPlan.cs
@@ -20,11 +20,13 @@ namespace AiDotNet.Tensors.Engines.Compilation;
 /// into a matching replayable pass; C adds the optimizer + loss scaling; D/E take it to GPU + AiDotNet.
 /// Gated behind <c>AIDOTNET_FP16_ACTIVATIONS</c>; the default FP32 fused path is untouched.</para>
 /// </summary>
-public sealed class MixedPrecisionCompiledPlan
+public sealed class MixedPrecisionCompiledPlan : IDisposable
 {
     private readonly IEngine _engine;
     private readonly ILazyNode[] _order;   // producers-first topological order
     private readonly Tensor<float> _output;
+    private TensorStorageLeaseSet? _storageLeases;
+    private int _disposed;
 
     /// <summary>The compiled node list in execution (producers-first) order — used by the Phase B backward.</summary>
     internal IReadOnlyList<ILazyNode> Order => _order;
@@ -84,6 +86,20 @@ public sealed class MixedPrecisionCompiledPlan
         _order = order;
         _output = output;
         _paging = paging;
+
+        var storageLeases = new TensorStorageLeaseSet();
+        try
+        {
+            for (int i = 0; i < order.Length; i++) storageLeases.Add(order[i]);
+            storageLeases.Add(output);
+            _storageLeases = storageLeases;
+        }
+        catch
+        {
+            storageLeases.Dispose();
+            throw;
+        }
+
         _gpuFp16 = (paging && engine is DirectGpuTensorEngine dg
                     && Environment.GetEnvironmentVariable("AIDOTNET_FP16_GPU_CACHE") == "1") ? dg : null;
         if (_paging) BuildPagingSchedule();
@@ -172,17 +188,26 @@ public sealed class MixedPrecisionCompiledPlan
         if (forward is null) throw new ArgumentNullException(nameof(forward));
         engine ??= AiDotNetEngine.Current;
 
-        var scope = new LazyTensorScope(null);
+        var scope = new LazyTensorScope(GraphMode.Current);
         var prevForce = MixedPrecisionEmit.TestOverrideEnabled;
         MixedPrecisionEmit.TestOverrideEnabled = true; // force FP16 activation emission for this trace
-        Tensor<float> loss;
-        using (new Gpu.AutocastScope(Gpu.PrecisionMode.Float16))
+        try
         {
-            GraphMode.SetCurrent(scope);
-            try { loss = forward(); }
-            finally { GraphMode.SetCurrent(null); MixedPrecisionEmit.TestOverrideEnabled = prevForce; }
+            using (new Gpu.AutocastScope(Gpu.PrecisionMode.Float16))
+            {
+                GraphMode.SetCurrent(scope);
+                var loss = forward();
+                scope.MarkCompiled();
+                return Compile(loss, engine);
+            }
         }
-        return Compile(loss, engine);
+        finally
+        {
+            // A failed trace is incomplete and must not be auto-realized while unwinding.
+            scope.MarkCompiled();
+            scope.Dispose();
+            MixedPrecisionEmit.TestOverrideEnabled = prevForce;
+        }
     }
 
     /// <summary>
@@ -201,7 +226,15 @@ public sealed class MixedPrecisionCompiledPlan
         // Detach outputs so AsWritableSpan/AsSpan during replay don't re-trigger Realize.
         foreach (var n in order) n.ClearOutputLazySource();
 
-        return new MixedPrecisionCompiledPlan(engine, order, finalOutput, PagingEnabledDefault);
+        var plan = new MixedPrecisionCompiledPlan(engine, order, finalOutput, PagingEnabledDefault);
+
+        // Direct Compile callers may still be inside the scope that produced this root. The
+        // plan now owns an independent lease snapshot, so terminate only that matching trace.
+        var currentScope = GraphMode.Current;
+        if (currentScope is not null && currentScope.Nodes.Contains(root))
+            currentScope.MarkCompiled();
+
+        return plan;
     }
 
     /// <summary>Replay the forward: run every node's Execute into its stable buffer; return the output.
@@ -209,6 +242,8 @@ public sealed class MixedPrecisionCompiledPlan
     /// forward use, so peak resident float = the live working set, not the whole activation set.</summary>
     public Tensor<float> Forward()
     {
+        ThrowIfDisposed();
+        using var recordingSuspension = GraphMode.SuspendRecording();
         var eng = _engine;
         // Engage the Half-resident forward store for the GPU hetero forward so each Half matmul output stays a
         // HALF GPU buffer (half the VRAM) instead of being up-cast to FP32 — but ONLY when the caller hasn't set
@@ -248,12 +283,15 @@ public sealed class MixedPrecisionCompiledPlan
         {
             _halfStore!.Remove(o);
             o.RestoreStorageFromBytes(new byte[(long)o.Length * sizeof(float)]);
+            _storageLeases!.Add(o);
         }
     }
 
     /// <summary>Backward over the captured order, with FP16 activation paging (page-in/free) when on.</summary>
     private MixedPrecisionGraphBackward.Result RunBackward(float seedScale)
     {
+        ThrowIfDisposed();
+        using var recordingSuspension = GraphMode.SuspendRecording();
         if (!_paging)
         {
             if (_freeEng is null)
@@ -396,7 +434,7 @@ public sealed class MixedPrecisionCompiledPlan
         var span = t.AsSpan();
         var h = new Half[span.Length];
         for (int i = 0; i < span.Length; i++) h[i] = (Half)span[i];
-        if (t.TryDropStorageForStreaming()) { _halfStore[t] = h; _droppedThisStep!.Add(t); PageOutCount++; }
+        if (TryDropPlanOwnedStorage(t)) { _halfStore[t] = h; _droppedThisStep!.Add(t); PageOutCount++; }
         // else: shared/view storage — can't drop safely; leave float resident (discard h).
     }
 
@@ -407,6 +445,7 @@ public sealed class MixedPrecisionCompiledPlan
         var f = new float[h.Length];
         for (int i = 0; i < h.Length; i++) f[i] = (float)h[i];
         t.RestoreStorageFromBytes(MemoryMarshal.AsBytes(f.AsSpan()));
+        _storageLeases!.Add(t);
         _halfStore.Remove(t);
     }
 
@@ -415,7 +454,25 @@ public sealed class MixedPrecisionCompiledPlan
         // GPU FP16 mode: re-compress after the last backward read (frees the upcast FP32 GPU buffer).
         if (_gpuFp16 is not null) { _gpuFp16.CompressActivationFp16(t); return; }
         // CPU mode: after the last backward read the activation is float-resident and never read again.
-        if (!_halfStore!.ContainsKey(t) && t.TryDropStorageForStreaming()) _droppedThisStep!.Add(t);
+        if (!_halfStore!.ContainsKey(t) && TryDropPlanOwnedStorage(t)) _droppedThisStep!.Add(t);
+    }
+
+    private bool TryDropPlanOwnedStorage(Tensor<float> tensor)
+    {
+        bool removedPlanLease = _storageLeases!.Remove(tensor);
+        try
+        {
+            if (tensor.TryDropStorageForStreaming())
+                return true;
+        }
+        catch
+        {
+            if (removedPlanLease) _storageLeases.Add(tensor);
+            throw;
+        }
+
+        if (removedPlanLease) _storageLeases.Add(tensor);
+        return false;
     }
 
     /// <summary>
@@ -808,4 +865,32 @@ public sealed class MixedPrecisionCompiledPlan
         }
         return order;
     }
+
+    private void ThrowIfDisposed()
+    {
+        if (System.Threading.Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(MixedPrecisionCompiledPlan));
+    }
+
+    /// <summary>Releases the graph storage retained for future replay.</summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _storageLeases?.Dispose();
+        _storageLeases = null;
+        if (disposing)
+        {
+            _halfStore?.Clear();
+            _droppedThisStep?.Clear();
+            _adamState?.Clear();
+        }
+    }
+
+    ~MixedPrecisionCompiledPlan() => Dispose(disposing: false);
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/OpType.cs
@@ -95,6 +95,19 @@ internal enum OpType : byte
 
     // Appended to preserve the serialized byte ordinals of every existing operation.
     Expand,
+
+    // Composite inference kernels. Appended to preserve serialized ordinals.
+    MultiHeadAttentionForward,
+    MlpForward,
+    LstmSequenceForward,
+    ScaledDotProductAttentionGqa,
+    FusedLinearMaxout,
+    FusedHierarchicalSoftmax,
+    TensorRepeatInterleave,
+    TensorMaskedFill,
+    TensorPermute,
+    TensorMultiplyScalar,
+    GroupedQueryAttention,
 }
 
 internal static class OpTypeParser
@@ -163,6 +176,17 @@ internal static class OpTypeParser
         "TensorBinaryCrossEntropy" => OpType.BinaryCrossEntropy,
         "Embedding" or "TensorEmbeddingLookup" or "TensorEmbeddingLookupFromFloatIndices" => OpType.Embedding,
         "Expand" => OpType.Expand,
+        "MultiHeadAttentionForward" => OpType.MultiHeadAttentionForward,
+        "MlpForward" => OpType.MlpForward,
+        "LstmSequenceForward" => OpType.LstmSequenceForward,
+        "ScaledDotProductAttentionGqa" => OpType.ScaledDotProductAttentionGqa,
+        "FusedLinearMaxout" => OpType.FusedLinearMaxout,
+        "FusedHierarchicalSoftmax" => OpType.FusedHierarchicalSoftmax,
+        "TensorRepeatInterleave" => OpType.TensorRepeatInterleave,
+        "TensorMaskedFill" => OpType.TensorMaskedFill,
+        "TensorPermute" => OpType.TensorPermute,
+        "TensorMultiplyScalar" => OpType.TensorMultiplyScalar,
+        "GroupedQueryAttention" => OpType.GroupedQueryAttention,
         _ => OpType.Unknown,
     };
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/InferencePlanReader.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/InferencePlanReader.cs
@@ -110,8 +110,20 @@ internal static class InferencePlanReader
         // ── Tensor table ────────────────────────────────────────────────
         var tensorTable = TensorTableReader.Read<T>(reader);
 
-        // Compiled input tensor is ID 0 by convention.
-        var compiledInputTensor = tensorTable.Length > 0 ? tensorTable[0] : null;
+        // Ordered mutable-input identities (format v6+).
+        int compiledInputCount = reader.ReadInt32();
+        RequireNonNegative(compiledInputCount, nameof(compiledInputCount));
+        RequireWithinStream(bodyStream, (long)compiledInputCount * sizeof(int), nameof(compiledInputCount));
+        var compiledInputTensors = new Tensor<T>[compiledInputCount];
+        for (int i = 0; i < compiledInputCount; i++)
+        {
+            int tensorId = reader.ReadInt32();
+            if ((uint)tensorId >= (uint)tensorTable.Length)
+                throw new InvalidDataException(
+                    $"Compiled input slot {i} references tensor ID {tensorId} " +
+                    $"out of range [0, {tensorTable.Length}). The plan file is corrupt.");
+            compiledInputTensors[i] = tensorTable[tensorId];
+        }
 
         // ── Op sequence ─────────────────────────────────────────────────
         int savedStepCount = reader.ReadInt32();
@@ -143,7 +155,7 @@ internal static class InferencePlanReader
 
         // ── Construct plan ──────────────────────────────────────────────
         return CompiledInferencePlan<T>.CreateFromDeserialized(
-            steps, finalOutput, engine, inputShape, compiledInputTensor);
+            steps, finalOutput, engine, inputShape, compiledInputTensors);
     }
 
     private static CompiledStep<T> ReadStep<T>(BinaryReader reader, Tensor<T>[] tensorTable, IEngine engine, Stream bodyStream)

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/InferencePlanWriter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/InferencePlanWriter.cs
@@ -21,7 +21,7 @@ internal static class InferencePlanWriter
         CompiledStep<T>[] steps,
         Tensor<T> finalOutput,
         int[] compiledInputShape,
-        Tensor<T>? compiledInputTensor)
+        Tensor<T>[] compiledInputTensors)
     {
         // Write the body to a MemoryStream first so we can hash it (XXHash64
         // is one-shot, not incremental) before streaming to the destination.
@@ -53,8 +53,14 @@ internal static class InferencePlanWriter
         writer.Write(fpBytes);
 
         // ── Tensor table ────────────────────────────────────────────────
-        var tensorMap = TensorTableWriter.BuildMap(steps, compiledInputTensor);
-        TensorTableWriter.Write(writer, tensorMap, steps, compiledInputTensor, parameterTensors: null);
+        var tensorMap = TensorTableWriter.BuildMap(steps, compiledInputTensors);
+        TensorTableWriter.Write(writer, tensorMap, steps, compiledInputTensors, parameterTensors: null);
+
+        // Ordered mutable-input identities (format v6+). Tensor-table flags alone cannot preserve
+        // slot order and historically only tensor ID 0 was restored after load.
+        writer.Write(compiledInputTensors.Length);
+        for (int i = 0; i < compiledInputTensors.Length; i++)
+            writer.Write(tensorMap.GetId(compiledInputTensors[i]));
 
         // ── Op sequence ─────────────────────────────────────────────────
         writer.Write(steps.Length);

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/OpSerializationRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/OpSerializationRegistry.cs
@@ -87,6 +87,19 @@ internal static class OpSerializationRegistry<T>
             // ── FusedLinear ─────────────────────────────────────────────
             OpType.FusedLinear => RebuildFusedLinear(inputs),
 
+            // Composite inference kernels.
+            OpType.MultiHeadAttentionForward => RebuildMultiHeadAttentionForward(inputs, savedState),
+            OpType.MlpForward => RebuildMlpForward(inputs, savedState),
+            OpType.LstmSequenceForward => RebuildLstmSequenceForward(inputs, savedState),
+            OpType.ScaledDotProductAttentionGqa => RebuildScaledDotProductAttentionGqa(inputs, savedState),
+            OpType.FusedLinearMaxout => RebuildFusedLinearMaxout(inputs, savedState),
+            OpType.FusedHierarchicalSoftmax => RebuildFusedHierarchicalSoftmax(inputs, savedState),
+            OpType.TensorRepeatInterleave => RebuildTensorRepeatInterleave(inputs, savedState),
+            OpType.TensorMaskedFill => RebuildTensorMaskedFill(inputs, savedState),
+            OpType.TensorPermute => RebuildTensorPermute(inputs, savedState),
+            OpType.TensorMultiplyScalar => RebuildTensorMultiplyScalar(inputs, savedState),
+            OpType.GroupedQueryAttention => RebuildGroupedQueryAttention(inputs, savedState),
+
             // ── Loss ────────────────────────────────────────────────────
             OpType.CrossEntropyLoss => Binary(inputs, (e, a, b) => e.TensorCrossEntropyLoss(a, b)),
 
@@ -131,6 +144,12 @@ internal static class OpSerializationRegistry<T>
         OpType.Conv2D or OpType.MaxPool2D or OpType.AvgPool2D or
         OpType.BatchNorm or OpType.LayerNorm or
         OpType.ScaledDotProductAttention or OpType.FusedLinear or
+        OpType.MultiHeadAttentionForward or OpType.MlpForward or
+        OpType.LstmSequenceForward or OpType.ScaledDotProductAttentionGqa or
+        OpType.FusedLinearMaxout or OpType.FusedHierarchicalSoftmax or
+        OpType.TensorRepeatInterleave or OpType.TensorMaskedFill or
+        OpType.TensorPermute or OpType.TensorMultiplyScalar or
+        OpType.GroupedQueryAttention or
         // Loss
         OpType.CrossEntropyLoss => true,
         _ => false,
@@ -460,5 +479,203 @@ internal static class OpSerializationRegistry<T>
                 r.AsSpan().CopyTo(output.AsWritableSpan());
             }
         };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildMultiHeadAttentionForward(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 5, "MultiHeadAttentionForward");
+        if (state is not { Length: 3 } || state[0] is not int numHeads)
+            throw new InvalidDataException("MultiHeadAttentionForward saved state is invalid.");
+        Tensor<bool>? mask = RebuildBoolTensor(state[1], state[2], "MultiHeadAttentionForward mask");
+        return (eng, output) =>
+        {
+            var result = eng.MultiHeadAttentionForward(
+                inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], numHeads, mask);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildMlpForward(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        if (state is not { Length: 5 } || state[0] is not int[] biasInputIndices ||
+            state[1] is not FusedActivationType hiddenActivation ||
+            state[2] is not FusedActivationType outputActivation)
+            throw new InvalidDataException("MlpForward saved state is invalid.");
+
+        int layerCount = biasInputIndices.Length;
+        if (inputs.Length < 1 + layerCount)
+            throw new InvalidDataException(
+                $"MlpForward requires at least {1 + layerCount} inputs, got {inputs.Length}.");
+        var weights = new Tensor<T>[layerCount];
+        var biases = new Tensor<T>?[layerCount];
+        for (int i = 0; i < layerCount; i++)
+        {
+            weights[i] = inputs[1 + i];
+            int biasIndex = biasInputIndices[i];
+            if (biasIndex < -1 || biasIndex >= inputs.Length)
+                throw new InvalidDataException(
+                    $"MlpForward bias index {biasIndex} for layer {i} is out of range.");
+            biases[i] = biasIndex < 0 ? null : inputs[biasIndex];
+        }
+        var hiddenParams = state[3] as FusedActivationParams;
+        var outputParams = state[4] as FusedActivationParams;
+        return (eng, output) =>
+        {
+            var result = eng.MlpForward(
+                inputs[0], weights, biases, hiddenActivation, outputActivation,
+                hiddenParams, outputParams);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildLstmSequenceForward(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        if (state is not { Length: 2 } || state[0] is not bool returnSequences ||
+            state[1] is not LstmSequenceOptionalInputs optionalInputs)
+            throw new InvalidDataException("LstmSequenceForward saved state is invalid.");
+        CpuEngine.UnpackLstmSequenceInputs(
+            inputs, optionalInputs,
+            out var input, out var h0, out var c0, out var wIh, out var wHh, out var bIh, out var bHh);
+        return (eng, output) =>
+        {
+            var result = eng.LstmSequenceForward(
+                input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildScaledDotProductAttentionGqa(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 3, "ScaledDotProductAttentionGqa");
+        if (state is not { Length: 3 } || state[0] is not double scale ||
+            state[1] is not bool isCausal || state[2] is not double softcap)
+            throw new InvalidDataException("ScaledDotProductAttentionGqa saved state is invalid.");
+        return (eng, output) =>
+        {
+            var result = eng.ScaledDotProductAttentionGqa(
+                inputs[0], inputs[1], inputs[2], scale, isCausal, softcap);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildGroupedQueryAttention(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 3, "GroupedQueryAttention");
+        if (state is not { Length: 5 } || state[0] is not int numQueriesPerKV ||
+            state[1] is not bool hasScale || state[2] is not double scaleValue ||
+            state[3] is not bool isCausal || state[4] is not int selectedOutput ||
+            selectedOutput is < 0 or > 1)
+            throw new InvalidDataException("GroupedQueryAttention saved state is invalid.");
+
+        double? scale = hasScale ? scaleValue : null;
+        return (eng, output) =>
+        {
+            Tensor<T> result = eng.GroupedQueryAttention(
+                inputs[0], inputs[1], inputs[2], numQueriesPerKV, scale, isCausal,
+                out Tensor<T> attentionWeights);
+            DirectGpuTensorEngine.CopyResultInto(
+                eng, selectedOutput == 0 ? result : attentionWeights, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildFusedLinearMaxout(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputsInRange(inputs, 2, 3, "FusedLinearMaxout");
+        if (state is not { Length: 1 } || state[0] is not int numPieces)
+            throw new InvalidDataException("FusedLinearMaxout saved state is invalid.");
+        return (eng, output) =>
+        {
+            var result = eng.FusedLinearMaxout(
+                inputs[0], inputs[1], inputs.Length == 3 ? inputs[2] : null, numPieces);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildFusedHierarchicalSoftmax(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 2, "FusedHierarchicalSoftmax");
+        if (state is not { Length: 1 } || state[0] is not int numClasses)
+            throw new InvalidDataException("FusedHierarchicalSoftmax saved state is invalid.");
+        return (eng, output) =>
+        {
+            var result = eng.FusedHierarchicalSoftmax(inputs[0], inputs[1], numClasses);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildTensorRepeatInterleave(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 1, "TensorRepeatInterleave");
+        if (state is not { Length: 2 } || state[0] is not int repeats || state[1] is not int dim)
+            throw new InvalidDataException("TensorRepeatInterleave saved state is invalid.");
+        return (eng, output) =>
+        {
+            var result = eng.TensorRepeatInterleave(inputs[0], repeats, dim);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildTensorMaskedFill(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 1, "TensorMaskedFill");
+        if (state is not { Length: 3 } || state[2] is not double fillValue)
+            throw new InvalidDataException("TensorMaskedFill saved state is invalid.");
+        var mask = RebuildBoolTensor(state[0], state[1], "TensorMaskedFill mask")
+            ?? throw new InvalidDataException("TensorMaskedFill mask cannot be null.");
+        var value = MathHelper.GetNumericOperations<T>().FromDouble(fillValue);
+        return (eng, output) =>
+        {
+            var result = eng.TensorMaskedFill(inputs[0], mask, value);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildTensorPermute(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 1, "TensorPermute");
+        if (state is not { Length: 1 } || state[0] is not int[] axes)
+            throw new InvalidDataException("TensorPermute saved state is invalid.");
+        return (eng, output) => eng.TensorPermuteInto(output, inputs[0], axes);
+    }
+
+    private static Action<IEngine, Tensor<T>> RebuildTensorMultiplyScalar(
+        Tensor<T>[] inputs, object[]? state)
+    {
+        RequireInputs(inputs, 1, "TensorMultiplyScalar");
+        if (state is not { Length: 1 } || state[0] is not T scalar)
+            throw new InvalidDataException("TensorMultiplyScalar saved state is invalid.");
+        return (eng, output) =>
+        {
+            var result = eng.TensorMultiplyScalar(inputs[0], scalar);
+            DirectGpuTensorEngine.CopyResultInto(eng, result, output);
+        };
+    }
+
+    private static Tensor<bool>? RebuildBoolTensor(object? dataState, object? shapeState, string description)
+    {
+        if (dataState is null && shapeState is null) return null;
+        if (dataState is not bool[] data || shapeState is not int[] shape)
+            throw new InvalidDataException($"{description} saved state is invalid.");
+        long length = 1;
+        for (int i = 0; i < shape.Length; i++)
+        {
+            if (shape[i] < 0)
+                throw new InvalidDataException($"{description} has a negative shape extent.");
+            length *= shape[i];
+        }
+        if (length != data.Length)
+            throw new InvalidDataException(
+                $"{description} shape describes {length} values but contains {data.Length}.");
+        return new Tensor<bool>((bool[])data.Clone(), (int[])shape.Clone());
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/PlanFormatConstants.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/PlanFormatConstants.cs
@@ -29,8 +29,10 @@ internal static class PlanFormatConstants
     /// Version 5 adds Fletcher-Reeves conjugate-gradient scalar state to the
     /// same payload. Version 4 plans do not contain that value and must be
     /// rejected rather than shifting the following parameter-state fields.
+    /// Version 6 records the complete ordered mutable-input tensor ID list for
+    /// inference plans. Earlier versions retained only the first input slot.
     /// </remarks>
-    internal const ushort CurrentFormatVersion = 5;
+    internal const ushort CurrentFormatVersion = 6;
 
     /// <summary>
     /// Tensor-codec version. Semantically distinct from the format version:
@@ -39,7 +41,7 @@ internal static class PlanFormatConstants
     /// than codec V1 — the loader checks this and returns null (forces
     /// recompile) rather than silently mis-replaying.
     /// </summary>
-    internal const int TensorCodecVersion = 1;
+    internal const int TensorCodecVersion = 2;
 
     // ── Plan type ───────────────────────────────────────────────────────────
     internal const byte PlanTypeInference = 0;
@@ -94,6 +96,8 @@ internal static class PlanFormatConstants
     internal const byte TagEnum       = 0x09; // assembly-qualified type name + int value
     internal const byte TagInt64      = 0x0A;
     internal const byte TagInt64Array = 0x0B; // long[] — used by index snapshots that may exceed int.MaxValue (large-vocab embeddings)
+    internal const byte TagBoolArray  = 0x0C;
+    internal const byte TagFusedActivationParams = 0x0D;
 
     // ── Tensor table flags ──────────────────────────────────────────────────
     internal const byte TensorFlagWeight       = 0x01; // model parameter

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/SavedStateSerializer.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/SavedStateSerializer.cs
@@ -11,7 +11,8 @@ namespace AiDotNet.Tensors.Engines.Compilation.Serialization;
 ///
 /// <para>Supported types: <c>null</c>, <c>int</c>, <c>int[]</c>, <c>long</c>,
 /// <c>long[]</c>, <c>double</c>, <c>float</c>, <c>bool</c>, <c>string</c>,
-/// <c>byte[]</c>, and <c>Tensor&lt;T&gt;</c> (serialized as a tensor-table
+/// <c>byte[]</c>, <c>bool[]</c>, <see cref="FusedActivationParams"/>, and
+/// <c>Tensor&lt;T&gt;</c> (serialized as a tensor-table
 /// ID reference). <c>long[]</c> support exists for index snapshots that may
 /// exceed <c>int.MaxValue</c> (e.g. large-vocab embedding lookups with
 /// <c>Tensor&lt;long&gt;</c> indices).</para>
@@ -114,6 +115,30 @@ internal static class SavedStateSerializer
                 writer.Write(byteArr);
                 break;
 
+            case bool[] boolArr:
+                writer.Write(PlanFormatConstants.TagBoolArray);
+                writer.Write(boolArr.Length);
+                for (int j = 0; j < boolArr.Length; j++)
+                    writer.Write(boolArr[j]);
+                break;
+
+            case FusedActivationParams activationParams:
+                writer.Write(PlanFormatConstants.TagFusedActivationParams);
+                WriteNullableSingle(writer, activationParams.Alpha);
+                WriteNullableSingle(writer, activationParams.Beta);
+                WriteNullableSingle(writer, activationParams.Theta);
+                if (activationParams.PReluSlope is null)
+                {
+                    writer.Write(-1);
+                }
+                else
+                {
+                    writer.Write(activationParams.PReluSlope.Length);
+                    for (int j = 0; j < activationParams.PReluSlope.Length; j++)
+                        writer.Write(activationParams.PReluSlope[j]);
+                }
+                break;
+
             case Tensor<T> tensor:
                 writer.Write(PlanFormatConstants.TagTensorRef);
                 writer.Write(tensorMap.GetId(tensor));
@@ -142,7 +167,7 @@ internal static class SavedStateSerializer
                 // load never encounters a mystery tag byte.
                 throw new NotSupportedException(
                     $"SavedState entry of type {value.GetType().FullName} cannot be serialized. " +
-                    "Supported types: null, int, int[], long, long[], double, float, bool, string, byte[], Tensor<T>, Enum.");
+                    "Supported types: null, int, int[], long, long[], double, float, bool, string, byte[], bool[], FusedActivationParams, Tensor<T>, Enum.");
         }
     }
 
@@ -156,6 +181,8 @@ internal static class SavedStateSerializer
             PlanFormatConstants.TagInt32Array => ReadInt32Array(reader),
             PlanFormatConstants.TagInt64      => reader.ReadInt64(),
             PlanFormatConstants.TagInt64Array => ReadInt64Array(reader),
+            PlanFormatConstants.TagBoolArray  => ReadBoolArray(reader),
+            PlanFormatConstants.TagFusedActivationParams => ReadFusedActivationParams(reader),
             PlanFormatConstants.TagDouble     => reader.ReadDouble(),
             PlanFormatConstants.TagFloat      => (object)reader.ReadSingle(),
             PlanFormatConstants.TagBool       => reader.ReadBoolean(),
@@ -232,6 +259,50 @@ internal static class SavedStateSerializer
         for (int i = 0; i < len; i++)
             arr[i] = reader.ReadInt64();
         return arr;
+    }
+
+    private static bool[] ReadBoolArray(BinaryReader reader)
+    {
+        int len = reader.ReadInt32();
+        if (len < 0)
+            throw new InvalidDataException($"SavedState bool[] length {len} cannot be negative. The plan file is corrupt.");
+        var arr = new bool[len];
+        for (int i = 0; i < len; i++)
+            arr[i] = reader.ReadBoolean();
+        return arr;
+    }
+
+    private static void WriteNullableSingle(BinaryWriter writer, float? value)
+    {
+        writer.Write(value.HasValue);
+        if (value.HasValue) writer.Write(value.Value);
+    }
+
+    private static float? ReadNullableSingle(BinaryReader reader)
+        => reader.ReadBoolean() ? reader.ReadSingle() : null;
+
+    private static FusedActivationParams ReadFusedActivationParams(BinaryReader reader)
+    {
+        float? alpha = ReadNullableSingle(reader);
+        float? beta = ReadNullableSingle(reader);
+        float? theta = ReadNullableSingle(reader);
+        int slopeLength = reader.ReadInt32();
+        if (slopeLength < -1)
+            throw new InvalidDataException(
+                $"SavedState PReLU slope length {slopeLength} is invalid. The plan file is corrupt.");
+        float[]? slopes = null;
+        if (slopeLength >= 0)
+        {
+            slopes = new float[slopeLength];
+            for (int i = 0; i < slopeLength; i++) slopes[i] = reader.ReadSingle();
+        }
+        return new FusedActivationParams
+        {
+            Alpha = alpha,
+            Beta = beta,
+            Theta = theta,
+            PReluSlope = slopes
+        };
     }
 
     private static string ReadString(BinaryReader reader)

--- a/src/AiDotNet.Tensors/Engines/Compilation/Serialization/TensorTableWriter.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/Serialization/TensorTableWriter.cs
@@ -22,12 +22,22 @@ internal static class TensorTableWriter
         CompiledStep<T>[] steps,
         Tensor<T>? compiledInputTensor,
         Tensor<T>[]? parameterTensors = null)
+        => BuildMap(
+            steps,
+            compiledInputTensor is null ? Array.Empty<Tensor<T>>() : new[] { compiledInputTensor },
+            parameterTensors);
+
+    internal static TensorIdMap<T> BuildMap<T>(
+        CompiledStep<T>[] steps,
+        Tensor<T>[] compiledInputTensors,
+        Tensor<T>[]? parameterTensors = null)
     {
         var map = new TensorIdMap<T>();
 
-        // Register compiled input first (ID 0 by convention).
-        if (compiledInputTensor is not null)
-            map.GetOrAdd(compiledInputTensor);
+        // Register mutable inputs first and in slot order. The inference writer also emits their
+        // explicit IDs, so ordering remains stable even if map construction evolves later.
+        for (int i = 0; i < compiledInputTensors.Length; i++)
+            map.GetOrAdd(compiledInputTensors[i]);
 
         // Register parameter tensors (training plans).
         if (parameterTensors is not null)
@@ -70,6 +80,19 @@ internal static class TensorTableWriter
         CompiledStep<T>[] steps,
         Tensor<T>? compiledInputTensor,
         Tensor<T>[]? parameterTensors)
+        => Write(
+            writer,
+            map,
+            steps,
+            compiledInputTensor is null ? Array.Empty<Tensor<T>>() : new[] { compiledInputTensor },
+            parameterTensors);
+
+    internal static void Write<T>(
+        BinaryWriter writer,
+        TensorIdMap<T> map,
+        CompiledStep<T>[] steps,
+        Tensor<T>[] compiledInputTensors,
+        Tensor<T>[]? parameterTensors)
     {
         var tensors = map.Ordered;
         writer.Write(tensors.Count);
@@ -82,6 +105,9 @@ internal static class TensorTableWriter
         // but different identity.
         var paramSet = new HashSet<Tensor<T>>(
             parameterTensors ?? Array.Empty<Tensor<T>>(),
+            ReferenceEqualityComparer<Tensor<T>>.Instance);
+        var inputSet = new HashSet<Tensor<T>>(
+            compiledInputTensors,
             ReferenceEqualityComparer<Tensor<T>>.Instance);
 
         // Build the set of tensors that are step OUTPUT buffers. Any tensor
@@ -108,7 +134,7 @@ internal static class TensorTableWriter
 
             // Classify this tensor.
             bool isExplicitParam = paramSet.Contains(tensor);
-            bool isLeaf = ReferenceEquals(tensor, compiledInputTensor);
+            bool isLeaf = inputSet.Contains(tensor);
             bool isOutputBuffer = outputBufferSet.Contains(tensor);
 
             // A "frozen weight" is a tensor that:

--- a/src/AiDotNet.Tensors/Engines/Compilation/TensorCodec.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/TensorCodec.cs
@@ -53,7 +53,7 @@ internal static class TensorCodec
         TensorCodecOptions.SetCurrent(opts);
         try
         {
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             computation();
             return scope.CompileInference<T>();
         }

--- a/src/AiDotNet.Tensors/Engines/Compilation/TensorStorageLeaseSet.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/TensorStorageLeaseSet.cs
@@ -1,0 +1,92 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Compilation;
+
+/// <summary>
+/// Deduplicated ownership of the storages retained by a live graph or compiled plan.
+/// Tensor objects are graph metadata; this set independently retains the backing storage so
+/// disposing a composite operation's local tensor cannot invalidate a recorded node.
+/// </summary>
+internal sealed class TensorStorageLeaseSet : IDisposable
+{
+    private readonly struct LeaseVisitor : ISavedStateTensorVisitor
+    {
+        private readonly TensorStorageLeaseSet _owner;
+
+        internal LeaseVisitor(TensorStorageLeaseSet owner) => _owner = owner;
+        public void Visit(ITensorStorageLeaseSource tensor) => _owner.Add(tensor);
+    }
+
+    private sealed class IdentityComparer : IEqualityComparer<object>
+    {
+        internal static readonly IdentityComparer Instance = new();
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+        public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+    }
+
+    private readonly Dictionary<object, TensorStorageLease> _leases = new(IdentityComparer.Instance);
+    private bool _disposed;
+
+    internal void Add(ITensorStorageLeaseSource tensor)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(TensorStorageLeaseSet));
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+
+        var lease = tensor.AcquireStorageLease();
+        if (!_leases.ContainsKey(lease.StorageIdentity))
+        {
+            _leases.Add(lease.StorageIdentity, lease);
+            return;
+        }
+
+        lease.Dispose();
+    }
+
+    /// <summary>
+    /// Releases this set's ownership of the tensor's current storage. Paging uses this only
+    /// for the short interval in which the tensor atomically replaces its sole-owned storage.
+    /// </summary>
+    internal bool Remove(ITensorStorageLeaseSource tensor)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(TensorStorageLeaseSet));
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+
+        object identity = tensor.StorageIdentity;
+        if (_leases.TryGetValue(identity, out var lease))
+        {
+            _leases.Remove(identity);
+            lease.Dispose();
+            return true;
+        }
+
+        return false;
+    }
+
+    internal void Add(ILazyNode node)
+    {
+        if (node is null) throw new ArgumentNullException(nameof(node));
+        node.AddStorageLeases(this);
+    }
+
+    internal void AddSavedState(object[]? savedState)
+    {
+        var visitor = new LeaseVisitor(this);
+        SavedStateTensorTraversal.Visit(savedState, ref visitor);
+    }
+
+    internal void Add<T>(CompiledStep<T> step)
+    {
+        for (int i = 0; i < step.Inputs.Length; i++) Add(step.Inputs[i]);
+        Add(step.OutputBuffer);
+        AddSavedState(step.SavedState);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        foreach (var lease in _leases.Values)
+            lease.Dispose();
+        _leases.Clear();
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Detection.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Detection.cs
@@ -4,6 +4,7 @@ using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines.Compilation;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -41,6 +42,9 @@ public partial class CpuEngine
     public virtual Tensor<T> BoxConvert<T>(Tensor<T> boxes, BoxFormat from, BoxFormat to)
     {
         ValidateBoxes(boxes, nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { boxes }, engine => engine.BoxConvert(boxes, from, to));
         // CXCYWH uses ½ in element type; integral T silently truncates to 0.
         if (from == BoxFormat.CXCYWH || to == BoxFormat.CXCYWH)
             RequireFloatingPoint<T>(nameof(BoxConvert));
@@ -110,6 +114,8 @@ public partial class CpuEngine
     public virtual Tensor<T> BoxArea<T>(Tensor<T> boxes)
     {
         ValidateBoxes(boxes, nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { boxes }, engine => engine.BoxArea(boxes));
         var ops = MathHelper.GetNumericOperations<T>();
         int n = boxes.Length / 4;
         // Output shape is the input shape minus the trailing 4.
@@ -138,6 +144,9 @@ public partial class CpuEngine
     {
         ValidateBoxes(boxesA, nameof(boxesA));
         ValidateBoxes(boxesB, nameof(boxesB));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { boxesA, boxesB }, engine => engine.BoxIou(boxesA, boxesB));
         if (boxesA.Rank != 2 || boxesB.Rank != 2)
             throw new ArgumentException("BoxIou requires rank-2 boxes [N, 4] and [M, 4].");
         var (iou, _, _, _) = ComputePairwiseIoU(boxesA, boxesB);
@@ -150,6 +159,9 @@ public partial class CpuEngine
     {
         ValidateBoxes(boxesA, nameof(boxesA));
         ValidateBoxes(boxesB, nameof(boxesB));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { boxesA, boxesB }, engine => engine.GeneralizedBoxIou(boxesA, boxesB));
         if (boxesA.Rank != 2 || boxesB.Rank != 2)
             throw new ArgumentException("GeneralizedBoxIou requires rank-2 boxes [N, 4] and [M, 4].");
         var ops = MathHelper.GetNumericOperations<T>();
@@ -190,6 +202,11 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> DistanceBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
     {
+        if (boxesA == null) throw new ArgumentNullException(nameof(boxesA));
+        if (boxesB == null) throw new ArgumentNullException(nameof(boxesB));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { boxesA, boxesB }, engine => engine.DistanceBoxIou(boxesA, boxesB));
         var result = DiouLikeImpl(boxesA, boxesB, includeAspect: false);
         DifferentiableOps.RecordBinary("DistanceBoxIou", result, boxesA, boxesB,
             BackwardFunctions<T>.DistanceBoxIouBackward);
@@ -199,6 +216,11 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> CompleteBoxIou<T>(Tensor<T> boxesA, Tensor<T> boxesB)
     {
+        if (boxesA == null) throw new ArgumentNullException(nameof(boxesA));
+        if (boxesB == null) throw new ArgumentNullException(nameof(boxesB));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { boxesA, boxesB }, engine => engine.CompleteBoxIou(boxesA, boxesB));
         var result = DiouLikeImpl(boxesA, boxesB, includeAspect: true);
         DifferentiableOps.RecordBinary("CompleteBoxIou", result, boxesA, boxesB,
             BackwardFunctions<T>.CompleteBoxIouBackward);
@@ -208,6 +230,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> Nms<T>(Tensor<T> boxes, Tensor<T> scores, double iouThreshold)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         ValidateBoxes(boxes, nameof(boxes));
         if (boxes.Rank != 2) throw new ArgumentException("Nms requires rank-2 boxes [N, 4].");
         if (scores.Rank != 1 || scores._shape[0] != boxes._shape[0])
@@ -272,6 +296,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> BatchedNms<T>(Tensor<T> boxes, Tensor<T> scores, Tensor<int> classIds, double iouThreshold)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         ValidateBoxes(boxes, nameof(boxes));
         if (boxes.Rank != 2) throw new ArgumentException("BatchedNms requires rank-2 boxes [N, 4].");
         int n = boxes._shape[0];
@@ -315,6 +341,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> MasksToBoxes<T>(Tensor<T> masks)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (masks.Rank != 3)
             throw new ArgumentException("MasksToBoxes requires rank-3 masks [N, H, W].");
         var ops = MathHelper.GetNumericOperations<T>();

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.FusedLinearCrossEntropy.cs
@@ -38,6 +38,7 @@ public partial class CpuEngine
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (bias is null) throw new ArgumentNullException(nameof(bias));
         if (targetIds is null) throw new ArgumentNullException(nameof(targetIds));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         GradientTape<T>.Current?.BindEngineIfUnset(this);
         if (hidden.Rank != 2)
             throw new ArgumentException($"hidden must be rank-2 [N, d]; got rank {hidden.Rank}.", nameof(hidden));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Geometry.cs
@@ -435,6 +435,11 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> PadNd<T>(Tensor<T> input, int[] pad, PadMode mode, T value = default!)
     {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (pad is null) throw new ArgumentNullException(nameof(pad));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.PadNd(input, pad, mode, value));
         var result = PadNdImpl(input, pad, mode, value);
         AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
             "PadNd", result, input,
@@ -764,6 +769,12 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> AffineGrid3D<T>(Tensor<T> theta, int outputDepth, int outputHeight, int outputWidth, bool alignCorners = false)
     {
+        if (theta is null) throw new ArgumentNullException(nameof(theta));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { theta },
+                engine => engine.AffineGrid3D(
+                    theta, outputDepth, outputHeight, outputWidth, alignCorners));
         var result = AffineGrid3DImpl(theta, outputDepth, outputHeight, outputWidth, alignCorners);
         AiDotNet.Tensors.Engines.Autodiff.DifferentiableOps.RecordUnary(
             "AffineGrid3D", result, theta,

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GraphCapture.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GraphCapture.cs
@@ -1,0 +1,136 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System.Runtime.CompilerServices;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines;
+
+public partial class CpuEngine
+{
+    /// <summary>
+    /// Captures a kernel as one opaque inference node while preserving the public tensor operands
+    /// as graph leaves. The eager trace invocation establishes the exact output shape; replay calls
+    /// the engine bound to the graph, so a DirectGpuTensorEngine trace continues to dispatch to GPU
+    /// kernels instead of being pinned to the CPU implementation.
+    /// </summary>
+    /// <remarks>
+    /// This helper is inference-only by construction. Training and compatibility traces continue
+    /// through each method's primitive implementation so an opaque node cannot silently erase a
+    /// backward graph.
+    /// </remarks>
+    protected Tensor<T> CaptureInferenceKernel<T>(
+        Tensor<T>[] inputs,
+        Func<IEngine, Tensor<T>> execute,
+        [CallerMemberName] string operationName = "")
+    {
+        var scope = GraphMode.Current
+            ?? throw new InvalidOperationException("Inference kernel capture requires an active graph scope.");
+        if (!GraphMode.IsInferenceTrace)
+            throw new InvalidOperationException("Opaque kernel capture is valid only for an inference trace.");
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (inputs.Length == 0)
+            throw new ArgumentException("An inference kernel must have at least one tensor input.", nameof(inputs));
+        if (execute is null) throw new ArgumentNullException(nameof(execute));
+
+        scope.BindEngineIfUnset(this);
+
+        Tensor<T> tracedOutput;
+        using (GraphMode.SuspendRecording())
+            tracedOutput = execute(this);
+
+        return scope.RecordMaterializedVariadic(
+            LazyNodeType.Custom,
+            operationName,
+            inputs,
+            tracedOutput,
+            (engine, output) =>
+            {
+                Tensor<T> result = execute(engine);
+                DirectGpuTensorEngine.CopyResultInto(engine, result, output);
+            });
+    }
+
+    /// <summary>
+    /// Captures every tensor returned by a homogeneous multi-output inference kernel. Each output
+    /// remains independently selectable as a compiled-plan result. Coordinating sibling execution
+    /// into a single launch is a performance optimization; it is deliberately separate from this
+    /// correctness boundary.
+    /// </summary>
+    protected Tensor<T>[] CaptureInferenceKernelOutputs<T>(
+        Tensor<T>[] inputs,
+        Func<IEngine, Tensor<T>[]> execute,
+        [CallerMemberName] string operationName = "")
+    {
+        var scope = GraphMode.Current
+            ?? throw new InvalidOperationException("Inference kernel capture requires an active graph scope.");
+        if (!GraphMode.IsInferenceTrace)
+            throw new InvalidOperationException("Opaque kernel capture is valid only for an inference trace.");
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (inputs.Length == 0)
+            throw new ArgumentException("An inference kernel must have at least one tensor input.", nameof(inputs));
+        if (execute is null) throw new ArgumentNullException(nameof(execute));
+
+        scope.BindEngineIfUnset(this);
+
+        Tensor<T>[] tracedOutputs;
+        using (GraphMode.SuspendRecording())
+            tracedOutputs = execute(this);
+        if (tracedOutputs is null || tracedOutputs.Length == 0)
+            throw new InvalidOperationException("A multi-output inference kernel returned no tensors.");
+
+        var captured = new Tensor<T>[tracedOutputs.Length];
+        for (int outputIndex = 0; outputIndex < captured.Length; outputIndex++)
+        {
+            int selectedOutput = outputIndex;
+            captured[outputIndex] = scope.RecordMaterializedVariadic(
+                LazyNodeType.Custom,
+                $"{operationName}[{selectedOutput}]",
+                inputs,
+                tracedOutputs[outputIndex],
+                (engine, output) =>
+                {
+                    Tensor<T>[] results = execute(engine);
+                    if (results.Length != tracedOutputs.Length)
+                        throw new InvalidOperationException(
+                            $"{operationName} changed its output count between trace and replay.");
+                    DirectGpuTensorEngine.CopyResultInto(engine, results[selectedOutput], output);
+                });
+        }
+
+        return captured;
+    }
+
+    /// <summary>
+    /// Captures an inference kernel whose public contract writes into a caller-provided output.
+    /// The destination is the node output, not an input dependency, so memory planning may safely
+    /// bind its storage while the read operands remain explicit graph leaves.
+    /// </summary>
+    protected void CaptureInferenceIntoKernel<T>(
+        Tensor<T> destination,
+        Tensor<T>[] inputs,
+        Action<IEngine, Tensor<T>> execute,
+        [CallerMemberName] string operationName = "")
+    {
+        var scope = GraphMode.Current
+            ?? throw new InvalidOperationException("Inference kernel capture requires an active graph scope.");
+        if (!GraphMode.IsInferenceTrace)
+            throw new InvalidOperationException("Opaque kernel capture is valid only for an inference trace.");
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (inputs.Length == 0)
+            throw new ArgumentException("An inference kernel must have at least one tensor input.", nameof(inputs));
+        if (execute is null) throw new ArgumentNullException(nameof(execute));
+
+        scope.BindEngineIfUnset(this);
+        using (GraphMode.SuspendRecording())
+            execute(this, destination);
+
+        scope.RecordMaterializedVariadic(
+            LazyNodeType.Custom,
+            operationName,
+            inputs,
+            destination,
+            execute);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Image.cs
@@ -22,6 +22,9 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<byte> ImageDecode(byte[] encoded, ImageFormat? format = null)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HostBoundary);
+
         if (encoded is null) throw new ArgumentNullException(nameof(encoded));
         if (encoded.Length < 8) throw new ArgumentException("encoded image is too short.");
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.LstmSequence.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
 using System.Runtime.CompilerServices;
 #if NET5_0_OR_GREATER
 using System.Runtime.Intrinsics;
@@ -12,6 +14,16 @@ using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Tensors.Engines;
+
+[Flags]
+internal enum LstmSequenceOptionalInputs : byte
+{
+    None = 0,
+    InitialHidden = 1 << 0,
+    InitialCell = 1 << 1,
+    InputBias = 1 << 2,
+    RecurrentBias = 1 << 3
+}
 
 public partial class CpuEngine
 {
@@ -186,6 +198,58 @@ public partial class CpuEngine
         if (bHh is not null && (bHh.Rank != 1 || bHh.Shape[0] != gateRows))
             throw new ArgumentException($"bHh must be [{gateRows}].", nameof(bHh));
 
+        if (GraphMode.IsActive)
+        {
+            // The state-returning API has three live outputs, while the compiled IR owns one
+            // output per node. Build it from ordinary recorded primitives instead of executing
+            // the fused kernel multiple times or refreshing out-parameters through side effects.
+            // Compiled training takes the same differentiable path. The common single-output
+            // inference overload remains one fused replay step.
+            if (wantState || !GraphMode.IsInferenceTrace)
+            {
+                return LstmSequenceForwardGraph(
+                    input, h0, c0, wIh, wHh, bIh, bHh,
+                    batch, seqLen, inFeatures, hidden, returnSequences,
+                    out finalHidden, out finalCell);
+            }
+
+            var optionalInputs = LstmSequenceOptionalInputs.None;
+            var graphInputs = new List<Tensor<T>> { input, wIh, wHh };
+            if (h0 is not null) { optionalInputs |= LstmSequenceOptionalInputs.InitialHidden; graphInputs.Add(h0); }
+            if (c0 is not null) { optionalInputs |= LstmSequenceOptionalInputs.InitialCell; graphInputs.Add(c0); }
+            if (bIh is not null) { optionalInputs |= LstmSequenceOptionalInputs.InputBias; graphInputs.Add(bIh); }
+            if (bHh is not null) { optionalInputs |= LstmSequenceOptionalInputs.RecurrentBias; graphInputs.Add(bHh); }
+
+            var capturedInputs = graphInputs.ToArray();
+            var outputShape = returnSequences
+                ? new[] { batch, seqLen, hidden }
+                : new[] { batch, hidden };
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            object[] savedState = { returnSequences, optionalInputs };
+            finalHidden = Tensor<T>.Empty();
+            finalCell = Tensor<T>.Empty();
+            return scope.RecordVariadic(
+                LazyNodeType.LstmSequenceForward,
+                "LstmSequenceForward",
+                capturedInputs,
+                outputShape,
+                (eng, output) =>
+                {
+                    UnpackLstmSequenceInputs(
+                        capturedInputs, optionalInputs,
+                        out var capturedInput, out var capturedH0, out var capturedC0,
+                        out var capturedWIh, out var capturedWHh,
+                        out var capturedBIh, out var capturedBHh);
+                    var eager = eng.LstmSequenceForward(
+                        capturedInput, capturedH0, capturedC0, capturedWIh, capturedWHh,
+                        capturedBIh, capturedBHh, returnSequences);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState: savedState);
+        }
+
         // Under an active gradient tape, float routes to the fused training path: exact
         // activations, saved per-timestep state, and a single fused BPTT node
         // (CpuEngine.LstmSequenceBackward.cs). Collapses the per-timestep training graph
@@ -193,6 +257,18 @@ public partial class CpuEngine
         // RecordIfActive keys on — GraphMode is the separate graph-compilation flag.
         if (Autodiff.DifferentiableOps.IsRecording<T>())
         {
+            // The fused BPTT node has one output edge, so it cannot represent gradients arriving
+            // independently through the sequence output, final hidden state, and final cell state.
+            // This path previously threw. Build only the state-returning tape path from ordinary
+            // differentiable primitives; inference and the single-output training hot path remain fused.
+            if (wantState)
+            {
+                return LstmSequenceForwardGraph(
+                    input, h0, c0, wIh, wHh, bIh, bHh,
+                    batch, seqLen, inFeatures, hidden, returnSequences,
+                    out finalHidden, out finalCell);
+            }
+
             if (typeof(T) == typeof(float))
             {
                 var trainOut = LstmSequenceForwardFloatTrain(
@@ -232,12 +308,6 @@ public partial class CpuEngine
                 "Route other element types through the decomposed LSTMLayer.Forward path.");
         }
 
-        // Graph-compilation mode (distinct from the eager tape) is not yet supported.
-        if (GraphMode.IsActive)
-            throw new InvalidOperationException(
-                "LstmSequenceForward does not yet support graph-compilation mode. " +
-                "Call it outside an active graph-mode scope.");
-
         // Float fast path: SimdGemm + vectorized sigmoid/tanh + ArrayPool
         // scratch buffers reused across timesteps. This is the path that
         // closes the AIsEval LSTM gap on CPU. Generic-T path below stays
@@ -263,6 +333,86 @@ public partial class CpuEngine
             input, h0, c0, wIh, wHh, bIh, bHh,
             batch, seqLen, inFeatures, hidden, gateRows, returnSequences, wantState,
             out finalHidden, out finalCell);
+    }
+
+    private Tensor<T> LstmSequenceForwardGraph<T>(
+        Tensor<T> input,
+        Tensor<T>? h0,
+        Tensor<T>? c0,
+        Tensor<T> wIh,
+        Tensor<T> wHh,
+        Tensor<T>? bIh,
+        Tensor<T>? bHh,
+        int batch,
+        int seqLen,
+        int inFeatures,
+        int hidden,
+        bool returnSequences,
+        out Tensor<T> finalHidden,
+        out Tensor<T> finalCell)
+    {
+        if (seqLen == 0)
+            throw new NotSupportedException(
+                "Graph capture of an empty LSTM sequence has no timestep node from which to derive its outputs.");
+
+        Tensor<T> currentH = h0 ?? new Tensor<T>(new[] { batch, hidden });
+        Tensor<T> currentC = c0 ?? new Tensor<T>(new[] { batch, hidden });
+        var hiddenStates = returnSequences ? new List<Tensor<T>>(seqLen) : null;
+
+        for (int t = 0; t < seqLen; t++)
+        {
+            var xt = Reshape(
+                TensorSlice(input, new[] { 0, t, 0 }, new[] { batch, 1, inFeatures }),
+                new[] { batch, inFeatures });
+            var gates = TensorAdd(
+                TensorMatMulTransposed(xt, wIh),
+                TensorMatMulTransposed(currentH, wHh));
+            if (bIh is not null) gates = TensorAdd(gates, bIh);
+            if (bHh is not null) gates = TensorAdd(gates, bHh);
+
+            var inputGate = Sigmoid(TensorSlice(gates, new[] { 0, 0 }, new[] { batch, hidden }));
+            var forgetGate = Sigmoid(TensorSlice(gates, new[] { 0, hidden }, new[] { batch, hidden }));
+            var candidate = Tanh(TensorSlice(gates, new[] { 0, 2 * hidden }, new[] { batch, hidden }));
+            var outputGate = Sigmoid(TensorSlice(gates, new[] { 0, 3 * hidden }, new[] { batch, hidden }));
+
+            currentC = TensorAdd(
+                TensorMultiply(forgetGate, currentC),
+                TensorMultiply(inputGate, candidate));
+            currentH = TensorMultiply(outputGate, Tanh(currentC));
+            hiddenStates?.Add(Reshape(currentH, new[] { batch, 1, hidden }));
+        }
+
+        finalHidden = currentH;
+        finalCell = currentC;
+        return returnSequences
+            ? TensorConcatenate(hiddenStates!.ToArray(), axis: 1)
+            : currentH;
+    }
+
+    internal static void UnpackLstmSequenceInputs<T>(
+        Tensor<T>[] inputs,
+        LstmSequenceOptionalInputs optionalInputs,
+        out Tensor<T> input,
+        out Tensor<T>? h0,
+        out Tensor<T>? c0,
+        out Tensor<T> wIh,
+        out Tensor<T> wHh,
+        out Tensor<T>? bIh,
+        out Tensor<T>? bHh)
+    {
+        if (inputs.Length < 3)
+            throw new InvalidDataException($"LSTM replay requires at least 3 inputs, got {inputs.Length}.");
+        int index = 0;
+        input = inputs[index++];
+        wIh = inputs[index++];
+        wHh = inputs[index++];
+        h0 = optionalInputs.HasFlag(LstmSequenceOptionalInputs.InitialHidden) ? inputs[index++] : null;
+        c0 = optionalInputs.HasFlag(LstmSequenceOptionalInputs.InitialCell) ? inputs[index++] : null;
+        bIh = optionalInputs.HasFlag(LstmSequenceOptionalInputs.InputBias) ? inputs[index++] : null;
+        bHh = optionalInputs.HasFlag(LstmSequenceOptionalInputs.RecurrentBias) ? inputs[index++] : null;
+        if (index != inputs.Length)
+            throw new InvalidDataException(
+                $"LSTM replay flags describe {index} inputs, but the node contains {inputs.Length}.");
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Mlp.cs
@@ -82,9 +82,88 @@ public partial class CpuEngine
                 nameof(biases));
 
         if (GraphMode.IsActive)
-            throw new InvalidOperationException(
-                "MlpForward is inference-only and does not yet support GradientTape. " +
-                "For training, call the decomposed FusedLinear / DenseLayer path which records each layer.");
+        {
+            if (!GraphMode.IsInferenceTrace)
+            {
+                var trainingValue = input;
+                int trainingLast = weights.Count - 1;
+                for (int i = 0; i < weights.Count; i++)
+                {
+                    var activation = i == trainingLast ? outputActivation : hiddenActivation;
+                    var activationParams = i == trainingLast ? outputActivationParams : hiddenActivationParams;
+                    trainingValue = FusedLinear(trainingValue, weights[i], biases[i], activation, activationParams);
+                }
+                return trainingValue;
+            }
+
+            if (input.Rank < 1)
+                throw new ArgumentException("MlpForward input must have at least one dimension.", nameof(input));
+
+            int runningFeatures = input._shape[input.Rank - 1];
+            var capturedWeights = new Tensor<T>[weights.Count];
+            var capturedBiases = new Tensor<T>?[biases.Count];
+            var biasInputIndices = new int[biases.Count];
+            var graphInputs = new List<Tensor<T>>(1 + weights.Count + biases.Count) { input };
+            for (int i = 0; i < weights.Count; i++)
+            {
+                var weight = weights[i]
+                    ?? throw new ArgumentException($"weights[{i}] cannot be null.", nameof(weights));
+                if (weight.Rank != 2 || weight._shape[0] != runningFeatures)
+                    throw new ArgumentException(
+                        $"weights[{i}] must be [{runningFeatures}, outFeatures]; got [{string.Join(",", weight._shape)}].",
+                        nameof(weights));
+                var bias = biases[i];
+                if (bias is not null && (bias.Rank != 1 || bias._shape[0] != weight._shape[1]))
+                    throw new ArgumentException(
+                        $"biases[{i}] must be [{weight._shape[1]}].", nameof(biases));
+
+                capturedWeights[i] = weight;
+                capturedBiases[i] = bias;
+                graphInputs.Add(weight);
+                runningFeatures = weight._shape[1];
+            }
+            for (int i = 0; i < capturedBiases.Length; i++)
+            {
+                if (capturedBiases[i] is null)
+                {
+                    biasInputIndices[i] = -1;
+                }
+                else
+                {
+                    biasInputIndices[i] = graphInputs.Count;
+                    graphInputs.Add(capturedBiases[i]!);
+                }
+            }
+
+            var outputShape = (int[])input._shape.Clone();
+            outputShape[outputShape.Length - 1] = runningFeatures;
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            var capturedInputs = graphInputs.ToArray();
+            object[] savedState =
+            {
+                biasInputIndices,
+                hiddenActivation,
+                outputActivation,
+                hiddenActivationParams!,
+                outputActivationParams!
+            };
+            return scope.RecordVariadic(
+                LazyNodeType.MlpForward,
+                "MlpForward",
+                capturedInputs,
+                outputShape,
+                (eng, output) =>
+                {
+                    var eager = eng.MlpForward(
+                        capturedInputs[0], capturedWeights, capturedBiases,
+                        hiddenActivation, outputActivation,
+                        hiddenActivationParams, outputActivationParams);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState: savedState);
+        }
 
         // Issue #436: small-batch inference GEMMs are oversubscribed by the
         // default all-cores native-BLAS thread count. On a 16-core box the

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.MultiHeadAttention.cs
@@ -79,6 +79,8 @@ public partial class CpuEngine
         if (kWeight is null) throw new ArgumentNullException(nameof(kWeight));
         if (vWeight is null) throw new ArgumentNullException(nameof(vWeight));
         if (outWeight is null) throw new ArgumentNullException(nameof(outWeight));
+        if (mask is not null)
+            GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (input.Rank != 3)
             throw new ArgumentException($"MultiHeadAttentionForward expects rank-3 input [B, seq, dModel]; got rank {input.Rank}.", nameof(input));
         if (numHeads <= 0)
@@ -102,9 +104,43 @@ public partial class CpuEngine
             throw new ArgumentException($"outWeight must be [{dModel}, {dModel}].", nameof(outWeight));
 
         if (GraphMode.IsActive)
-            throw new InvalidOperationException(
-                "MultiHeadAttentionForward is inference-only and does not yet support GradientTape. " +
-                "For training, call the decomposed Q/K/V + SDPA + output projection primitives directly.");
+        {
+            // Compiled training must retain a differentiable primitive graph. Compiled inference,
+            // however, must preserve this fused operation as one replay step; decomposing it there
+            // recreates the dispatch/transposition cliff this kernel exists to avoid.
+            if (!GraphMode.IsInferenceTrace)
+            {
+                var expandedMask = ExpandAttentionMaskForGraph(mask, batch, numHeads, seqLen, seqLen);
+                return MultiHeadAttentionForwardGraph(
+                    input, qWeight, kWeight, vWeight, outWeight,
+                    expandedMask, batch, seqLen, dModel, numHeads, dHead);
+            }
+
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            var graphInputs = new[] { input, qWeight, kWeight, vWeight, outWeight };
+            var capturedMask = mask;
+            object[] savedState =
+            {
+                numHeads,
+                mask is null ? null! : mask.GetFlattenedData(),
+                mask is null ? null! : (int[])mask._shape.Clone()
+            };
+            return scope.RecordVariadic(
+                LazyNodeType.MultiHeadAttentionForward,
+                "MultiHeadAttentionForward",
+                graphInputs,
+                (int[])input._shape.Clone(),
+                (eng, output) =>
+                {
+                    var eager = eng.MultiHeadAttentionForward(
+                        graphInputs[0], graphInputs[1], graphInputs[2], graphInputs[3], graphInputs[4],
+                        numHeads, capturedMask);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState);
+        }
 
         // Float fast path: direct SimdGemm + in-layout Q/K/V scratch + a
         // single output-projection transpose. Avoids the 4 strided-transpose
@@ -761,5 +797,67 @@ public partial class CpuEngine
         var concatFlat = concat.Reshape(new[] { batch * seqLen, dModel });
         var outFlat = TensorMatMul(concatFlat, outWeight);
         return outFlat.Reshape(new[] { batch, seqLen, dModel });
+    }
+
+    private Tensor<T> MultiHeadAttentionForwardGraph<T>(
+        Tensor<T> input,
+        Tensor<T> qWeight,
+        Tensor<T> kWeight,
+        Tensor<T> vWeight,
+        Tensor<T> outWeight,
+        Tensor<bool>? mask,
+        int batch,
+        int seqLen,
+        int dModel,
+        int numHeads,
+        int dHead)
+    {
+        var inputFlat = Reshape(input, new[] { batch * seqLen, dModel });
+        var qFlat = TensorMatMul(inputFlat, qWeight);
+        var kFlat = TensorMatMul(inputFlat, kWeight);
+        var vFlat = TensorMatMul(inputFlat, vWeight);
+
+        var q = TensorPermute(Reshape(qFlat, new[] { batch, seqLen, numHeads, dHead }), new[] { 0, 2, 1, 3 });
+        var k = TensorPermute(Reshape(kFlat, new[] { batch, seqLen, numHeads, dHead }), new[] { 0, 2, 1, 3 });
+        var v = TensorPermute(Reshape(vFlat, new[] { batch, seqLen, numHeads, dHead }), new[] { 0, 2, 1, 3 });
+        var attended = ScaledDotProductAttention(q, k, v, mask, scale: null, out _);
+        var concat = Reshape(
+            TensorPermute(attended, new[] { 0, 2, 1, 3 }),
+            new[] { batch * seqLen, dModel });
+        return Reshape(TensorMatMul(concat, outWeight), new[] { batch, seqLen, dModel });
+    }
+
+    private static Tensor<bool>? ExpandAttentionMaskForGraph(
+        Tensor<bool>? mask, int batch, int heads, int seqQ, int seqK)
+    {
+        if (mask is null) return null;
+        if (mask.Rank != 4)
+            throw new ArgumentException("Attention mask must be rank 4.", nameof(mask));
+
+        int[] target = { batch, heads, seqQ, seqK };
+        for (int axis = 0; axis < 4; axis++)
+        {
+            if (mask._shape[axis] != 1 && mask._shape[axis] != target[axis])
+                throw new ArgumentException(
+                    $"Attention mask axis {axis} has extent {mask._shape[axis]}; expected 1 or {target[axis]}.",
+                    nameof(mask));
+        }
+
+        if (mask._shape[0] == batch && mask._shape[1] == heads &&
+            mask._shape[2] == seqQ && mask._shape[3] == seqK)
+            return mask;
+
+        var expanded = new bool[batch * heads * seqQ * seqK];
+        int dst = 0;
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < heads; h++)
+                for (int q = 0; q < seqQ; q++)
+                    for (int k = 0; k < seqK; k++)
+                        expanded[dst++] = mask[
+                            mask._shape[0] == 1 ? 0 : b,
+                            mask._shape[1] == 1 ? 0 : h,
+                            mask._shape[2] == 1 ? 0 : q,
+                            mask._shape[3] == 1 ? 0 : k];
+        return new Tensor<bool>(expanded, target);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210.cs
@@ -189,8 +189,8 @@ public partial class CpuEngine
                 var cd = dim;
                 var graphShape = (int[])tensor._shape.Clone();
                 graphShape[dim] = tensor._shape[dim] * repeats;
-                return scope.RecordUnary(LazyNodeType.Custom, "TensorRepeatInterleave", tensor, graphShape,
-                    (eng, output) => { var r = eng.TensorRepeatInterleave(ct, cr, cd); r.AsSpan().CopyTo(output.AsWritableSpan()); },
+                return scope.RecordUnary(LazyNodeType.TensorRepeatInterleave, "TensorRepeatInterleave", tensor, graphShape,
+                    (eng, output) => { var r = eng.TensorRepeatInterleave(ct, cr, cd); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
                     BackwardFunctions<T>.RepeatInterleaveBackward, new object[] { cr, cd });
             }
         }
@@ -330,6 +330,8 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorAtLeast1D<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return Reshape(tensor, tensor.Rank >= 1 ? tensor._shape : new[] { 1 });
         return tensor.Rank >= 1 ? tensor : tensor.Reshape(new[] { 1 });
     }
 
@@ -439,6 +441,7 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -477,6 +480,7 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int rank = tensor.Rank;
         if (dim < 0) dim += rank;
         if (dim < 0 || dim >= rank) throw new ArgumentOutOfRangeException(nameof(dim));
@@ -593,6 +597,9 @@ public partial class CpuEngine
         if (b == null) throw new ArgumentNullException(nameof(b));
         if (axesA == null) throw new ArgumentNullException(nameof(axesA));
         if (axesB == null) throw new ArgumentNullException(nameof(axesB));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { a, b }, engine => engine.TensorDot(a, b, axesA, axesB));
         if (axesA.Length != axesB.Length)
             throw new ArgumentException("axesA and axesB must have the same length");
 
@@ -669,6 +676,9 @@ public partial class CpuEngine
     {
         if (x1 == null) throw new ArgumentNullException(nameof(x1));
         if (x2 == null) throw new ArgumentNullException(nameof(x2));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { x1, x2 }, engine => engine.TensorCosineSimilarity(x1, x2, dim, eps));
         if (!x1._shape.SequenceEqual(x2._shape))
             throw new ArgumentException("CosineSimilarity: shapes must match");
 
@@ -747,6 +757,8 @@ public partial class CpuEngine
         // Output shape: 1-D of length N·(N-1)/2, ordered (0,1),(0,2),...,
         // matching torch.pdist.
         if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.TensorPDist(input, p));
         if (input.Rank != 2) throw new ArgumentException("PDist requires rank-2 input");
         int n = input._shape[0];
         int d = input._shape[1];
@@ -782,6 +794,9 @@ public partial class CpuEngine
         // Cross pairwise p-norm: output[i, j] = ‖x1[i] − x2[j]‖_p.
         if (x1 == null) throw new ArgumentNullException(nameof(x1));
         if (x2 == null) throw new ArgumentNullException(nameof(x2));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { x1, x2 }, engine => engine.TensorCDist(x1, x2, p));
         if (x1.Rank != 2 || x2.Rank != 2)
             throw new ArgumentException("CDist requires rank-2 inputs");
         if (x1._shape[1] != x2._shape[1])
@@ -902,6 +917,8 @@ public partial class CpuEngine
         // from i*b_dim + j along each axis.
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorKron(a, b));
 
         int rankA = a.Rank;
         int rankB = b.Rank;
@@ -982,6 +999,8 @@ public partial class CpuEngine
         // a.shape[:-1] + b.shape[:-1]; contracts matching last-axis sizes.
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorInner(a, b));
         if (a._shape[a.Rank - 1] != b._shape[b.Rank - 1])
             throw new ArgumentException(
                 $"Inner: last-axis sizes must match ({a._shape[a.Rank - 1]} vs {b._shape[b.Rank - 1]})");
@@ -1019,6 +1038,8 @@ public partial class CpuEngine
         if (tensors == null) throw new ArgumentNullException(nameof(tensors));
         if (tensors.Length == 0)
             throw new ArgumentException("CartesianProd requires at least one tensor");
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(tensors, engine => engine.TensorCartesianProd(tensors));
         foreach (var t in tensors)
         {
             if (t == null) throw new ArgumentNullException(nameof(tensors));
@@ -1068,6 +1089,9 @@ public partial class CpuEngine
     {
         if (tensors == null) throw new ArgumentNullException(nameof(tensors));
         if (tensors.Length == 0) return System.Array.Empty<Tensor<T>>();
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernelOutputs(
+                tensors, engine => engine.TensorMeshgrid(tensors, indexing));
         foreach (var t in tensors)
         {
             if (t == null) throw new ArgumentNullException(nameof(tensors));
@@ -1113,7 +1137,7 @@ public partial class CpuEngine
                 var rshape = new int[d];
                 for (int i = 0; i < d; i++) rshape[i] = 1;
                 rshape[axis] = tensors[k]._shape[0];
-                taped[k] = TensorBroadcastTo(tensors[k].Reshape(rshape), outShape);
+                taped[k] = TensorBroadcastTo(Reshape(tensors[k], rshape), outShape);
             }
 
             return taped;
@@ -1420,6 +1444,9 @@ public partial class CpuEngine
         // result[i] = m + log(s)
         // Numerically stable across wide dynamic ranges.
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorLogCumSumExp(tensor, axis));
         int rank = tensor.Rank;
         if (axis < 0) axis += rank;
         if (axis < 0 || axis >= rank) throw new ArgumentOutOfRangeException(nameof(axis));
@@ -1694,6 +1721,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> TensorNonzero<T>(Tensor<T> tensor)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         var ops = MathHelper.GetNumericOperations<T>();
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
@@ -1802,6 +1831,8 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorClampMin<T>(Tensor<T> tensor, T min)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { tensor }, engine => engine.TensorClampMin(tensor, min));
         var ops = MathHelper.GetNumericOperations<T>();
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
         var src = tensor.AsSpan();
@@ -1825,6 +1856,8 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorClampMax<T>(Tensor<T> tensor, T max)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { tensor }, engine => engine.TensorClampMax(tensor, max));
         var ops = MathHelper.GetNumericOperations<T>();
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
         var src = tensor.AsSpan();
@@ -1848,6 +1881,14 @@ public partial class CpuEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (min is null && max is null)
             throw new ArgumentException("At least one of min / max must be supplied");
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] inputs = min is null
+                ? new[] { tensor, max! }
+                : max is null ? new[] { tensor, min } : new[] { tensor, min, max };
+            return CaptureInferenceKernel(
+                inputs, engine => engine.TensorClampTensor(tensor, min, max));
+        }
 
         var ops = MathHelper.GetNumericOperations<T>();
         // #257: preserve the user-facing ref before .Contiguous() discards GradFn. Recording the
@@ -1926,6 +1967,10 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (source == null) throw new ArgumentNullException(nameof(source));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor, source },
+                engine => engine.TensorSelectScatter(tensor, source, dim, index));
         int rank = tensor.Rank;
         if (dim < 0) dim += rank;
         if (dim < 0 || dim >= rank) throw new ArgumentOutOfRangeException(nameof(dim));
@@ -2005,6 +2050,7 @@ public partial class CpuEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int rank = tensor.Rank;
         if (axis < 0) axis += rank;
         if (axis < 0 || axis >= rank) throw new ArgumentOutOfRangeException(nameof(axis));
@@ -2076,6 +2122,8 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorIndexPut<T>(
         Tensor<T> tensor, Tensor<int>[] indices, Tensor<T> source, bool accumulate = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2145,6 +2193,7 @@ public partial class CpuEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int rank = tensor.Rank;
         if (axis < 0) axis += rank;
         if (axis < 0 || axis >= rank) throw new ArgumentOutOfRangeException(nameof(axis));
@@ -2214,6 +2263,9 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (other == null) throw new ArgumentNullException(nameof(other));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor, other }, engine => engine.TensorExpandAs(tensor, other));
         return TensorBroadcastTo(tensor, other._shape);
     }
 
@@ -2278,6 +2330,8 @@ public partial class CpuEngine
     {
         if (matrices == null) throw new ArgumentNullException(nameof(matrices));
         if (matrices.Length == 0) throw new ArgumentException("BlockDiag requires at least one matrix");
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(matrices, engine => engine.TensorBlockDiag(matrices));
 
         var ops = MathHelper.GetNumericOperations<T>();
         int totalRows = 0, totalCols = 0;
@@ -2321,6 +2375,10 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (source == null) throw new ArgumentNullException(nameof(source));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor, source },
+                engine => engine.TensorSliceScatter(tensor, source, dim, start, length));
         int rank = tensor.Rank;
         if (dim < 0) dim += rank;
         if (dim < 0 || dim >= rank) throw new ArgumentOutOfRangeException(nameof(dim));
@@ -2372,6 +2430,8 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorIndexFill<T>(
         Tensor<T> tensor, int axis, Tensor<int> indices, T value)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         int rank = tensor.Rank;
@@ -2413,6 +2473,8 @@ public partial class CpuEngine
         Tensor<T> tensor, int dim, Tensor<int> indices, Tensor<T> source,
         ScatterReduceMode mode, bool includeSelf = true)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));
@@ -2552,6 +2614,7 @@ public partial class CpuEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (mask == null) throw new ArgumentNullException(nameof(mask));
         if (source == null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (!tensor._shape.SequenceEqual(mask._shape))
             throw new ArgumentException(
                 $"mask shape [{string.Join(", ", mask._shape)}] must match tensor shape [{string.Join(", ", tensor._shape)}]");
@@ -2664,6 +2727,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> TensorArgsort<T>(Tensor<T> input, int axis = -1, bool descending = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         // Argsort is just Sort discarding the values tensor. We share the
         // same kernel path so any future SIMD Sort lands here too.
         var (_, indices) = TensorSort(input, axis, descending);
@@ -2793,6 +2858,9 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorHistc<T>(Tensor<T> input, int bins, T min, T max)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.TensorHistc(input, bins, min, max));
         if (bins < 1) throw new ArgumentOutOfRangeException(nameof(bins));
 
         var ops = MathHelper.GetNumericOperations<T>();
@@ -2913,6 +2981,9 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (sections <= 0) throw new ArgumentOutOfRangeException(nameof(sections));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernelOutputs(
+                new[] { tensor }, engine => engine.TensorTensorSplit(tensor, sections, dim));
         int rank = tensor.Rank;
         if (dim < 0) dim += rank;
         if (dim < 0 || dim >= rank) throw new ArgumentOutOfRangeException(nameof(dim));
@@ -2938,6 +3009,9 @@ public partial class CpuEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernelOutputs(
+                new[] { tensor }, engine => engine.TensorTensorSplit(tensor, indices, dim));
         int rank = tensor.Rank;
         if (dim < 0) dim += rank;
         if (dim < 0 || dim >= rank) throw new ArgumentOutOfRangeException(nameof(dim));
@@ -2990,6 +3064,9 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorUnfold<T>(Tensor<T> tensor, int dim, int size, int step)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorUnfold(tensor, dim, size, step));
         if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size), "size must be positive");
         if (step <= 0) throw new ArgumentOutOfRangeException(nameof(step), "step must be positive");
         int rank = tensor.Rank;
@@ -3060,6 +3137,11 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> TensorZeta<T>(Tensor<T> x, Tensor<T> q)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (q == null) throw new ArgumentNullException(nameof(q));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { x, q }, engine => engine.TensorZeta(x, q));
+
         // ζ(x, q) = Σ_{k=0}^∞ (k + q)^{-x}.
         //
         // Strategy: accelerated Euler-Maclaurin summation. For x ≤ 1 the
@@ -3196,6 +3278,8 @@ public partial class CpuEngine
     public virtual Tensor<int> TensorSearchSorted<T>(
         Tensor<T> sortedSequence, Tensor<T> values, bool right = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (sortedSequence == null) throw new ArgumentNullException(nameof(sortedSequence));
         if (values == null) throw new ArgumentNullException(nameof(values));
         if (sortedSequence.Rank != 1)
@@ -3303,11 +3387,16 @@ public partial class CpuEngine
 
     /// <inheritdoc/>
     public virtual Tensor<int> TensorBucketize<T>(Tensor<T> input, Tensor<T> boundaries, bool right = false)
-        => TensorSearchSorted(boundaries, input, right);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+        return TensorSearchSorted(boundaries, input, right);
+    }
 
     /// <inheritdoc/>
     public virtual Tensor<int> TensorBinCount(Tensor<int> input, int? minLength = null)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (input.Rank != 1) throw new ArgumentException("BinCount requires a 1-D int tensor");
         if (!input.IsContiguous) input = input.Contiguous();
@@ -3334,6 +3423,8 @@ public partial class CpuEngine
     {
         if (matrices == null) throw new ArgumentNullException(nameof(matrices));
         if (matrices.Length == 0) throw new ArgumentException("MultiDot requires at least one matrix");
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(matrices, engine => engine.TensorMultiDot(matrices));
         if (matrices.Length == 1) return matrices[0];
 
         // Build einsum equation: "ab,bc,cd,...->a?" — one distinct char per
@@ -3361,6 +3452,8 @@ public partial class CpuEngine
     public virtual Tensor<int> TensorHistogramDD<T>(
         Tensor<T> samples, int[] bins, T[] mins, T[] maxs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (samples == null) throw new ArgumentNullException(nameof(samples));
         if (bins == null) throw new ArgumentNullException(nameof(bins));
         if (mins == null) throw new ArgumentNullException(nameof(mins));
@@ -3425,6 +3518,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> TensorHistogram<T>(Tensor<T> input, int bins, T min, T max)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (bins < 1) throw new ArgumentOutOfRangeException(nameof(bins));
 
@@ -3578,6 +3673,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> TensorLdexp<T>(Tensor<T> x, Tensor<int> exp)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (x == null) throw new ArgumentNullException(nameof(x));
         if (exp == null) throw new ArgumentNullException(nameof(exp));
         if (!x._shape.SequenceEqual(exp._shape))
@@ -3697,6 +3794,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> TensorPut<T>(Tensor<T> tensor, Tensor<int> indices, Tensor<T> source)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         // Flat-indexed scatter. Inverse of Take: tensor[indices.flatten()] = source.
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
@@ -3796,6 +3895,10 @@ public partial class CpuEngine
     public virtual Tensor<T> TensorPolygamma<T>(int n, Tensor<T> tensor)
     {
         if (n < 0) throw new ArgumentOutOfRangeException(nameof(n), "Polygamma order must be >= 0");
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorPolygamma(n, tensor));
         if (n == 0) return TensorDigamma(tensor);
 
         var result = ElementwiseUnary(tensor, x => {
@@ -4035,6 +4138,14 @@ public partial class CpuEngine
                 edst[i] = 0;
                 continue;
             }
+            // frexp preserves non-finite values and reports no meaningful exponent. Without
+            // this guard +Infinity reached the normalization loop below and never terminated.
+            if (System.Double.IsNaN(xd) || System.Double.IsInfinity(xd))
+            {
+                mdst[i] = src[i];
+                edst[i] = 0;
+                continue;
+            }
             int e = (int)System.Math.Floor(System.Math.Log(System.Math.Abs(xd), 2.0)) + 1;
             double m = xd * System.Math.Pow(2.0, -e);
             // Normalise into [0.5, 1) — adjust by one step if floating error
@@ -4050,6 +4161,10 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> TensorDigamma<T>(Tensor<T> tensor)
     {
+        if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { tensor }, engine => engine.TensorDigamma(tensor));
+
         var result = ElementwiseUnary(tensor, x => {
             var ops = MathHelper.GetNumericOperations<T>();
             double xd = ToDoubleSafe(x);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210Packed.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.Parity210Packed.cs
@@ -1,5 +1,6 @@
 using System;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines.Compilation;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -37,6 +38,8 @@ public partial class CpuEngine
     public virtual Tensor<byte> TensorGatherPacked(
         Tensor<byte> packed, Tensor<int> indices, int axis, int valuesPerByte)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (packed == null) throw new ArgumentNullException(nameof(packed));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (valuesPerByte != 1 && valuesPerByte != 2 && valuesPerByte != 4 && valuesPerByte != 8)
@@ -89,6 +92,8 @@ public partial class CpuEngine
     public virtual Tensor<byte> TensorScatterPacked(
         Tensor<byte> packed, Tensor<int> indices, Tensor<byte> source, int axis, int valuesPerByte)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (packed == null) throw new ArgumentNullException(nameof(packed));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -10,6 +10,7 @@ using System;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines.Compilation;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -24,6 +25,13 @@ public partial class CpuEngine
         int outputHeight, int outputWidth,
         float spatialScale, int samplingRatio, bool aligned)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (boxes == null) throw new ArgumentNullException(nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input, boxes },
+                engine => engine.RoIAlign(
+                    input, boxes, outputHeight, outputWidth, spatialScale, samplingRatio, aligned));
         var result = RoIAlignImpl(input, boxes, outputHeight, outputWidth, spatialScale, samplingRatio, aligned);
         DifferentiableOps.RecordBinary("RoIAlign", result, input, boxes,
             BackwardFunctions<T>.RoIAlignBackward,
@@ -119,6 +127,12 @@ public partial class CpuEngine
     public virtual Tensor<T> RoIPool<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, float spatialScale)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (boxes == null) throw new ArgumentNullException(nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input, boxes },
+                engine => engine.RoIPool(input, boxes, outputHeight, outputWidth, spatialScale));
         var result = RoIPoolImpl(input, boxes, outputHeight, outputWidth, spatialScale);
         DifferentiableOps.RecordBinary("RoIPool", result, input, boxes,
             BackwardFunctions<T>.RoIPoolBackward,
@@ -201,6 +215,14 @@ public partial class CpuEngine
         int outputHeight, int outputWidth, int outputChannels,
         float spatialScale, int samplingRatio)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (boxes == null) throw new ArgumentNullException(nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input, boxes },
+                engine => engine.PsRoIAlign(
+                    input, boxes, outputHeight, outputWidth, outputChannels, spatialScale,
+                    samplingRatio));
         var result = PsRoIAlignImpl(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale, samplingRatio);
         DifferentiableOps.RecordBinary("PsRoIAlign", result, input, boxes,
             BackwardFunctions<T>.PsRoIAlignBackward,
@@ -273,6 +295,13 @@ public partial class CpuEngine
     public virtual Tensor<T> PsRoIPool<T>(Tensor<T> input, Tensor<T> boxes,
         int outputHeight, int outputWidth, int outputChannels, float spatialScale)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (boxes == null) throw new ArgumentNullException(nameof(boxes));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input, boxes },
+                engine => engine.PsRoIPool(
+                    input, boxes, outputHeight, outputWidth, outputChannels, spatialScale));
         var result = PsRoIPoolImpl(input, boxes, outputHeight, outputWidth, outputChannels, spatialScale);
         DifferentiableOps.RecordBinary("PsRoIPool", result, input, boxes,
             BackwardFunctions<T>.PsRoIPoolBackward,
@@ -341,6 +370,14 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Spectrogram<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
     {
+        if (waveform == null) throw new ArgumentNullException(nameof(waveform));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] inputs = window is null ? new[] { waveform } : new[] { waveform, window };
+            return CaptureInferenceKernel(
+                inputs,
+                engine => engine.Spectrogram(waveform, nFft, hopLength, winLength, window));
+        }
         // Run STFT and return only magnitude. Backward uses the saved
         // phase to pipe the magnitude gradient through ISTFT — see
         // BackwardFunctions<T>.SpectrogramBackward.
@@ -368,6 +405,10 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> AmplitudeToDB<T>(Tensor<T> input, float minAmplitude = 1e-10f, float? topDb = null)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.AmplitudeToDB(input, minAmplitude, topDb));
         var result = AmplitudeToDBImpl(input, minAmplitude, topDb);
         // topDb clips post-hoc against the peak — the clip mask ideally
         // zeros gradient where clipped, but that needs a saved mask.
@@ -408,6 +449,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (quantizationChannels < 2)
             throw new ArgumentException("quantizationChannels must be >= 2 (μ = qc − 1 must be positive).",
                 nameof(quantizationChannels));
@@ -432,6 +475,8 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (quantizationChannels < 2)
             throw new ArgumentException("quantizationChannels must be >= 2.", nameof(quantizationChannels));
         var ops = MathHelper.GetNumericOperations<T>();
@@ -452,6 +497,10 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> ComputeDeltas<T>(Tensor<T> input, int winLength = 5)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.ComputeDeltas(input, winLength));
         var result = ComputeDeltasImpl(input, winLength);
         DifferentiableOps.RecordUnary("ComputeDeltas", result, input,
             BackwardFunctions<T>.ComputeDeltasBackward,
@@ -500,6 +549,10 @@ public partial class CpuEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Resample<T>(Tensor<T> waveform, int origRate, int newRate)
     {
+        if (waveform == null) throw new ArgumentNullException(nameof(waveform));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveform }, engine => engine.Resample(waveform, origRate, newRate));
         var result = ResampleImpl(waveform, origRate, newRate);
         DifferentiableOps.RecordUnary("Resample", result, waveform,
             BackwardFunctions<T>.ResampleBackward,
@@ -589,6 +642,11 @@ public partial class CpuEngine
     public virtual Tensor<T> PitchShift<T>(Tensor<T> waveform, int sampleRate, double nSteps,
         int nFft = 512, int hopLength = 128)
     {
+        if (waveform == null) throw new ArgumentNullException(nameof(waveform));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveform },
+                engine => engine.PitchShift(waveform, sampleRate, nSteps, nFft, hopLength));
         // Semitone ratio.
         double rate = Math.Pow(2.0, nSteps / 12.0);
         // Time-stretch by 1/rate so pitch shifts when resampled back.
@@ -603,6 +661,10 @@ public partial class CpuEngine
     public virtual Tensor<T> TimeStretch<T>(Tensor<T> waveform, double rate,
         int nFft = 512, int hopLength = 128)
     {
+        if (waveform == null) throw new ArgumentNullException(nameof(waveform));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveform }, engine => engine.TimeStretch(waveform, rate, nFft, hopLength));
         if (rate <= 0) throw new ArgumentException("rate must be positive.");
         if (nFft < 2) throw new ArgumentException("nFft must be at least 2 (Hann window divides by nFft−1).");
         if (hopLength <= 0) throw new ArgumentException("hopLength must be positive.");

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -2125,6 +2125,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> ReorderToNchw<T>(Tensor<T> tensor)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace && tensor.Layout == LinearAlgebra.TensorLayout.Nchw)
+            return Reshape(tensor, tensor._shape);
         if (tensor.Layout == LinearAlgebra.TensorLayout.Nchw) return tensor;
         if (tensor.Rank != 4)
             throw new ArgumentException($"NCHWc → NCHW reorder requires rank-4 input, got rank {tensor.Rank}.");
@@ -2450,6 +2452,10 @@ public partial class CpuEngine : ITensorLevelEngine
         if (beta == null) throw new ArgumentNullException(nameof(beta));
         if (mean == null) throw new ArgumentNullException(nameof(mean));
         if (variance == null) throw new ArgumentNullException(nameof(variance));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { x, gamma, beta, mean, variance },
+                engine => engine.BatchNormAffine(x, gamma, beta, mean, variance, epsilon));
         if (x.Rank != 4) throw new ArgumentException($"BatchNormAffine requires rank-4 NCHW input, got rank {x.Rank}.");
 
         var xOrig = x;
@@ -4138,6 +4144,28 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (gamma is null) throw new ArgumentNullException(nameof(gamma));
         if (beta is null) throw new ArgumentNullException(nameof(beta));
+        if (GraphMode.IsInferenceTrace)
+        {
+            CaptureInferenceIntoKernel(
+                output,
+                new[] { input, gamma, beta },
+                (engine, destination) =>
+                    engine.GroupNormInto(
+                        destination, input, numGroups, gamma, beta, epsilon, out _, out _));
+            Tensor<T>[] statistics = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta },
+                engine =>
+                {
+                    engine.GroupNorm(
+                        input, numGroups, gamma, beta, epsilon, out Tensor<T> freshMean,
+                        out Tensor<T> freshVariance);
+                    return new[] { freshMean, freshVariance };
+                },
+                operationName: "GroupNormIntoStatistics");
+            mean = statistics[0];
+            variance = statistics[1];
+            return;
+        }
         if (!output.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
         if (numGroups <= 0) throw new ArgumentOutOfRangeException(nameof(numGroups), "Number of groups must be positive.");
 
@@ -4372,6 +4400,14 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+        {
+            CaptureInferenceIntoKernel(
+                destination,
+                new[] { input },
+                (engine, output) => engine.GELUInto(output, input));
+            return;
+        }
         if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
@@ -6392,6 +6428,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorEquals<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorEquals(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6411,6 +6450,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorEquals(a, b));
         var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!a.IsContiguous) a = a.Contiguous();
         var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -6437,6 +6478,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorNotEquals<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorNotEquals(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6456,6 +6500,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorNotEquals(a, b));
         var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!a.IsContiguous) a = a.Contiguous();
         var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -6483,6 +6529,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorGreaterThan(a, b));
         var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!a.IsContiguous) a = a.Contiguous();
         var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -6509,6 +6557,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorGreaterThan<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorGreaterThan(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6528,6 +6579,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorLessThan(a, b));
         var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!a.IsContiguous) a = a.Contiguous();
         var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -6554,6 +6607,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorLessThan<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { tensor }, engine => engine.TensorLessThan(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -7313,8 +7369,9 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException("Grid must be 4D tensor of shape [D, H, W, C]", nameof(grid));
         if (positions._shape.Length != 2 || positions._shape[1] != 3)
             throw new ArgumentException("Positions must be 2D tensor of shape [N, 3]", nameof(positions));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_grid = grid; var c_positions = positions; return scope.RecordBinary(LazyNodeType.Custom, "TensorTrilinearInterpolate", grid, positions, grid._shape, (eng, output) => { var r = eng.TensorTrilinearInterpolate(c_grid, c_positions); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.TrilinearInterpolateBackward); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorTrilinearInterpolate", grid._shape); if (ac is not null) return ac.Execute(); }
+        var outputShape = new[] { positions._shape[0], grid._shape[3] };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_grid = grid; var c_positions = positions; return scope.RecordBinary(LazyNodeType.Custom, "TensorTrilinearInterpolate", grid, positions, outputShape, (eng, output) => { var r = eng.TensorTrilinearInterpolate(c_grid, c_positions); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.TrilinearInterpolateBackward); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorTrilinearInterpolate", outputShape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int depth = grid._shape[0];
@@ -7323,7 +7380,7 @@ public partial class CpuEngine : ITensorLevelEngine
         int channels = grid._shape[3];
         int numPositions = positions._shape[0];
 
-        var result = TensorAllocator.Rent<T>(new[] { numPositions, channels });
+        var result = TensorAllocator.Rent<T>(outputShape);
 
         // Rewritten from per-element Tensor-indexer access (grid[z,y,x,c] × 8 corners/channel +
         // positions[n,i] + numOps.ToDouble/FromDouble dispatch) to raw-array access with native
@@ -12014,6 +12071,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.GeGLU(input, dim));
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -12147,6 +12206,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.SwiGLU(input, dim));
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -12271,6 +12332,8 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.ReGLU(input, dim));
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -12812,14 +12875,19 @@ public partial class CpuEngine : ITensorLevelEngine
 
     internal void TensorMatMulFloatInto(Tensor<float> a, Tensor<float> b, Tensor<float> output)
     {
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!b.IsContiguous) b = b.Contiguous();
 
-        var aArr = a.GetDataArray();
-        var bArr = b.GetDataArray();
-        var oArr = output.GetDataArray();
+        // Read and write the tensors through their logical spans. Compiled plans commonly
+        // allocate tensors from ArrayPool buckets whose backing arrays are larger than the
+        // logical tensor. GetDataArray() must copy those tensors to preserve its exact-array
+        // contract, which both allocates on every replay and gives the cached-B GEMM path a
+        // different array identity on every call. Logical spans address pooled padding safely
+        // without materializing an intermediate array.
+        ReadOnlySpan<float> aSpan = a.AsSpan();
+        ReadOnlySpan<float> bSpan = b.AsSpan();
+        Span<float> outputSpan = output.AsWritableSpan();
+        float[]? liveB = b.GetLiveBackingArrayAllowingPaddingOrNull();
 
         // 2D × 2D — route through cached-B path (Path A: pre-pack weights)
         if (a.Rank == 2 && b.Rank == 2)
@@ -12831,11 +12899,24 @@ public partial class CpuEngine : ITensorLevelEngine
                 return;
             }
 
-            Simd.SimdGemm.SgemmWithCachedB(
-                new System.ReadOnlySpan<float>(aArr, 0, m * k),
-                bArr,
-                new System.Span<float>(oArr, 0, m * n),
-                m, k, n);
+            if (liveB is not null)
+            {
+                Simd.SimdGemm.SgemmWithCachedB(
+                    aSpan.Slice(0, m * k),
+                    liveB,
+                    outputSpan.Slice(0, m * n),
+                    m, k, n);
+            }
+            else
+            {
+                // Array-identity caching is valid only for genuine zero-offset backing
+                // storage. Views and native/mapped storage stay allocation-free via spans.
+                Simd.SimdGemm.Sgemm(
+                    aSpan.Slice(0, m * k),
+                    bSpan.Slice(0, k * n),
+                    outputSpan.Slice(0, m * n),
+                    m, k, n);
+            }
             return;
         }
 
@@ -12850,11 +12931,22 @@ public partial class CpuEngine : ITensorLevelEngine
             int n = b._shape[1];
             int batchSize = 1;
             for (int i = 0; i < aRank - 2; i++) batchSize *= a._shape[i];
-            Simd.SimdGemm.SgemmWithCachedB(
-                new System.ReadOnlySpan<float>(aArr, 0, batchSize * m * k),
-                bArr,
-                new System.Span<float>(oArr, 0, batchSize * m * n),
-                batchSize * m, k, n);
+            if (liveB is not null)
+            {
+                Simd.SimdGemm.SgemmWithCachedB(
+                    aSpan.Slice(0, batchSize * m * k),
+                    liveB,
+                    outputSpan.Slice(0, batchSize * m * n),
+                    batchSize * m, k, n);
+            }
+            else
+            {
+                Simd.SimdGemm.Sgemm(
+                    aSpan.Slice(0, batchSize * m * k),
+                    bSpan.Slice(0, k * n),
+                    outputSpan.Slice(0, batchSize * m * n),
+                    batchSize * m, k, n);
+            }
             return;
         }
 
@@ -12873,21 +12965,41 @@ public partial class CpuEngine : ITensorLevelEngine
             if (batchSize == 1)
             {
                 Simd.SimdGemm.Sgemm(
-                    new System.ReadOnlySpan<float>(aArr, 0, sliceA),
-                    new System.ReadOnlySpan<float>(bArr, 0, sliceB),
-                    new System.Span<float>(oArr, 0, sliceC),
+                    aSpan.Slice(0, sliceA),
+                    bSpan.Slice(0, sliceB),
+                    outputSpan.Slice(0, sliceC),
                     m, k, n);
             }
             else
             {
-                AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(0, batchSize, (long)batchSize * m * n * k, batch =>
+                // Spans cannot be captured by the parallel callback. Pin their storage for
+                // the synchronous extent of ParallelForOrSerial and capture only stable
+                // addresses; each worker reconstructs spans over its disjoint batch slice.
+                unsafe
                 {
-                    Simd.SimdGemm.SgemmSequential(
-                        new System.ReadOnlySpan<float>(aArr, batch * sliceA, sliceA),
-                        new System.ReadOnlySpan<float>(bArr, batch * sliceB, sliceB),
-                        new System.Span<float>(oArr, batch * sliceC, sliceC),
-                        m, k, n);
-                });
+                    fixed (float* aPointer = aSpan)
+                    fixed (float* bPointer = bSpan)
+                    fixed (float* outputPointer = outputSpan)
+                    {
+                        IntPtr aAddress = (IntPtr)aPointer;
+                        IntPtr bAddress = (IntPtr)bPointer;
+                        IntPtr outputAddress = (IntPtr)outputPointer;
+
+                        AiDotNet.Tensors.Helpers.CpuParallelSettings.ParallelForOrSerial(
+                            0,
+                            batchSize,
+                            (long)batchSize * m * n * k,
+                            batch =>
+                            {
+                                Simd.SimdGemm.SgemmSequential(
+                                    new ReadOnlySpan<float>((float*)aAddress.ToPointer() + batch * sliceA, sliceA),
+                                    new ReadOnlySpan<float>((float*)bAddress.ToPointer() + batch * sliceB, sliceB),
+                                    new Span<float>((float*)outputAddress.ToPointer() + batch * sliceC, sliceC),
+                                    m, k, n);
+                            },
+                            deterministicSafe: true);
+                    }
+                }
             }
             return;
         }
@@ -16627,6 +16739,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> MaxPool2DWithTensorIndices<T>(
         Tensor<T> input, int[] poolSize, int[] stride, out Tensor<int> maxIndices)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         Tensor<T> result;
         int[,,,,] coordinateIndices;
         using (new NoGradScope<T>())
@@ -21383,6 +21497,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> MaxPool3DWithTensorIndices<T>(
         Tensor<T> input, int[] poolSize, int[] stride, out Tensor<int> maxIndices)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         Tensor<T> result;
         int[,,,,,] coordinateIndices;
         using (new NoGradScope<T>())
@@ -23561,6 +23677,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> SphericalSoftmax<T>(Tensor<T> input, int axis = -1)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.SphericalSoftmax(input, axis));
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int rank = input.Rank;
@@ -23720,6 +23839,21 @@ public partial class CpuEngine : ITensorLevelEngine
         // pass dispatches to a different engine than the forward pass. See
         // BindEngineIfUnset's docstring for the full rationale (issue #350).
         AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current?.BindEngineIfUnset(this);
+
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta },
+                engine =>
+                {
+                    Tensor<T> result = engine.BatchNorm(
+                        input, gamma, beta, epsilon, out Tensor<T> freshMean, out Tensor<T> freshVariance);
+                    return new[] { result, freshMean, freshVariance };
+                });
+            mean = outputs[1];
+            variance = outputs[2];
+            return outputs[0];
+        }
 
         // GraphMode: execute eagerly (out params), but record result in graph for compiled plan
         if (GraphMode.IsActive)
@@ -25177,6 +25311,21 @@ public partial class CpuEngine : ITensorLevelEngine
         if (beta == null) throw new ArgumentNullException(nameof(beta));
         GradientTape<T>.Current?.BindEngineIfUnset(this);
 
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta },
+                engine =>
+                {
+                    Tensor<T> result = engine.LayerNorm(
+                        input, gamma, beta, epsilon, out Tensor<T> freshMean, out Tensor<T> freshVariance);
+                    return new[] { result, freshMean, freshVariance };
+                });
+            mean = outputs[1];
+            variance = outputs[2];
+            return outputs[0];
+        }
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -26610,6 +26759,22 @@ public partial class CpuEngine : ITensorLevelEngine
         if (gamma == null) throw new ArgumentNullException(nameof(gamma));
         if (beta == null) throw new ArgumentNullException(nameof(beta));
 
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta },
+                engine =>
+                {
+                    Tensor<T> result = engine.GroupNorm(
+                        input, numGroups, gamma, beta, epsilon,
+                        out Tensor<T> freshMean, out Tensor<T> freshVariance);
+                    return new[] { result, freshMean, freshVariance };
+                });
+            mean = outputs[1];
+            variance = outputs[2];
+            return outputs[0];
+        }
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -27271,6 +27436,19 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (gamma == null) throw new ArgumentNullException(nameof(gamma));
 
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma },
+                engine =>
+                {
+                    Tensor<T> result = engine.RMSNorm(input, gamma, epsilon, out Tensor<T> freshRms);
+                    return new[] { result, freshRms };
+                });
+            rms = outputs[1];
+            return outputs[0];
+        }
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -27595,6 +27773,42 @@ public partial class CpuEngine : ITensorLevelEngine
         if (kvHeads <= 0 || qHeads % kvHeads != 0)
             throw new ArgumentException($"Query heads ({qHeads}) must be a positive multiple of KV heads ({kvHeads}).");
 
+        if (GraphMode.IsActive)
+        {
+            if (!GraphMode.IsInferenceTrace)
+            {
+                int repeats = qHeads / kvHeads;
+                var graphKey = repeats == 1 ? key : TensorRepeatInterleave(key, repeats, 1);
+                var graphValue = repeats == 1 ? value : TensorRepeatInterleave(value, repeats, 1);
+                var graphMask = isCausal
+                    ? CreateCausalAttentionMaskForGraph(
+                        query._shape[0], qHeads, query._shape[2], key._shape[2],
+                        key._shape[2] - query._shape[2])
+                    : null;
+                return ScaledDotProductAttention(
+                    query, graphKey, graphValue, graphMask, scale, out _, softcap);
+            }
+
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            var graphInputs = new[] { query, key, value };
+            var outputShape = new[] { query._shape[0], qHeads, query._shape[2], value._shape[3] };
+            object[] savedState = { scale, isCausal, softcap };
+            return scope.RecordVariadic(
+                LazyNodeType.ScaledDotProductAttentionGqa,
+                "ScaledDotProductAttentionGqa",
+                graphInputs,
+                outputShape,
+                (eng, output) =>
+                {
+                    var eager = eng.ScaledDotProductAttentionGqa(
+                        graphInputs[0], graphInputs[1], graphInputs[2], scale, isCausal, softcap);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState: savedState);
+        }
+
         // CPU path: materialize the shared KV heads (managed, not on the record path — the GPU engine overrides
         // this to the fused GQA kernel that broadcasts inside the kernel with no copy), then run standard SDPA.
         Tensor<T> k = qHeads == kvHeads ? key : BroadcastKvHeads(key, qHeads);
@@ -27660,6 +27874,19 @@ public partial class CpuEngine : ITensorLevelEngine
         return new Tensor<T>(outArr, new[] { batch, qHeads, seq, headDim });
     }
 
+    private static Tensor<bool> CreateCausalAttentionMaskForGraph(
+        int batch, int heads, int seqQ, int seqK, int queryOffset)
+    {
+        var data = new bool[batch * heads * seqQ * seqK];
+        int index = 0;
+        for (int b = 0; b < batch; b++)
+            for (int h = 0; h < heads; h++)
+                for (int q = 0; q < seqQ; q++)
+                    for (int k = 0; k < seqK; k++)
+                        data[index++] = k <= q + queryOffset;
+        return new Tensor<bool>(data, new[] { batch, heads, seqQ, seqK });
+    }
+
     public Tensor<T> ScaledDotProductAttention<T>(
         Tensor<T> query,
         Tensor<T> key,
@@ -27676,6 +27903,8 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentNullException(nameof(key));
         if (value == null)
             throw new ArgumentNullException(nameof(value));
+        if (mask is not null)
+            GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
 
         // AiDotNet#1331: under GraphMode, decompose into primitive ops so each
         // records itself and the compiled plan's backward chains through the
@@ -29045,6 +29274,23 @@ public partial class CpuEngine : ITensorLevelEngine
         if (key == null) throw new ArgumentNullException(nameof(key));
         if (value == null) throw new ArgumentNullException(nameof(value));
 
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] inputs = attentionBias is null
+                ? new[] { query, key, value }
+                : new[] { query, key, value, attentionBias };
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                inputs,
+                engine =>
+                {
+                    Tensor<T> result = engine.FlashAttention(
+                        query, key, value, scale, isCausal, out Tensor<T> freshStats, attentionBias);
+                    return new[] { result, freshStats };
+                });
+            softmaxStats = outputs[1];
+            return outputs[0];
+        }
+
         var numOps = MathHelper.GetNumericOperations<T>();
 
         int batch = query._shape[0];
@@ -30267,6 +30513,69 @@ public partial class CpuEngine : ITensorLevelEngine
         if (numQHeads != numKVHeads * numQueriesPerKV)
             throw new ArgumentException($"Query heads ({numQHeads}) must equal KV heads ({numKVHeads}) * numQueriesPerKV ({numQueriesPerKV})");
 
+        if (GraphMode.IsInferenceTrace)
+        {
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            var graphInputs = new[] { query, key, value };
+
+            object[] SavedStateFor(int selectedOutput) =>
+                new object[]
+                {
+                    numQueriesPerKV,
+                    scale.HasValue,
+                    scale.GetValueOrDefault(),
+                    isCausal,
+                    selectedOutput
+                };
+
+            Action<IEngine, Tensor<T>> ReplaySelectedOutput(int selectedOutput) => (engine, output) =>
+            {
+                Tensor<T> result = engine.GroupedQueryAttention(
+                    graphInputs[0], graphInputs[1], graphInputs[2], numQueriesPerKV, scale, isCausal,
+                    out Tensor<T> freshAttentionWeights);
+                DirectGpuTensorEngine.CopyResultInto(
+                    engine, selectedOutput == 0 ? result : freshAttentionWeights, output);
+            };
+
+            Tensor<T> graphOutput = scope.RecordVariadic(
+                LazyNodeType.GroupedQueryAttention,
+                "GroupedQueryAttention",
+                graphInputs,
+                new[] { batch, numQHeads, seqQ, value._shape[3] },
+                ReplaySelectedOutput(0),
+                backwardFn: null,
+                savedState: SavedStateFor(0));
+            attentionWeights = scope.RecordVariadic(
+                LazyNodeType.GroupedQueryAttention,
+                "GroupedQueryAttention",
+                graphInputs,
+                new[] { batch, numQHeads, seqQ, seqK },
+                ReplaySelectedOutput(1),
+                backwardFn: null,
+                savedState: SavedStateFor(1));
+            return graphOutput;
+        }
+
+        if (GraphMode.IsActive)
+        {
+            // Preserve both public outputs without a side-effect-only secondary tensor: repeating
+            // K/V and invoking the already-recorded SDPA primitive naturally places the returned
+            // attention weights in the graph. This path is used only while tracing; eager GPU
+            // execution keeps the fused GroupedQueryAttention override.
+            var graphKey = numQueriesPerKV == 1
+                ? key
+                : TensorRepeatInterleave(key, numQueriesPerKV, 1);
+            var graphValue = numQueriesPerKV == 1
+                ? value
+                : TensorRepeatInterleave(value, numQueriesPerKV, 1);
+            var graphMask = isCausal
+                ? CreateCausalAttentionMaskForGraph(batch, numQHeads, seqQ, seqK, queryOffset: 0)
+                : null;
+            return ScaledDotProductAttention(
+                query, graphKey, graphValue, graphMask, scale, out attentionWeights);
+        }
+
         // Compute scale
         double scaleValue = scale ?? 1.0 / Math.Sqrt(headDim);
         T scaleFactor = numOps.FromDouble(scaleValue);
@@ -30534,6 +30843,8 @@ public partial class CpuEngine : ITensorLevelEngine
         double leakyReluAlpha,
         out Tensor<T> attentionCoeffs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         var numOps = MathHelper.GetNumericOperations<T>();
 
         int batchSize = nodeFeatures._shape[0];
@@ -30894,6 +31205,8 @@ public partial class CpuEngine : ITensorLevelEngine
         bool concatenate,
         out Tensor<T> attentionCoeffs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (nodeFeatures is null) throw new ArgumentNullException(nameof(nodeFeatures));
         if (edgeSourceIndices is null) throw new ArgumentNullException(nameof(edgeSourceIndices));
         if (edgeTargetIndices is null) throw new ArgumentNullException(nameof(edgeTargetIndices));
@@ -31086,7 +31399,7 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentNullException(nameof(source));
         if (indices == null)
             throw new ArgumentNullException(nameof(indices));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_source = source; var c_indices = indices; var c_dim = dim; var c_outputSize = outputSize; return scope.RecordUnary(LazyNodeType.Custom, "ScatterAdd", source, source._shape, (eng, output) => { var r = eng.ScatterAdd(c_source, c_indices, c_dim, c_outputSize); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterAddBackward); } }
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         { var ac = AutoTracer.TryGetCompiledPlan<T>("ScatterAdd", source._shape); if (ac is not null) return ac.Execute(); }
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -31207,6 +31520,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </summary>
     public virtual Tensor<T> ScatterMean<T>(Tensor<T> source, Tensor<int> indices, out Tensor<int>? counts, int dim = 0, int? outputSize = null)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         if (source == null)
             throw new ArgumentNullException(nameof(source));
         if (indices == null)
@@ -31450,6 +31765,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </summary>
     public Tensor<T> ScatterMax<T>(Tensor<T> source, Tensor<int> indices, out Tensor<int>? argmax, int dim = 0, int? outputSize = null)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         if (source == null)
             throw new ArgumentNullException(nameof(source));
         if (indices == null)
@@ -31604,6 +31921,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// </summary>
     public Tensor<T> ScatterSoftmax<T>(Tensor<T> source, Tensor<int> indices, int dim = 0, int? outputSize = null)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (source == null)
             throw new ArgumentNullException(nameof(source));
         if (indices == null)
@@ -31807,6 +32126,26 @@ public partial class CpuEngine : ITensorLevelEngine
         return uniqueAxes.OrderBy(a => a).ToArray();
     }
 
+    private static int[] GetReductionOutputShape(int[] inputShape, int[] normalizedAxes, bool keepDims)
+    {
+        var reducedAxes = new HashSet<int>(normalizedAxes);
+        var outputShape = new List<int>(inputShape.Length);
+        for (int dimension = 0; dimension < inputShape.Length; dimension++)
+        {
+            if (reducedAxes.Contains(dimension))
+            {
+                if (keepDims)
+                    outputShape.Add(1);
+            }
+            else
+            {
+                outputShape.Add(inputShape[dimension]);
+            }
+        }
+
+        return outputShape.Count == 0 ? new[] { 1 } : outputShape.ToArray();
+    }
+
     /// <inheritdoc/>
     public virtual Tensor<T> ReduceMax<T>(Tensor<T> input, int[] axes, bool keepDims, out int[] maxIndices)
     {
@@ -31822,14 +32161,8 @@ public partial class CpuEngine : ITensorLevelEngine
             {
                 // Compute output shape
                 var effectiveAxes = axes ?? Enumerable.Range(0, input.Rank).ToArray();
-                var normAxes = new HashSet<int>(effectiveAxes.Select(a => a < 0 ? input.Rank + a : a));
-                var outShapeList = new List<int>();
-                for (int d = 0; d < input.Rank; d++)
-                {
-                    if (normAxes.Contains(d)) { if (keepDims) outShapeList.Add(1); }
-                    else outShapeList.Add(input._shape[d]);
-                }
-                var outShape = outShapeList.Count > 0 ? outShapeList.ToArray() : new[] { 1 };
+                var captureAxes = ValidateAndNormalizeAxes(effectiveAxes, input.Rank);
+                var outShape = GetReductionOutputShape(input._shape, captureAxes, keepDims);
 
                 var capturedInput = input;
                 var capturedAxes = axes;
@@ -31942,19 +32275,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var normalizedAxes = ValidateAndNormalizeAxes(axes, inputShape.Length);
 
         // Compute output shape
-        var outputShapeList = new List<int>();
-        for (int i = 0; i < inputShape.Length; i++)
-        {
-            if (normalizedAxes.Contains(i))
-            {
-                if (keepDims) outputShapeList.Add(1);
-            }
-            else
-            {
-                outputShapeList.Add(inputShape[i]);
-            }
-        }
-        var outputShape = outputShapeList.Count > 0 ? outputShapeList.ToArray() : [1];
+        var outputShape = GetReductionOutputShape(inputShape, normalizedAxes, keepDims);
 
         int outputSize = outputShape.Aggregate(1, (a, b) => a * b);
         var outputData = new T[outputSize];
@@ -32005,6 +32326,13 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> ReduceMaxWithTensorIndices<T>(
         Tensor<T> input, int[] axes, bool keepDims, out Tensor<int> maxIndices)
     {
+        if (GraphMode.IsActive)
+        {
+            throw new NotSupportedException(
+                "ReduceMaxWithTensorIndices graph capture returns heterogeneous Tensor<T>/Tensor<int> " +
+                "outputs, which the homogeneous compiled-plan output contract cannot replay safely.");
+        }
+
         Tensor<T> result;
         int[] absoluteIndices;
         using (new NoGradScope<T>())
@@ -32791,8 +33119,13 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null)
             throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axes = axes; var c_keepDims = keepDims; var c_epsilon = epsilon; return scope.RecordUnary(LazyNodeType.Custom, "ReduceLogVariance", input, input._shape, (eng, output) => { var r = eng.ReduceLogVariance(c_input, c_axes, c_keepDims, c_epsilon); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ReduceLogVarianceBackward); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("ReduceLogVariance", input._shape); if (ac is not null) return ac.Execute(); }
+        var effectiveAxes = axes == null || axes.Length == 0
+            ? Enumerable.Range(0, input.Rank).ToArray()
+            : axes;
+        var normalizedAxes = ValidateAndNormalizeAxes(effectiveAxes, input.Rank);
+        var outputShape = GetReductionOutputShape(input._shape, normalizedAxes, keepDims);
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_axes = effectiveAxes; var c_keepDims = keepDims; var c_epsilon = epsilon; return scope.RecordUnary(LazyNodeType.Custom, "ReduceLogVariance", input, outputShape, (eng, output) => { var r = eng.ReduceLogVariance(c_input, c_axes, c_keepDims, c_epsilon); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ReduceLogVarianceBackward); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("ReduceLogVariance", outputShape); if (ac is not null) return ac.Execute(); }
 
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
@@ -32800,7 +33133,7 @@ public partial class CpuEngine : ITensorLevelEngine
         var numOps = MathHelper.GetNumericOperations<T>();
 
         // Compute variance first
-        var variance = ReduceVariance(input, axes, keepDims);
+        var variance = ReduceVariance(input, effectiveAxes, keepDims);
         var varianceData = variance.GetDataArray();
 
         // Apply log(variance + epsilon) into SEPARATE buffers.
@@ -32831,10 +33164,10 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<T> mean;
         using (new NoGradScope<T>())
         {
-            mean = ReduceMean(input, axes, keepDims);
+            mean = ReduceMean(input, effectiveAxes, keepDims);
         }
-        DifferentiableOps.RecordUnary("ReduceLogVariance", logVarResult, inputOrig, BackwardFunctions<T>.ReduceLogVarianceBackward, new object[] { axes, mean, varianceForBackward });
-        { var ci = input; var ca = axes; var ck = keepDims; var ce = epsilon; AutoTracer.RecordOp("ReduceLogVariance", logVarResult, eng => eng.ReduceLogVariance(ci, ca, ck, ce)); }
+        DifferentiableOps.RecordUnary("ReduceLogVariance", logVarResult, inputOrig, BackwardFunctions<T>.ReduceLogVarianceBackward, new object[] { effectiveAxes, mean, varianceForBackward });
+        { var ci = input; var ca = effectiveAxes; var ck = keepDims; var ce = epsilon; AutoTracer.RecordOp("ReduceLogVariance", logVarResult, eng => eng.ReduceLogVariance(ci, ca, ck, ce)); }
         return logVarResult;
     }
 
@@ -33401,6 +33734,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> AffineGrid<T>(Tensor<T> theta, int outputHeight, int outputWidth)
     {
         if (theta == null) throw new ArgumentNullException(nameof(theta));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { theta }, engine => engine.AffineGrid(theta, outputHeight, outputWidth));
         if (theta._shape.Length != 3 || theta._shape[1] != 2 || theta._shape[2] != 3)
             throw new ArgumentException("AffineGrid expects theta shape [batch, 2, 3]");
 
@@ -33826,6 +34162,17 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (aReal == null || aImag == null || bReal == null || bImag == null)
             throw new ArgumentNullException("ComplexMatMul inputs cannot be null");
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { aReal, aImag, bReal, bImag },
+                engine =>
+                {
+                    var result = engine.ComplexMatMul(aReal, aImag, bReal, bImag);
+                    return new[] { result.real, result.imag };
+                });
+            return (outputs[0], outputs[1]);
+        }
         var aShape = aReal._shape;
         var bShape = bReal._shape;
         if (aShape.Length != 2 || bShape.Length != 2 || aShape[1] != bShape[0])
@@ -33889,11 +34236,35 @@ public partial class CpuEngine : ITensorLevelEngine
 
     public (Tensor<T> real, Tensor<T> imag) ComplexNormalize<T>(Tensor<T> real, Tensor<T> imag)
     {
+        if (real == null) throw new ArgumentNullException(nameof(real));
+        if (imag == null) throw new ArgumentNullException(nameof(imag));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { real, imag },
+                engine =>
+                {
+                    var result = engine.ComplexNormalize(real, imag);
+                    return new[] { result.real, result.imag };
+                });
+            return (outputs[0], outputs[1]);
+        }
         var magSq = ComplexMagnitudeSquared(real, imag);
         var total = TensorSum(magSq);
         var numOps = MathHelper.GetNumericOperations<T>();
         if (numOps.Equals(total, numOps.Zero))
             return (real.Clone(), imag.Clone());
+
+        // Keep the norm on the tape. Turning the reduction into a host scalar made the divisor a
+        // detached constant, so gradients included only the direct numerator path and silently
+        // omitted the normalization term. Preserve the allocation-light scalar path outside tape.
+        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        {
+            var normSquared = ReduceSum(magSq, axes: null, keepDims: false);
+            var norm = TensorSqrt(normSquared);
+            return (TensorDivide(real, norm), TensorDivide(imag, norm));
+        }
+
         var denom = numOps.Sqrt(total);
         var denomTensor = AutoTensorCache.RentOrAllocate<T>(magSq._shape);
         denomTensor.Fill(denom);
@@ -34583,6 +34954,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (embeddings == null) throw new ArgumentNullException(nameof(embeddings));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
         if (embeddings.Rank != 2)
             throw new ArgumentException($"Embeddings must be a 2D tensor [vocab_size, embedding_dim]. Got rank {embeddings.Rank}.");
 
@@ -34875,9 +35247,6 @@ public partial class CpuEngine : ITensorLevelEngine
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (centers == null) throw new ArgumentNullException(nameof(centers));
         if (epsilons == null) throw new ArgumentNullException(nameof(epsilons));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_centers = centers; var c_epsilons = epsilons; return scope.RecordVariadic(LazyNodeType.Custom, "RBFKernel", new[] { input, centers, epsilons }, input._shape, (eng, output) => { var r = eng.RBFKernel(c_input, c_centers, c_epsilons); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RBFKernelBackward); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("RBFKernel", input._shape); if (ac is not null) return ac.Execute(); }
-
         if (input.Rank != 2)
             throw new ArgumentException($"input must be 2D [batch, features], got rank {input.Rank}", nameof(input));
         if (centers.Rank != 2)
@@ -34895,7 +35264,11 @@ public partial class CpuEngine : ITensorLevelEngine
         if (epsilons._shape[0] != numCenters)
             throw new ArgumentException($"epsilons length ({epsilons._shape[0]}) must match number of centers ({numCenters})", nameof(epsilons));
 
-        var output = TensorAllocator.Rent<T>([batchSize, numCenters]);
+        var outputShape = new[] { batchSize, numCenters };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_centers = centers; var c_epsilons = epsilons; return scope.RecordVariadic(LazyNodeType.Custom, "RBFKernel", new[] { input, centers, epsilons }, outputShape, (eng, output) => { var r = eng.RBFKernel(c_input, c_centers, c_epsilons); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RBFKernelBackward); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("RBFKernel", outputShape); if (ac is not null) return ac.Execute(); }
+
+        var output = TensorAllocator.Rent<T>(outputShape);
         var inputData = input.GetFlattenedData();
         var centersData = centers.GetFlattenedData();
         var epsilonsData = epsilons.GetFlattenedData();
@@ -35041,13 +35414,11 @@ public partial class CpuEngine : ITensorLevelEngine
         if (repeats < 1) throw new ArgumentOutOfRangeException(nameof(repeats), "Repeats must be at least 1");
         if (axis < 0 || axis >= tensor._shape.Length)
             throw new ArgumentOutOfRangeException(nameof(axis), $"Axis {axis} out of range for tensor with {tensor._shape.Length} dimensions");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; var c_repeats = repeats; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TensorRepeatElements", tensor, tensor._shape, (eng, output) => { var r = eng.TensorRepeatElements(c_tensor, c_repeats, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RepeatElementsBackward); } }
-
-
         // Calculate output shape
         var outputShape = new int[tensor._shape.Length];
         Array.Copy(tensor._shape, outputShape, tensor._shape.Length);
         outputShape[axis] *= repeats;
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; var c_repeats = repeats; var c_axis = axis; return scope.RecordUnary(LazyNodeType.Custom, "TensorRepeatElements", tensor, outputShape, (eng, output) => { var r = eng.TensorRepeatElements(c_tensor, c_repeats, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.RepeatElementsBackward); } }
 
         var result = AutoTensorCache.RentOrAllocate<T>(outputShape);
 
@@ -35428,13 +35799,13 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
-
-
         // Flatten both tensors to 1D
         int n = a.Length;
         int m = b.Length;
-        var result = TensorAllocator.Rent<T>([n, m]);
+        var outputShape = new[] { n, m };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuterProduct", a, b, outputShape, (eng, output) => { var r = eng.TensorOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
+
+        var result = TensorAllocator.Rent<T>(outputShape);
         var numOps = MathHelper.GetNumericOperations<T>();
 
         var aData = a.GetFlattenedData();
@@ -35465,13 +35836,13 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException("Both tensors must be 2D [batch, features]");
         if (a._shape[0] != b._shape[0])
             throw new ArgumentException("Batch sizes must match");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchOuterProduct", a, b, a._shape, (eng, output) => { var r = eng.TensorBatchOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
-
-
         int batch = a._shape[0];
         int n = a._shape[1];
         int m = b._shape[1];
-        var result = TensorAllocator.Rent<T>([batch, n, m]);
+        var outputShape = new[] { batch, n, m };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorBatchOuterProduct", a, b, outputShape, (eng, output) => { var r = eng.TensorBatchOuterProduct(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
+
+        var result = TensorAllocator.Rent<T>(outputShape);
         var numOps = MathHelper.GetNumericOperations<T>();
 
         CpuParallelSettings.ParallelForOrSerial(0, batch, (long)batch * n * m, bIdx =>
@@ -35708,11 +36079,11 @@ public partial class CpuEngine : ITensorLevelEngine
             if (scope != null)
             {
                 var captured = tensor;
-                var capturedAxes = axes;
+                var capturedAxes = (int[])axes.Clone();
                 // Compute permuted output shape
                 var outShape = new int[axes.Length];
                 for (int i = 0; i < axes.Length; i++) outShape[i] = tensor._shape[axes[i]];
-                return scope.RecordUnary(LazyNodeType.Custom, "TensorPermute", tensor, outShape,
+                return scope.RecordUnary(LazyNodeType.TensorPermute, "TensorPermute", tensor, outShape,
                     // Permute directly INTO the pre-allocated output via TensorPermuteInto: on the GPU engine
                     // this runs backend.Permute into output's resident buffer and leaves it GPU-resident (no
                     // host materialize/download — which would break the residency chain + abort CUDA-graph
@@ -35841,6 +36212,7 @@ public partial class CpuEngine : ITensorLevelEngine
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (updates == null) throw new ArgumentNullException(nameof(updates));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_destination = destination; var c_indices = indices; var c_updates = updates; var c_axis = axis; return scope.RecordBinary(LazyNodeType.Custom, "TensorScatterAdd", destination, updates, destination._shape, (eng, output) => { var r = eng.TensorScatterAdd(c_destination, c_indices, c_updates, c_axis); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterAddBackward); } }
 
         if (!destination.IsContiguous) throw new InvalidOperationException("Output tensor must be contiguous.");
@@ -35922,6 +36294,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (source == null) throw new ArgumentNullException(nameof(source));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         var indicesOrig = indices;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!indices.IsContiguous) indices = indices.Contiguous();
 
@@ -36707,6 +37080,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorDiag<T>(Tensor<T> diagonal)
     {
         if (diagonal == null) throw new ArgumentNullException(nameof(diagonal));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { diagonal }, engine => engine.TensorDiag(diagonal));
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int n = diagonal.Length;
@@ -36730,10 +37105,9 @@ public partial class CpuEngine : ITensorLevelEngine
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (tensor._shape.Length != 2)
             throw new ArgumentException("Tensor must be 2D");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorDiagonal", tensor, tensor._shape, (eng, output) => { var r = eng.TensorDiagonal(c_tensor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.DiagonalBackward); } }
-
-
         int n = Math.Min(tensor._shape[0], tensor._shape[1]);
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_tensor = tensor; return scope.RecordUnary(LazyNodeType.Custom, "TensorDiagonal", tensor, new[] { n }, (eng, output) => { var r = eng.TensorDiagonal(c_tensor); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.DiagonalBackward); } }
+
         var result = AutoTensorCache.RentOrAllocate<T>([n]);
 
         for (int i = 0; i < n; i++)
@@ -37538,6 +37912,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<int> TensorArgMax<T>(Tensor<T> tensor, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -37589,6 +37965,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<int> TensorArgMin<T>(Tensor<T> tensor, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
@@ -37828,6 +38206,23 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (x == null) throw new ArgumentNullException(nameof(x));
         if (y == null) throw new ArgumentNullException(nameof(y));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { x, y },
+                engine =>
+                {
+                    var grid = engine.TensorMeshgrid(x, y);
+                    return new[] { grid.X, grid.Y };
+                });
+            return (outputs[0], outputs[1]);
+        }
+
+        if (DifferentiableOps.IsTapeActiveForThread<T>())
+        {
+            Tensor<T>[] outputs = TensorMeshgrid(new[] { x, y }, "xy");
+            return (outputs[0], outputs[1]);
+        }
 
         int width = x.Length;
         int height = y.Length;
@@ -38269,6 +38664,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> TensorTopK<T>(Tensor<T> tensor, int k, int axis, out Tensor<int> indices)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (k <= 0) throw new ArgumentException("k must be positive.", nameof(k));
 
@@ -38322,6 +38719,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> TensorScatter<T>(Tensor<T> destination, Tensor<int> indices, Tensor<T> source, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (destination == null) throw new ArgumentNullException(nameof(destination));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
         if (source == null) throw new ArgumentNullException(nameof(source));
@@ -38356,6 +38755,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (indices == null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
 
         if (axis < 0) axis = tensor.Rank + axis;
 
@@ -38566,6 +38966,10 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> TensorMaskedFill<T>(Tensor<T> tensor, Tensor<bool> mask, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
+        if (mask == null) throw new ArgumentNullException(nameof(mask));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+        if (!tensor._shape.SequenceEqual(mask._shape))
+            throw new ArgumentException($"Tensor shape [{string.Join(", ", tensor._shape)}] must match mask shape [{string.Join(", ", mask._shape)}].", nameof(mask));
 
         if (GraphMode.IsActive)
         {
@@ -38573,14 +38977,17 @@ public partial class CpuEngine : ITensorLevelEngine
             if (scope != null)
             {
                 var ct = tensor; var cm = mask; var cv = value;
-                return scope.RecordUnary(LazyNodeType.Custom, "TensorMaskedFill", tensor, tensor._shape,
+                var maskData = mask.GetFlattenedData();
+                var maskShape = (int[])mask._shape.Clone();
+                double fillValue = MathHelper.GetNumericOperations<T>().ToDouble(value);
+                return scope.RecordUnary(LazyNodeType.TensorMaskedFill, "TensorMaskedFill", tensor, tensor._shape,
                     (eng, output) => { var r = eng.TensorMaskedFill(ct, cm, cv); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
-                    BackwardFunctions<T>.MaskedFillBackward, new object[] { mask });
+                    BackwardFunctions<T>.MaskedFillBackward,
+                    new object[] { (bool[])maskData.Clone(), maskShape, fillValue });
             }
         }
         { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorMaskedFill", tensor._shape); if (ac is not null) return ac.Execute(); }
 
-        if (mask == null) throw new ArgumentNullException(nameof(mask));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -38605,6 +39012,7 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
         if (mask == null) throw new ArgumentNullException(nameof(mask));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
         if (!tensor._shape.SequenceEqual(mask._shape))
@@ -38701,6 +39109,9 @@ public partial class CpuEngine : ITensorLevelEngine
         if (condition == null) throw new ArgumentNullException(nameof(condition));
         if (x == null) throw new ArgumentNullException(nameof(x));
         if (y == null) throw new ArgumentNullException(nameof(y));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+        if (!condition._shape.SequenceEqual(x._shape) || !x._shape.SequenceEqual(y._shape))
+            throw new ArgumentException("condition, x, and y must have the same shape.");
 
         var result = AutoTensorCache.RentOrAllocate<T>(x._shape);
         var condData = condition.GetFlattenedData();
@@ -38731,14 +39142,15 @@ public partial class CpuEngine : ITensorLevelEngine
         if (condition == null) throw new ArgumentNullException(nameof(condition));
         if (x == null) throw new ArgumentNullException(nameof(x));
         if (y == null) throw new ArgumentNullException(nameof(y));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         var yOrig = y;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!y.IsContiguous) y = y.Contiguous();
         var xOrig = x;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!x.IsContiguous) x = x.Contiguous();
         var conditionOrig = condition;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!condition.IsContiguous) condition = condition.Contiguous();
-        if (x.Length != y.Length || x.Length != condition.Length)
-            throw new ArgumentException("All tensors must have the same length.");
+        if (!condition._shape.SequenceEqual(x._shape) || !x._shape.SequenceEqual(y._shape))
+            throw new ArgumentException("condition, x, and y must have the same shape.");
 
         var result = AutoTensorCache.RentOrAllocate<T>(x._shape);
         var condData = condition.GetFlattenedData();
@@ -38768,6 +39180,10 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> PositionalEncoding<T>(Tensor<T> positions, int numFrequencies)
     {
+        if (positions == null) throw new ArgumentNullException(nameof(positions));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { positions }, engine => engine.PositionalEncoding(positions, numFrequencies));
         return NeRFOperations.PositionalEncoding(positions, numFrequencies);
     }
 
@@ -38780,6 +39196,13 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> VolumeRendering<T>(Tensor<T> rgbSamples, Tensor<T> densitySamples, Tensor<T> tValues)
     {
+        if (rgbSamples == null) throw new ArgumentNullException(nameof(rgbSamples));
+        if (densitySamples == null) throw new ArgumentNullException(nameof(densitySamples));
+        if (tValues == null) throw new ArgumentNullException(nameof(tValues));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { rgbSamples, densitySamples, tValues },
+                engine => engine.VolumeRendering(rgbSamples, densitySamples, tValues));
         return NeRFOperations.VolumeRendering(rgbSamples, densitySamples, tValues);
     }
 
@@ -38806,6 +39229,21 @@ public partial class CpuEngine : ITensorLevelEngine
         int numSamples,
         bool stratified = true)
     {
+        if (rayOrigins == null) throw new ArgumentNullException(nameof(rayOrigins));
+        if (rayDirections == null) throw new ArgumentNullException(nameof(rayDirections));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { rayOrigins, rayDirections },
+                engine =>
+                {
+                    var sampled = engine.SampleRayPoints(
+                        rayOrigins, rayDirections, nearBound, farBound, numSamples, stratified);
+                    return new[] { sampled.positions, sampled.directions, sampled.tValues };
+                });
+            return (outputs[0], outputs[1], outputs[2]);
+        }
+
         return NeRFOperations.SampleRayPoints(
             rayOrigins, rayDirections, nearBound, farBound, numSamples, stratified);
     }
@@ -38824,6 +39262,7 @@ public partial class CpuEngine : ITensorLevelEngine
         int imageHeight,
         T focalLength)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HostBoundary);
         return NeRFOperations.GenerateCameraRays(
             cameraPosition, cameraRotation, imageWidth, imageHeight, focalLength);
     }
@@ -38833,7 +39272,7 @@ public partial class CpuEngine : ITensorLevelEngine
     #region Gaussian Splatting Operations
 
     /// <inheritdoc/>
-    public void ProjectGaussians3DTo2D<T>(
+    public virtual void ProjectGaussians3DTo2D<T>(
         Tensor<T> means3D,
         Tensor<T> covariances3D,
         Matrix<T> viewMatrix,
@@ -38845,6 +39284,7 @@ public partial class CpuEngine : ITensorLevelEngine
         out Tensor<T> depths,
         out Tensor<bool> visible)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HostBoundary);
         GaussianSplattingOperations.ProjectGaussians3DTo2D(
             means3D, covariances3D, viewMatrix, projMatrix,
             imageWidth, imageHeight,
@@ -38862,6 +39302,18 @@ public partial class CpuEngine : ITensorLevelEngine
         int imageHeight,
         int tileSize = 16)
     {
+        if (means2D == null) throw new ArgumentNullException(nameof(means2D));
+        if (covariances2D == null) throw new ArgumentNullException(nameof(covariances2D));
+        if (colors == null) throw new ArgumentNullException(nameof(colors));
+        if (opacities == null) throw new ArgumentNullException(nameof(opacities));
+        if (depths == null) throw new ArgumentNullException(nameof(depths));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { means2D, covariances2D, colors, opacities, depths },
+                engine => engine.RasterizeGaussians(
+                    means2D, covariances2D, colors, opacities, depths, imageWidth, imageHeight,
+                    tileSize));
+
         return GaussianSplattingOperations.RasterizeGaussians(
             means2D, covariances2D, colors, opacities, depths,
             imageWidth, imageHeight, tileSize);
@@ -38892,6 +39344,12 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> EvaluateSphericalHarmonics<T>(Tensor<T> shCoefficients, Tensor<T> viewDirections, int degree)
     {
+        if (shCoefficients == null) throw new ArgumentNullException(nameof(shCoefficients));
+        if (viewDirections == null) throw new ArgumentNullException(nameof(viewDirections));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { shCoefficients, viewDirections },
+                engine => engine.EvaluateSphericalHarmonics(shCoefficients, viewDirections, degree));
         return GaussianSplattingOperations.EvaluateSphericalHarmonics(shCoefficients, viewDirections, degree);
     }
 
@@ -38909,6 +39367,12 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> ComputeGaussianCovariance<T>(Tensor<T> rotations, Tensor<T> scales)
     {
+        if (rotations == null) throw new ArgumentNullException(nameof(rotations));
+        if (scales == null) throw new ArgumentNullException(nameof(scales));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { rotations, scales },
+                engine => engine.ComputeGaussianCovariance(rotations, scales));
         return GaussianSplattingOperations.ComputeGaussianCovariance(rotations, scales);
     }
 
@@ -38936,6 +39400,13 @@ public partial class CpuEngine : ITensorLevelEngine
         int[] resolutions,
         int featuresPerLevel)
     {
+        if (positions == null) throw new ArgumentNullException(nameof(positions));
+        if (hashTables == null) throw new ArgumentNullException(nameof(hashTables));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { positions }.Concat(hashTables).ToArray(),
+                engine => engine.MultiresolutionHashEncoding(
+                    positions, hashTables, resolutions, featuresPerLevel));
         return InstantNGPOperations.MultiresolutionHashEncoding(
             positions, hashTables, resolutions, featuresPerLevel);
     }
@@ -38961,12 +39432,21 @@ public partial class CpuEngine : ITensorLevelEngine
         T threshold,
         T decayFactor)
     {
+        if (occupancyGrid == null) throw new ArgumentNullException(nameof(occupancyGrid));
+        if (densities == null) throw new ArgumentNullException(nameof(densities));
+        if (positions == null) throw new ArgumentNullException(nameof(positions));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { occupancyGrid, densities, positions },
+                engine => engine.UpdateOccupancyGrid(
+                    occupancyGrid, densities, positions, gridSize, threshold, decayFactor));
+
         return InstantNGPOperations.UpdateOccupancyGrid(
             occupancyGrid, densities, positions, gridSize, threshold, decayFactor);
     }
 
     /// <inheritdoc/>
-    public (Tensor<T> positions, Tensor<T> directions, Tensor<bool> validMask, Tensor<T> tValues) SampleRaysWithOccupancy<T>(
+    public virtual (Tensor<T> positions, Tensor<T> directions, Tensor<bool> validMask, Tensor<T> tValues) SampleRaysWithOccupancy<T>(
         Tensor<T> rayOrigins,
         Tensor<T> rayDirections,
         Tensor<uint> occupancyBitfield,
@@ -38977,6 +39457,7 @@ public partial class CpuEngine : ITensorLevelEngine
         T farBound,
         int maxSamples)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         return InstantNGPOperations.SampleRaysWithOccupancy(
             rayOrigins, rayDirections, occupancyBitfield, gridSize,
             sceneBoundsMin, sceneBoundsMax, nearBound, farBound, maxSamples);
@@ -38993,6 +39474,7 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<T> weights,
         Tensor<T> biases)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         return MeshConvolutionOperations.SpiralConv(vertexFeatures, spiralIndices, weights, biases);
     }
 
@@ -39029,6 +39511,15 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<T> biases,
         T diffusionTime)
     {
+        if (vertexFeatures == null) throw new ArgumentNullException(nameof(vertexFeatures));
+        if (laplacian == null) throw new ArgumentNullException(nameof(laplacian));
+        if (weights == null) throw new ArgumentNullException(nameof(weights));
+        if (biases == null) throw new ArgumentNullException(nameof(biases));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { vertexFeatures, laplacian, weights, biases },
+                engine => engine.DiffusionConv(
+                    vertexFeatures, laplacian, weights, biases, diffusionTime));
         return MeshConvolutionOperations.DiffusionConv(vertexFeatures, laplacian, weights, biases, diffusionTime);
     }
 
@@ -39049,6 +39540,7 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<int> faces,
         LaplacianType laplacianType = LaplacianType.Cotangent)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         return MeshConvolutionOperations.ComputeMeshLaplacian(vertices, faces, laplacianType);
     }
 
@@ -39058,6 +39550,8 @@ public partial class CpuEngine : ITensorLevelEngine
         Tensor<int> faces,
         int spiralLength)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         return MeshConvolutionOperations.GenerateSpiralIndices(vertices, faces, spiralLength);
     }
 
@@ -39068,6 +39562,11 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> PairwiseDistanceSquared<T>(Tensor<T> x, Tensor<T> y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (y == null) throw new ArgumentNullException(nameof(y));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { x, y }, engine => engine.PairwiseDistanceSquared(x, y));
         if (x._shape.Length != 2 || y._shape.Length != 2)
             throw new ArgumentException("Input tensors must be 2D [N, D]");
         if (x._shape[1] != y._shape[1])
@@ -39169,6 +39668,10 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> PairwiseDistance<T>(Tensor<T> x, Tensor<T> y)
     {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (y == null) throw new ArgumentNullException(nameof(y));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { x, y }, engine => engine.PairwiseDistance(x, y));
         var xOrig = x;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!x.IsContiguous) x = x.Contiguous();
         var yOrig = y;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -39245,6 +39748,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<int> ArgSort<T>(Tensor<T> input, int axis = -1, bool descending = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (axis < 0) axis = input._shape.Length + axis;
         if (axis < 0 || axis >= input._shape.Length)
             throw new ArgumentException($"Invalid axis {axis} for tensor with {input._shape.Length} dimensions");
@@ -39294,6 +39799,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> Gather<T>(Tensor<T> input, Tensor<int> indices, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
         if (axis < 0) axis = input._shape.Length + axis;
@@ -39359,6 +39866,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> Scatter<T>(Tensor<T> input, Tensor<int> indices, Tensor<T> values, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cind = indices; var cv = values; var ca = axis; return scope.RecordBinary(LazyNodeType.Custom, "Scatter", input, values, input._shape, (eng, output) => { var r = eng.Scatter(ci, cind, cv, ca); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ScatterBackward, new object[] { indices, axis }); } }
 
         { var ac = AutoTracer.TryGetCompiledPlan<T>("Scatter", input._shape); if (ac is not null) return ac.Execute(); }
@@ -39406,6 +39915,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> ScatterAdd<T>(Tensor<T> input, Tensor<int> indices, Tensor<T> values, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
         var indicesOrig = indices;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -39571,13 +40082,14 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a._shape.Length != 1 || b._shape.Length != 1)
             throw new ArgumentException("Both inputs must be 1D tensors");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuter", a, b, a._shape, (eng, output) => { var r = eng.TensorOuter(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorOuter", a._shape); if (ac is not null) return ac.Execute(); }
-
         int n = a._shape[0];
         int m = b._shape[0];
+        var outputShape = new[] { n, m };
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "TensorOuter", a, b, outputShape, (eng, output) => { var r = eng.TensorOuter(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.OuterProductBackward); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("TensorOuter", outputShape); if (ac is not null) return ac.Execute(); }
+
         var numOps = MathHelper.GetNumericOperations<T>();
-        var result = TensorAllocator.Rent<T>([n, m]);
+        var result = TensorAllocator.Rent<T>(outputShape);
 
         for (int i = 0; i < n; i++)
         {
@@ -40237,6 +40749,48 @@ public partial class CpuEngine : ITensorLevelEngine
         if (weights == null) throw new ArgumentNullException(nameof(weights));
         if (numPieces < 2) throw new ArgumentException("numPieces must be >= 2.", nameof(numPieces));
 
+        if (GraphMode.IsActive)
+        {
+            if (input.Rank < 1 || weights.Rank != 2 || input._shape[input.Rank - 1] != weights._shape[0])
+                throw new ArgumentException("FusedLinearMaxout input and weight shapes are incompatible.", nameof(weights));
+            int graphFeatures = weights._shape[1];
+            if (graphFeatures % numPieces != 0)
+                throw new ArgumentException(
+                    $"Maxout feature dimension ({graphFeatures}) must be divisible by numPieces ({numPieces}).",
+                    nameof(numPieces));
+            int graphUnits = graphFeatures / numPieces;
+
+            if (!GraphMode.IsInferenceTrace)
+            {
+                var graphPre = FusedLinear(input, weights, bias, FusedActivationType.None);
+                var groupedShape = new int[graphPre.Rank + 1];
+                for (int i = 0; i < graphPre.Rank - 1; i++) groupedShape[i] = graphPre._shape[i];
+                groupedShape[groupedShape.Length - 2] = graphUnits;
+                groupedShape[groupedShape.Length - 1] = numPieces;
+                return ReduceMax(Reshape(graphPre, groupedShape), new[] { groupedShape.Length - 1 }, keepDims: false);
+            }
+
+            var outputShape = (int[])input._shape.Clone();
+            outputShape[outputShape.Length - 1] = graphUnits;
+            var graphInputs = bias is null ? new[] { input, weights } : new[] { input, weights, bias };
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            return scope.RecordVariadic(
+                LazyNodeType.FusedLinearMaxout,
+                "FusedLinearMaxout",
+                graphInputs,
+                outputShape,
+                (eng, output) =>
+                {
+                    var eager = eng.FusedLinearMaxout(
+                        graphInputs[0], graphInputs[1], graphInputs.Length == 3 ? graphInputs[2] : null,
+                        numPieces);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState: new object[] { numPieces });
+        }
+
         // GEMM + bias (no activation) — reuse the fused linear fast path.
         var pre = FusedLinear(input, weights, bias, FusedActivationType.None);
         int n = pre._shape[pre._shape.Length - 1];
@@ -40304,6 +40858,31 @@ public partial class CpuEngine : ITensorLevelEngine
             throw new ArgumentException(
                 $"treeDepth ({treeDepth}) is too small for {numClasses} classes; need >= {minDepth}.",
                 nameof(nodeWeights));
+
+        if (GraphMode.IsActive)
+        {
+            if (!GraphMode.IsInferenceTrace)
+                throw new NotSupportedException(
+                    "FusedHierarchicalSoftmax has no backward contract. Compiled training cannot capture it safely.");
+
+            var outputShape = (int[])input._shape.Clone();
+            outputShape[outputShape.Length - 1] = numClasses;
+            var scope = GraphMode.Current!;
+            scope.BindEngineIfUnset(this);
+            return scope.RecordBinary(
+                LazyNodeType.FusedHierarchicalSoftmax,
+                "FusedHierarchicalSoftmax",
+                input,
+                nodeWeights,
+                outputShape,
+                (eng, output) =>
+                {
+                    var eager = eng.FusedHierarchicalSoftmax(input, nodeWeights, numClasses);
+                    DirectGpuTensorEngine.CopyResultInto(eng, eager, output);
+                },
+                backwardFn: null,
+                savedState: new object[] { numClasses });
+        }
 
         int rows = input.Length / d;
         var outShape = (int[])input._shape.Clone();
@@ -40593,6 +41172,29 @@ public partial class CpuEngine : ITensorLevelEngine
         out Tensor<T> saveMean,
         out Tensor<T> saveVar)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (gamma == null) throw new ArgumentNullException(nameof(gamma));
+        if (beta == null) throw new ArgumentNullException(nameof(beta));
+        if (runningMean == null) throw new ArgumentNullException(nameof(runningMean));
+        if (runningVar == null) throw new ArgumentNullException(nameof(runningVar));
+        if (GraphMode.IsInferenceTrace)
+        {
+            if (training)
+                GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.Stateful);
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta, runningMean, runningVar },
+                engine =>
+                {
+                    Tensor<T> result = engine.FusedBatchNorm(
+                        input, gamma, beta, runningMean, runningVar, epsilon, momentum, training,
+                        activation, out Tensor<T> freshMean, out Tensor<T> freshVariance);
+                    return new[] { result, freshMean, freshVariance };
+                });
+            saveMean = outputs[1];
+            saveVar = outputs[2];
+            return outputs[0];
+        }
+
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (gamma == null) throw new ArgumentNullException(nameof(gamma));
         if (beta == null) throw new ArgumentNullException(nameof(beta));
@@ -40902,10 +41504,6 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> RFFT<T>(Tensor<T> input)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; return scope.RecordUnary(LazyNodeType.Custom, "RFFT", input, input._shape, (eng, output) => { var r = eng.RFFT(c_input); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("RFFT", input._shape); if (ac is not null) return ac.Execute(); }
-
-        var numOps = MathHelper.GetNumericOperations<T>();
         int n = input._shape[^1]; // Last dimension is the signal length
         if (n <= 0)
             throw new ArgumentException("The signal length must be positive.", nameof(input));
@@ -40919,6 +41517,10 @@ public partial class CpuEngine : ITensorLevelEngine
         // Compute shape for output (last dim becomes 2 * numFreqs for interleaved complex)
         var outputShape = input.Shape.ToArray();
         outputShape[^1] = numFreqs * 2; // Interleaved real/imag
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; return scope.RecordUnary(LazyNodeType.Custom, "RFFT", input, outputShape, (eng, output) => { var r = eng.RFFT(c_input); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("RFFT", outputShape); if (ac is not null) return ac.Execute(); }
+
+        var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(outputShape);
         var inputData = input.GetFlattenedData();
         var resultData = result.GetDataArray();
@@ -40987,8 +41589,13 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> IRFFT<T>(Tensor<T> input, int outputLength)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_outputLength = outputLength; return scope.RecordUnary(LazyNodeType.Custom, "IRFFT", input, input._shape, (eng, output) => { var r = eng.IRFFT(c_input, c_outputLength); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
-        { var ac = AutoTracer.TryGetCompiledPlan<T>("IRFFT", input._shape); if (ac is not null) return ac.Execute(); }
+        if (outputLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outputLength), "Output length must be positive.");
+
+        var outputShape = input.Shape.ToArray();
+        outputShape[^1] = outputLength;
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_input = input; var c_outputLength = outputLength; return scope.RecordUnary(LazyNodeType.Custom, "IRFFT", input, outputShape, (eng, output) => { var r = eng.IRFFT(c_input, c_outputLength); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, null); } }
+        { var ac = AutoTracer.TryGetCompiledPlan<T>("IRFFT", outputShape); if (ac is not null) return ac.Execute(); }
 
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
@@ -41009,9 +41616,6 @@ public partial class CpuEngine : ITensorLevelEngine
         if (nFft < outputLength) nFft = outputLength;
         if (nFft < 1) nFft = 1;
 
-        // Output shape
-        var outputShape = input.Shape.ToArray();
-        outputShape[^1] = outputLength;
         var result = AutoTensorCache.RentOrAllocate<T>(outputShape);
         var inputData = input.GetFlattenedData();
         var resultData = result.GetDataArray();
@@ -41077,6 +41681,19 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (inputReal == null) throw new ArgumentNullException(nameof(inputReal));
         if (inputImag == null) throw new ArgumentNullException(nameof(inputImag));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { inputReal, inputImag },
+                engine =>
+                {
+                    engine.FFT(inputReal, inputImag, out Tensor<T> real, out Tensor<T> imaginary);
+                    return new[] { real, imaginary };
+                });
+            outputReal = outputs[0];
+            outputImag = outputs[1];
+            return;
+        }
         if (!inputReal._shape.SequenceEqual(inputImag._shape))
             throw new ArgumentException("Input real and imaginary parts must have the same shape");
 
@@ -41122,6 +41739,19 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (inputReal == null) throw new ArgumentNullException(nameof(inputReal));
         if (inputImag == null) throw new ArgumentNullException(nameof(inputImag));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { inputReal, inputImag },
+                engine =>
+                {
+                    engine.IFFT(inputReal, inputImag, out Tensor<T> real, out Tensor<T> imaginary);
+                    return new[] { real, imaginary };
+                });
+            outputReal = outputs[0];
+            outputImag = outputs[1];
+            return;
+        }
         var inputRealOrig = inputReal;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!inputReal.IsContiguous) inputReal = inputReal.Contiguous();
         var inputImagOrig = inputImag;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -41173,6 +41803,19 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (inputReal == null) throw new ArgumentNullException(nameof(inputReal));
         if (inputImag == null) throw new ArgumentNullException(nameof(inputImag));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { inputReal, inputImag },
+                engine =>
+                {
+                    engine.FFT2D(inputReal, inputImag, out Tensor<T> real, out Tensor<T> imaginary);
+                    return new[] { real, imaginary };
+                });
+            outputReal = outputs[0];
+            outputImag = outputs[1];
+            return;
+        }
         var inputRealOrig = inputReal;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!inputReal.IsContiguous) inputReal = inputReal.Contiguous();
         var inputImagOrig = inputImag;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
@@ -41233,6 +41876,19 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (inputReal == null) throw new ArgumentNullException(nameof(inputReal));
         if (inputImag == null) throw new ArgumentNullException(nameof(inputImag));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { inputReal, inputImag },
+                engine =>
+                {
+                    engine.IFFT2D(inputReal, inputImag, out Tensor<T> real, out Tensor<T> imaginary);
+                    return new[] { real, imaginary };
+                });
+            outputReal = outputs[0];
+            outputImag = outputs[1];
+            return;
+        }
         if (inputReal._shape.Length < 2)
             throw new ArgumentException("Input must be at least 2D");
 
@@ -41320,6 +41976,21 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (window == null) throw new ArgumentNullException(nameof(window));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, window },
+                engine =>
+                {
+                    engine.STFT(
+                        input, nFft, hopLength, window, center, out Tensor<T> magnitude,
+                        out Tensor<T> phase);
+                    return new[] { magnitude, phase };
+                });
+            magnitudeOut = outputs[0];
+            phaseOut = outputs[1];
+            return;
+        }
         if (window.Length != nFft)
             throw new ArgumentException($"Window length {window.Length} must equal nFft {nFft}");
 
@@ -41459,6 +42130,11 @@ public partial class CpuEngine : ITensorLevelEngine
         if (magnitude == null) throw new ArgumentNullException(nameof(magnitude));
         if (phase == null) throw new ArgumentNullException(nameof(phase));
         if (window == null) throw new ArgumentNullException(nameof(window));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { magnitude, phase, window },
+                engine => engine.ISTFT(
+                    magnitude, phase, nFft, hopLength, window, center, length));
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int numFreqs = magnitude._shape[^2];
@@ -41623,6 +42299,12 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (input == null) throw new ArgumentNullException(nameof(input));
         if (window == null) throw new ArgumentNullException(nameof(window));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { input, window },
+                engine => engine.MelSpectrogram(
+                    input, sampleRate, nFft, hopLength, nMels, fMin, fMax, window,
+                    powerToDb));
 
         var numOps = MathHelper.GetNumericOperations<T>();
 
@@ -41737,6 +42419,11 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (magnitude == null) throw new ArgumentNullException(nameof(magnitude));
         if (window == null) throw new ArgumentNullException(nameof(window));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { magnitude, window },
+                engine => engine.GriffinLim(
+                    magnitude, nFft, hopLength, window, iterations, momentum, length));
 
         var numOps = MathHelper.GetNumericOperations<T>();
         int numFreqs = magnitude._shape[^2];
@@ -42943,6 +43630,25 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> InstanceNorm<T>(Tensor<T> input, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (gamma == null) throw new ArgumentNullException(nameof(gamma));
+        if (beta == null) throw new ArgumentNullException(nameof(beta));
+
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input, gamma, beta },
+                engine =>
+                {
+                    Tensor<T> result = engine.InstanceNorm(
+                        input, gamma, beta, epsilon, out Tensor<T> freshMean, out Tensor<T> freshVariance);
+                    return new[] { result, freshMean, freshVariance };
+                });
+            mean = outputs[1];
+            variance = outputs[2];
+            return outputs[0];
+        }
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -43134,6 +43840,20 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Dropout<T>(Tensor<T> input, double dropoutRate, bool training, out Tensor<T> mask)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace && (!training || dropoutRate <= 0))
+        {
+            Tensor<T>[] outputs = CaptureInferenceKernelOutputs(
+                new[] { input },
+                engine =>
+                {
+                    Tensor<T> result = engine.Dropout(input, dropoutRate, training, out Tensor<T> freshMask);
+                    return new[] { result, freshMask };
+                });
+            mask = outputs[1];
+            return outputs[0];
+        }
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -43293,6 +44013,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> Embedding<T>(Tensor<int> indices, Tensor<T> embeddingTable)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (GraphMode.IsActive)
         {
             var scope = GraphMode.Current;
@@ -43577,6 +44299,9 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> GlobalAvgPool2D<T>(Tensor<T> input)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.GlobalAvgPool2D(input));
         var numOps = MathHelper.GetNumericOperations<T>();
         int batch = input._shape[0];
         int channels = input._shape[1];
@@ -43665,6 +44390,9 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public Tensor<T> GlobalMaxPool2D<T>(Tensor<T> input)
     {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.GlobalMaxPool2D(input));
         var inputOrig = input;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!input.IsContiguous) input = input.Contiguous();
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -44920,6 +45648,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <summary>Cosine similarity loss between two tensors.</summary>
     public Tensor<T> TensorCosineSimilarityLoss<T>(Tensor<T> a, Tensor<T> b)
     {
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "CosineSimilarity", a, b, new[] { 1 }, (eng, output) => { var r = eng.TensorCosineSimilarityLoss(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.CosineSimilarityBackward); } }
+
         var numOps = MathHelper.GetNumericOperations<T>();
         double dotProd = 0, normA = 0, normB = 0;
         for (int i = 0; i < a.Length; i++)
@@ -44931,8 +45661,6 @@ public partial class CpuEngine : ITensorLevelEngine
             normB += vb * vb;
         }
         double sim = dotProd / (Math.Sqrt(normA) * Math.Sqrt(normB) + 1e-8);
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c_a = a; var c_b = b; return scope.RecordBinary(LazyNodeType.Custom, "CosineSimilarity", a, b, a._shape, (eng, output) => { var r = eng.TensorCosineSimilarityLoss(c_a, c_b); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.CosineSimilarityBackward); } }
-
         var result = new Tensor<T>(new[] { numOps.FromDouble(sim) }, [1]);
         DifferentiableOps.RecordBinary("CosineSimilarity", result, a, b,
             BackwardFunctions<T>.CosineSimilarityBackward);
@@ -45446,6 +46174,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <summary>IndexSelect: select indices along a given axis (differentiable).</summary>
     public Tensor<T> TensorIndexSelectDiff<T>(Tensor<T> source, Tensor<int> indices, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         // TensorIndexSelect already records to the tape — no additional recording needed
         return TensorIndexSelect(source, indices, axis);
     }
@@ -46180,7 +46910,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearReLU<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearReLU, "FusedLinearReLU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearReLU(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddReLUBackward); } }
+        if (GraphMode.IsActive)
+            return FusedLinear(input, weight, bias, FusedActivationType.ReLU);
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -46198,7 +46929,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearSigmoid<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearSigmoid, "FusedLinearSigmoid", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSigmoid(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddSigmoidBackward); } }
+        if (GraphMode.IsActive)
+            return FusedLinear(input, weight, bias, FusedActivationType.Sigmoid);
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -46214,7 +46946,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearTanh<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearTanh", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearTanh(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddTanhBackward); } }
+        if (GraphMode.IsActive)
+            return FusedLinear(input, weight, bias, FusedActivationType.Tanh);
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -46230,7 +46963,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearGELU<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.FusedLinearGELU, "FusedLinearGELU", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearGELU(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddGELUBackward); } }
+        if (GraphMode.IsActive)
+            return FusedLinear(input, weight, bias, FusedActivationType.GELU);
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -46248,7 +46982,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc/>
     public virtual Tensor<T> FusedLinearSwish<T>(Tensor<T> input, Tensor<T> weight, Tensor<T> bias)
     {
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var ci = input; var cw = weight; var cb = bias; return scope.RecordVariadic(LazyNodeType.Custom, "FusedLinearSwish", new[] { input, weight, bias }, input._shape, (eng, output) => { var r = eng.FusedLinearSwish(ci, cw, cb); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.FusedMatMulAddSwishBackward); } }
+        if (GraphMode.IsActive)
+            return FusedLinear(input, weight, bias, FusedActivationType.Swish);
 
         var linear = TensorMatMul(input, weight);
         var biased = TensorBroadcastAdd(linear, bias);
@@ -46993,11 +47728,10 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a.Length % 2 != 0)
             throw new ArgumentException("Complex tensors must have even length (interleaved re/im).");
-        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexMagnitude", a, a._shape, (eng, output) => { var r = eng.TensorComplexMagnitude(c); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexMagnitudeBackward); } }
-
-
         var ops = MathHelper.GetNumericOperations<T>();
         int pairs = a.Length / 2;
+        if (GraphMode.IsActive) { var scope = GraphMode.Current; if (scope is not null) { var c = a; return scope.RecordUnary(LazyNodeType.Custom, "ComplexMagnitude", a, new[] { pairs }, (eng, output) => { var r = eng.TensorComplexMagnitude(c); DirectGpuTensorEngine.CopyResultInto(eng, r, output); }, BackwardFunctions<T>.ComplexMagnitudeBackward); } }
+
         var result = new Tensor<T>(new[] { pairs });
 
         for (int i = 0; i < pairs; i++)
@@ -47553,6 +48287,13 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeNormalizeRows<T>(Tensor<T> input, bool inPlace = false)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+        {
+            if (inPlace)
+                GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.Stateful);
+            return CaptureInferenceKernel(
+                new[] { input }, engine => engine.NativeNormalizeRows(input, inPlace));
+        }
         if (input.Rank != 2) throw new ArgumentException($"NativeNormalizeRows requires a 2D tensor. Got rank {input.Rank}.", nameof(input));
 
         int rows = input._shape[0];
@@ -47779,6 +48520,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeTanh<T>(Tensor<T> input)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.NativeTanh(input));
         var result = new Tensor<T>(input._shape);
         int n = input.Length;
 
@@ -47825,6 +48568,8 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeExp<T>(Tensor<T> input)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(new[] { input }, engine => engine.NativeExp(input));
         var result = new Tensor<T>(input._shape);
         int n = input.Length;
 
@@ -47880,6 +48625,9 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (imag is null) throw new ArgumentNullException(nameof(imag));
         if (real is null) throw new ArgumentNullException(nameof(real));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { imag, real }, engine => engine.NativeAtan2(imag, real));
         // Require matching shape, not just length. Equal-length tensors with different shapes
         // would silently pair values by flat index which is almost never what the caller wants.
         if (imag.Rank != real.Rank)
@@ -47936,6 +48684,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc />
     public virtual Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
         if (input is null) throw new ArgumentNullException(nameof(input));
         var magnitude = new Tensor<T>(input._shape);
         phase = new Tensor<T>(input._shape);
@@ -48048,6 +48797,11 @@ public partial class CpuEngine : ITensorLevelEngine
         if (cavityFilters._shape[1] != n) throw new ArgumentException("cavityFilters last dim must match input N.");
         ValidatePowerOfTwo(n, nameof(input));
 
+        if (GraphMode.IsActive)
+            throw new NotSupportedException(
+                "NativeBatchedCavityForward graph capture requires heterogeneous Tensor<T>/Tensor<Complex<T>> inputs; " +
+                "executing eagerly here would freeze the cavity filter into the compiled plan.");
+
         var result = new Tensor<T>([batch, numCavities, n]);
         var ops = MathHelper.GetNumericOperations<T>();
 
@@ -48105,6 +48859,10 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeMfccFeatures<T>(Tensor<T> waveforms, int numSegments, int numMfcc, int paddedDim)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveforms },
+                engine => engine.NativeMfccFeatures(waveforms, numSegments, numMfcc, paddedDim));
         if (waveforms.Rank != 1 && waveforms.Rank != 2)
             throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
         if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.", nameof(numSegments));
@@ -48179,6 +48937,10 @@ public partial class CpuEngine : ITensorLevelEngine
     public virtual Tensor<T> NativeWidebandFeatures<T>(Tensor<T> waveforms, int numSegments, int numBins)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveforms },
+                engine => engine.NativeWidebandFeatures(waveforms, numSegments, numBins));
         if (waveforms.Rank != 1 && waveforms.Rank != 2)
             throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
         if (numSegments <= 0) throw new ArgumentException("numSegments must be positive.", nameof(numSegments));
@@ -48251,6 +49013,11 @@ public partial class CpuEngine : ITensorLevelEngine
         double thetaLow, double thetaHigh, (double low, double high)[] gammaBands)
     {
         if (waveforms is null) throw new ArgumentNullException(nameof(waveforms));
+        if (GraphMode.IsInferenceTrace)
+            return CaptureInferenceKernel(
+                new[] { waveforms },
+                engine => engine.NativePacFeatures(
+                    waveforms, sampleRate, envelopeRate, thetaLow, thetaHigh, gammaBands));
         if (waveforms.Rank != 1 && waveforms.Rank != 2)
             throw new ArgumentException($"waveforms must be 1D [N] or 2D [batch, N]. Got rank {waveforms.Rank}.", nameof(waveforms));
         if (sampleRate <= 0) throw new ArgumentException("sampleRate must be positive.", nameof(sampleRate));
@@ -50337,6 +51104,8 @@ public partial class CpuEngine : ITensorLevelEngine
     /// <inheritdoc />
     public Tensor<T> TensorCTCLoss<T>(Tensor<T> logProbs, Tensor<int> targets, int[] inputLengths, int[] targetLengths, int blank = 0)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (logProbs.Rank != 3)
             throw new ArgumentException("logProbs must be 3D [T, N, C].");
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/CudaBackend.InstantNgp.cs
@@ -2,7 +2,7 @@ using AiDotNet.Tensors.Engines.DirectGpu.CUDA.Ptx;
 
 namespace AiDotNet.Tensors.Engines.DirectGpu.CUDA;
 
-public sealed partial class CudaBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed partial class CudaBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     private IntPtr ResolveInstantNgpKernel(string name)
     {
@@ -63,6 +63,107 @@ public sealed partial class CudaBackend : IInstantNgpBackend, IUniqueConsecutive
         int n = length;
         void** args = stackalloc void*[4];
         args[0] = &i; args[1] = &o; args[2] = &c; args[3] = &n;
+        LaunchKernel(kernel, 1, 1, args);
+    }
+
+    public unsafe void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("frexp_decompose");
+        using var _ = PushContext();
+        IntPtr i = input.Handle, m = mantissa.Handle, e = exponent.Handle;
+        int n = length;
+        void** args = stackalloc void*[4];
+        args[0] = &i; args[1] = &m; args[2] = &e; args[3] = &n;
+        LaunchKernel(kernel, (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+    }
+
+    public unsafe void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("unique_consecutive_with_info");
+        using var _ = PushContext();
+        IntPtr i = input.Handle, v = outputValues.Handle, inverse = outputInverse.Handle;
+        IntPtr counts = outputCounts.Handle, count = outputCount.Handle;
+        int n = length, ri = returnInverse ? 1 : 0, rc = returnCounts ? 1 : 0;
+        void** args = stackalloc void*[8];
+        args[0] = &i; args[1] = &v; args[2] = &inverse; args[3] = &counts;
+        args[4] = &count; args[5] = &n; args[6] = &ri; args[7] = &rc;
+        LaunchKernel(kernel, 1, 1, args);
+    }
+
+    public unsafe void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        var kernel = ResolveInstantNgpKernel("project_gaussians_3d_to_2d");
+        using var _ = PushContext();
+        IntPtr m3 = means3D.Handle, c3 = covariances3D.Handle, m2 = means2D.Handle;
+        IntPtr c2 = covariances2D.Handle, d = depths.Handle, vis = visible.Handle;
+        int n = numGaussians, cs = covarianceStride, width = imageWidth, height = imageHeight;
+        void** args = stackalloc void*[24];
+        args[0] = &m3; args[1] = &c3; args[2] = &m2; args[3] = &c2;
+        args[4] = &d; args[5] = &vis; args[6] = &n; args[7] = &cs;
+        args[8] = &width; args[9] = &height;
+        args[10] = &v00; args[11] = &v01; args[12] = &v02; args[13] = &v03;
+        args[14] = &v10; args[15] = &v11; args[16] = &v12; args[17] = &v13;
+        args[18] = &v20; args[19] = &v21; args[20] = &v22; args[21] = &v23;
+        args[22] = &p00; args[23] = &p11;
+        LaunchKernel(kernel,
+            (uint)((numGaussians + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+    }
+
+    public unsafe void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        var kernel = ResolveInstantNgpKernel("sample_rays_with_occupancy");
+        using var _ = PushContext();
+        IntPtr o = rayOrigins.Handle, di = rayDirections.Handle, occ = occupancyBitfield.Handle;
+        IntPtr p = positions.Handle, dout = directions.Handle, mask = validMask.Handle, tv = tValues.Handle;
+        int nr = numRays, words = occupancyWordCount, gs = gridSize, samples = maxSamples;
+        void** args = stackalloc void*[19];
+        args[0] = &o; args[1] = &di; args[2] = &occ; args[3] = &p;
+        args[4] = &dout; args[5] = &mask; args[6] = &tv; args[7] = &nr;
+        args[8] = &words; args[9] = &gs; args[10] = &samples;
+        args[11] = &minX; args[12] = &minY; args[13] = &minZ;
+        args[14] = &maxX; args[15] = &maxY; args[16] = &maxZ;
+        args[17] = &nearBound; args[18] = &farBound;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+    }
+
+    public unsafe void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("unique_sorted_with_info");
+        using var _ = PushContext();
+        IntPtr i = sortedInput.Handle, original = sortedOriginalIndices.Handle;
+        IntPtr v = outputValues.Handle, inverse = outputInverse.Handle;
+        IntPtr counts = outputCounts.Handle, count = outputCount.Handle;
+        int n = length, ri = returnInverse ? 1 : 0, rc = returnCounts ? 1 : 0;
+        void** args = stackalloc void*[9];
+        args[0] = &i; args[1] = &original; args[2] = &v; args[3] = &inverse;
+        args[4] = &counts; args[5] = &count; args[6] = &n; args[7] = &ri; args[8] = &rc;
         LaunchKernel(kernel, 1, 1, args);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaInstantNgpKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/CUDA/Kernels/CudaInstantNgpKernels.cs
@@ -4,7 +4,7 @@ public static class CudaInstantNgpKernels
 {
     public static string[] GetKernelNames() =>
         ["instant_ngp_hash_encode_level", "instant_ngp_hash_encode_level_backward",
-            "unique_consecutive_compact", "resident_mode", "resident_indices_to_int32", "resident_index_add", "resident_index_select", "resident_scatter_max_argmax_rows", "resident_uniform_mesh_laplacian", "resident_scatter_add_rows", "resident_scatter_mean_rows_counts", "resident_scatter_softmax_rows", "resident_scatter_add_backward_rows", "resident_scatter_mean_backward_rows", "resident_scatter_max_backward_rows", "resident_scatter_softmax_backward_rows", "nonzero_compact", "ctc_loss_forward", "importance_sampling", "resident_nms",
+            "frexp_decompose", "unique_consecutive_compact", "unique_consecutive_with_info", "unique_sorted_with_info", "project_gaussians_3d_to_2d", "sample_rays_with_occupancy", "resident_mode", "resident_indices_to_int32", "resident_index_add", "resident_index_select", "resident_scatter_max_argmax_rows", "resident_uniform_mesh_laplacian", "resident_scatter_add_rows", "resident_scatter_mean_rows_counts", "resident_scatter_softmax_rows", "resident_scatter_add_backward_rows", "resident_scatter_mean_backward_rows", "resident_scatter_max_backward_rows", "resident_scatter_softmax_backward_rows", "nonzero_compact", "ctc_loss_forward", "importance_sampling", "resident_nms",
             "generate_spiral_indices"];
 
     public static string GetSource() => @"
@@ -113,6 +113,196 @@ extern ""C"" __global__ void unique_consecutive_compact(
         if (input[i] != input[i - 1]) output[count++] = input[i];
     }
     outputCount[0] = (float)count;
+}
+
+extern ""C"" __global__ void unique_consecutive_with_info(
+    const float* __restrict__ input,
+    float* __restrict__ outputValues,
+    float* __restrict__ outputInverse,
+    float* __restrict__ outputCounts,
+    float* __restrict__ outputCount,
+    int length, int returnInverse, int returnCounts)
+{
+    if (blockIdx.x != 0 || threadIdx.x != 0) return;
+    if (length <= 0) { outputCount[0] = 0.0f; return; }
+    int count = 1;
+    outputValues[0] = input[0];
+    if (returnInverse != 0) outputInverse[0] = 0.0f;
+    if (returnCounts != 0) outputCounts[0] = 1.0f;
+    for (int i = 1; i < length; i++) {
+        if (input[i] != input[i - 1]) {
+            outputValues[count] = input[i];
+            if (returnCounts != 0) outputCounts[count] = 1.0f;
+            count++;
+        } else if (returnCounts != 0) {
+            outputCounts[count - 1] += 1.0f;
+        }
+        if (returnInverse != 0) outputInverse[i] = (float)(count - 1);
+    }
+    outputCount[0] = (float)count;
+}
+
+extern ""C"" __global__ void unique_sorted_with_info(
+    const float* __restrict__ sortedInput,
+    const float* __restrict__ sortedOriginalIndices,
+    float* __restrict__ outputValues,
+    float* __restrict__ outputInverse,
+    float* __restrict__ outputCounts,
+    float* __restrict__ outputCount,
+    int length, int returnInverse, int returnCounts)
+{
+    if (blockIdx.x != 0 || threadIdx.x != 0) return;
+    int count = 0;
+    for (int i = 0; i < length; i++) {
+        if (i == 0 || sortedInput[i] != sortedInput[i - 1]) {
+            outputValues[count] = sortedInput[i];
+            if (returnCounts != 0) outputCounts[count] = 0.0f;
+            count++;
+        }
+        int group = count - 1;
+        if (returnCounts != 0) outputCounts[group] += 1.0f;
+        if (returnInverse != 0)
+            outputInverse[(int)sortedOriginalIndices[i]] = (float)group;
+    }
+    outputCount[0] = (float)count;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void frexp_decompose(
+    const float* __restrict__ input,
+    float* __restrict__ mantissa,
+    float* __restrict__ exponent,
+    int length)
+{
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= length) return;
+    float value = input[gid];
+    unsigned int bits = __float_as_uint(value);
+    unsigned int magnitude = bits & 0x7fffffffu;
+    unsigned int exponentBits = magnitude >> 23;
+    if (exponentBits == 0xffu || magnitude == 0u) {
+        mantissa[gid] = value;
+        exponent[gid] = 0.0f;
+        return;
+    }
+    int scaleAdjustment = 0;
+    if (exponentBits == 0u) {
+        value *= 16777216.0f;
+        bits = __float_as_uint(value);
+        exponentBits = (bits & 0x7fffffffu) >> 23;
+        scaleAdjustment = -24;
+    }
+    mantissa[gid] = __uint_as_float((bits & 0x807fffffu) | (126u << 23));
+    exponent[gid] = (float)((int)exponentBits - 126 + scaleAdjustment);
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void project_gaussians_3d_to_2d(
+    const float* __restrict__ means3D,
+    const float* __restrict__ covariances3D,
+    float* __restrict__ means2D,
+    float* __restrict__ covariances2D,
+    float* __restrict__ depths,
+    float* __restrict__ visible,
+    int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+    float v00, float v01, float v02, float v03,
+    float v10, float v11, float v12, float v13,
+    float v20, float v21, float v22, float v23,
+    float p00, float p11)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numGaussians) return;
+    means2D[i * 2] = 0.0f; means2D[i * 2 + 1] = 0.0f;
+    covariances2D[i * 3] = 0.0f; covariances2D[i * 3 + 1] = 0.0f;
+    covariances2D[i * 3 + 2] = 0.0f; depths[i] = 0.0f; visible[i] = 0.0f;
+
+    float mx = means3D[i * 3], my = means3D[i * 3 + 1], mz = means3D[i * 3 + 2];
+    float camX = v00 * mx + v01 * my + v02 * mz + v03;
+    float camY = v10 * mx + v11 * my + v12 * mz + v13;
+    float camZ = v20 * mx + v21 * my + v22 * mz + v23;
+    if (camZ <= 0.001f) return;
+    float invZ = 1.0f / camZ;
+    float cx = (float)imageWidth * 0.5f, cy = (float)imageHeight * 0.5f;
+    float screenX = p00 * camX * invZ * cx + cx;
+    float screenY = p11 * camY * invZ * cy + cy;
+    if (screenX < -(float)imageWidth || screenX > 2.0f * (float)imageWidth ||
+        screenY < -(float)imageHeight || screenY > 2.0f * (float)imageHeight) return;
+
+    int c = i * covarianceStride;
+    float c00 = covariances3D[c];
+    float c01 = covariances3D[c + 1];
+    float c02 = covariances3D[c + 2];
+    float c11 = covariances3D[c + (covarianceStride == 6 ? 3 : 4)];
+    float c12 = covariances3D[c + (covarianceStride == 6 ? 4 : 5)];
+    float c22 = covariances3D[c + (covarianceStride == 6 ? 5 : 8)];
+    float j00 = p00 * invZ, j02 = -p00 * camX * invZ * invZ;
+    float j11 = p11 * invZ, j12 = -p11 * camY * invZ * invZ;
+    float cov00 = j00*j00*c00 + 2.0f*j00*j02*c02 + j02*j02*c22 + 0.3f;
+    float cov01 = j00*j11*c01 + j00*j12*c02 + j02*j11*c12 + j02*j12*c22;
+    float cov11 = j11*j11*c11 + 2.0f*j11*j12*c12 + j12*j12*c22 + 0.3f;
+    means2D[i * 2] = screenX; means2D[i * 2 + 1] = screenY;
+    covariances2D[i * 3] = cov00; covariances2D[i * 3 + 1] = cov01;
+    covariances2D[i * 3 + 2] = cov11; depths[i] = camZ; visible[i] = 1.0f;
+}
+
+__device__ __forceinline__ bool sample_ray_axis(
+    float origin, float direction, float minimum, float maximum,
+    float* tMin, float* tMax)
+{
+    if (fabsf(direction) < 1.0e-8f)
+        return origin >= minimum && origin <= maximum;
+    float t1 = (minimum - origin) / direction;
+    float t2 = (maximum - origin) / direction;
+    if (t1 > t2) { float temporary = t1; t1 = t2; t2 = temporary; }
+    *tMin = fmaxf(*tMin, t1); *tMax = fminf(*tMax, t2);
+    return *tMax >= *tMin;
+}
+
+extern ""C"" __global__ __launch_bounds__(256) void sample_rays_with_occupancy(
+    const float* __restrict__ rayOrigins,
+    const float* __restrict__ rayDirections,
+    const unsigned int* __restrict__ occupancyBitfield,
+    float* __restrict__ positions,
+    float* __restrict__ directions,
+    float* __restrict__ validMask,
+    float* __restrict__ tValues,
+    int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+    float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+    float nearBound, float farBound)
+{
+    int sampleIndex = blockIdx.x * blockDim.x + threadIdx.x;
+    int totalSamples = numRays * maxSamples;
+    if (sampleIndex >= totalSamples) return;
+    int positionIndex = sampleIndex * 3;
+    positions[positionIndex] = 0.0f; positions[positionIndex + 1] = 0.0f;
+    positions[positionIndex + 2] = 0.0f; directions[positionIndex] = 0.0f;
+    directions[positionIndex + 1] = 0.0f; directions[positionIndex + 2] = 0.0f;
+    validMask[sampleIndex] = 0.0f; tValues[sampleIndex] = 0.0f;
+
+    int ray = sampleIndex / maxSamples, sample = sampleIndex - ray * maxSamples;
+    float ox = rayOrigins[ray * 3], oy = rayOrigins[ray * 3 + 1], oz = rayOrigins[ray * 3 + 2];
+    float dx = rayDirections[ray * 3], dy = rayDirections[ray * 3 + 1], dz = rayDirections[ray * 3 + 2];
+    float tMin = nearBound, tMax = farBound;
+    if (!sample_ray_axis(ox, dx, minX, maxX, &tMin, &tMax) ||
+        !sample_ray_axis(oy, dy, minY, maxY, &tMin, &tMax) ||
+        !sample_ray_axis(oz, dz, minZ, maxZ, &tMin, &tMax) || tMax < tMin) return;
+
+    float t = tMin + ((tMax - tMin) / (float)maxSamples) * ((float)sample + 0.5f);
+    float px = ox + t * dx, py = oy + t * dy, pz = oz + t * dz;
+    float invX = 1.0f / fmaxf(1.0e-10f, maxX - minX);
+    float invY = 1.0f / fmaxf(1.0e-10f, maxY - minY);
+    float invZ = 1.0f / fmaxf(1.0e-10f, maxZ - minZ);
+    float nx = fminf(fmaxf((px - minX) * invX, 0.0f), 0.999999f);
+    float ny = fminf(fmaxf((py - minY) * invY, 0.0f), 0.999999f);
+    float nz = fminf(fmaxf((pz - minZ) * invZ, 0.0f), 0.999999f);
+    int gx = min((int)(nx * (float)gridSize), gridSize - 1);
+    int gy = min((int)(ny * (float)gridSize), gridSize - 1);
+    int gz = min((int)(nz * (float)gridSize), gridSize - 1);
+    int cell = (gx * gridSize + gy) * gridSize + gz;
+    int word = cell >> 5, bit = cell & 31;
+    bool occupied = word < occupancyWordCount &&
+        (occupancyBitfield[word] & (1u << bit)) != 0u;
+    positions[positionIndex] = px; positions[positionIndex + 1] = py; positions[positionIndex + 2] = pz;
+    directions[positionIndex] = dx; directions[positionIndex + 1] = dy; directions[positionIndex + 2] = dz;
+    validMask[sampleIndex] = occupied ? 1.0f : 0.0f; tValues[sampleIndex] = t;
 }
 
 extern ""C"" __global__ void resident_mode(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/GpuBufferPool.cs
@@ -9,11 +9,36 @@ internal interface IPoolableGpuBuffer
     void Release();
 }
 
+/// <summary>
+/// Typed reuse domain for an asynchronous GPU buffer. The global value preserves the
+/// existing single-stream CUDA/HIP pool. Backends with independent command queues use a
+/// native-queue affinity so an in-flight allocation is never recycled onto an unordered queue.
+/// </summary>
+internal readonly struct GpuBufferPoolAffinity : IEquatable<GpuBufferPoolAffinity>
+{
+    private readonly long _value;
+
+    private GpuBufferPoolAffinity(long value) => _value = value;
+
+    internal static GpuBufferPoolAffinity Global => default;
+
+    internal static GpuBufferPoolAffinity ForNativeQueue(IntPtr queue)
+    {
+        if (queue == IntPtr.Zero)
+            throw new ArgumentException("A GPU buffer-pool queue affinity requires a valid native queue.", nameof(queue));
+        return new GpuBufferPoolAffinity(queue.ToInt64());
+    }
+
+    public bool Equals(GpuBufferPoolAffinity other) => _value == other._value;
+    public override bool Equals(object? obj) => obj is GpuBufferPoolAffinity other && Equals(other);
+    public override int GetHashCode() => _value.GetHashCode();
+}
+
 internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class, IGpuBuffer, IPoolableGpuBuffer
 {
     private sealed class Bucket
     {
-        public readonly ConcurrentBag<TBuffer> Buffers = new();
+        public readonly ConcurrentDictionary<GpuBufferPoolAffinity, ConcurrentBag<TBuffer>> Buffers = new();
         public int Count;
     }
 
@@ -46,6 +71,9 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
     }
 
     public bool TryRent(int size, out TBuffer? buffer)
+        => TryRent(size, GpuBufferPoolAffinity.Global, out buffer);
+
+    public bool TryRent(int size, GpuBufferPoolAffinity affinity, out TBuffer? buffer)
     {
         buffer = null;
         if (Volatile.Read(ref _disposed) != 0 || size <= 0 || size > _maxSize)
@@ -55,7 +83,9 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
 
         // Use power-of-two bucket key for higher cache hit rate
         int bucketKey = NextPowerOfTwo(size);
-        if (_buckets.TryGetValue(bucketKey, out var bucket) && bucket.Buffers.TryTake(out var candidate))
+        if (_buckets.TryGetValue(bucketKey, out var bucket)
+            && bucket.Buffers.TryGetValue(affinity, out var affinityBuffers)
+            && affinityBuffers.TryTake(out var candidate))
         {
             // Verify the pooled buffer's actual allocation is large enough.
             // Power-of-two bucketing can match a smaller buffer (e.g., 6272 → bucket 8192)
@@ -64,7 +94,7 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
             {
                 // Return the too-small buffer to the pool (count stays consistent since
                 // we took one out and are putting the same one back)
-                bucket.Buffers.Add(candidate);
+                affinityBuffers.Add(candidate);
                 return false;
             }
 
@@ -78,6 +108,9 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
     }
 
     public void Return(TBuffer buffer)
+        => Return(buffer, GpuBufferPoolAffinity.Global);
+
+    public void Return(TBuffer buffer, GpuBufferPoolAffinity affinity)
     {
         if (Volatile.Read(ref _disposed) != 0 || buffer.Size > _maxSize)
         {
@@ -102,7 +135,7 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
             return;
         }
 
-        bucket.Buffers.Add(buffer);
+        bucket.Buffers.GetOrAdd(affinity, _ => new ConcurrentBag<TBuffer>()).Add(buffer);
     }
 
     /// <summary>
@@ -123,11 +156,14 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
         int released = 0;
         foreach (var bucket in _buckets.Values)
         {
-            while (bucket.Buffers.TryTake(out var buffer))
+            foreach (var affinityBuffers in bucket.Buffers.Values)
             {
-                Interlocked.Decrement(ref bucket.Count);
-                buffer.Release();
-                released++;
+                while (affinityBuffers.TryTake(out var buffer))
+                {
+                    Interlocked.Decrement(ref bucket.Count);
+                    buffer.Release();
+                    released++;
+                }
             }
         }
         return released;
@@ -153,9 +189,12 @@ internal sealed class GpuBufferPool<TBuffer> : IDisposable where TBuffer : class
         {
             foreach (var bucket in _buckets.Values)
             {
-                while (bucket.Buffers.TryTake(out var buffer))
+                foreach (var affinityBuffers in bucket.Buffers.Values)
                 {
-                    buffer.Release();
+                    while (affinityBuffers.TryTake(out var buffer))
+                    {
+                        buffer.Release();
+                    }
                 }
             }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/HIP/HipBackend.InstantNgp.cs
@@ -1,6 +1,6 @@
 namespace AiDotNet.Tensors.Engines.DirectGpu.HIP;
 
-public sealed partial class HipBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed partial class HipBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     private IntPtr ResolveInstantNgpKernel(string name)
     {
@@ -58,6 +58,107 @@ public sealed partial class HipBackend : IInstantNgpBackend, IUniqueConsecutiveB
         int n = length;
         void** args = stackalloc void*[4];
         args[0] = &i; args[1] = &o; args[2] = &c; args[3] = &n;
+        LaunchKernel(kernel, 1, 1, args);
+        Synchronize();
+    }
+
+    public unsafe void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("frexp_decompose");
+        IntPtr i = input.Handle, m = mantissa.Handle, e = exponent.Handle;
+        int n = length;
+        void** args = stackalloc void*[4];
+        args[0] = &i; args[1] = &m; args[2] = &e; args[3] = &n;
+        LaunchKernel(kernel, (uint)((length + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("unique_consecutive_with_info");
+        IntPtr i = input.Handle, v = outputValues.Handle, inverse = outputInverse.Handle;
+        IntPtr counts = outputCounts.Handle, count = outputCount.Handle;
+        int n = length, ri = returnInverse ? 1 : 0, rc = returnCounts ? 1 : 0;
+        void** args = stackalloc void*[8];
+        args[0] = &i; args[1] = &v; args[2] = &inverse; args[3] = &counts;
+        args[4] = &count; args[5] = &n; args[6] = &ri; args[7] = &rc;
+        LaunchKernel(kernel, 1, 1, args);
+        Synchronize();
+    }
+
+    public unsafe void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        var kernel = ResolveInstantNgpKernel("project_gaussians_3d_to_2d");
+        IntPtr m3 = means3D.Handle, c3 = covariances3D.Handle, m2 = means2D.Handle;
+        IntPtr c2 = covariances2D.Handle, d = depths.Handle, vis = visible.Handle;
+        int n = numGaussians, cs = covarianceStride, width = imageWidth, height = imageHeight;
+        void** args = stackalloc void*[24];
+        args[0] = &m3; args[1] = &c3; args[2] = &m2; args[3] = &c2;
+        args[4] = &d; args[5] = &vis; args[6] = &n; args[7] = &cs;
+        args[8] = &width; args[9] = &height;
+        args[10] = &v00; args[11] = &v01; args[12] = &v02; args[13] = &v03;
+        args[14] = &v10; args[15] = &v11; args[16] = &v12; args[17] = &v13;
+        args[18] = &v20; args[19] = &v21; args[20] = &v22; args[21] = &v23;
+        args[22] = &p00; args[23] = &p11;
+        LaunchKernel(kernel,
+            (uint)((numGaussians + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        var kernel = ResolveInstantNgpKernel("sample_rays_with_occupancy");
+        IntPtr o = rayOrigins.Handle, di = rayDirections.Handle, occ = occupancyBitfield.Handle;
+        IntPtr p = positions.Handle, dout = directions.Handle, mask = validMask.Handle, tv = tValues.Handle;
+        int nr = numRays, words = occupancyWordCount, gs = gridSize, samples = maxSamples;
+        void** args = stackalloc void*[19];
+        args[0] = &o; args[1] = &di; args[2] = &occ; args[3] = &p;
+        args[4] = &dout; args[5] = &mask; args[6] = &tv; args[7] = &nr;
+        args[8] = &words; args[9] = &gs; args[10] = &samples;
+        args[11] = &minX; args[12] = &minY; args[13] = &minZ;
+        args[14] = &maxX; args[15] = &maxY; args[16] = &maxZ;
+        args[17] = &nearBound; args[18] = &farBound;
+        LaunchKernel(kernel, (uint)((total + DefaultBlockSize - 1) / DefaultBlockSize),
+            DefaultBlockSize, args);
+        Synchronize();
+    }
+
+    public unsafe void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = ResolveInstantNgpKernel("unique_sorted_with_info");
+        IntPtr i = sortedInput.Handle, original = sortedOriginalIndices.Handle;
+        IntPtr v = outputValues.Handle, inverse = outputInverse.Handle;
+        IntPtr counts = outputCounts.Handle, count = outputCount.Handle;
+        int n = length, ri = returnInverse ? 1 : 0, rc = returnCounts ? 1 : 0;
+        void** args = stackalloc void*[9];
+        args[0] = &i; args[1] = &original; args[2] = &v; args[3] = &inverse;
+        args[4] = &counts; args[5] = &count; args[6] = &n; args[7] = &ri; args[8] = &rc;
         LaunchKernel(kernel, 1, 1, args);
         Synchronize();
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IFrexpBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IFrexpBackend.cs
@@ -1,0 +1,16 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>Optional native FP32 decomposition into mantissa and exponent.</summary>
+public interface IFrexpBackend
+{
+    /// <summary>
+    /// Computes <c>input = mantissa * 2^exponent</c>. Exponents are stored as exactly
+    /// representable float integers, matching the DirectGPU integer-tensor convention.
+    /// </summary>
+    void Frexp(
+        IGpuBuffer input,
+        IGpuBuffer mantissa,
+        IGpuBuffer exponent,
+        int length);
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IRenderingGeometryBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IRenderingGeometryBackend.cs
@@ -1,0 +1,40 @@
+// Copyright (c) AiDotNet. All rights reserved.
+namespace AiDotNet.Tensors.Engines.DirectGpu;
+
+/// <summary>Optional native kernels for fixed-shape rendering and ray-sampling geometry.</summary>
+public interface IRenderingGeometryBackend
+{
+    /// <summary>Projects camera-space Gaussian covariance and world-space means to image space.</summary>
+    void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D,
+        IGpuBuffer covariances3D,
+        IGpuBuffer means2D,
+        IGpuBuffer covariances2D,
+        IGpuBuffer depths,
+        IGpuBuffer visible,
+        int numGaussians,
+        int covarianceStride,
+        int imageWidth,
+        int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23,
+        float p00, float p11);
+
+    /// <summary>Samples fixed ray slots and marks those whose packed occupancy bit is set.</summary>
+    void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins,
+        IGpuBuffer rayDirections,
+        IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions,
+        IGpuBuffer directions,
+        IGpuBuffer validMask,
+        IGpuBuffer tValues,
+        int numRays,
+        int occupancyWordCount,
+        int gridSize,
+        int maxSamples,
+        float minX, float minY, float minZ,
+        float maxX, float maxY, float maxZ,
+        float nearBound, float farBound);
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/IUniqueConsecutiveBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/IUniqueConsecutiveBackend.cs
@@ -12,4 +12,33 @@ public interface IUniqueConsecutiveBackend
         IGpuBuffer outputCapacity,
         IGpuBuffer outputCount,
         int length);
+
+    /// <summary>
+    /// Compacts adjacent runs and optionally emits the run index for each input element and the
+    /// length of each run. Unrequested metadata buffers are not written.
+    /// </summary>
+    void UniqueConsecutiveWithInfo(
+        IGpuBuffer input,
+        IGpuBuffer outputValues,
+        IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts,
+        IGpuBuffer outputCount,
+        int length,
+        bool returnInverse,
+        bool returnCounts);
+
+    /// <summary>
+    /// Compacts already-sorted values while mapping inverse indices back through the matching
+    /// original-position buffer. Original positions use the DirectGPU exact-float index convention.
+    /// </summary>
+    void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput,
+        IGpuBuffer sortedOriginalIndices,
+        IGpuBuffer outputValues,
+        IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts,
+        IGpuBuffer outputCount,
+        int length,
+        bool returnInverse,
+        bool returnCounts);
 }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalBackend.InstantNgp.cs
@@ -1,6 +1,6 @@
 namespace AiDotNet.Tensors.Engines.DirectGpu.Metal;
 
-public sealed partial class MetalBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed partial class MetalBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     private void DispatchInstantNgp(
         string kernelName,
@@ -64,6 +64,120 @@ public sealed partial class MetalBackend : IInstantNgpBackend, IUniqueConsecutiv
         encoder.SetPipelineState(pipeline.Handle);
         encoder.SetBuffer(inputBuffer, 0); encoder.SetBuffer(outputBuffer, 1);
         encoder.SetBuffer(countBuffer, 2); encoder.SetBytes(length, 3);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        var pipeline = GetPipeline(AudioLibName, _audioLibrary, "frexp_decompose");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(length);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)input, 0);
+        encoder.SetBuffer((MetalGpuBuffer)mantissa, 1);
+        encoder.SetBuffer((MetalGpuBuffer)exponent, 2);
+        encoder.SetBytes(length, 3);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        var pipeline = GetPipeline(AudioLibName, _audioLibrary, "unique_consecutive_with_info");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(1);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)input, 0);
+        encoder.SetBuffer((MetalGpuBuffer)outputValues, 1);
+        encoder.SetBuffer((MetalGpuBuffer)outputInverse, 2);
+        encoder.SetBuffer((MetalGpuBuffer)outputCounts, 3);
+        encoder.SetBuffer((MetalGpuBuffer)outputCount, 4);
+        encoder.SetBytes(length, 5);
+        encoder.SetBytes(returnInverse ? 1 : 0, 6);
+        encoder.SetBytes(returnCounts ? 1 : 0, 7);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        ThrowIfDisposed();
+        var pipeline = GetPipeline(AudioLibName, _audioLibrary, "project_gaussians_3d_to_2d");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(numGaussians);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)means3D, 0);
+        encoder.SetBuffer((MetalGpuBuffer)covariances3D, 1);
+        encoder.SetBuffer((MetalGpuBuffer)means2D, 2);
+        encoder.SetBuffer((MetalGpuBuffer)covariances2D, 3);
+        encoder.SetBuffer((MetalGpuBuffer)depths, 4); encoder.SetBuffer((MetalGpuBuffer)visible, 5);
+        encoder.SetBytes(numGaussians, 6); encoder.SetBytes(covarianceStride, 7);
+        encoder.SetBytes(imageWidth, 8); encoder.SetBytes(imageHeight, 9);
+        encoder.SetBytes(v00, 10); encoder.SetBytes(v01, 11); encoder.SetBytes(v02, 12); encoder.SetBytes(v03, 13);
+        encoder.SetBytes(v10, 14); encoder.SetBytes(v11, 15); encoder.SetBytes(v12, 16); encoder.SetBytes(v13, 17);
+        encoder.SetBytes(v20, 18); encoder.SetBytes(v21, 19); encoder.SetBytes(v22, 20); encoder.SetBytes(v23, 21);
+        encoder.SetBytes(p00, 22); encoder.SetBytes(p11, 23);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        ThrowIfDisposed();
+        var pipeline = GetPipeline(AudioLibName, _audioLibrary, "sample_rays_with_occupancy");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(total);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)rayOrigins, 0); encoder.SetBuffer((MetalGpuBuffer)rayDirections, 1);
+        encoder.SetBuffer((MetalGpuBuffer)occupancyBitfield, 2); encoder.SetBuffer((MetalGpuBuffer)positions, 3);
+        encoder.SetBuffer((MetalGpuBuffer)directions, 4); encoder.SetBuffer((MetalGpuBuffer)validMask, 5);
+        encoder.SetBuffer((MetalGpuBuffer)tValues, 6); encoder.SetBytes(numRays, 7);
+        encoder.SetBytes(occupancyWordCount, 8); encoder.SetBytes(gridSize, 9); encoder.SetBytes(maxSamples, 10);
+        encoder.SetBytes(minX, 11); encoder.SetBytes(minY, 12); encoder.SetBytes(minZ, 13);
+        encoder.SetBytes(maxX, 14); encoder.SetBytes(maxY, 15); encoder.SetBytes(maxZ, 16);
+        encoder.SetBytes(nearBound, 17); encoder.SetBytes(farBound, 18);
+        encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
+    }
+
+    public void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        ThrowIfDisposed();
+        var pipeline = GetPipeline(AudioLibName, _audioLibrary, "unique_sorted_with_info");
+        var (threadgroups, threadsPerGroup) = pipeline.Calculate1DDispatch(1);
+        using var encoder = _commandQueue.CreateScopedComputeEncoder();
+        encoder.SetPipelineState(pipeline.Handle);
+        encoder.SetBuffer((MetalGpuBuffer)sortedInput, 0);
+        encoder.SetBuffer((MetalGpuBuffer)sortedOriginalIndices, 1);
+        encoder.SetBuffer((MetalGpuBuffer)outputValues, 2);
+        encoder.SetBuffer((MetalGpuBuffer)outputInverse, 3);
+        encoder.SetBuffer((MetalGpuBuffer)outputCounts, 4);
+        encoder.SetBuffer((MetalGpuBuffer)outputCount, 5);
+        encoder.SetBytes(length, 6);
+        encoder.SetBytes(returnInverse ? 1 : 0, 7);
+        encoder.SetBytes(returnCounts ? 1 : 0, 8);
         encoder.DispatchThreadgroups(threadgroups, threadsPerGroup);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalInstantNgpKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Metal/MetalInstantNgpKernels.cs
@@ -117,6 +117,202 @@ kernel void unique_consecutive_compact(
     outputCount[0] = float(count);
 }
 
+kernel void unique_consecutive_with_info(
+    device const float* input [[buffer(0)]],
+    device float* outputValues [[buffer(1)]],
+    device float* outputInverse [[buffer(2)]],
+    device float* outputCounts [[buffer(3)]],
+    device float* outputCount [[buffer(4)]],
+    constant int& length [[buffer(5)]],
+    constant int& returnInverse [[buffer(6)]],
+    constant int& returnCounts [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid != 0) return;
+    if (length <= 0) { outputCount[0] = 0.0f; return; }
+    int count = 1;
+    outputValues[0] = input[0];
+    if (returnInverse != 0) outputInverse[0] = 0.0f;
+    if (returnCounts != 0) outputCounts[0] = 1.0f;
+    for (int i = 1; i < length; i++) {
+        if (input[i] != input[i - 1]) {
+            outputValues[count] = input[i];
+            if (returnCounts != 0) outputCounts[count] = 1.0f;
+            count++;
+        } else if (returnCounts != 0) {
+            outputCounts[count - 1] += 1.0f;
+        }
+        if (returnInverse != 0) outputInverse[i] = float(count - 1);
+    }
+    outputCount[0] = float(count);
+}
+
+kernel void unique_sorted_with_info(
+    device const float* sortedInput [[buffer(0)]],
+    device const float* sortedOriginalIndices [[buffer(1)]],
+    device float* outputValues [[buffer(2)]],
+    device float* outputInverse [[buffer(3)]],
+    device float* outputCounts [[buffer(4)]],
+    device float* outputCount [[buffer(5)]],
+    constant int& length [[buffer(6)]],
+    constant int& returnInverse [[buffer(7)]],
+    constant int& returnCounts [[buffer(8)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid != 0) return;
+    int count = 0;
+    for (int i = 0; i < length; i++) {
+        if (i == 0 || sortedInput[i] != sortedInput[i - 1]) {
+            outputValues[count] = sortedInput[i];
+            if (returnCounts != 0) outputCounts[count] = 0.0f;
+            count++;
+        }
+        int group = count - 1;
+        if (returnCounts != 0) outputCounts[group] += 1.0f;
+        if (returnInverse != 0)
+            outputInverse[int(sortedOriginalIndices[i])] = float(group);
+    }
+    outputCount[0] = float(count);
+}
+
+kernel void frexp_decompose(
+    device const float* input [[buffer(0)]],
+    device float* mantissa [[buffer(1)]],
+    device float* exponent [[buffer(2)]],
+    constant int& length [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (int(gid) >= length) return;
+    float value = input[gid];
+    uint bits = as_type<uint>(value);
+    uint magnitude = bits & 0x7fffffffu;
+    uint exponentBits = magnitude >> 23;
+    if (exponentBits == 0xffu || magnitude == 0u) {
+        mantissa[gid] = value;
+        exponent[gid] = 0.0f;
+        return;
+    }
+    int scaleAdjustment = 0;
+    if (exponentBits == 0u) {
+        value *= 16777216.0f;
+        bits = as_type<uint>(value);
+        exponentBits = (bits & 0x7fffffffu) >> 23;
+        scaleAdjustment = -24;
+    }
+    mantissa[gid] = as_type<float>((bits & 0x807fffffu) | (126u << 23));
+    exponent[gid] = float(int(exponentBits) - 126 + scaleAdjustment);
+}
+
+kernel void project_gaussians_3d_to_2d(
+    device const float* means3D [[buffer(0)]],
+    device const float* covariances3D [[buffer(1)]],
+    device float* means2D [[buffer(2)]],
+    device float* covariances2D [[buffer(3)]],
+    device float* depths [[buffer(4)]],
+    device float* visible [[buffer(5)]],
+    constant int& numGaussians [[buffer(6)]],
+    constant int& covarianceStride [[buffer(7)]],
+    constant int& imageWidth [[buffer(8)]], constant int& imageHeight [[buffer(9)]],
+    constant float& v00 [[buffer(10)]], constant float& v01 [[buffer(11)]],
+    constant float& v02 [[buffer(12)]], constant float& v03 [[buffer(13)]],
+    constant float& v10 [[buffer(14)]], constant float& v11 [[buffer(15)]],
+    constant float& v12 [[buffer(16)]], constant float& v13 [[buffer(17)]],
+    constant float& v20 [[buffer(18)]], constant float& v21 [[buffer(19)]],
+    constant float& v22 [[buffer(20)]], constant float& v23 [[buffer(21)]],
+    constant float& p00 [[buffer(22)]], constant float& p11 [[buffer(23)]],
+    uint i [[thread_position_in_grid]])
+{
+    if (int(i) >= numGaussians) return;
+    means2D[i * 2] = 0.0f; means2D[i * 2 + 1] = 0.0f;
+    covariances2D[i * 3] = 0.0f; covariances2D[i * 3 + 1] = 0.0f;
+    covariances2D[i * 3 + 2] = 0.0f; depths[i] = 0.0f; visible[i] = 0.0f;
+    float mx = means3D[i * 3], my = means3D[i * 3 + 1], mz = means3D[i * 3 + 2];
+    float camX = v00 * mx + v01 * my + v02 * mz + v03;
+    float camY = v10 * mx + v11 * my + v12 * mz + v13;
+    float camZ = v20 * mx + v21 * my + v22 * mz + v23;
+    if (camZ <= 0.001f) return;
+    float invZ = 1.0f / camZ;
+    float cx = float(imageWidth) * 0.5f, cy = float(imageHeight) * 0.5f;
+    float screenX = p00 * camX * invZ * cx + cx;
+    float screenY = p11 * camY * invZ * cy + cy;
+    if (screenX < -float(imageWidth) || screenX > 2.0f * float(imageWidth) ||
+        screenY < -float(imageHeight) || screenY > 2.0f * float(imageHeight)) return;
+    int c = int(i) * covarianceStride;
+    float c00 = covariances3D[c], c01 = covariances3D[c + 1], c02 = covariances3D[c + 2];
+    float c11 = covariances3D[c + (covarianceStride == 6 ? 3 : 4)];
+    float c12 = covariances3D[c + (covarianceStride == 6 ? 4 : 5)];
+    float c22 = covariances3D[c + (covarianceStride == 6 ? 5 : 8)];
+    float j00 = p00 * invZ, j02 = -p00 * camX * invZ * invZ;
+    float j11 = p11 * invZ, j12 = -p11 * camY * invZ * invZ;
+    float cov00 = j00*j00*c00 + 2.0f*j00*j02*c02 + j02*j02*c22 + 0.3f;
+    float cov01 = j00*j11*c01 + j00*j12*c02 + j02*j11*c12 + j02*j12*c22;
+    float cov11 = j11*j11*c11 + 2.0f*j11*j12*c12 + j12*j12*c22 + 0.3f;
+    means2D[i * 2] = screenX; means2D[i * 2 + 1] = screenY;
+    covariances2D[i * 3] = cov00; covariances2D[i * 3 + 1] = cov01;
+    covariances2D[i * 3 + 2] = cov11; depths[i] = camZ; visible[i] = 1.0f;
+}
+
+inline bool sample_ray_axis(
+    float origin, float direction, float minimum, float maximum,
+    thread float& tMin, thread float& tMax)
+{
+    if (fabs(direction) < 1.0e-8f)
+        return origin >= minimum && origin <= maximum;
+    float t1 = (minimum - origin) / direction;
+    float t2 = (maximum - origin) / direction;
+    if (t1 > t2) { float temporary = t1; t1 = t2; t2 = temporary; }
+    tMin = fmax(tMin, t1); tMax = fmin(tMax, t2);
+    return tMax >= tMin;
+}
+
+kernel void sample_rays_with_occupancy(
+    device const float* rayOrigins [[buffer(0)]],
+    device const float* rayDirections [[buffer(1)]],
+    device const uint* occupancyBitfield [[buffer(2)]],
+    device float* positions [[buffer(3)]],
+    device float* directions [[buffer(4)]],
+    device float* validMask [[buffer(5)]],
+    device float* tValues [[buffer(6)]],
+    constant int& numRays [[buffer(7)]],
+    constant int& occupancyWordCount [[buffer(8)]],
+    constant int& gridSize [[buffer(9)]], constant int& maxSamples [[buffer(10)]],
+    constant float& minX [[buffer(11)]], constant float& minY [[buffer(12)]],
+    constant float& minZ [[buffer(13)]], constant float& maxX [[buffer(14)]],
+    constant float& maxY [[buffer(15)]], constant float& maxZ [[buffer(16)]],
+    constant float& nearBound [[buffer(17)]], constant float& farBound [[buffer(18)]],
+    uint sampleIndex [[thread_position_in_grid]])
+{
+    int totalSamples = numRays * maxSamples;
+    if (int(sampleIndex) >= totalSamples) return;
+    int positionIndex = int(sampleIndex) * 3;
+    positions[positionIndex] = 0.0f; positions[positionIndex + 1] = 0.0f;
+    positions[positionIndex + 2] = 0.0f; directions[positionIndex] = 0.0f;
+    directions[positionIndex + 1] = 0.0f; directions[positionIndex + 2] = 0.0f;
+    validMask[sampleIndex] = 0.0f; tValues[sampleIndex] = 0.0f;
+    int ray = int(sampleIndex) / maxSamples, sample = int(sampleIndex) - ray * maxSamples;
+    float ox = rayOrigins[ray * 3], oy = rayOrigins[ray * 3 + 1], oz = rayOrigins[ray * 3 + 2];
+    float dx = rayDirections[ray * 3], dy = rayDirections[ray * 3 + 1], dz = rayDirections[ray * 3 + 2];
+    float tMin = nearBound, tMax = farBound;
+    if (!sample_ray_axis(ox, dx, minX, maxX, tMin, tMax) ||
+        !sample_ray_axis(oy, dy, minY, maxY, tMin, tMax) ||
+        !sample_ray_axis(oz, dz, minZ, maxZ, tMin, tMax) || tMax < tMin) return;
+    float t = tMin + ((tMax - tMin) / float(maxSamples)) * (float(sample) + 0.5f);
+    float px = ox + t * dx, py = oy + t * dy, pz = oz + t * dz;
+    float nx = clamp((px - minX) / fmax(1.0e-10f, maxX - minX), 0.0f, 0.999999f);
+    float ny = clamp((py - minY) / fmax(1.0e-10f, maxY - minY), 0.0f, 0.999999f);
+    float nz = clamp((pz - minZ) / fmax(1.0e-10f, maxZ - minZ), 0.0f, 0.999999f);
+    int gx = min(int(nx * float(gridSize)), gridSize - 1);
+    int gy = min(int(ny * float(gridSize)), gridSize - 1);
+    int gz = min(int(nz * float(gridSize)), gridSize - 1);
+    int cell = (gx * gridSize + gy) * gridSize + gz;
+    int word = cell >> 5, bit = cell & 31;
+    bool occupied = word < occupancyWordCount &&
+        (occupancyBitfield[word] & (1u << uint(bit))) != 0u;
+    positions[positionIndex] = px; positions[positionIndex + 1] = py; positions[positionIndex + 2] = pz;
+    directions[positionIndex] = dx; directions[positionIndex + 1] = dy; directions[positionIndex + 2] = dz;
+    validMask[sampleIndex] = occupied ? 1.0f : 0.0f; tValues[sampleIndex] = t;
+}
+
 kernel void resident_mode(
     device const float* input [[buffer(0)]],
     device float* output [[buffer(1)]],

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClBuffer.cs
@@ -36,7 +36,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
     /// <summary>
     /// OpenCL buffer wrapper using pure P/Invoke. No managed GPU runtime dependency.
     /// </summary>
-    internal sealed class DirectOpenClBuffer : IDisposable
+    internal sealed class DirectOpenClBuffer : IDisposable, IDirectOpenClMemoryObject
     {
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
@@ -48,6 +48,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         public IntPtr Handle => _buffer;
         public int Length => _length;
+        public IntPtr NativeHandle => _buffer;
+        public DirectOpenClContext OwningContext => _context;
+        public IntPtr LastSubmissionQueue { get; set; }
 
         /// <summary>
         /// Creates a buffer and uploads data from host.
@@ -72,6 +75,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     throw new InvalidOperationException($"Failed to create OpenCL buffer: {err}");
 
                 GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+                _context.RegisterMemoryObject(this);
             }
             finally
             {
@@ -99,6 +103,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException($"Failed to create OpenCL buffer: {err}");
 
             GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+            _context.RegisterMemoryObject(this);
         }
 
         /// <summary>
@@ -122,16 +127,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GCHandle handle = GCHandle.Alloc(destination, GCHandleType.Pinned);
             try
             {
-                int err = OpenClNativeBindings.EnqueueReadBuffer(
-                    _context.CommandQueue,
-                    _buffer,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(_length * sizeof(float)),
-                    handle.AddrOfPinnedObject(),
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(this);
+                int err;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        err = OpenClNativeBindings.EnqueueReadBuffer(
+                            queue, _buffer, 1, UIntPtr.Zero,
+                            (UIntPtr)(_length * sizeof(float)), handle.AddrOfPinnedObject(),
+                            waits.Count, waits.Pointer, IntPtr.Zero);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to read OpenCL buffer: {err}");
@@ -153,16 +168,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GCHandle handle = GCHandle.Alloc(source, GCHandleType.Pinned);
             try
             {
-                int err = OpenClNativeBindings.EnqueueWriteBuffer(
-                    _context.CommandQueue,
-                    _buffer,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(source.Length * sizeof(float)),
-                    handle.AddrOfPinnedObject(),
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(this);
+                int err;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        err = OpenClNativeBindings.EnqueueWriteBuffer(
+                            queue, _buffer, 1, UIntPtr.Zero,
+                            (UIntPtr)(source.Length * sizeof(float)), handle.AddrOfPinnedObject(),
+                            waits.Count, waits.Pointer, IntPtr.Zero);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to write OpenCL buffer: {err}");
@@ -179,9 +204,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (_buffer != IntPtr.Zero)
             {
-                OpenClNativeBindings.ReleaseMemObject(_buffer);
-                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
+                IntPtr memoryObject = _buffer;
                 _buffer = IntPtr.Zero;
+                _context.RetireMemoryObject(this, memoryObject, ByteSize);
             }
 
             _disposed = true;
@@ -192,7 +217,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
     /// OpenCL byte buffer wrapper using pure P/Invoke.
     /// Used for storing packed sparse indices (1 byte per group of 4 elements).
     /// </summary>
-    internal sealed class DirectOpenClByteBuffer : IDisposable
+    internal sealed class DirectOpenClByteBuffer : IDisposable, IDirectOpenClMemoryObject
     {
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
@@ -204,6 +229,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         public IntPtr Handle => _buffer;
         public int Length => _length;
+        public IntPtr NativeHandle => _buffer;
+        public DirectOpenClContext OwningContext => _context;
+        public IntPtr LastSubmissionQueue { get; set; }
 
         /// <summary>
         /// Creates a byte buffer and uploads data from host.
@@ -228,6 +256,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     throw new InvalidOperationException($"Failed to create OpenCL byte buffer: {err}");
 
                 GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+                _context.RegisterMemoryObject(this);
             }
             finally
             {
@@ -255,6 +284,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException($"Failed to create OpenCL byte buffer: {err}");
 
             GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+            _context.RegisterMemoryObject(this);
         }
 
         /// <summary>
@@ -278,16 +308,25 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GCHandle handle = GCHandle.Alloc(destination, GCHandleType.Pinned);
             try
             {
-                int err = OpenClNativeBindings.EnqueueReadBuffer(
-                    _context.CommandQueue,
-                    _buffer,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)_length,
-                    handle.AddrOfPinnedObject(),
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(this);
+                int err;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        err = OpenClNativeBindings.EnqueueReadBuffer(
+                            queue, _buffer, 1, UIntPtr.Zero, (UIntPtr)_length,
+                            handle.AddrOfPinnedObject(), waits.Count, waits.Pointer, IntPtr.Zero);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to read OpenCL byte buffer: {err}");
@@ -311,16 +350,25 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GCHandle handle = GCHandle.Alloc(source, GCHandleType.Pinned);
             try
             {
-                int err = OpenClNativeBindings.EnqueueWriteBuffer(
-                    _context.CommandQueue,
-                    _buffer,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)source.Length,
-                    handle.AddrOfPinnedObject(),
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(this);
+                int err;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        err = OpenClNativeBindings.EnqueueWriteBuffer(
+                            queue, _buffer, 1, UIntPtr.Zero, (UIntPtr)source.Length,
+                            handle.AddrOfPinnedObject(), waits.Count, waits.Pointer, IntPtr.Zero);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to write OpenCL byte buffer: {err}");
@@ -337,9 +385,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (_buffer != IntPtr.Zero)
             {
-                OpenClNativeBindings.ReleaseMemObject(_buffer);
-                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
+                IntPtr memoryObject = _buffer;
                 _buffer = IntPtr.Zero;
+                _context.RetireMemoryObject(this, memoryObject, ByteSize);
             }
 
             _disposed = true;
@@ -350,7 +398,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
     /// OpenCL int buffer wrapper using pure P/Invoke.
     /// Used for atomic counters in work-stealing kernels.
     /// </summary>
-    internal sealed class DirectOpenClIntBuffer : IDisposable
+    internal sealed class DirectOpenClIntBuffer : IDisposable, IDirectOpenClMemoryObject
     {
         private IntPtr _buffer;
         private readonly DirectOpenClContext _context;
@@ -362,6 +410,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         public IntPtr Handle => _buffer;
         public int Length => _length;
+        public IntPtr NativeHandle => _buffer;
+        public DirectOpenClContext OwningContext => _context;
+        public IntPtr LastSubmissionQueue { get; set; }
 
         /// <summary>
         /// Creates an int buffer and uploads data from host.
@@ -386,6 +437,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                     throw new InvalidOperationException($"Failed to create OpenCL int buffer: {err}");
 
                 GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+                _context.RegisterMemoryObject(this);
             }
             finally
             {
@@ -413,6 +465,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
                 throw new InvalidOperationException($"Failed to create OpenCL int buffer: {err}");
 
             GpuKernelDiagnostics.RecordBufferAllocated(ByteSize);
+            _context.RegisterMemoryObject(this);
         }
 
         /// <summary>
@@ -436,16 +489,26 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             GCHandle handle = GCHandle.Alloc(destination, GCHandleType.Pinned);
             try
             {
-                int err = OpenClNativeBindings.EnqueueReadBuffer(
-                    _context.CommandQueue,
-                    _buffer,
-                    1, // blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(_length * sizeof(int)),
-                    handle.AddrOfPinnedObject(),
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(this);
+                int err;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        err = OpenClNativeBindings.EnqueueReadBuffer(
+                            queue, _buffer, 1, UIntPtr.Zero,
+                            (UIntPtr)(_length * sizeof(int)), handle.AddrOfPinnedObject(),
+                            waits.Count, waits.Pointer, IntPtr.Zero);
+                        if (err == OpenClNativeBindings.CL_SUCCESS)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to read OpenCL int buffer: {err}");
@@ -462,9 +525,9 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             if (_buffer != IntPtr.Zero)
             {
-                OpenClNativeBindings.ReleaseMemObject(_buffer);
-                GpuKernelDiagnostics.RecordBufferReleased(ByteSize);
+                IntPtr memoryObject = _buffer;
                 _buffer = IntPtr.Zero;
+                _context.RetireMemoryObject(this, memoryObject, ByteSize);
             }
 
             _disposed = true;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClContext.cs
@@ -3,6 +3,8 @@
 // Works on ALL .NET versions including .NET Framework 4.6.2.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -34,6 +36,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         private IntPtr _platform;
         private bool _profilingSupported;
         private bool _disposed;
+        private readonly object _retirementLock = new object();
+        private readonly List<RetiredMemoryObject> _retiredMemoryObjects = new List<RetiredMemoryObject>();
+        private readonly List<PendingHostTransfer> _pendingHostTransfers = new List<PendingHostTransfer>();
+        private readonly ConcurrentDictionary<IntPtr, byte> _completedQueues = new ConcurrentDictionary<IntPtr, byte>();
         // Per-instance lock that serializes the ONE-TIME clCreateCommandQueue
         // call per worker thread. The OpenCL 1.2 spec § 5.1.1 lists
         // clCreateCommandQueue as thread-safe, but at least AMD's RDNA1 driver
@@ -45,6 +51,32 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         // matches PyTorch's CUDA stream pool which serialises cudaStreamCreate
         // for the same reason on older NVIDIA drivers.
         private readonly object _queueCreateLock = new object();
+
+        private readonly struct RetiredMemoryObject
+        {
+            internal readonly IntPtr MemoryObject;
+            internal readonly IntPtr CompletionEvent;
+            internal readonly long ByteSize;
+
+            internal RetiredMemoryObject(IntPtr memoryObject, IntPtr completionEvent, long byteSize)
+            {
+                MemoryObject = memoryObject;
+                CompletionEvent = completionEvent;
+                ByteSize = byteSize;
+            }
+        }
+
+        private readonly struct PendingHostTransfer
+        {
+            internal readonly IntPtr CompletionEvent;
+            internal readonly GCHandle PinnedMemory;
+
+            internal PendingHostTransfer(IntPtr completionEvent, GCHandle pinnedMemory)
+            {
+                CompletionEvent = completionEvent;
+                PinnedMemory = pinnedMemory;
+            }
+        }
 
         public IntPtr Context => _context;
 
@@ -93,6 +125,155 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public bool IsProfilingEnabled => _profilingSupported;
 
         public IntPtr Device => _device;
+
+        internal bool IsQueueKnownComplete(IntPtr queue)
+            => queue != IntPtr.Zero && _completedQueues.ContainsKey(queue);
+
+        internal void RegisterMemoryObject(IDirectOpenClMemoryObject memory)
+        {
+            ReapCompletedResources();
+            DirectOpenClSubmission.Register(memory);
+        }
+
+        /// <summary>
+        /// Retains a pinned managed transfer buffer until its non-blocking OpenCL command completes. A
+        /// <c>fixed</c> statement that ends immediately after <c>clEnqueueRead/WriteBuffer</c> is not a valid
+        /// asynchronous lifetime: the GC may move that array while the device still owns its pointer.
+        /// </summary>
+        internal void TrackHostTransfer(IntPtr completionEvent, GCHandle pinnedMemory)
+        {
+            if (completionEvent == IntPtr.Zero)
+            {
+                if (pinnedMemory.IsAllocated) pinnedMemory.Free();
+                throw new ArgumentException("An asynchronous host transfer requires a completion event.", nameof(completionEvent));
+            }
+
+            lock (_retirementLock)
+                _pendingHostTransfers.Add(new PendingHostTransfer(completionEvent, pinnedMemory));
+            ReapCompletedResources();
+        }
+
+        /// <summary>
+        /// Detaches a native memory object from future submissions and retires it behind a marker on its
+        /// last-use queue. This is deliberately asynchronous: pool overflow must not turn into a hidden
+        /// <c>clFinish</c> on the allocation hot path.
+        /// </summary>
+        internal void RetireMemoryObject(
+            IDirectOpenClMemoryObject memory,
+            IntPtr memoryObject,
+            long byteSize)
+        {
+            if (memoryObject == IntPtr.Zero) return;
+
+            bool releaseImmediately = false;
+            lock (DirectOpenClSubmission.Gate)
+            {
+                DirectOpenClSubmission.Unregister(memoryObject, memory);
+                IntPtr lastQueue = memory.LastSubmissionQueue;
+                memory.LastSubmissionQueue = IntPtr.Zero;
+
+                if (_disposed || lastQueue == IntPtr.Zero || IsQueueKnownComplete(lastQueue))
+                {
+                    releaseImmediately = true;
+                }
+                else
+                {
+                    int err = OpenClNativeBindings.EnqueueMarkerWithWaitList(
+                        lastQueue, 0, null, out IntPtr completionEvent);
+                    if (err == OpenClNativeBindings.CL_SUCCESS && completionEvent != IntPtr.Zero)
+                    {
+                        // Start the marker without waiting. Reaping is performed opportunistically by later
+                        // allocations/retirements and deterministically during context disposal.
+                        OpenClNativeBindings.Flush(lastQueue);
+                        lock (_retirementLock)
+                            _retiredMemoryObjects.Add(
+                                new RetiredMemoryObject(memoryObject, completionEvent, byteSize));
+                    }
+                    else
+                    {
+                        // Event creation failed, so there is no safe asynchronous ownership token. Finish only
+                        // this exceptional reclamation path rather than risking a use-after-release.
+                        OpenClNativeBindings.Finish(lastQueue);
+                        releaseImmediately = true;
+                    }
+                }
+            }
+
+            if (releaseImmediately)
+                ReleaseMemoryObject(memoryObject, byteSize);
+            else
+                ReapCompletedResources();
+        }
+
+        /// <summary>Reclaims event-fenced memory and host pins whose commands completed, without blocking.</summary>
+        internal void ReapCompletedResources()
+        {
+            lock (_retirementLock)
+            {
+                for (int i = _retiredMemoryObjects.Count - 1; i >= 0; i--)
+                {
+                    var retired = _retiredMemoryObjects[i];
+                    if (!IsEventComplete(retired.CompletionEvent)) continue;
+                    _retiredMemoryObjects.RemoveAt(i);
+                    OpenClNativeBindings.ReleaseEvent(retired.CompletionEvent);
+                    ReleaseMemoryObject(retired.MemoryObject, retired.ByteSize);
+                }
+
+                for (int i = _pendingHostTransfers.Count - 1; i >= 0; i--)
+                {
+                    var transfer = _pendingHostTransfers[i];
+                    if (!IsEventComplete(transfer.CompletionEvent)) continue;
+                    _pendingHostTransfers.RemoveAt(i);
+                    OpenClNativeBindings.ReleaseEvent(transfer.CompletionEvent);
+                    if (transfer.PinnedMemory.IsAllocated) transfer.PinnedMemory.Free();
+                }
+            }
+        }
+
+        internal int PendingMemoryRetirementCount
+        {
+            get { lock (_retirementLock) return _retiredMemoryObjects.Count; }
+        }
+
+        private static bool IsEventComplete(IntPtr eventHandle)
+        {
+            IntPtr statusPtr = Marshal.AllocHGlobal(sizeof(int));
+            try
+            {
+                int err = OpenClNativeBindings.GetEventInfo(
+                    eventHandle,
+                    OpenClNativeBindings.CL_EVENT_COMMAND_EXECUTION_STATUS,
+                    (UIntPtr)sizeof(int),
+                    statusPtr,
+                    out _);
+                if (err != OpenClNativeBindings.CL_SUCCESS) return false;
+                // Negative values are terminal command errors and are just as safe to reclaim as success.
+                return Marshal.ReadInt32(statusPtr) <= OpenClNativeBindings.CL_COMPLETE;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(statusPtr);
+            }
+        }
+
+        private static void ReleaseMemoryObject(IntPtr memoryObject, long byteSize)
+        {
+            OpenClNativeBindings.ReleaseMemObject(memoryObject);
+            GpuKernelDiagnostics.RecordBufferReleased(byteSize);
+        }
+
+        internal void CompleteQueueForDisposal(IntPtr queue)
+        {
+            if (queue == IntPtr.Zero) return;
+            lock (DirectOpenClSubmission.Gate)
+            {
+                int err = OpenClNativeBindings.Finish(queue);
+                if (err != OpenClNativeBindings.CL_SUCCESS)
+                    throw new InvalidOperationException($"Failed to finish OpenCL command queue during disposal: {err}");
+                _completedQueues.TryAdd(queue, 0);
+            }
+            ReapCompletedResources();
+        }
 
         public string DeviceName { get; private set; } = string.Empty;
         public string DeviceVendor { get; private set; } = string.Empty;
@@ -461,10 +642,70 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public void Dispose()
         {
             if (_disposed) return;
-            // Mark disposed FIRST so any concurrent lazy-init from a worker thread
-            // sees the flag and returns IntPtr.Zero instead of creating a new queue
-            // that would leak past disposal.
-            _disposed = true;
+
+            // Stop new submissions and finish every implicit queue under the same gate used to enqueue
+            // kernels. This closes the check/enqueue/dispose race and makes context teardown a real lifetime
+            // boundary instead of releasing queue handles while work is still outstanding.
+            lock (DirectOpenClSubmission.Gate)
+            {
+                if (_disposed) return;
+                _disposed = true;
+
+                var regularToFinish = _threadCommandQueue;
+                if (regularToFinish is not null)
+                {
+                    foreach (IntPtr q in regularToFinish.Values)
+                    {
+                        if (q == IntPtr.Zero) continue;
+                        OpenClNativeBindings.Finish(q);
+                        _completedQueues.TryAdd(q, 0);
+                    }
+                }
+
+                var profilingToFinish = _threadProfilingCommandQueue;
+                if (profilingToFinish is not null)
+                {
+                    foreach (IntPtr q in profilingToFinish.Values)
+                    {
+                        if (q == IntPtr.Zero) continue;
+                        OpenClNativeBindings.Finish(q);
+                        _completedQueues.TryAdd(q, 0);
+                    }
+                }
+            }
+
+            // Every retirement marker is now either complete or belongs to an explicit stream. Waiting for
+            // those event handles covers the latter without needing to retain or enumerate stream wrappers.
+            lock (_retirementLock)
+            {
+                int eventCount = _retiredMemoryObjects.Count + _pendingHostTransfers.Count;
+                if (eventCount > 0)
+                {
+                    var events = new IntPtr[eventCount];
+                    int eventIndex = 0;
+                    for (int i = 0; i < _retiredMemoryObjects.Count; i++)
+                        events[eventIndex++] = _retiredMemoryObjects[i].CompletionEvent;
+                    for (int i = 0; i < _pendingHostTransfers.Count; i++)
+                        events[eventIndex++] = _pendingHostTransfers[i].CompletionEvent;
+                    OpenClNativeBindings.WaitForEvents((uint)events.Length, events);
+
+                    for (int i = 0; i < _retiredMemoryObjects.Count; i++)
+                    {
+                        var retired = _retiredMemoryObjects[i];
+                        OpenClNativeBindings.ReleaseEvent(retired.CompletionEvent);
+                        ReleaseMemoryObject(retired.MemoryObject, retired.ByteSize);
+                    }
+                    _retiredMemoryObjects.Clear();
+
+                    for (int i = 0; i < _pendingHostTransfers.Count; i++)
+                    {
+                        var transfer = _pendingHostTransfers[i];
+                        OpenClNativeBindings.ReleaseEvent(transfer.CompletionEvent);
+                        if (transfer.PinnedMemory.IsAllocated) transfer.PinnedMemory.Free();
+                    }
+                    _pendingHostTransfers.Clear();
+                }
+            }
 
             var profiling = _threadProfilingCommandQueue;
             _threadProfilingCommandQueue = null;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClKernel.cs
@@ -45,7 +45,14 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             public readonly uint Index;
             public readonly ArgKind Kind;
             public readonly long Raw; // buffer handle / int / float-bits / ulong / local byte size
-            public PendingArg(uint index, ArgKind kind, long raw) { Index = index; Kind = kind; Raw = raw; }
+            public readonly IDirectOpenClMemoryObject? Memory;
+            public PendingArg(uint index, ArgKind kind, long raw, IDirectOpenClMemoryObject? memory = null)
+            {
+                Index = index;
+                Kind = kind;
+                Raw = raw;
+                Memory = memory;
+            }
         }
 
         // Per-thread pending args. Each op sets a kernel's args then immediately
@@ -67,7 +74,10 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
         // Serializes the apply-args + enqueue critical section across ALL kernels
         // (the shared cl_kernel arg state and the shared command queue both require it).
-        private static readonly object _submitLock = new object();
+        private static object SubmitLock => DirectOpenClSubmission.Gate;
+
+        [ThreadStatic]
+        private static System.Collections.Generic.List<IDirectOpenClMemoryObject>? _pendingMemories;
 
         private static System.Collections.Generic.List<PendingArg> Pending
             => _pendingArgs ??= new System.Collections.Generic.List<PendingArg>(8);
@@ -101,7 +111,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         #region SetArg Overloads
 
         public void SetArg(uint index, IntPtr bufferHandle)
-            => Stage(this, index).Add(new PendingArg(index, ArgKind.Buffer, (long)bufferHandle));
+            => Stage(this, index).Add(new PendingArg(
+                index,
+                ArgKind.Buffer,
+                (long)bufferHandle,
+                DirectOpenClSubmission.Resolve(bufferHandle)));
 
         public void SetArg(uint index, int value)
             => Stage(this, index).Add(new PendingArg(index, ArgKind.Int32, value));
@@ -119,7 +133,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             => Stage(this, index).Add(new PendingArg(index, ArgKind.Local, sizeInBytes));
 
         // Applies the per-thread pending args to the shared kernel. MUST be called
-        // while holding _submitLock and immediately before the matching enqueue.
+        // while holding the shared submission gate and immediately before the matching enqueue.
         private void ApplyPendingArgsLocked()
         {
             ThrowIfUnusable();
@@ -180,6 +194,67 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             }
         }
 
+        private static System.Collections.Generic.List<IDirectOpenClMemoryObject> CollectPendingMemories()
+        {
+            var memories = _pendingMemories
+                ??= new System.Collections.Generic.List<IDirectOpenClMemoryObject>(8);
+            memories.Clear();
+            var pending = _pendingArgs;
+            if (pending is null) return memories;
+
+            for (int i = 0; i < pending.Count; i++)
+            {
+                var memory = pending[i].Memory;
+                if (memory is null) continue;
+                bool seen = false;
+                for (int j = 0; j < memories.Count; j++)
+                    if (ReferenceEquals(memories[j], memory)) { seen = true; break; }
+                if (!seen) memories.Add(memory);
+            }
+            return memories;
+        }
+
+        /// <summary>
+        /// Applies arguments, establishes cross-queue memory dependencies, enqueues, and commits each
+        /// buffer's last-use queue as one indivisible operation. The ordinary same-queue path allocates no
+        /// events and remains fully asynchronous.
+        /// </summary>
+        private int EnqueueKernel(
+            IntPtr commandQueue,
+            uint workDim,
+            UIntPtr[] globalSizes,
+            UIntPtr[] localSizes,
+            IntPtr eventOut)
+        {
+            lock (SubmitLock)
+            {
+                var memories = CollectPendingMemories();
+                try
+                {
+                    using var waits = DirectOpenClSubmission.PrepareLocked(commandQueue, memories);
+                    ApplyPendingArgsLocked();
+                    int err = OpenClNativeBindings.EnqueueNDRangeKernel(
+                        commandQueue,
+                        _kernel,
+                        workDim,
+                        null,
+                        globalSizes,
+                        localSizes,
+                        waits.Count,
+                        waits.Pointer,
+                        eventOut);
+                    if (err == OpenClNativeBindings.CL_SUCCESS)
+                        DirectOpenClSubmission.CommitLocked(commandQueue, memories);
+                    return err;
+                }
+                finally
+                {
+                    memories.Clear();
+                    DiscardPendingArgs();
+                }
+            }
+        }
+
         #endregion
 
         #region Execution
@@ -199,22 +274,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    _context.CommandQueue,
-                    _kernel,
-                    1, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                _context.CommandQueue, 1, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
             {
@@ -242,22 +303,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    _context.CommandQueue,
-                    _kernel,
-                    2, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                _context.CommandQueue, 2, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
             {
@@ -286,22 +333,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    _context.CommandQueue,
-                    _kernel,
-                    3, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                _context.CommandQueue, 3, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
             {
@@ -335,22 +368,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    commandQueue,
-                    _kernel,
-                    1, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                commandQueue, 1, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
@@ -383,22 +402,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    commandQueue,
-                    _kernel,
-                    2, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                commandQueue, 2, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
@@ -435,22 +440,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             BeginLaunch(TotalOf(globalSizes), TotalOf(localSizes));
 
-            int err;
-            lock (_submitLock)
-            {
-                ApplyPendingArgsLocked();
-                err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                    commandQueue,
-                    _kernel,
-                    3, // work_dim
-                    null, // global_work_offset
-                    globalSizes,
-                    localSizes,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-                DiscardPendingArgs();
-            }
+            int err = EnqueueKernel(
+                commandQueue, 3, globalSizes, localSizes, IntPtr.Zero);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to enqueue kernel on queue: {err}");
@@ -493,22 +484,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             IntPtr eventHandle = Marshal.AllocHGlobal(IntPtr.Size);
             try
             {
-                int err;
-                lock (_submitLock)
-                {
-                    ApplyPendingArgsLocked();
-                    err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                        _context.ProfilingCommandQueue,
-                        _kernel,
-                        2, // work_dim
-                        null, // global_work_offset
-                        globalSizes,
-                        localSizes,
-                        0,
-                        IntPtr.Zero,
-                        eventHandle);
-                    DiscardPendingArgs();
-                }
+                int err = EnqueueKernel(
+                    _context.ProfilingCommandQueue, 2, globalSizes, localSizes, eventHandle);
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
@@ -559,22 +536,8 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             IntPtr eventHandle = Marshal.AllocHGlobal(IntPtr.Size);
             try
             {
-                int err;
-                lock (_submitLock)
-                {
-                    ApplyPendingArgsLocked();
-                    err = OpenClNativeBindings.EnqueueNDRangeKernel(
-                        _context.ProfilingCommandQueue,
-                        _kernel,
-                        1,
-                        null,
-                        globalSizes,
-                        localSizes,
-                        0,
-                        IntPtr.Zero,
-                        eventHandle);
-                    DiscardPendingArgs();
-                }
+                int err = EnqueueKernel(
+                    _context.ProfilingCommandQueue, 1, globalSizes, localSizes, eventHandle);
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"Failed to enqueue kernel: {err}");
@@ -701,7 +664,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             // the launch then hands the released handle to clSetKernelArg. Taking the same lock the
             // apply-and-enqueue critical section holds makes release and submission mutually
             // exclusive, so a validated handle stays valid until its enqueue completes.
-            lock (_submitLock)
+            lock (SubmitLock)
             {
                 DisposeLocked();
             }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClSubmission.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/DirectOpenClSubmission.cs
@@ -1,0 +1,196 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
+{
+    /// <summary>
+    /// A native OpenCL memory object whose queue ownership is tracked at submission time.
+    /// Queue handles and memory-object handles are process-local native identities, not user policy strings.
+    /// </summary>
+    internal interface IDirectOpenClMemoryObject
+    {
+        IntPtr NativeHandle { get; }
+        DirectOpenClContext OwningContext { get; }
+
+        /// <summary>
+        /// Last queue on which a command using this memory object was submitted. Access is serialized by
+        /// <see cref="DirectOpenClSubmission.Gate"/>.
+        /// </summary>
+        IntPtr LastSubmissionQueue { get; set; }
+    }
+
+    /// <summary>
+    /// Serializes OpenCL submission bookkeeping with the native enqueue it describes. The existing kernel
+    /// submit lock protected shared <c>cl_kernel</c> argument state, but buffer dependencies and retirement
+    /// must be committed in that same critical section or another thread can reclaim a buffer between the
+    /// bookkeeping update and <c>clEnqueue*</c>.
+    /// </summary>
+    internal static class DirectOpenClSubmission
+    {
+        internal static readonly object Gate = new object();
+
+        private static readonly ConcurrentDictionary<IntPtr, IDirectOpenClMemoryObject> MemoryObjects = new();
+
+        [ThreadStatic]
+        private static List<IDirectOpenClMemoryObject>? _directSubmissionMemories;
+
+        internal static void Register(IDirectOpenClMemoryObject memory)
+        {
+            IntPtr handle = memory.NativeHandle;
+            if (handle == IntPtr.Zero)
+                throw new ArgumentException("Cannot register a null OpenCL memory-object handle.", nameof(memory));
+            if (!MemoryObjects.TryAdd(handle, memory))
+                throw new InvalidOperationException("An OpenCL memory-object handle is already registered.");
+        }
+
+        internal static IDirectOpenClMemoryObject? Resolve(IntPtr handle)
+            => handle != IntPtr.Zero && MemoryObjects.TryGetValue(handle, out var memory) ? memory : null;
+
+        internal static void Unregister(IntPtr handle, IDirectOpenClMemoryObject memory)
+        {
+            if (handle == IntPtr.Zero) return;
+            if (MemoryObjects.TryGetValue(handle, out var registered) && ReferenceEquals(registered, memory))
+                MemoryObjects.TryRemove(handle, out _);
+        }
+
+        internal static List<IDirectOpenClMemoryObject> GetDirectSubmissionMemories(
+            IDirectOpenClMemoryObject first,
+            IDirectOpenClMemoryObject? second = null,
+            IDirectOpenClMemoryObject? third = null)
+        {
+            var memories = _directSubmissionMemories
+                ??= new List<IDirectOpenClMemoryObject>(2);
+            if (memories.Count != 0)
+                throw new InvalidOperationException("Nested direct OpenCL submission bookkeeping is not supported.");
+            memories.Add(first);
+            if (second is not null && !ReferenceEquals(first, second)) memories.Add(second);
+            if (third is not null && !ReferenceEquals(first, third) && !ReferenceEquals(second, third))
+                memories.Add(third);
+            return memories;
+        }
+
+        internal static void ReleaseDirectSubmissionMemories(List<IDirectOpenClMemoryObject> memories)
+            => memories.Clear();
+
+        /// <summary>
+        /// Creates device-side dependencies for memory objects moving between independent queues. The common
+        /// same-queue path allocates nothing and enqueues no event. Call only while holding <see cref="Gate"/>.
+        /// </summary>
+        internal static SubmissionWaitList PrepareLocked(
+            IntPtr destinationQueue,
+            IReadOnlyList<IDirectOpenClMemoryObject> memories)
+        {
+            if (destinationQueue == IntPtr.Zero)
+                throw new ArgumentException("A submission requires a valid OpenCL command queue.", nameof(destinationQueue));
+
+            List<IntPtr>? sourceQueues = null;
+            for (int i = 0; i < memories.Count; i++)
+            {
+                var memory = memories[i];
+                IntPtr sourceQueue = memory.LastSubmissionQueue;
+                if (sourceQueue == IntPtr.Zero || sourceQueue == destinationQueue
+                    || memory.OwningContext.IsQueueKnownComplete(sourceQueue))
+                    continue;
+
+                sourceQueues ??= new List<IntPtr>(2);
+                bool seen = false;
+                for (int j = 0; j < sourceQueues.Count; j++)
+                    if (sourceQueues[j] == sourceQueue) { seen = true; break; }
+                if (!seen) sourceQueues.Add(sourceQueue);
+            }
+
+            if (sourceQueues is null)
+                return default;
+
+            var events = new IntPtr[sourceQueues.Count];
+            int created = 0;
+            try
+            {
+                for (int i = 0; i < sourceQueues.Count; i++)
+                {
+                    IntPtr sourceQueue = sourceQueues[i];
+                    int err = OpenClNativeBindings.EnqueueMarkerWithWaitList(
+                        sourceQueue, 0, null, out IntPtr markerEvent);
+                    if (err != OpenClNativeBindings.CL_SUCCESS || markerEvent == IntPtr.Zero)
+                    {
+                        // A queue wrapper synchronizes before it is released and records that fact with the
+                        // context. If a foreign/driver queue disappeared without that notification, fail closed:
+                        // silently omitting the dependency would allow the consumer to race its producer.
+                        throw new InvalidOperationException(
+                            $"Failed to fence OpenCL producer queue before a cross-queue buffer use: {err}.");
+                    }
+
+                    events[created++] = markerEvent;
+                    // A marker held only by the host event reference is not guaranteed to leave the driver's
+                    // submission batch promptly. Flush starts it without waiting and preserves GPU overlap.
+                    OpenClNativeBindings.Flush(sourceQueue);
+                }
+
+                IntPtr waitList = Marshal.AllocHGlobal(checked(created * IntPtr.Size));
+                for (int i = 0; i < created; i++)
+                    Marshal.WriteIntPtr(waitList, i * IntPtr.Size, events[i]);
+                return new SubmissionWaitList(events, created, waitList);
+            }
+            catch
+            {
+                for (int i = 0; i < created; i++)
+                    OpenClNativeBindings.ReleaseEvent(events[i]);
+                throw;
+            }
+        }
+
+        /// <summary>Commits queue ownership after, and only after, a successful native enqueue.</summary>
+        internal static void CommitLocked(
+            IntPtr destinationQueue,
+            IReadOnlyList<IDirectOpenClMemoryObject> memories)
+        {
+            for (int i = 0; i < memories.Count; i++)
+                memories[i].LastSubmissionQueue = destinationQueue;
+        }
+
+        internal readonly struct SubmissionWaitList : IDisposable
+        {
+            private readonly IntPtr[]? _events;
+            private readonly int _eventCount;
+
+            internal uint Count => (uint)_eventCount;
+            internal IntPtr Pointer { get; }
+
+            internal SubmissionWaitList(IntPtr[] events, int eventCount, IntPtr pointer)
+            {
+                _events = events;
+                _eventCount = eventCount;
+                Pointer = pointer;
+            }
+
+            /// <summary>
+            /// Inserts the wait list into a destination queue for native libraries, such as CLBlast, whose
+            /// API accepts a queue but exposes no OpenCL event wait-list parameter. The following library
+            /// enqueue is ordered after this bridge marker because AiDotNet creates in-order queues.
+            /// </summary>
+            internal void EnqueueBridgeMarker(IntPtr destinationQueue)
+            {
+                if (_eventCount == 0 || _events is null) return;
+                int err = OpenClNativeBindings.EnqueueMarkerWithWaitList(
+                    destinationQueue, (uint)_eventCount, _events, out IntPtr bridgeEvent);
+                if (err != OpenClNativeBindings.CL_SUCCESS || bridgeEvent == IntPtr.Zero)
+                    throw new InvalidOperationException(
+                        $"Failed to enqueue an OpenCL cross-queue dependency marker: {err}.");
+                OpenClNativeBindings.ReleaseEvent(bridgeEvent);
+            }
+
+            public void Dispose()
+            {
+                if (Pointer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(Pointer);
+                if (_events is null) return;
+                for (int i = 0; i < _eventCount; i++)
+                    if (_events[i] != IntPtr.Zero) OpenClNativeBindings.ReleaseEvent(_events[i]);
+            }
+        }
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.InstantNgp.cs
@@ -1,7 +1,7 @@
 #if !NET462
 namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
 
-public sealed partial class OpenClBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed partial class OpenClBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     private DirectOpenClKernel GetInstantNgpKernel(string name)
     {
@@ -54,6 +54,98 @@ public sealed partial class OpenClBackend : IInstantNgpBackend, IUniqueConsecuti
         kernel.SetArg(1, InstantNgpHandle(outputCapacity));
         kernel.SetArg(2, InstantNgpHandle(outputCount));
         kernel.SetArg(3, length);
+        kernel.Execute1D(1, 1);
+    }
+
+    public void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        var kernel = GetInstantNgpKernel("frexp_decompose");
+        kernel.SetArg(0, InstantNgpHandle(input));
+        kernel.SetArg(1, InstantNgpHandle(mantissa));
+        kernel.SetArg(2, InstantNgpHandle(exponent));
+        kernel.SetArg(3, length);
+        kernel.Execute1D(length, CalculateOptimalWorkGroupSize1D(length));
+    }
+
+    public void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = GetInstantNgpKernel("unique_consecutive_with_info");
+        kernel.SetArg(0, InstantNgpHandle(input));
+        kernel.SetArg(1, InstantNgpHandle(outputValues));
+        kernel.SetArg(2, InstantNgpHandle(outputInverse));
+        kernel.SetArg(3, InstantNgpHandle(outputCounts));
+        kernel.SetArg(4, InstantNgpHandle(outputCount));
+        kernel.SetArg(5, length); kernel.SetArg(6, returnInverse ? 1 : 0);
+        kernel.SetArg(7, returnCounts ? 1 : 0);
+        kernel.Execute1D(1, 1);
+    }
+
+    public void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        var kernel = GetInstantNgpKernel("project_gaussians_3d_to_2d");
+        kernel.SetArg(0, InstantNgpHandle(means3D));
+        kernel.SetArg(1, InstantNgpHandle(covariances3D));
+        kernel.SetArg(2, InstantNgpHandle(means2D));
+        kernel.SetArg(3, InstantNgpHandle(covariances2D));
+        kernel.SetArg(4, InstantNgpHandle(depths)); kernel.SetArg(5, InstantNgpHandle(visible));
+        kernel.SetArg(6, numGaussians); kernel.SetArg(7, covarianceStride);
+        kernel.SetArg(8, imageWidth); kernel.SetArg(9, imageHeight);
+        kernel.SetArg(10, v00); kernel.SetArg(11, v01); kernel.SetArg(12, v02); kernel.SetArg(13, v03);
+        kernel.SetArg(14, v10); kernel.SetArg(15, v11); kernel.SetArg(16, v12); kernel.SetArg(17, v13);
+        kernel.SetArg(18, v20); kernel.SetArg(19, v21); kernel.SetArg(20, v22); kernel.SetArg(21, v23);
+        kernel.SetArg(22, p00); kernel.SetArg(23, p11);
+        kernel.Execute1D(numGaussians, CalculateOptimalWorkGroupSize1D(numGaussians));
+    }
+
+    public void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        var kernel = GetInstantNgpKernel("sample_rays_with_occupancy");
+        kernel.SetArg(0, InstantNgpHandle(rayOrigins)); kernel.SetArg(1, InstantNgpHandle(rayDirections));
+        kernel.SetArg(2, InstantNgpHandle(occupancyBitfield)); kernel.SetArg(3, InstantNgpHandle(positions));
+        kernel.SetArg(4, InstantNgpHandle(directions)); kernel.SetArg(5, InstantNgpHandle(validMask));
+        kernel.SetArg(6, InstantNgpHandle(tValues)); kernel.SetArg(7, numRays);
+        kernel.SetArg(8, occupancyWordCount); kernel.SetArg(9, gridSize); kernel.SetArg(10, maxSamples);
+        kernel.SetArg(11, minX); kernel.SetArg(12, minY); kernel.SetArg(13, minZ);
+        kernel.SetArg(14, maxX); kernel.SetArg(15, maxY); kernel.SetArg(16, maxZ);
+        kernel.SetArg(17, nearBound); kernel.SetArg(18, farBound);
+        kernel.Execute1D(total, CalculateOptimalWorkGroupSize1D(total));
+    }
+
+    public void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        var kernel = GetInstantNgpKernel("unique_sorted_with_info");
+        kernel.SetArg(0, InstantNgpHandle(sortedInput));
+        kernel.SetArg(1, InstantNgpHandle(sortedOriginalIndices));
+        kernel.SetArg(2, InstantNgpHandle(outputValues));
+        kernel.SetArg(3, InstantNgpHandle(outputInverse));
+        kernel.SetArg(4, InstantNgpHandle(outputCounts));
+        kernel.SetArg(5, InstantNgpHandle(outputCount));
+        kernel.SetArg(6, length); kernel.SetArg(7, returnInverse ? 1 : 0);
+        kernel.SetArg(8, returnCounts ? 1 : 0);
         kernel.Execute1D(1, 1);
     }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -124,6 +124,12 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             get => _isAvailable && !_disposed;
             private set => _isAvailable = value;
         }
+        internal void ReapCompletedOpenClResources()
+            => _context?.ReapCompletedResources();
+
+        internal void CompleteCommandQueueForDisposal(IntPtr commandQueue)
+            => _context?.CompleteQueueForDisposal(commandQueue);
+
         public string? InitializationError { get; private set; }
         public string BackendName => "OpenCL";
         public TensorDevice DeviceType => TensorDevice.OpenCL;
@@ -1258,14 +1264,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
 
-            if (_bufferPool.TryRent(data.Length, out var pooled) && pooled != null)
+            var affinity = GpuBufferPoolAffinity.ForNativeQueue(_context.CommandQueue);
+            if (_bufferPool.TryRent(data.Length, affinity, out var pooled) && pooled != null)
             {
                 pooled.Buffer.CopyFromHost(data);
                 return pooled;
             }
 
             var buffer = new DirectOpenClBuffer(_context, data);
-            return new DirectOpenClGpuBuffer(buffer, _bufferPool.Return);
+            return new DirectOpenClGpuBuffer(buffer, ReturnOpenClBufferToPool);
         }
 
         public IGpuBuffer AllocateBuffer(int size)
@@ -1273,11 +1280,29 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
 
-            if (_bufferPool.TryRent(size, out var pooled) && pooled != null)
+            var affinity = GpuBufferPoolAffinity.ForNativeQueue(_context.CommandQueue);
+            if (_bufferPool.TryRent(size, affinity, out var pooled) && pooled != null)
                 return pooled;
 
             var buffer = new DirectOpenClBuffer(_context, size);
-            return new DirectOpenClGpuBuffer(buffer, _bufferPool.Return);
+            return new DirectOpenClGpuBuffer(buffer, ReturnOpenClBufferToPool);
+        }
+
+        private void ReturnOpenClBufferToPool(DirectOpenClGpuBuffer buffer)
+        {
+            var context = _context;
+            if (context is null || _disposed)
+            {
+                buffer.Release();
+                return;
+            }
+
+            IntPtr lastQueue;
+            lock (DirectOpenClSubmission.Gate)
+                lastQueue = buffer.Buffer.LastSubmissionQueue;
+            if (lastQueue == IntPtr.Zero)
+                lastQueue = context.CommandQueue;
+            _bufferPool.Return(buffer, GpuBufferPoolAffinity.ForNativeQueue(lastQueue));
         }
 
         public float[] DownloadBuffer(IGpuBuffer buffer)
@@ -1337,17 +1362,55 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var sizeBytes = new UIntPtr((ulong)size * sizeof(float));
 
             GpuLaunchProbe.OnLaunch(); // device-to-device copy = GPU-resident work (keeps data on device)
-            int err = OpenClNativeBindings.EnqueueCopyBuffer(
+            int err = EnqueueTrackedCopy(
                 _context.CommandQueue,
+                ((DirectOpenClGpuBuffer)source).Buffer,
+                ((DirectOpenClGpuBuffer)destination).Buffer,
                 srcHandle,
                 destHandle,
                 srcOffsetBytes,
                 destOffsetBytes,
-                sizeBytes,
-                0, IntPtr.Zero, IntPtr.Zero);
+                sizeBytes);
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"OpenCL copy failed: {err}");
+        }
+
+        private static int EnqueueTrackedCopy(
+            IntPtr commandQueue,
+            DirectOpenClBuffer source,
+            DirectOpenClBuffer destination,
+            IntPtr sourceHandle,
+            IntPtr destinationHandle,
+            UIntPtr sourceOffset,
+            UIntPtr destinationOffset,
+            UIntPtr byteCount)
+        {
+            var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(source, destination);
+            try
+            {
+                lock (DirectOpenClSubmission.Gate)
+                {
+                    using var waits = DirectOpenClSubmission.PrepareLocked(commandQueue, memories);
+                    int err = OpenClNativeBindings.EnqueueCopyBuffer(
+                        commandQueue,
+                        sourceHandle,
+                        destinationHandle,
+                        sourceOffset,
+                        destinationOffset,
+                        byteCount,
+                        waits.Count,
+                        waits.Pointer,
+                        IntPtr.Zero);
+                    if (err == OpenClNativeBindings.CL_SUCCESS)
+                        DirectOpenClSubmission.CommitLocked(commandQueue, memories);
+                    return err;
+                }
+            }
+            finally
+            {
+                DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+            }
         }
 
         #endregion
@@ -2354,22 +2417,38 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (ClBlastNative.IsAvailable)
             {
                 IntPtr queue = _context.CommandQueue;
+                var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(bufferA, bufferB, bufferC);
 
                 // CLBlast row-major: C[M,N] = A[M,K] · Bᵀ where B is stored as
                 // [N, K] row-major. We pass transA=No, transB=Yes; ldA=K (row
                 // stride of A), ldB=K (row stride of B as stored), ldC=N.
-                var status = ClBlastNative.Sgemm(
-                    ClBlastNative.Layout.RowMajor,
-                    ClBlastNative.Transpose.No,
-                    ClBlastNative.Transpose.Yes,
-                    (UIntPtr)M, (UIntPtr)N, (UIntPtr)K,
-                    alpha,
-                    bufferA.Handle, UIntPtr.Zero, (UIntPtr)K,
-                    bufferB.Handle, UIntPtr.Zero, (UIntPtr)K,
-                    beta,
-                    bufferC.Handle, UIntPtr.Zero, (UIntPtr)N,
-                    ref queue,
-                    IntPtr.Zero);
+                ClBlastNative.StatusCode status;
+                try
+                {
+                    lock (DirectOpenClSubmission.Gate)
+                    {
+                        using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                        waits.EnqueueBridgeMarker(queue);
+                        status = ClBlastNative.Sgemm(
+                            ClBlastNative.Layout.RowMajor,
+                            ClBlastNative.Transpose.No,
+                            ClBlastNative.Transpose.Yes,
+                            (UIntPtr)M, (UIntPtr)N, (UIntPtr)K,
+                            alpha,
+                            bufferA.Handle, UIntPtr.Zero, (UIntPtr)K,
+                            bufferB.Handle, UIntPtr.Zero, (UIntPtr)K,
+                            beta,
+                            bufferC.Handle, UIntPtr.Zero, (UIntPtr)N,
+                            ref queue,
+                            IntPtr.Zero);
+                        if (status == ClBlastNative.StatusCode.Success)
+                            DirectOpenClSubmission.CommitLocked(queue, memories);
+                    }
+                }
+                finally
+                {
+                    DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                }
                 if (status == ClBlastNative.StatusCode.Success)
                 {
                     // CLBlast enqueues directly through the native OpenCL command queue,
@@ -4596,7 +4675,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         /// <inheritdoc/>
-        public unsafe void UploadBufferAsync(float[] data, IGpuBuffer buffer, IGpuStream stream)
+        public void UploadBufferAsync(float[] data, IGpuBuffer buffer, IGpuStream stream)
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
@@ -4605,53 +4684,62 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             var openClBuffer = (DirectOpenClGpuBuffer)buffer;
-            fixed (float* dataPtr = data)
+            GCHandle pinned = GCHandle.Alloc(data, GCHandleType.Pinned);
+            IntPtr transferEvent = IntPtr.Zero;
+            bool ownershipTransferred = false;
+            var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(openClBuffer.Buffer);
+            try
             {
-                int err = OpenClNativeBindings.EnqueueWriteBuffer(
-                    stream.Handle,
-                    openClBuffer.Buffer.Handle,
-                    0, // non-blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(data.Length * sizeof(float)),
-                    (IntPtr)dataPtr,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                int err;
+                lock (DirectOpenClSubmission.Gate)
+                {
+                    using var waits = DirectOpenClSubmission.PrepareLocked(stream.Handle, memories);
+                    err = OpenClNativeBindings.EnqueueWriteBufferWithEvent(
+                        stream.Handle, openClBuffer.Buffer.Handle, 0, UIntPtr.Zero,
+                        (UIntPtr)(data.Length * sizeof(float)), pinned.AddrOfPinnedObject(),
+                        waits.Count, waits.Pointer, out transferEvent);
+                    if (err == OpenClNativeBindings.CL_SUCCESS)
+                        DirectOpenClSubmission.CommitLocked(stream.Handle, memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"clEnqueueWriteBuffer failed: {err}");
+
+                OpenClNativeBindings.Flush(stream.Handle);
+                _context.TrackHostTransfer(transferEvent, pinned);
+                ownershipTransferred = true;
+            }
+            finally
+            {
+                DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                if (!ownershipTransferred)
+                {
+                    if (transferEvent != IntPtr.Zero)
+                    {
+                        OpenClNativeBindings.WaitForEvents(1, new[] { transferEvent });
+                        OpenClNativeBindings.ReleaseEvent(transferEvent);
+                    }
+                    if (pinned.IsAllocated) pinned.Free();
+                }
             }
         }
 
         /// <inheritdoc/>
-        public unsafe void UploadBufferAsync(ReadOnlySpan<float> data, IGpuBuffer buffer, IGpuStream stream)
+        public void UploadBufferAsync(ReadOnlySpan<float> data, IGpuBuffer buffer, IGpuStream stream)
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
-            var openClBuffer = (DirectOpenClGpuBuffer)buffer;
-            fixed (float* dataPtr = data)
-            {
-                int err = OpenClNativeBindings.EnqueueWriteBuffer(
-                    stream.Handle,
-                    openClBuffer.Buffer.Handle,
-                    0, // non-blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(data.Length * sizeof(float)),
-                    (IntPtr)dataPtr,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
-
-                if (err != OpenClNativeBindings.CL_SUCCESS)
-                    throw new InvalidOperationException($"clEnqueueWriteBuffer failed: {err}");
-            }
+            // A ReadOnlySpan may point at movable managed memory or the caller's stack. Neither can legally
+            // outlive this asynchronous method, so stage it into an owned array whose pin is retained by the
+            // event-backed array overload until the device copy completes.
+            UploadBufferAsync(data.ToArray(), buffer, stream);
         }
 
         /// <inheritdoc/>
-        public unsafe void DownloadBufferAsync(IGpuBuffer buffer, float[] destination, IGpuStream stream)
+        public void DownloadBufferAsync(IGpuBuffer buffer, float[] destination, IGpuStream stream)
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
@@ -4660,21 +4748,43 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             var openClBuffer = (DirectOpenClGpuBuffer)buffer;
-            fixed (float* destPtr = destination)
+            GCHandle pinned = GCHandle.Alloc(destination, GCHandleType.Pinned);
+            IntPtr transferEvent = IntPtr.Zero;
+            bool ownershipTransferred = false;
+            var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(openClBuffer.Buffer);
+            try
             {
-                int err = OpenClNativeBindings.EnqueueReadBuffer(
-                    stream.Handle,
-                    openClBuffer.Buffer.Handle,
-                    0, // non-blocking
-                    UIntPtr.Zero,
-                    (UIntPtr)(destination.Length * sizeof(float)),
-                    (IntPtr)destPtr,
-                    0,
-                    IntPtr.Zero,
-                    IntPtr.Zero);
+                int err;
+                lock (DirectOpenClSubmission.Gate)
+                {
+                    using var waits = DirectOpenClSubmission.PrepareLocked(stream.Handle, memories);
+                    err = OpenClNativeBindings.EnqueueReadBufferWithEvent(
+                        stream.Handle, openClBuffer.Buffer.Handle, 0, UIntPtr.Zero,
+                        (UIntPtr)(destination.Length * sizeof(float)), pinned.AddrOfPinnedObject(),
+                        waits.Count, waits.Pointer, out transferEvent);
+                    if (err == OpenClNativeBindings.CL_SUCCESS)
+                        DirectOpenClSubmission.CommitLocked(stream.Handle, memories);
+                }
 
                 if (err != OpenClNativeBindings.CL_SUCCESS)
                     throw new InvalidOperationException($"clEnqueueReadBuffer failed: {err}");
+
+                OpenClNativeBindings.Flush(stream.Handle);
+                _context.TrackHostTransfer(transferEvent, pinned);
+                ownershipTransferred = true;
+            }
+            finally
+            {
+                DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+                if (!ownershipTransferred)
+                {
+                    if (transferEvent != IntPtr.Zero)
+                    {
+                        OpenClNativeBindings.WaitForEvents(1, new[] { transferEvent });
+                        OpenClNativeBindings.ReleaseEvent(transferEvent);
+                    }
+                    if (pinned.IsAllocated) pinned.Free();
+                }
             }
         }
 
@@ -4699,16 +4809,15 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var dstBuffer = (DirectOpenClGpuBuffer)destination;
 
             GpuLaunchProbe.OnLaunch(); // device-to-device copy = GPU-resident work
-            int err = OpenClNativeBindings.EnqueueCopyBuffer(
+            int err = EnqueueTrackedCopy(
                 stream.Handle,
+                srcBuffer.Buffer,
+                dstBuffer.Buffer,
                 srcBuffer.Buffer.Handle,
                 dstBuffer.Buffer.Handle,
                 UIntPtr.Zero,
                 UIntPtr.Zero,
-                (UIntPtr)(size * sizeof(float)),
-                0,
-                IntPtr.Zero,
-                IntPtr.Zero);
+                (UIntPtr)(size * sizeof(float)));
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"clEnqueueCopyBuffer failed: {err}");
@@ -5620,19 +5729,34 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var bufferC = ((DirectOpenClGpuBuffer)C).Buffer;
 
             IntPtr queue = _context.CommandQueue;
-
-            var status = ClBlastNative.Sgemm(
-                ClBlastNative.Layout.RowMajor,
-                ClBlastNative.Transpose.No,
-                ClBlastNative.Transpose.No,
-                (UIntPtr)M, (UIntPtr)N, (UIntPtr)K,
-                alpha,
-                bufferA.Handle, UIntPtr.Zero, (UIntPtr)K,
-                bufferB.Handle, UIntPtr.Zero, (UIntPtr)N,
-                beta,
-                bufferC.Handle, UIntPtr.Zero, (UIntPtr)N,
-                ref queue,
-                IntPtr.Zero);
+            var memories = DirectOpenClSubmission.GetDirectSubmissionMemories(bufferA, bufferB, bufferC);
+            ClBlastNative.StatusCode status;
+            try
+            {
+                lock (DirectOpenClSubmission.Gate)
+                {
+                    using var waits = DirectOpenClSubmission.PrepareLocked(queue, memories);
+                    waits.EnqueueBridgeMarker(queue);
+                    status = ClBlastNative.Sgemm(
+                        ClBlastNative.Layout.RowMajor,
+                        ClBlastNative.Transpose.No,
+                        ClBlastNative.Transpose.No,
+                        (UIntPtr)M, (UIntPtr)N, (UIntPtr)K,
+                        alpha,
+                        bufferA.Handle, UIntPtr.Zero, (UIntPtr)K,
+                        bufferB.Handle, UIntPtr.Zero, (UIntPtr)N,
+                        beta,
+                        bufferC.Handle, UIntPtr.Zero, (UIntPtr)N,
+                        ref queue,
+                        IntPtr.Zero);
+                    if (status == ClBlastNative.StatusCode.Success)
+                        DirectOpenClSubmission.CommitLocked(queue, memories);
+                }
+            }
+            finally
+            {
+                DirectOpenClSubmission.ReleaseDirectSubmissionMemories(memories);
+            }
 
             if (status != ClBlastNative.StatusCode.Success)
             {
@@ -8727,7 +8851,6 @@ KERNEL VARIANTS (A/B testing):
             Fill(gradQuery, 0f, batch * numQHeads * seqQ * headDim);
             Fill(gradKey, 0f, batch * numKVHeads * seqK * headDim);
             Fill(gradValue, 0f, batch * numKVHeads * seqK * headDim);
-
             if (GpuDeterminism.IsActive)
             {
                 // Issue #382: gradkey/gradValue scatter atomics are FP-non-deterministic;
@@ -11884,16 +12007,15 @@ KERNEL VARIANTS (A/B testing):
 
             // Use EnqueueCopyBuffer for device-to-device copy
             GpuLaunchProbe.OnLaunch(); // device-to-device copy = GPU-resident work
-            int err = OpenClNativeBindings.EnqueueCopyBuffer(
+            int err = EnqueueTrackedCopy(
                 _context.CommandQueue,
+                srcBuf,
+                dstBuf,
                 srcBuf.Handle,
                 dstBuf.Handle,
                 UIntPtr.Zero,
                 UIntPtr.Zero,
-                (UIntPtr)(size * sizeof(float)),
-                0,
-                IntPtr.Zero,
-                IntPtr.Zero);
+                (UIntPtr)(size * sizeof(float)));
 
             if (err != OpenClNativeBindings.CL_SUCCESS)
                 throw new InvalidOperationException($"Failed to copy OpenCL buffer: {err}");

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClCommandQueue.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClCommandQueue.cs
@@ -101,6 +101,7 @@ public sealed class OpenClCommandQueue : IGpuStream
         {
             throw new InvalidOperationException($"clFinish failed: {err}");
         }
+        _backend.ReapCompletedOpenClResources();
     }
 
     /// <inheritdoc/>
@@ -228,12 +229,17 @@ public sealed class OpenClCommandQueue : IGpuStream
         {
             try
             {
-                OpenClNativeBindings.ReleaseCommandQueue(_handle);
+                // A released queue handle cannot later accept the marker needed to fence a buffer whose
+                // last use occurred on this explicit stream. Finish it first and record that completion so
+                // subsequent buffer retirement/cross-queue use can proceed without touching a dead handle.
+                _backend.CompleteCommandQueueForDisposal(_handle);
             }
             catch
             {
-                // Ignore destruction errors during disposal
+                // Continue with native release; disposal remains best-effort after a device error.
             }
+            try { OpenClNativeBindings.ReleaseCommandQueue(_handle); }
+            catch { /* Ignore destruction errors during disposal. */ }
         }
 
         _handle = IntPtr.Zero;

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClInstantNgpKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClInstantNgpKernels.cs
@@ -5,7 +5,7 @@ public static class OpenClInstantNgpKernels
 {
     public static string[] GetKernelNames() =>
         ["instant_ngp_hash_encode_level", "instant_ngp_hash_encode_level_backward",
-            "unique_consecutive_compact", "resident_mode", "resident_indices_to_int32", "resident_index_add", "resident_index_select", "resident_scatter_max_argmax_rows", "resident_uniform_mesh_laplacian", "resident_scatter_mean_rows_counts", "nonzero_compact", "ctc_loss_forward", "importance_sampling", "resident_nms",
+            "frexp_decompose", "unique_consecutive_compact", "unique_consecutive_with_info", "unique_sorted_with_info", "project_gaussians_3d_to_2d", "sample_rays_with_occupancy", "resident_mode", "resident_indices_to_int32", "resident_index_add", "resident_index_select", "resident_scatter_max_argmax_rows", "resident_uniform_mesh_laplacian", "resident_scatter_mean_rows_counts", "nonzero_compact", "ctc_loss_forward", "importance_sampling", "resident_nms",
             "generate_spiral_indices"];
 
     public static string GetSource() => @"
@@ -112,6 +112,187 @@ __kernel void unique_consecutive_compact(
         if (input[i] != input[i - 1]) output[count++] = input[i];
     }
     outputCount[0] = (float)count;
+}
+
+__kernel void unique_consecutive_with_info(
+    __global const float* input,
+    __global float* outputValues,
+    __global float* outputInverse,
+    __global float* outputCounts,
+    __global float* outputCount,
+    int length, int returnInverse, int returnCounts)
+{
+    if (get_global_id(0) != 0) return;
+    if (length <= 0) { outputCount[0] = 0.0f; return; }
+    int count = 1;
+    outputValues[0] = input[0];
+    if (returnInverse != 0) outputInverse[0] = 0.0f;
+    if (returnCounts != 0) outputCounts[0] = 1.0f;
+    for (int i = 1; i < length; i++) {
+        if (input[i] != input[i - 1]) {
+            outputValues[count] = input[i];
+            if (returnCounts != 0) outputCounts[count] = 1.0f;
+            count++;
+        } else if (returnCounts != 0) {
+            outputCounts[count - 1] += 1.0f;
+        }
+        if (returnInverse != 0) outputInverse[i] = (float)(count - 1);
+    }
+    outputCount[0] = (float)count;
+}
+
+__kernel void unique_sorted_with_info(
+    __global const float* sortedInput,
+    __global const float* sortedOriginalIndices,
+    __global float* outputValues,
+    __global float* outputInverse,
+    __global float* outputCounts,
+    __global float* outputCount,
+    int length, int returnInverse, int returnCounts)
+{
+    if (get_global_id(0) != 0) return;
+    int count = 0;
+    for (int i = 0; i < length; i++) {
+        if (i == 0 || sortedInput[i] != sortedInput[i - 1]) {
+            outputValues[count] = sortedInput[i];
+            if (returnCounts != 0) outputCounts[count] = 0.0f;
+            count++;
+        }
+        int group = count - 1;
+        if (returnCounts != 0) outputCounts[group] += 1.0f;
+        if (returnInverse != 0)
+            outputInverse[(int)sortedOriginalIndices[i]] = (float)group;
+    }
+    outputCount[0] = (float)count;
+}
+
+__kernel void frexp_decompose(
+    __global const float* input,
+    __global float* mantissa,
+    __global float* exponent,
+    int length)
+{
+    int gid = get_global_id(0);
+    if (gid >= length) return;
+    float value = input[gid];
+    uint bits = as_uint(value);
+    uint magnitude = bits & 0x7fffffffu;
+    uint exponentBits = magnitude >> 23;
+    if (exponentBits == 0xffu || magnitude == 0u) {
+        mantissa[gid] = value;
+        exponent[gid] = 0.0f;
+        return;
+    }
+    int scaleAdjustment = 0;
+    if (exponentBits == 0u) {
+        value *= 16777216.0f;
+        bits = as_uint(value);
+        exponentBits = (bits & 0x7fffffffu) >> 23;
+        scaleAdjustment = -24;
+    }
+    mantissa[gid] = as_float((bits & 0x807fffffu) | (126u << 23));
+    exponent[gid] = (float)((int)exponentBits - 126 + scaleAdjustment);
+}
+
+__kernel void project_gaussians_3d_to_2d(
+    __global const float* means3D,
+    __global const float* covariances3D,
+    __global float* means2D,
+    __global float* covariances2D,
+    __global float* depths,
+    __global float* visible,
+    int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+    float v00, float v01, float v02, float v03,
+    float v10, float v11, float v12, float v13,
+    float v20, float v21, float v22, float v23,
+    float p00, float p11)
+{
+    int i = get_global_id(0);
+    if (i >= numGaussians) return;
+    means2D[i * 2] = 0.0f; means2D[i * 2 + 1] = 0.0f;
+    covariances2D[i * 3] = 0.0f; covariances2D[i * 3 + 1] = 0.0f;
+    covariances2D[i * 3 + 2] = 0.0f; depths[i] = 0.0f; visible[i] = 0.0f;
+    float mx = means3D[i * 3], my = means3D[i * 3 + 1], mz = means3D[i * 3 + 2];
+    float camX = v00 * mx + v01 * my + v02 * mz + v03;
+    float camY = v10 * mx + v11 * my + v12 * mz + v13;
+    float camZ = v20 * mx + v21 * my + v22 * mz + v23;
+    if (camZ <= 0.001f) return;
+    float invZ = 1.0f / camZ;
+    float cx = (float)imageWidth * 0.5f, cy = (float)imageHeight * 0.5f;
+    float screenX = p00 * camX * invZ * cx + cx;
+    float screenY = p11 * camY * invZ * cy + cy;
+    if (screenX < -(float)imageWidth || screenX > 2.0f * (float)imageWidth ||
+        screenY < -(float)imageHeight || screenY > 2.0f * (float)imageHeight) return;
+    int c = i * covarianceStride;
+    float c00 = covariances3D[c], c01 = covariances3D[c + 1], c02 = covariances3D[c + 2];
+    float c11 = covariances3D[c + (covarianceStride == 6 ? 3 : 4)];
+    float c12 = covariances3D[c + (covarianceStride == 6 ? 4 : 5)];
+    float c22 = covariances3D[c + (covarianceStride == 6 ? 5 : 8)];
+    float j00 = p00 * invZ, j02 = -p00 * camX * invZ * invZ;
+    float j11 = p11 * invZ, j12 = -p11 * camY * invZ * invZ;
+    float cov00 = j00*j00*c00 + 2.0f*j00*j02*c02 + j02*j02*c22 + 0.3f;
+    float cov01 = j00*j11*c01 + j00*j12*c02 + j02*j11*c12 + j02*j12*c22;
+    float cov11 = j11*j11*c11 + 2.0f*j11*j12*c12 + j12*j12*c22 + 0.3f;
+    means2D[i * 2] = screenX; means2D[i * 2 + 1] = screenY;
+    covariances2D[i * 3] = cov00; covariances2D[i * 3 + 1] = cov01;
+    covariances2D[i * 3 + 2] = cov11; depths[i] = camZ; visible[i] = 1.0f;
+}
+
+inline int sample_ray_axis(
+    float origin, float direction, float minimum, float maximum,
+    __private float* tMin, __private float* tMax)
+{
+    if (fabs(direction) < 1.0e-8f)
+        return origin >= minimum && origin <= maximum;
+    float t1 = (minimum - origin) / direction;
+    float t2 = (maximum - origin) / direction;
+    if (t1 > t2) { float temporary = t1; t1 = t2; t2 = temporary; }
+    *tMin = fmax(*tMin, t1); *tMax = fmin(*tMax, t2);
+    return *tMax >= *tMin;
+}
+
+__kernel void sample_rays_with_occupancy(
+    __global const float* rayOrigins,
+    __global const float* rayDirections,
+    __global const uint* occupancyBitfield,
+    __global float* positions,
+    __global float* directions,
+    __global float* validMask,
+    __global float* tValues,
+    int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+    float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+    float nearBound, float farBound)
+{
+    int sampleIndex = get_global_id(0);
+    int totalSamples = numRays * maxSamples;
+    if (sampleIndex >= totalSamples) return;
+    int positionIndex = sampleIndex * 3;
+    positions[positionIndex] = 0.0f; positions[positionIndex + 1] = 0.0f;
+    positions[positionIndex + 2] = 0.0f; directions[positionIndex] = 0.0f;
+    directions[positionIndex + 1] = 0.0f; directions[positionIndex + 2] = 0.0f;
+    validMask[sampleIndex] = 0.0f; tValues[sampleIndex] = 0.0f;
+    int ray = sampleIndex / maxSamples, sample = sampleIndex - ray * maxSamples;
+    float ox = rayOrigins[ray * 3], oy = rayOrigins[ray * 3 + 1], oz = rayOrigins[ray * 3 + 2];
+    float dx = rayDirections[ray * 3], dy = rayDirections[ray * 3 + 1], dz = rayDirections[ray * 3 + 2];
+    float tMin = nearBound, tMax = farBound;
+    if (!sample_ray_axis(ox, dx, minX, maxX, &tMin, &tMax) ||
+        !sample_ray_axis(oy, dy, minY, maxY, &tMin, &tMax) ||
+        !sample_ray_axis(oz, dz, minZ, maxZ, &tMin, &tMax) || tMax < tMin) return;
+    float t = tMin + ((tMax - tMin) / (float)maxSamples) * ((float)sample + 0.5f);
+    float px = ox + t * dx, py = oy + t * dy, pz = oz + t * dz;
+    float nx = clamp((px - minX) / fmax(1.0e-10f, maxX - minX), 0.0f, 0.999999f);
+    float ny = clamp((py - minY) / fmax(1.0e-10f, maxY - minY), 0.0f, 0.999999f);
+    float nz = clamp((pz - minZ) / fmax(1.0e-10f, maxZ - minZ), 0.0f, 0.999999f);
+    int gx = min((int)(nx * (float)gridSize), gridSize - 1);
+    int gy = min((int)(ny * (float)gridSize), gridSize - 1);
+    int gz = min((int)(nz * (float)gridSize), gridSize - 1);
+    int cell = (gx * gridSize + gy) * gridSize + gz;
+    int word = cell >> 5, bit = cell & 31;
+    int occupied = word < occupancyWordCount &&
+        (occupancyBitfield[word] & (1u << bit)) != 0u;
+    positions[positionIndex] = px; positions[positionIndex + 1] = py; positions[positionIndex + 2] = pz;
+    directions[positionIndex] = dx; directions[positionIndex + 1] = dy; directions[positionIndex + 2] = dz;
+    validMask[sampleIndex] = occupied ? 1.0f : 0.0f; tValues[sampleIndex] = t;
 }
 
 __kernel void resident_mode(

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClNativeBindings.cs
@@ -253,6 +253,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             IntPtr eventWaitList,
             IntPtr eventOut);
 
+        [DllImport(OpenClLibrary, EntryPoint = "clEnqueueReadBuffer")]
+        public static extern int EnqueueReadBufferWithEvent(
+            IntPtr commandQueue,
+            IntPtr buffer,
+            uint blockingRead,
+            UIntPtr offset,
+            UIntPtr size,
+            IntPtr ptr,
+            uint numEventsInWaitList,
+            IntPtr eventWaitList,
+            out IntPtr eventOut);
+
         [DllImport(OpenClLibrary, EntryPoint = "clEnqueueWriteBuffer")]
         public static extern int EnqueueWriteBuffer(
             IntPtr commandQueue,
@@ -264,6 +276,18 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             uint numEventsInWaitList,
             IntPtr eventWaitList,
             IntPtr eventOut);
+
+        [DllImport(OpenClLibrary, EntryPoint = "clEnqueueWriteBuffer")]
+        public static extern int EnqueueWriteBufferWithEvent(
+            IntPtr commandQueue,
+            IntPtr buffer,
+            uint blockingWrite,
+            UIntPtr offset,
+            UIntPtr size,
+            IntPtr ptr,
+            uint numEventsInWaitList,
+            IntPtr eventWaitList,
+            out IntPtr eventOut);
 
         // clCreateSubBuffer — creates a buffer object from a region of an existing buffer
         public static IntPtr CreateSubBuffer(IntPtr buffer, int byteOffset, int byteSize)
@@ -799,4 +823,3 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         #endregion
     }
 }
-

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanBackend.InstantNgp.cs
@@ -1,6 +1,6 @@
 namespace AiDotNet.Tensors.Engines.DirectGpu.Vulkan;
 
-public sealed unsafe partial class VulkanBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed unsafe partial class VulkanBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     public void HashGridEncodeLevel(
         IGpuBuffer positions, IGpuBuffer hashTable, IGpuBuffer output,
@@ -32,6 +32,75 @@ public sealed unsafe partial class VulkanBackend : IInstantNgpBackend, IUniqueCo
         if (length <= 0) return;
         GlslDispatchN(VulkanInstantNgpKernels.UniqueConsecutive, 1,
             [input, outputCapacity, outputCount], [(uint)length]);
+    }
+
+    public void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        GlslDispatchN(VulkanInstantNgpKernels.Frexp, length,
+            [input, mantissa, exponent], [(uint)length]);
+    }
+
+    public void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        GlslDispatchN(VulkanInstantNgpKernels.UniqueConsecutiveWithInfo, 1,
+            [input, outputValues, outputInverse, outputCounts, outputCount],
+            [(uint)length, returnInverse ? 1u : 0u, returnCounts ? 1u : 0u]);
+    }
+
+    public void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        GlslDispatchN(VulkanInstantNgpKernels.ProjectGaussians3DTo2D, numGaussians,
+            [means3D, covariances3D, means2D, covariances2D, depths, visible],
+            [
+                (uint)numGaussians, (uint)covarianceStride, (uint)imageWidth, (uint)imageHeight,
+                FloatBits(v00), FloatBits(v01), FloatBits(v02), FloatBits(v03),
+                FloatBits(v10), FloatBits(v11), FloatBits(v12), FloatBits(v13),
+                FloatBits(v20), FloatBits(v21), FloatBits(v22), FloatBits(v23),
+                FloatBits(p00), FloatBits(p11),
+            ]);
+    }
+
+    public void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        GlslDispatchN(VulkanInstantNgpKernels.SampleRaysWithOccupancy, total,
+            [rayOrigins, rayDirections, occupancyBitfield, positions, directions, validMask, tValues],
+            [
+                (uint)numRays, (uint)occupancyWordCount, (uint)gridSize, (uint)maxSamples,
+                FloatBits(minX), FloatBits(minY), FloatBits(minZ),
+                FloatBits(maxX), FloatBits(maxY), FloatBits(maxZ),
+                FloatBits(nearBound), FloatBits(farBound),
+            ]);
+    }
+
+    public void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        GlslDispatchN(VulkanInstantNgpKernels.UniqueSortedWithInfo, 1,
+            [sortedInput, sortedOriginalIndices, outputValues, outputInverse, outputCounts, outputCount],
+            [(uint)length, returnInverse ? 1u : 0u, returnCounts ? 1u : 0u]);
     }
 
     public void Nonzero(IGpuBuffer input, IGpuBuffer strides, IGpuBuffer outputCapacity,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanInstantNgpKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/Vulkan/VulkanInstantNgpKernels.cs
@@ -115,6 +115,196 @@ void main() {
 }
 ";
 
+    public static string Frexp => @"#version 450
+layout(local_size_x = 256) in;
+layout(set = 0, binding = 0) readonly buffer Input { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer Mantissa { float mantissa[]; };
+layout(set = 0, binding = 2) writeonly buffer Exponent { float exponent[]; };
+layout(push_constant) uniform P { int length; };
+void main() {
+    int gid = int(gl_GlobalInvocationID.x);
+    if (gid >= length) return;
+    float value = input_[gid];
+    uint bits = floatBitsToUint(value);
+    uint magnitude = bits & 0x7fffffffu;
+    uint exponentBits = magnitude >> 23;
+    if (exponentBits == 0xffu || magnitude == 0u) {
+        mantissa[gid] = value;
+        exponent[gid] = 0.0;
+        return;
+    }
+    int scaleAdjustment = 0;
+    if (exponentBits == 0u) {
+        value *= 16777216.0;
+        bits = floatBitsToUint(value);
+        exponentBits = (bits & 0x7fffffffu) >> 23;
+        scaleAdjustment = -24;
+    }
+    mantissa[gid] = uintBitsToFloat((bits & 0x807fffffu) | (126u << 23));
+    exponent[gid] = float(int(exponentBits) - 126 + scaleAdjustment);
+}
+";
+
+    public static string UniqueConsecutiveWithInfo => @"#version 450
+layout(local_size_x = 1) in;
+layout(set = 0, binding = 0) readonly buffer Input { float input_[]; };
+layout(set = 0, binding = 1) writeonly buffer Values { float outputValues[]; };
+layout(set = 0, binding = 2) writeonly buffer Inverse { float outputInverse[]; };
+layout(set = 0, binding = 3) buffer Counts { float outputCounts[]; };
+layout(set = 0, binding = 4) writeonly buffer Count { float outputCount[]; };
+layout(push_constant) uniform P { int length; int returnInverse; int returnCounts; };
+void main() {
+    if (gl_GlobalInvocationID.x != 0) return;
+    if (length <= 0) { outputCount[0] = 0.0; return; }
+    int count = 1;
+    outputValues[0] = input_[0];
+    if (returnInverse != 0) outputInverse[0] = 0.0;
+    if (returnCounts != 0) outputCounts[0] = 1.0;
+    for (int i = 1; i < length; i++) {
+        if (input_[i] != input_[i - 1]) {
+            outputValues[count] = input_[i];
+            if (returnCounts != 0) outputCounts[count] = 1.0;
+            count++;
+        } else if (returnCounts != 0) {
+            outputCounts[count - 1] += 1.0;
+        }
+        if (returnInverse != 0) outputInverse[i] = float(count - 1);
+    }
+    outputCount[0] = float(count);
+}
+";
+
+    public static string UniqueSortedWithInfo => @"#version 450
+layout(local_size_x = 1) in;
+layout(set = 0, binding = 0) readonly buffer Input { float sortedInput[]; };
+layout(set = 0, binding = 1) readonly buffer Original { float sortedOriginalIndices[]; };
+layout(set = 0, binding = 2) writeonly buffer Values { float outputValues[]; };
+layout(set = 0, binding = 3) writeonly buffer Inverse { float outputInverse[]; };
+layout(set = 0, binding = 4) buffer Counts { float outputCounts[]; };
+layout(set = 0, binding = 5) writeonly buffer Count { float outputCount[]; };
+layout(push_constant) uniform P { int length; int returnInverse; int returnCounts; };
+void main() {
+    if (gl_GlobalInvocationID.x != 0) return;
+    int count = 0;
+    for (int i = 0; i < length; i++) {
+        if (i == 0 || sortedInput[i] != sortedInput[i - 1]) {
+            outputValues[count] = sortedInput[i];
+            if (returnCounts != 0) outputCounts[count] = 0.0;
+            count++;
+        }
+        int group = count - 1;
+        if (returnCounts != 0) outputCounts[group] += 1.0;
+        if (returnInverse != 0)
+            outputInverse[int(sortedOriginalIndices[i])] = float(group);
+    }
+    outputCount[0] = float(count);
+}
+";
+
+    public static string ProjectGaussians3DTo2D => @"#version 450
+layout(local_size_x = 256) in;
+layout(set = 0, binding = 0) readonly buffer Means3D { float means3D[]; };
+layout(set = 0, binding = 1) readonly buffer Covariances3D { float covariances3D[]; };
+layout(set = 0, binding = 2) writeonly buffer Means2D { float means2D[]; };
+layout(set = 0, binding = 3) writeonly buffer Covariances2D { float covariances2D[]; };
+layout(set = 0, binding = 4) writeonly buffer Depths { float depths[]; };
+layout(set = 0, binding = 5) writeonly buffer Visible { float visible[]; };
+layout(push_constant) uniform P {
+    int numGaussians; int covarianceStride; int imageWidth; int imageHeight;
+    float v00; float v01; float v02; float v03;
+    float v10; float v11; float v12; float v13;
+    float v20; float v21; float v22; float v23; float p00; float p11;
+};
+void main() {
+    int i = int(gl_GlobalInvocationID.x);
+    if (i >= numGaussians) return;
+    means2D[i * 2] = 0.0; means2D[i * 2 + 1] = 0.0;
+    covariances2D[i * 3] = 0.0; covariances2D[i * 3 + 1] = 0.0;
+    covariances2D[i * 3 + 2] = 0.0; depths[i] = 0.0; visible[i] = 0.0;
+    float mx = means3D[i * 3], my = means3D[i * 3 + 1], mz = means3D[i * 3 + 2];
+    float camX = v00 * mx + v01 * my + v02 * mz + v03;
+    float camY = v10 * mx + v11 * my + v12 * mz + v13;
+    float camZ = v20 * mx + v21 * my + v22 * mz + v23;
+    if (camZ <= 0.001) return;
+    float invZ = 1.0 / camZ;
+    float cx = float(imageWidth) * 0.5, cy = float(imageHeight) * 0.5;
+    float screenX = p00 * camX * invZ * cx + cx;
+    float screenY = p11 * camY * invZ * cy + cy;
+    if (screenX < -float(imageWidth) || screenX > 2.0 * float(imageWidth) ||
+        screenY < -float(imageHeight) || screenY > 2.0 * float(imageHeight)) return;
+    int c = i * covarianceStride;
+    float c00 = covariances3D[c], c01 = covariances3D[c + 1], c02 = covariances3D[c + 2];
+    float c11 = covariances3D[c + (covarianceStride == 6 ? 3 : 4)];
+    float c12 = covariances3D[c + (covarianceStride == 6 ? 4 : 5)];
+    float c22 = covariances3D[c + (covarianceStride == 6 ? 5 : 8)];
+    float j00 = p00 * invZ, j02 = -p00 * camX * invZ * invZ;
+    float j11 = p11 * invZ, j12 = -p11 * camY * invZ * invZ;
+    float cov00 = j00*j00*c00 + 2.0*j00*j02*c02 + j02*j02*c22 + 0.3;
+    float cov01 = j00*j11*c01 + j00*j12*c02 + j02*j11*c12 + j02*j12*c22;
+    float cov11 = j11*j11*c11 + 2.0*j11*j12*c12 + j12*j12*c22 + 0.3;
+    means2D[i * 2] = screenX; means2D[i * 2 + 1] = screenY;
+    covariances2D[i * 3] = cov00; covariances2D[i * 3 + 1] = cov01;
+    covariances2D[i * 3 + 2] = cov11; depths[i] = camZ; visible[i] = 1.0;
+}
+";
+
+    public static string SampleRaysWithOccupancy => @"#version 450
+layout(local_size_x = 256) in;
+layout(set = 0, binding = 0) readonly buffer Origins { float rayOrigins[]; };
+layout(set = 0, binding = 1) readonly buffer DirectionsIn { float rayDirections[]; };
+layout(set = 0, binding = 2) readonly buffer Occupancy { uint occupancyBitfield[]; };
+layout(set = 0, binding = 3) writeonly buffer Positions { float positions[]; };
+layout(set = 0, binding = 4) writeonly buffer DirectionsOut { float directions[]; };
+layout(set = 0, binding = 5) writeonly buffer Valid { float validMask[]; };
+layout(set = 0, binding = 6) writeonly buffer TValues { float tValues[]; };
+layout(push_constant) uniform P {
+    int numRays; int occupancyWordCount; int gridSize; int maxSamples;
+    float minX; float minY; float minZ; float maxX; float maxY; float maxZ;
+    float nearBound; float farBound;
+};
+bool sample_ray_axis(float origin, float direction, float minimum, float maximum,
+    inout float tMin, inout float tMax) {
+    if (abs(direction) < 1.0e-8) return origin >= minimum && origin <= maximum;
+    float t1 = (minimum - origin) / direction;
+    float t2 = (maximum - origin) / direction;
+    if (t1 > t2) { float temporary = t1; t1 = t2; t2 = temporary; }
+    tMin = max(tMin, t1); tMax = min(tMax, t2);
+    return tMax >= tMin;
+}
+void main() {
+    int sampleIndex = int(gl_GlobalInvocationID.x);
+    int totalSamples = numRays * maxSamples;
+    if (sampleIndex >= totalSamples) return;
+    int positionIndex = sampleIndex * 3;
+    positions[positionIndex] = 0.0; positions[positionIndex + 1] = 0.0;
+    positions[positionIndex + 2] = 0.0; directions[positionIndex] = 0.0;
+    directions[positionIndex + 1] = 0.0; directions[positionIndex + 2] = 0.0;
+    validMask[sampleIndex] = 0.0; tValues[sampleIndex] = 0.0;
+    int ray = sampleIndex / maxSamples, sample = sampleIndex - ray * maxSamples;
+    float ox = rayOrigins[ray * 3], oy = rayOrigins[ray * 3 + 1], oz = rayOrigins[ray * 3 + 2];
+    float dx = rayDirections[ray * 3], dy = rayDirections[ray * 3 + 1], dz = rayDirections[ray * 3 + 2];
+    float tMin = nearBound, tMax = farBound;
+    if (!sample_ray_axis(ox, dx, minX, maxX, tMin, tMax) ||
+        !sample_ray_axis(oy, dy, minY, maxY, tMin, tMax) ||
+        !sample_ray_axis(oz, dz, minZ, maxZ, tMin, tMax) || tMax < tMin) return;
+    float t = tMin + ((tMax - tMin) / float(maxSamples)) * (float(sample) + 0.5);
+    float px = ox + t * dx, py = oy + t * dy, pz = oz + t * dz;
+    float nx = clamp((px - minX) / max(1.0e-10, maxX - minX), 0.0, 0.999999);
+    float ny = clamp((py - minY) / max(1.0e-10, maxY - minY), 0.0, 0.999999);
+    float nz = clamp((pz - minZ) / max(1.0e-10, maxZ - minZ), 0.0, 0.999999);
+    int gx = min(int(nx * float(gridSize)), gridSize - 1);
+    int gy = min(int(ny * float(gridSize)), gridSize - 1);
+    int gz = min(int(nz * float(gridSize)), gridSize - 1);
+    int cell = (gx * gridSize + gy) * gridSize + gz;
+    int word = cell >> 5, bit = cell & 31;
+    bool occupied = word < occupancyWordCount &&
+        (occupancyBitfield[word] & (1u << uint(bit))) != 0u;
+    positions[positionIndex] = px; positions[positionIndex + 1] = py; positions[positionIndex + 2] = pz;
+    directions[positionIndex] = dx; directions[positionIndex + 1] = dy; directions[positionIndex + 2] = dz;
+    validMask[sampleIndex] = occupied ? 1.0 : 0.0; tValues[sampleIndex] = t;
+}
+";
+
     public static string Nonzero => @"#version 450
 layout(local_size_x = 1) in;
 layout(set = 0, binding = 0) readonly buffer Input { float input_[]; };

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.InstantNgp.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuBackend.InstantNgp.cs
@@ -1,7 +1,7 @@
 #if NET7_0_OR_GREATER
 namespace AiDotNet.Tensors.Engines.DirectGpu.WebGpu;
 
-public sealed partial class WebGpuBackend : IInstantNgpBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
+public sealed partial class WebGpuBackend : IInstantNgpBackend, IFrexpBackend, IRenderingGeometryBackend, IUniqueConsecutiveBackend, INonzeroBackend, IModeBackend, IResidentIndexBackend, ICtcLossBackend, IImportanceSamplingBackend, INmsBackend, ISpiralIndicesBackend
 {
     private static float[] InstantNgpUniforms(
         int numPoints, int resolution, int tableSize, int featuresPerLevel,
@@ -51,6 +51,93 @@ public sealed partial class WebGpuBackend : IInstantNgpBackend, IUniqueConsecuti
             "main", input, outputCapacity, outputCount,
             [BitConverter.Int32BitsToSingle(length), 0f, 0f, 0f], 1)
             .GetAwaiter().GetResult();
+    }
+
+    public void Frexp(
+        IGpuBuffer input, IGpuBuffer mantissa, IGpuBuffer exponent, int length)
+    {
+        if (length <= 0) return;
+        Dispatch3BufferAsync("Frexp", WebGpuInstantNgpKernels.Frexp, "main",
+            input, mantissa, exponent,
+            [BitConverter.Int32BitsToSingle(length), 0f, 0f, 0f], length)
+            .GetAwaiter().GetResult();
+    }
+
+    public void UniqueConsecutiveWithInfo(
+        IGpuBuffer input, IGpuBuffer outputValues, IGpuBuffer outputInverse,
+        IGpuBuffer outputCounts, IGpuBuffer outputCount, int length,
+        bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        Dispatch5BufferAsync("UniqueConsecutiveWithInfo",
+            WebGpuInstantNgpKernels.UniqueConsecutiveWithInfo, "main",
+            input, outputValues, outputInverse, outputCounts, outputCount,
+            [
+                BitConverter.Int32BitsToSingle(length),
+                BitConverter.Int32BitsToSingle(returnInverse ? 1 : 0),
+                BitConverter.Int32BitsToSingle(returnCounts ? 1 : 0),
+                0f,
+            ], 1).GetAwaiter().GetResult();
+    }
+
+    public void ProjectGaussians3DTo2D(
+        IGpuBuffer means3D, IGpuBuffer covariances3D, IGpuBuffer means2D,
+        IGpuBuffer covariances2D, IGpuBuffer depths, IGpuBuffer visible,
+        int numGaussians, int covarianceStride, int imageWidth, int imageHeight,
+        float v00, float v01, float v02, float v03,
+        float v10, float v11, float v12, float v13,
+        float v20, float v21, float v22, float v23, float p00, float p11)
+    {
+        if (numGaussians <= 0) return;
+        Dispatch6BufferAsync("ProjectGaussians3DTo2D",
+            WebGpuInstantNgpKernels.ProjectGaussians3DTo2D, "main",
+            means3D, covariances3D, means2D, covariances2D, depths, visible,
+            [
+                BitConverter.Int32BitsToSingle(numGaussians),
+                BitConverter.Int32BitsToSingle(covarianceStride),
+                BitConverter.Int32BitsToSingle(imageWidth),
+                BitConverter.Int32BitsToSingle(imageHeight),
+                v00, v01, v02, v03, v10, v11, v12, v13,
+                v20, v21, v22, v23, p00, p11, 0f, 0f,
+            ], numGaussians).GetAwaiter().GetResult();
+    }
+
+    public void SampleRaysWithOccupancy(
+        IGpuBuffer rayOrigins, IGpuBuffer rayDirections, IGpuBuffer occupancyBitfield,
+        IGpuBuffer positions, IGpuBuffer directions, IGpuBuffer validMask, IGpuBuffer tValues,
+        int numRays, int occupancyWordCount, int gridSize, int maxSamples,
+        float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        float nearBound, float farBound)
+    {
+        int total = checked(numRays * maxSamples);
+        if (total <= 0) return;
+        DispatchNBufferAsync("SampleRaysWithOccupancy",
+            WebGpuInstantNgpKernels.SampleRaysWithOccupancy, "main",
+            [rayOrigins, rayDirections, occupancyBitfield, positions, directions, validMask, tValues],
+            [
+                BitConverter.Int32BitsToSingle(numRays),
+                BitConverter.Int32BitsToSingle(occupancyWordCount),
+                BitConverter.Int32BitsToSingle(gridSize),
+                BitConverter.Int32BitsToSingle(maxSamples),
+                minX, minY, minZ, maxX, maxY, maxZ, nearBound, farBound,
+            ], total).GetAwaiter().GetResult();
+    }
+
+    public void UniqueSortedWithInfo(
+        IGpuBuffer sortedInput, IGpuBuffer sortedOriginalIndices, IGpuBuffer outputValues,
+        IGpuBuffer outputInverse, IGpuBuffer outputCounts, IGpuBuffer outputCount,
+        int length, bool returnInverse, bool returnCounts)
+    {
+        if (length <= 0) return;
+        Dispatch6BufferAsync("UniqueSortedWithInfo",
+            WebGpuInstantNgpKernels.UniqueSortedWithInfo, "main",
+            sortedInput, sortedOriginalIndices, outputValues, outputInverse, outputCounts, outputCount,
+            [
+                BitConverter.Int32BitsToSingle(length),
+                BitConverter.Int32BitsToSingle(returnInverse ? 1 : 0),
+                BitConverter.Int32BitsToSingle(returnCounts ? 1 : 0),
+                0f,
+            ], 1).GetAwaiter().GetResult();
     }
 
     public void Nonzero(IGpuBuffer input, IGpuBuffer strides, IGpuBuffer outputCapacity,

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuInstantNgpKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/WebGpu/WebGpuInstantNgpKernels.cs
@@ -123,6 +123,205 @@ struct UniqueP { length: i32 };
 }
 ";
 
+    public static string Frexp => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> mantissa : array<f32>;
+@group(0) @binding(2) var<storage, read_write> exponent : array<f32>;
+struct FrexpP { length: i32 };
+@group(0) @binding(3) var<uniform> p : FrexpP;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let gid = i32(id.x);
+    if (gid >= p.length) { return; }
+    var value = input_[gid];
+    var bits = bitcast<u32>(value);
+    let magnitude = bits & 0x7fffffffu;
+    var exponentBits = magnitude >> 23u;
+    if (exponentBits == 0xffu || magnitude == 0u) {
+        mantissa[gid] = value;
+        exponent[gid] = 0.0;
+        return;
+    }
+    var scaleAdjustment = 0;
+    if (exponentBits == 0u) {
+        value = value * 16777216.0;
+        bits = bitcast<u32>(value);
+        exponentBits = (bits & 0x7fffffffu) >> 23u;
+        scaleAdjustment = -24;
+    }
+    mantissa[gid] = bitcast<f32>((bits & 0x807fffffu) | (126u << 23u));
+    exponent[gid] = f32(i32(exponentBits) - 126 + scaleAdjustment);
+}
+";
+
+    public static string UniqueConsecutiveWithInfo => @"
+@group(0) @binding(0) var<storage, read> input_ : array<f32>;
+@group(0) @binding(1) var<storage, read_write> outputValues : array<f32>;
+@group(0) @binding(2) var<storage, read_write> outputInverse : array<f32>;
+@group(0) @binding(3) var<storage, read_write> outputCounts : array<f32>;
+@group(0) @binding(4) var<storage, read_write> outputCount : array<f32>;
+struct UniqueInfoP { length: i32, returnInverse: i32, returnCounts: i32 };
+@group(0) @binding(5) var<uniform> p : UniqueInfoP;
+@compute @workgroup_size(1) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    if (id.x != 0u) { return; }
+    if (p.length <= 0) { outputCount[0] = 0.0; return; }
+    var count = 1;
+    outputValues[0] = input_[0];
+    if (p.returnInverse != 0) { outputInverse[0] = 0.0; }
+    if (p.returnCounts != 0) { outputCounts[0] = 1.0; }
+    for (var i = 1; i < p.length; i = i + 1) {
+        if (input_[i] != input_[i - 1]) {
+            outputValues[count] = input_[i];
+            if (p.returnCounts != 0) { outputCounts[count] = 1.0; }
+            count = count + 1;
+        } else if (p.returnCounts != 0) {
+            outputCounts[count - 1] = outputCounts[count - 1] + 1.0;
+        }
+        if (p.returnInverse != 0) { outputInverse[i] = f32(count - 1); }
+    }
+    outputCount[0] = f32(count);
+}
+";
+
+    public static string UniqueSortedWithInfo => @"
+@group(0) @binding(0) var<storage, read> sortedInput : array<f32>;
+@group(0) @binding(1) var<storage, read> sortedOriginalIndices : array<f32>;
+@group(0) @binding(2) var<storage, read_write> outputValues : array<f32>;
+@group(0) @binding(3) var<storage, read_write> outputInverse : array<f32>;
+@group(0) @binding(4) var<storage, read_write> outputCounts : array<f32>;
+@group(0) @binding(5) var<storage, read_write> outputCount : array<f32>;
+struct UniqueInfoP { length: i32, returnInverse: i32, returnCounts: i32 };
+@group(0) @binding(6) var<uniform> p : UniqueInfoP;
+@compute @workgroup_size(1) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    if (id.x != 0u) { return; }
+    var count = 0;
+    for (var i = 0; i < p.length; i = i + 1) {
+        if (i == 0 || sortedInput[i] != sortedInput[i - 1]) {
+            outputValues[count] = sortedInput[i];
+            if (p.returnCounts != 0) { outputCounts[count] = 0.0; }
+            count = count + 1;
+        }
+        let group = count - 1;
+        if (p.returnCounts != 0) { outputCounts[group] = outputCounts[group] + 1.0; }
+        if (p.returnInverse != 0) {
+            outputInverse[i32(sortedOriginalIndices[i])] = f32(group);
+        }
+    }
+    outputCount[0] = f32(count);
+}
+";
+
+    public static string ProjectGaussians3DTo2D => @"
+@group(0) @binding(0) var<storage, read> means3D : array<f32>;
+@group(0) @binding(1) var<storage, read> covariances3D : array<f32>;
+@group(0) @binding(2) var<storage, read_write> means2D : array<f32>;
+@group(0) @binding(3) var<storage, read_write> covariances2D : array<f32>;
+@group(0) @binding(4) var<storage, read_write> depths : array<f32>;
+@group(0) @binding(5) var<storage, read_write> visible : array<f32>;
+struct ProjectP {
+    numGaussians: i32, covarianceStride: i32, imageWidth: i32, imageHeight: i32,
+    v00: f32, v01: f32, v02: f32, v03: f32,
+    v10: f32, v11: f32, v12: f32, v13: f32,
+    v20: f32, v21: f32, v22: f32, v23: f32, p00: f32, p11: f32,
+};
+@group(0) @binding(6) var<uniform> p : ProjectP;
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let i = i32(id.x);
+    if (i >= p.numGaussians) { return; }
+    means2D[i * 2] = 0.0; means2D[i * 2 + 1] = 0.0;
+    covariances2D[i * 3] = 0.0; covariances2D[i * 3 + 1] = 0.0;
+    covariances2D[i * 3 + 2] = 0.0; depths[i] = 0.0; visible[i] = 0.0;
+    let mx = means3D[i * 3]; let my = means3D[i * 3 + 1]; let mz = means3D[i * 3 + 2];
+    let camX = p.v00 * mx + p.v01 * my + p.v02 * mz + p.v03;
+    let camY = p.v10 * mx + p.v11 * my + p.v12 * mz + p.v13;
+    let camZ = p.v20 * mx + p.v21 * my + p.v22 * mz + p.v23;
+    if (camZ <= 0.001) { return; }
+    let invZ = 1.0 / camZ;
+    let cx = f32(p.imageWidth) * 0.5; let cy = f32(p.imageHeight) * 0.5;
+    let screenX = p.p00 * camX * invZ * cx + cx;
+    let screenY = p.p11 * camY * invZ * cy + cy;
+    if (screenX < -f32(p.imageWidth) || screenX > 2.0 * f32(p.imageWidth) ||
+        screenY < -f32(p.imageHeight) || screenY > 2.0 * f32(p.imageHeight)) { return; }
+    let c = i * p.covarianceStride;
+    let c00 = covariances3D[c]; let c01 = covariances3D[c + 1]; let c02 = covariances3D[c + 2];
+    let c11 = covariances3D[c + select(4, 3, p.covarianceStride == 6)];
+    let c12 = covariances3D[c + select(5, 4, p.covarianceStride == 6)];
+    let c22 = covariances3D[c + select(8, 5, p.covarianceStride == 6)];
+    let j00 = p.p00 * invZ; let j02 = -p.p00 * camX * invZ * invZ;
+    let j11 = p.p11 * invZ; let j12 = -p.p11 * camY * invZ * invZ;
+    let cov00 = j00*j00*c00 + 2.0*j00*j02*c02 + j02*j02*c22 + 0.3;
+    let cov01 = j00*j11*c01 + j00*j12*c02 + j02*j11*c12 + j02*j12*c22;
+    let cov11 = j11*j11*c11 + 2.0*j11*j12*c12 + j12*j12*c22 + 0.3;
+    means2D[i * 2] = screenX; means2D[i * 2 + 1] = screenY;
+    covariances2D[i * 3] = cov00; covariances2D[i * 3 + 1] = cov01;
+    covariances2D[i * 3 + 2] = cov11; depths[i] = camZ; visible[i] = 1.0;
+}
+";
+
+    public static string SampleRaysWithOccupancy => @"
+@group(0) @binding(0) var<storage, read> rayOrigins : array<f32>;
+@group(0) @binding(1) var<storage, read> rayDirections : array<f32>;
+@group(0) @binding(2) var<storage, read> occupancyBitfield : array<u32>;
+@group(0) @binding(3) var<storage, read_write> positions : array<f32>;
+@group(0) @binding(4) var<storage, read_write> directions : array<f32>;
+@group(0) @binding(5) var<storage, read_write> validMask : array<f32>;
+@group(0) @binding(6) var<storage, read_write> tValues : array<f32>;
+struct SampleP {
+    numRays: i32, occupancyWordCount: i32, gridSize: i32, maxSamples: i32,
+    minX: f32, minY: f32, minZ: f32, maxX: f32, maxY: f32, maxZ: f32,
+    nearBound: f32, farBound: f32,
+};
+@group(0) @binding(7) var<uniform> p : SampleP;
+fn sample_ray_axis(origin: f32, direction: f32, minimum: f32, maximum: f32,
+    tMin: f32, tMax: f32) -> vec3<f32> {
+    if (abs(direction) < 1.0e-8) {
+        if (origin < minimum || origin > maximum) { return vec3<f32>(0.0, tMin, tMax); }
+        return vec3<f32>(1.0, tMin, tMax);
+    }
+    var t1 = (minimum - origin) / direction;
+    var t2 = (maximum - origin) / direction;
+    if (t1 > t2) { let temporary = t1; t1 = t2; t2 = temporary; }
+    let nextMin = max(tMin, t1); let nextMax = min(tMax, t2);
+    return vec3<f32>(select(0.0, 1.0, nextMax >= nextMin), nextMin, nextMax);
+}
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let sampleIndex = i32(id.x);
+    let totalSamples = p.numRays * p.maxSamples;
+    if (sampleIndex >= totalSamples) { return; }
+    let positionIndex = sampleIndex * 3;
+    positions[positionIndex] = 0.0; positions[positionIndex + 1] = 0.0;
+    positions[positionIndex + 2] = 0.0; directions[positionIndex] = 0.0;
+    directions[positionIndex + 1] = 0.0; directions[positionIndex + 2] = 0.0;
+    validMask[sampleIndex] = 0.0; tValues[sampleIndex] = 0.0;
+    let ray = sampleIndex / p.maxSamples; let sample = sampleIndex - ray * p.maxSamples;
+    let ox = rayOrigins[ray * 3]; let oy = rayOrigins[ray * 3 + 1]; let oz = rayOrigins[ray * 3 + 2];
+    let dx = rayDirections[ray * 3]; let dy = rayDirections[ray * 3 + 1]; let dz = rayDirections[ray * 3 + 2];
+    var tMin = p.nearBound; var tMax = p.farBound;
+    var hit = sample_ray_axis(ox, dx, p.minX, p.maxX, tMin, tMax);
+    if (hit.x == 0.0) { return; } tMin = hit.y; tMax = hit.z;
+    hit = sample_ray_axis(oy, dy, p.minY, p.maxY, tMin, tMax);
+    if (hit.x == 0.0) { return; } tMin = hit.y; tMax = hit.z;
+    hit = sample_ray_axis(oz, dz, p.minZ, p.maxZ, tMin, tMax);
+    if (hit.x == 0.0) { return; } tMin = hit.y; tMax = hit.z;
+    let t = tMin + ((tMax - tMin) / f32(p.maxSamples)) * (f32(sample) + 0.5);
+    let px = ox + t * dx; let py = oy + t * dy; let pz = oz + t * dz;
+    let nx = clamp((px - p.minX) / max(1.0e-10, p.maxX - p.minX), 0.0, 0.999999);
+    let ny = clamp((py - p.minY) / max(1.0e-10, p.maxY - p.minY), 0.0, 0.999999);
+    let nz = clamp((pz - p.minZ) / max(1.0e-10, p.maxZ - p.minZ), 0.0, 0.999999);
+    let gx = min(i32(nx * f32(p.gridSize)), p.gridSize - 1);
+    let gy = min(i32(ny * f32(p.gridSize)), p.gridSize - 1);
+    let gz = min(i32(nz * f32(p.gridSize)), p.gridSize - 1);
+    let cell = (gx * p.gridSize + gy) * p.gridSize + gz;
+    let word = cell >> 5; let bit = cell & 31;
+    var occupied = false;
+    if (word < p.occupancyWordCount) {
+        occupied = (occupancyBitfield[word] & (1u << u32(bit))) != 0u;
+    }
+    positions[positionIndex] = px; positions[positionIndex + 1] = py; positions[positionIndex + 2] = pz;
+    directions[positionIndex] = dx; directions[positionIndex + 1] = dy; directions[positionIndex + 2] = dz;
+    validMask[sampleIndex] = select(0.0, 1.0, occupied); tValues[sampleIndex] = t;
+}
+";
+
     public static string Nonzero => @"
 @group(0) @binding(0) var<storage, read> input_ : array<f32>;
 @group(0) @binding(1) var<storage, read> strides : array<i32>;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.Audio.cs
@@ -7,6 +7,7 @@
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Engines.Compilation;
 
 namespace AiDotNet.Tensors.Engines;
 
@@ -53,6 +54,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> MuLawEncoding<T>(Tensor<T> input, int quantizationChannels = 256)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (quantizationChannels <= 1)
             throw new ArgumentException("quantizationChannels must be > 1 (μ = qc − 1 must be positive).",
                 nameof(quantizationChannels));
@@ -81,6 +84,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> MuLawDecoding<T>(Tensor<int> input, int quantizationChannels = 256)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (quantizationChannels <= 1)
             throw new ArgumentException("quantizationChannels must be > 1.", nameof(quantizationChannels));
         if (typeof(T) == typeof(float))

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using AiDotNet.Tensors;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -65,6 +66,8 @@ public partial class DirectGpuTensorEngine
         Tensor<int> faces,
         int spiralLength)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (vertices is null) throw new ArgumentNullException(nameof(vertices));
         if (faces is null) throw new ArgumentNullException(nameof(faces));
         if (vertices.Rank != 2 || vertices._shape[1] != 3)
@@ -255,6 +258,7 @@ public partial class DirectGpuTensorEngine
         if (targets is null) throw new ArgumentNullException(nameof(targets));
         if (inputLengths is null) throw new ArgumentNullException(nameof(inputLengths));
         if (targetLengths is null) throw new ArgumentNullException(nameof(targetLengths));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (logProbs.Rank != 3)
             throw new ArgumentException("logProbs must be 3D [T, N, C].");
 
@@ -595,6 +599,8 @@ public partial class DirectGpuTensorEngine
     Tensor<T> IEngine.ComputeMeshLaplacian<T>(
         Tensor<T> vertices, Tensor<int> faces, LaplacianType laplacianType)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (typeof(T) != typeof(float) || laplacianType != LaplacianType.Uniform ||
             IsTapeActive<T>() || Compilation.GraphMode.IsActive || !TryGetBackend(out var backend) ||
             backend is not IResidentIndexBackend indexBackend)
@@ -659,6 +665,8 @@ public partial class DirectGpuTensorEngine
         double leakyReluAlpha,
         out Tensor<T> attentionCoeffs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (typeof(T) != typeof(float) || IsTapeActive<T>() || Compilation.GraphMode.IsActive ||
             !TryGetBackend(out var backend))
             return base.GraphAttention(nodeFeatures, edgeSourceIndices, edgeTargetIndices,
@@ -728,6 +736,8 @@ public partial class DirectGpuTensorEngine
         bool concatenate,
         out Tensor<T> attentionCoeffs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (typeof(T) != typeof(float) || IsTapeActive<T>() || Compilation.GraphMode.IsActive ||
             !TryGetBackend(out _))
             return base.MultiHeadGraphAttention(nodeFeatures, edgeSourceIndices, edgeTargetIndices,
@@ -2059,6 +2069,7 @@ public partial class DirectGpuTensorEngine
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.TensorTake(tensor, indices);
 
@@ -2090,6 +2101,7 @@ public partial class DirectGpuTensorEngine
         if (destination is null) throw new ArgumentNullException(nameof(destination));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (updates is null) throw new ArgumentNullException(nameof(updates));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (axis < 0) axis += destination.Rank;
 
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive)
@@ -2108,12 +2120,38 @@ public partial class DirectGpuTensorEngine
         return base.TensorScatterAdd(destination, indices, updates, axis);
     }
 
+    Tensor<T> IEngine.ScatterAdd<T>(Tensor<T> input, Tensor<int> indices, Tensor<T> values, int axis)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (indices is null) throw new ArgumentNullException(nameof(indices));
+        if (values is null) throw new ArgumentNullException(nameof(values));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+        int normalizedAxis = axis < 0 ? axis + input.Rank : axis;
+
+        // This overload has exactly index_add semantics: clone input, then add each values slice
+        // into the destination slice named by the one-dimensional indices tensor.
+        if (IsTapeActive<T>() || Compilation.GraphMode.IsActive)
+            return base.ScatterAdd(input, indices, values, axis);
+        try
+        {
+            if (TryIndexAddOnDevice(input, normalizedAxis, indices, values) is { } output)
+                return output;
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.ScatterAdd(input, indices, values, axis);
+        }
+        return base.ScatterAdd(input, indices, values, axis);
+    }
+
     /// <inheritdoc/>
     public override Tensor<T> TensorIndexAdd<T>(Tensor<T> tensor, int axis, Tensor<int> indices, Tensor<T> source)
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (source is null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (axis < 0) axis += tensor.Rank;
 
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive)
@@ -2700,6 +2738,150 @@ public partial class DirectGpuTensorEngine
             return rbfResult;
         }
         catch { return base.RBFKernel(input, centers, epsilons); }
+    }
+
+    (Tensor<T> gradInput, Tensor<T> gradCenters, Tensor<T> gradEpsilons) IEngine.RBFKernelBackward<T>(
+        Tensor<T> gradOutput, Tensor<T> input, Tensor<T> centers, Tensor<T> epsilons, Tensor<T> output)
+    {
+        if (gradOutput is null) throw new ArgumentNullException(nameof(gradOutput));
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (centers is null) throw new ArgumentNullException(nameof(centers));
+        if (epsilons is null) throw new ArgumentNullException(nameof(epsilons));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+
+        if (Compilation.GraphMode.IsActive || typeof(T) != typeof(float) ||
+            input.Rank != 2 || centers.Rank != 2 || epsilons.Rank != 1 ||
+            gradOutput.Rank != 2 || output.Rank != 2 ||
+            input._shape[1] != centers._shape[1] ||
+            centers._shape[0] != epsilons._shape[0] ||
+            gradOutput._shape[0] != input._shape[0] ||
+            gradOutput._shape[1] != centers._shape[0] ||
+            output._shape[0] != input._shape[0] ||
+            output._shape[1] != centers._shape[0] ||
+            !input.IsContiguous || !centers.IsContiguous || !epsilons.IsContiguous ||
+            !gradOutput.IsContiguous || !output.IsContiguous ||
+            input.Length == 0 || centers.Length == 0 || !TryGetBackend(out var backend))
+            return base.RBFKernelBackward(gradOutput, input, centers, epsilons, output);
+
+        try
+        {
+            int batch = input._shape[0];
+            int features = input._shape[1];
+            int numCenters = centers._shape[0];
+            int pairCount = batch * numCenters;
+
+            using var gradOutputBuffer = GetOrAllocateBuffer(backend, gradOutput);
+            using var inputBuffer = GetOrAllocateBuffer(backend, input);
+            using var centersBuffer = GetOrAllocateBuffer(backend, centers);
+            using var epsilonsBuffer = GetOrAllocateBuffer(backend, epsilons);
+            using var outputBuffer = GetOrAllocateBuffer(backend, output);
+
+            // W[b,c] = dL/dK[b,c] * K[b,c]
+            using var weightedKernel = AllocateOutputBuffer(backend, pairCount);
+            using var epsilonWeighted = AllocateOutputBuffer(backend, pairCount);
+            backend.Multiply(
+                gradOutputBuffer.Buffer, outputBuffer.Buffer, weightedKernel.Buffer, pairCount);
+            backend.BroadcastMultiplyLastAxis(
+                weightedKernel.Buffer, epsilonsBuffer.Buffer, epsilonWeighted.Buffer,
+                batch, numCenters);
+
+            // dL/dx = -2 * (x * rowSum(E) - E @ centers), E = W * epsilon.
+            using var rowSums = AllocateOutputBuffer(backend, batch);
+            using var scaledInput = AllocateOutputBuffer(backend, batch * features);
+            using var weightedCenters = AllocateOutputBuffer(backend, batch * features);
+            using var gradInputBuffer = AllocateOutputBuffer(backend, batch * features);
+            backend.SumAxis(epsilonWeighted.Buffer, rowSums.Buffer, batch, numCenters);
+            backend.BroadcastMultiplyFirstAxis(
+                inputBuffer.Buffer, rowSums.Buffer, scaledInput.Buffer, batch, features);
+            backend.Gemm(
+                epsilonWeighted.Buffer, centersBuffer.Buffer, weightedCenters.Buffer,
+                batch, features, numCenters);
+            backend.Subtract(
+                scaledInput.Buffer, weightedCenters.Buffer, gradInputBuffer.Buffer,
+                batch * features);
+            backend.Scale(
+                gradInputBuffer.Buffer, gradInputBuffer.Buffer, -2f, batch * features);
+
+            // dL/dc = 2 * (E^T @ x - c * rowSum(E^T)).
+            using var epsilonWeightedTranspose = AllocateOutputBuffer(backend, pairCount);
+            using var centerSums = AllocateOutputBuffer(backend, numCenters);
+            using var weightedInputs = AllocateOutputBuffer(backend, numCenters * features);
+            using var scaledCenters = AllocateOutputBuffer(backend, numCenters * features);
+            using var gradCentersBuffer = AllocateOutputBuffer(backend, numCenters * features);
+            backend.Transpose(
+                epsilonWeighted.Buffer, epsilonWeightedTranspose.Buffer, batch, numCenters);
+            backend.SumAxis(
+                epsilonWeightedTranspose.Buffer, centerSums.Buffer, numCenters, batch);
+            backend.Gemm(
+                epsilonWeightedTranspose.Buffer, inputBuffer.Buffer, weightedInputs.Buffer,
+                numCenters, features, batch);
+            backend.BroadcastMultiplyFirstAxis(
+                centersBuffer.Buffer, centerSums.Buffer, scaledCenters.Buffer,
+                numCenters, features);
+            backend.Subtract(
+                weightedInputs.Buffer, scaledCenters.Buffer, gradCentersBuffer.Buffer,
+                numCenters * features);
+            backend.Scale(
+                gradCentersBuffer.Buffer, gradCentersBuffer.Buffer, 2f,
+                numCenters * features);
+
+            // ||x-c||^2 = ||x||^2 + ||c||^2 - 2*x*c^T, then
+            // dL/depsilon[c] = -sum_b W[b,c] * ||x_b-c_c||^2.
+            using var inputSquares = AllocateOutputBuffer(backend, batch * features);
+            using var centerSquares = AllocateOutputBuffer(backend, numCenters * features);
+            using var inputNorms = AllocateOutputBuffer(backend, batch);
+            using var centerNorms = AllocateOutputBuffer(backend, numCenters);
+            using var centersTranspose = AllocateOutputBuffer(backend, numCenters * features);
+            using var distances = AllocateOutputBuffer(backend, pairCount);
+            using var tiledInputNorms = AllocateOutputBuffer(backend, pairCount);
+            using var epsilonContributions = AllocateOutputBuffer(backend, pairCount);
+            using var epsilonContributionsTranspose = AllocateOutputBuffer(backend, pairCount);
+            using var gradEpsilonsBuffer = AllocateOutputBuffer(backend, numCenters);
+            backend.Multiply(inputBuffer.Buffer, inputBuffer.Buffer, inputSquares.Buffer, batch * features);
+            backend.Multiply(
+                centersBuffer.Buffer, centersBuffer.Buffer, centerSquares.Buffer,
+                numCenters * features);
+            backend.SumAxis(inputSquares.Buffer, inputNorms.Buffer, batch, features);
+            backend.SumAxis(centerSquares.Buffer, centerNorms.Buffer, numCenters, features);
+            backend.Transpose(centersBuffer.Buffer, centersTranspose.Buffer, numCenters, features);
+            backend.Gemm(
+                inputBuffer.Buffer, centersTranspose.Buffer, distances.Buffer,
+                batch, numCenters, features, -2f, 0f);
+            backend.TileAxis(
+                inputNorms.Buffer, tiledInputNorms.Buffer,
+                outerSize: 1, axisSize: batch, innerSize: 1, repeats: numCenters);
+            backend.Add(distances.Buffer, tiledInputNorms.Buffer, distances.Buffer, pairCount);
+            backend.BroadcastAddLast(
+                distances.Buffer, centerNorms.Buffer, distances.Buffer, batch, numCenters);
+            backend.Multiply(
+                weightedKernel.Buffer, distances.Buffer, epsilonContributions.Buffer, pairCount);
+            backend.Transpose(
+                epsilonContributions.Buffer, epsilonContributionsTranspose.Buffer,
+                batch, numCenters);
+            backend.SumAxis(
+                epsilonContributionsTranspose.Buffer, gradEpsilonsBuffer.Buffer,
+                numCenters, batch);
+            backend.Scale(
+                gradEpsilonsBuffer.Buffer, gradEpsilonsBuffer.Buffer, -1f, numCenters);
+
+            Tensor<T> gradInputResult = DeferTensorResult<T>(
+                backend, gradInputBuffer.Buffer, batch * features, (int[])input._shape.Clone());
+            Tensor<T> gradCentersResult = DeferTensorResult<T>(
+                backend, gradCentersBuffer.Buffer, numCenters * features,
+                (int[])centers._shape.Clone());
+            Tensor<T> gradEpsilonsResult = DeferTensorResult<T>(
+                backend, gradEpsilonsBuffer.Buffer, numCenters, (int[])epsilons._shape.Clone());
+            gradInputBuffer.RelinquishOwnership();
+            gradCentersBuffer.RelinquishOwnership();
+            gradEpsilonsBuffer.RelinquishOwnership();
+            return (gradInputResult, gradCentersResult, gradEpsilonsResult);
+        }
+        catch (Exception ex)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            LogGpuFallback(nameof(IEngine.RBFKernelBackward), ex);
+            return base.RBFKernelBackward(gradOutput, input, centers, epsilons, output);
+        }
     }
 
     Tensor<T> IEngine.Upsample3D<T>(Tensor<T> input, int scaleD, int scaleH, int scaleW)
@@ -3328,6 +3510,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorHistogram<T>(Tensor<T> input, int bins, T min, T max)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (typeof(T) != typeof(float) || bins <= 0 || !TryGetBackend(out var backend))
             return base.TensorHistogram(input, bins, min, max);
@@ -3438,6 +3622,192 @@ public partial class DirectGpuTensorEngine
             }
         }
         catch (Exception) { return base.TensorUnique(input, sorted); }
+    }
+
+    /// <inheritdoc/>
+    public override (Tensor<T> Values, Tensor<int>? Inverse, Tensor<int>? Counts) TensorUniqueWithInfo<T>(
+        Tensor<T> input, bool sorted = true, bool returnInverse = false, bool returnCounts = false)
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (!returnInverse && !returnCounts)
+            return (TensorUnique(input, sorted), null, null);
+        if (typeof(T) != typeof(float) || !sorted || input.Length == 0 ||
+            input.Length > 16_777_216 || !TryGetBackend(out var backend) ||
+            backend is not IUniqueConsecutiveBackend compaction)
+            return base.TensorUniqueWithInfo(input, sorted, returnInverse, returnCounts);
+
+        var contiguous = input.IsContiguous ? input : (Tensor<T>)input.Contiguous();
+        int length = input.Length;
+        try
+        {
+            using var source = GetOrAllocateBuffer(backend, contiguous);
+            var (sortedValues, sortedIndices) = BitonicSortRowsToBuffers(
+                backend, source.Buffer, 1, length, descending: false);
+            using (sortedValues)
+            using (sortedIndices)
+            using (var valuesCapacity = AllocateOutputBuffer(backend, length))
+            using (var countBuffer = AllocateOutputBuffer(backend, 1))
+            {
+                var inverseCapacity = AllocateOutputBuffer(backend, returnInverse ? length : 1);
+                var countsCapacity = AllocateOutputBuffer(backend, returnCounts ? length : 1);
+                try
+                {
+                    compaction.UniqueSortedWithInfo(
+                        sortedValues.Buffer, sortedIndices.Buffer, valuesCapacity.Buffer,
+                        inverseCapacity.Buffer, countsCapacity.Buffer, countBuffer.Buffer,
+                        length, returnInverse, returnCounts);
+
+                    int count = checked((int)DownloadScalar(backend, countBuffer.Buffer));
+                    if (count < 1 || count > length)
+                        throw new InvalidOperationException(
+                            $"GPU sorted-unique returned invalid count {count} for length {length}.");
+
+                    var exactValues = new OwnedBuffer(backend.AllocateBuffer(count), ownsBuffer: true);
+                    try
+                    {
+                        backend.Copy(valuesCapacity.Buffer, 0, exactValues.Buffer, 0, count);
+                        var values = DeferTensorResult<T>(
+                            backend, exactValues.Buffer, count, new[] { count });
+                        exactValues.RelinquishOwnership();
+
+                        Tensor<int>? inverse = null;
+                        if (returnInverse)
+                        {
+                            inverse = DeferTensorResult<int>(backend, inverseCapacity.Buffer,
+                                length, (int[])input._shape.Clone());
+                            inverseCapacity.RelinquishOwnership();
+                        }
+
+                        Tensor<int>? counts = null;
+                        if (returnCounts)
+                        {
+                            var exactCounts = new OwnedBuffer(
+                                backend.AllocateBuffer(count), ownsBuffer: true);
+                            try
+                            {
+                                backend.Copy(countsCapacity.Buffer, 0,
+                                    exactCounts.Buffer, 0, count);
+                                counts = DeferTensorResult<int>(
+                                    backend, exactCounts.Buffer, count, new[] { count });
+                                exactCounts.RelinquishOwnership();
+                            }
+                            finally
+                            {
+                                exactCounts.Dispose();
+                            }
+                        }
+
+                        return (values, inverse, counts);
+                    }
+                    finally
+                    {
+                        exactValues.Dispose();
+                    }
+                }
+                finally
+                {
+                    inverseCapacity.Dispose();
+                    countsCapacity.Dispose();
+                }
+            }
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.TensorUniqueWithInfo(input, sorted, returnInverse, returnCounts);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override (Tensor<T> Values, Tensor<int>? Inverse, Tensor<int>? Counts) TensorUniqueConsecutiveWithInfo<T>(
+        Tensor<T> input, bool returnInverse = false, bool returnCounts = false)
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (!returnInverse && !returnCounts)
+            return (TensorUniqueConsecutive(input), null, null);
+        if (typeof(T) != typeof(float) || input.Length == 0 ||
+            input.Length > 16_777_216 || !TryGetBackend(out var backend) ||
+            backend is not IUniqueConsecutiveBackend compaction)
+            return base.TensorUniqueConsecutiveWithInfo(input, returnInverse, returnCounts);
+
+        var contiguous = input.IsContiguous ? input : (Tensor<T>)input.Contiguous();
+        int length = input.Length;
+        try
+        {
+            using var source = GetOrAllocateBuffer(backend, contiguous);
+            using var valuesCapacity = AllocateOutputBuffer(backend, length);
+            using var countBuffer = AllocateOutputBuffer(backend, 1);
+            var inverseCapacity = AllocateOutputBuffer(backend, returnInverse ? length : 1);
+            var countsCapacity = AllocateOutputBuffer(backend, returnCounts ? length : 1);
+            try
+            {
+                compaction.UniqueConsecutiveWithInfo(
+                    source.Buffer, valuesCapacity.Buffer, inverseCapacity.Buffer,
+                    countsCapacity.Buffer, countBuffer.Buffer, length,
+                    returnInverse, returnCounts);
+
+                int count = checked((int)DownloadScalar(backend, countBuffer.Buffer));
+                if (count < 1 || count > length)
+                    throw new InvalidOperationException(
+                        $"GPU unique-consecutive returned invalid count {count} for length {length}.");
+
+                var exactValues = new OwnedBuffer(backend.AllocateBuffer(count), ownsBuffer: true);
+                try
+                {
+                    backend.Copy(valuesCapacity.Buffer, 0, exactValues.Buffer, 0, count);
+                    var values = DeferTensorResult<T>(
+                        backend, exactValues.Buffer, count, new[] { count });
+                    exactValues.RelinquishOwnership();
+
+                    Tensor<int>? inverse = null;
+                    if (returnInverse)
+                    {
+                        inverse = DeferTensorResult<int>(backend, inverseCapacity.Buffer,
+                            length, (int[])input._shape.Clone());
+                        inverseCapacity.RelinquishOwnership();
+                    }
+
+                    Tensor<int>? counts = null;
+                    if (returnCounts)
+                    {
+                        var exactCounts = new OwnedBuffer(
+                            backend.AllocateBuffer(count), ownsBuffer: true);
+                        try
+                        {
+                            backend.Copy(countsCapacity.Buffer, 0,
+                                exactCounts.Buffer, 0, count);
+                            counts = DeferTensorResult<int>(
+                                backend, exactCounts.Buffer, count, new[] { count });
+                            exactCounts.RelinquishOwnership();
+                        }
+                        finally
+                        {
+                            exactCounts.Dispose();
+                        }
+                    }
+
+                    return (values, inverse, counts);
+                }
+                finally
+                {
+                    exactValues.Dispose();
+                }
+            }
+            finally
+            {
+                inverseCapacity.Dispose();
+                countsCapacity.Dispose();
+            }
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.TensorUniqueConsecutiveWithInfo(input, returnInverse, returnCounts);
+        }
     }
 
     // ----- Sort family (GPU bitonic sort) -----
@@ -3570,16 +3940,23 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorArgsort<T>(Tensor<T> input, int axis = -1, bool descending = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         // Argsort = Sort's indices; the GPU Sort override above carries it.
         var (_, indices) = TensorSort(input, axis, descending);
         return indices;
     }
 
     Tensor<int> IEngine.ArgSort<T>(Tensor<T> input, int axis, bool descending)
-        => TensorArgsort(input, axis, descending);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+        return TensorArgsort(input, axis, descending);
+    }
 
     Tensor<T> IEngine.TensorTopK<T>(Tensor<T> tensor, int k, int axis, out Tensor<int> indices)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         int normalizedAxis = axis < 0 ? axis + tensor.Rank : axis;
         if (typeof(T) != typeof(float) || tensor.Rank != 2 || normalizedAxis != 1
@@ -3622,6 +3999,25 @@ public partial class DirectGpuTensorEngine
             }
         }
         catch { return base.TensorTopK(tensor, k, axis, out indices); }
+    }
+
+    (Tensor<T> values, Tensor<int> indices) IEngine.TopK<T>(
+        Tensor<T> input, int k, int axis, bool largest)
+    {
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+        int normalizedAxis = axis < 0 ? axis + input.Rank : axis;
+        if (normalizedAxis < 0 || normalizedAxis >= input.Rank)
+            throw new ArgumentException($"Invalid axis {axis} for tensor with {input.Rank} dimensions", nameof(axis));
+        if (k > input._shape[normalizedAxis])
+            throw new ArgumentException(
+                $"k ({k}) cannot be greater than axis size ({input._shape[normalizedAxis]})", nameof(k));
+
+        if (!largest)
+            return base.TopK(input, k, axis, largest);
+
+        var values = ((IEngine)this).TensorTopK(input, k, axis, out var indices);
+        return (values, indices);
     }
 
     /// <inheritdoc/>
@@ -3701,6 +4097,7 @@ public partial class DirectGpuTensorEngine
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int rank = tensor.Rank;
         int d = dim < 0 ? dim + rank : dim;
         if (typeof(T) != typeof(float) || d < 0 || d >= rank || indices.Rank != rank || !TryGetBackend(out var backend))
@@ -3736,6 +4133,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorSearchSorted<T>(Tensor<T> sortedSequence, Tensor<T> values, bool right = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (sortedSequence is null) throw new ArgumentNullException(nameof(sortedSequence));
         if (values is null) throw new ArgumentNullException(nameof(values));
         if (typeof(T) != typeof(float) || sortedSequence.Rank != 1 || !TryGetBackend(out var backend))
@@ -3759,7 +4158,10 @@ public partial class DirectGpuTensorEngine
 
     /// <inheritdoc/>
     public override Tensor<int> TensorBucketize<T>(Tensor<T> input, Tensor<T> boundaries, bool right = false)
-        => TensorSearchSorted(boundaries, input, right);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+        return TensorSearchSorted(boundaries, input, right);
+    }
 
     /// <inheritdoc/>
     public new (Tensor<T> X, Tensor<T> Y) TensorMeshgrid<T>(Tensor<T> x, Tensor<T> y)
@@ -3845,7 +4247,7 @@ public partial class DirectGpuTensorEngine
                 var rshape = new int[d];
                 for (int i = 0; i < d; i++) rshape[i] = 1;
                 rshape[axis] = tensors[k]._shape[0];
-                result[k] = TensorBroadcastTo(tensors[k].Reshape(rshape), outShape);
+                result[k] = TensorBroadcastTo(Reshape(tensors[k], rshape), outShape);
             }
             return result;
         }
@@ -3962,6 +4364,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> TensorPut<T>(Tensor<T> tensor, Tensor<int> indices, Tensor<T> source)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -4024,6 +4428,7 @@ public partial class DirectGpuTensorEngine
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (mask is null) throw new ArgumentNullException(nameof(mask));
         if (source is null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         if (typeof(T) != typeof(float) || IsTapeActive<T>() || Compilation.GraphMode.IsActive
             || !ShapesEqual(tensor._shape, mask._shape) || tensor.Length > 16_777_216
             || !TryGetBackend(out var backend) || backend is not INonzeroBackend compaction)
@@ -4077,9 +4482,12 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> TensorScatterReduce<T>(
         Tensor<T> tensor, int dim, Tensor<int> indices, Tensor<T> source, ScatterReduceMode mode, bool includeSelf = true)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (source is null) throw new ArgumentNullException(nameof(source));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int rank = tensor.Rank;
         int d = dim < 0 ? dim + rank : dim;
         // kernel modes: 0=sum,1=prod,2=amax,3=amin. Mean / includeSelf=false defer to base.
@@ -4135,6 +4543,8 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> TensorIndexPut<T>(
         Tensor<T> tensor, Tensor<int>[] indices, Tensor<T> source, bool accumulate = false)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -4416,6 +4826,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<T> TensorIndexFill<T>(Tensor<T> tensor, int axis, Tensor<int> indices, T value)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         int rank = tensor.Rank;
@@ -4459,6 +4871,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> Nms<T>(Tensor<T> boxes, Tensor<T> scores, double iouThreshold)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         if (boxes is null) throw new ArgumentNullException(nameof(boxes));
         if (scores is null) throw new ArgumentNullException(nameof(scores));
         if (boxes.Rank != 2 || boxes._shape[1] != 4)
@@ -4476,6 +4890,8 @@ public partial class DirectGpuTensorEngine
     public override Tensor<int> BatchedNms<T>(
         Tensor<T> boxes, Tensor<T> scores, Tensor<int> classIds, double iouThreshold)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         if (boxes is null) throw new ArgumentNullException(nameof(boxes));
         if (scores is null) throw new ArgumentNullException(nameof(scores));
         if (classIds is null) throw new ArgumentNullException(nameof(classIds));
@@ -4546,6 +4962,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> MasksToBoxes<T>(Tensor<T> masks)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (masks is null) throw new ArgumentNullException(nameof(masks));
         if (masks.Rank != 3) throw new ArgumentException("MasksToBoxes requires rank-3 masks [N, H, W].");
         if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
@@ -4565,6 +4983,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorHistogramDD<T>(Tensor<T> samples, int[] bins, T[] mins, T[] maxs)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
         if (samples is null) throw new ArgumentNullException(nameof(samples));
         if (bins is null) throw new ArgumentNullException(nameof(bins));
         if (mins is null) throw new ArgumentNullException(nameof(mins));
@@ -4595,6 +5015,9 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorBinCount(Tensor<int> input, int? minLength = null)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.DataDependentOutputShape);
+
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (input.Rank != 1) throw new ArgumentException("BinCount requires a 1-D int tensor");
         if (minLength < 0)
@@ -5017,6 +5440,8 @@ public partial class DirectGpuTensorEngine
     /// <inheritdoc/>
     public override Tensor<int> TensorNonzero<T>(Tensor<T> tensor)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.DataDependentOutputShape);
+
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (tensor.Length == 0) return new Tensor<int>(new[] { 0, tensor.Rank });
         if (typeof(T) != typeof(float) || tensor.Length > 16_777_216 ||
@@ -5162,8 +5587,58 @@ public partial class DirectGpuTensorEngine
     }
 
     /// <inheritdoc/>
+    public override (Tensor<T> Mantissa, Tensor<int> Exponent) TensorFrexp<T>(Tensor<T> tensor)
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend) ||
+            backend is not IFrexpBackend frexp)
+            return base.TensorFrexp(tensor);
+
+        int length = tensor.Length;
+        if (length == 0)
+            return (new Tensor<T>((int[])tensor._shape.Clone()),
+                new Tensor<int>((int[])tensor._shape.Clone()));
+
+        var contiguous = tensor.IsContiguous ? tensor : (Tensor<T>)tensor.Contiguous();
+        using var input = GetOrAllocateBuffer(backend, contiguous);
+        var mantissaBuffer = AllocateOutputBuffer(backend, length);
+        var exponentBuffer = AllocateOutputBuffer(backend, length);
+        bool mantissaHandedOff = false;
+        bool exponentHandedOff = false;
+        try
+        {
+            frexp.Frexp(input.Buffer, mantissaBuffer.Buffer, exponentBuffer.Buffer, length);
+            var shape = (int[])tensor._shape.Clone();
+            var mantissa = DeferTensorResult<T>(
+                backend, mantissaBuffer.Buffer, length, shape);
+            mantissaBuffer.RelinquishOwnership();
+            mantissaHandedOff = true;
+
+            var exponent = DeferTensorResult<int>(
+                backend, exponentBuffer.Buffer, length, (int[])shape.Clone());
+            exponentBuffer.RelinquishOwnership();
+            exponentHandedOff = true;
+            return (mantissa, exponent);
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.TensorFrexp(tensor);
+        }
+        finally
+        {
+            if (!mantissaHandedOff) mantissaBuffer.Dispose();
+            if (!exponentHandedOff) exponentBuffer.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
     public override Tensor<T> TensorLdexp<T>(Tensor<T> x, Tensor<int> exp)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (x is null) throw new ArgumentNullException(nameof(x));
         if (exp is null) throw new ArgumentNullException(nameof(exp));
         if (typeof(T) != typeof(float) || !ShapesEqual(x._shape, exp._shape) || !TryGetBackend(out var backend))
@@ -5584,20 +6059,47 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> LstmSequenceForward<T>(
         Tensor<T> input, Tensor<T>? h0, Tensor<T>? c0, Tensor<T> wIh, Tensor<T> wHh,
         Tensor<T>? bIh, Tensor<T>? bHh, bool returnSequences = false)
+        => LstmSequenceForwardGpu(
+            input, h0, c0, wIh, wHh, bIh, bHh,
+            wantState: false, out _, out _, returnSequences);
+
+    /// <inheritdoc/>
+    public override Tensor<T> LstmSequenceForward<T>(
+        Tensor<T> input, Tensor<T>? h0, Tensor<T>? c0, Tensor<T> wIh, Tensor<T> wHh,
+        Tensor<T>? bIh, Tensor<T>? bHh,
+        out Tensor<T> finalHidden, out Tensor<T> finalCell,
+        bool returnSequences = false)
+        => LstmSequenceForwardGpu(
+            input, h0, c0, wIh, wHh, bIh, bHh,
+            wantState: true, out finalHidden, out finalCell, returnSequences);
+
+    private Tensor<T> LstmSequenceForwardGpu<T>(
+        Tensor<T> input, Tensor<T>? h0, Tensor<T>? c0, Tensor<T> wIh, Tensor<T> wHh,
+        Tensor<T>? bIh, Tensor<T>? bHh, bool wantState,
+        out Tensor<T> finalHidden, out Tensor<T> finalCell,
+        bool returnSequences)
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (wIh is null) throw new ArgumentNullException(nameof(wIh));
         if (wHh is null) throw new ArgumentNullException(nameof(wHh));
-        if (typeof(T) != typeof(float) || input.Rank != 3 || !TryGetBackend(out var backend))
-            return base.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+        if (GraphMode.IsActive ||
+            (wantState && DifferentiableOps.IsRecording<T>()) ||
+            typeof(T) != typeof(float) || input.Rank != 3 || !TryGetBackend(out var backend))
+            return LstmSequenceForwardFallback(
+                input, h0, c0, wIh, wHh, bIh, bHh,
+                wantState, out finalHidden, out finalCell, returnSequences);
 
         int B = input._shape[0], S = input._shape[1], In = input._shape[2];
         int gateRows = wIh._shape[0];
         if (gateRows % 4 != 0 || wIh._shape[1] != In || wHh._shape[0] != gateRows || wHh._shape[1] != gateRows / 4)
-            return base.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+            return LstmSequenceForwardFallback(
+                input, h0, c0, wIh, wHh, bIh, bHh,
+                wantState, out finalHidden, out finalCell, returnSequences);
         int Hd = gateRows / 4;
         if (B == 0 || S == 0)
-            return base.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
+            return LstmSequenceForwardFallback(
+                input, h0, c0, wIh, wHh, bIh, bHh,
+                wantState, out finalHidden, out finalCell, returnSequences);
 
         // Engine weights/bias/gates (PyTorch i,f,g,o; [4*hidden, *]) match the kernel exactly. The kernel
         // ALSO reads input and writes output in [batch, seq, *] order (inputOffset/output use
@@ -5622,14 +6124,16 @@ public partial class DirectGpuTensorEngine
             : GetOrAllocateBuffer(backend, bHh);
 
         IGpuBuffer? bufHf = null;
+        IGpuBuffer? bufCf = null;
         IGpuBuffer? bufOut = null;
         bool hFinalHandedOff = false;
+        bool cFinalHandedOff = false;
         bool sequenceHandedOff = false;
         try
         {
             bufHf = backend.AllocateBuffer(B * Hd);
             bufOut = backend.AllocateBuffer(S * B * Hd);
-            using var bufCf = backend.AllocateBuffer(B * Hd);
+            bufCf = backend.AllocateBuffer(B * Hd);
             using var bufAllH = backend.AllocateBuffer((S + 1) * B * Hd);
             using var bufAllC = backend.AllocateBuffer((S + 1) * B * Hd);
             using var bufGates = backend.AllocateBuffer(S * B * Hd * 4);
@@ -5653,6 +6157,29 @@ public partial class DirectGpuTensorEngine
             {
                 output = DeferTensorResult<T>(backend, bufHf, B * Hd, new[] { B, Hd });
                 hFinalHandedOff = true;
+            }
+
+            if (wantState)
+            {
+                if (returnSequences)
+                {
+                    finalHidden = DeferTensorResult<T>(backend, bufHf, B * Hd, new[] { B, Hd });
+                    hFinalHandedOff = true;
+                }
+                else
+                {
+                    // The primary result is h_n for the non-sequence form. Reuse the same resident
+                    // tensor rather than copying or reading it back solely to manufacture an alias.
+                    finalHidden = output;
+                }
+
+                finalCell = DeferTensorResult<T>(backend, bufCf, B * Hd, new[] { B, Hd });
+                cFinalHandedOff = true;
+            }
+            else
+            {
+                finalHidden = Tensor<T>.Empty();
+                finalCell = Tensor<T>.Empty();
             }
 
             // Training: if a float tape is recording, save the GPU forward caches to host and record a fused
@@ -5691,8 +6218,27 @@ public partial class DirectGpuTensorEngine
         finally
         {
             if (!hFinalHandedOff) bufHf?.Dispose();
+            if (!cFinalHandedOff) bufCf?.Dispose();
             if (!sequenceHandedOff) bufOut?.Dispose();
         }
+    }
+
+    private Tensor<T> LstmSequenceForwardFallback<T>(
+        Tensor<T> input, Tensor<T>? h0, Tensor<T>? c0, Tensor<T> wIh, Tensor<T> wHh,
+        Tensor<T>? bIh, Tensor<T>? bHh, bool wantState,
+        out Tensor<T> finalHidden, out Tensor<T> finalCell,
+        bool returnSequences)
+    {
+        if (wantState)
+        {
+            return base.LstmSequenceForward(
+                input, h0, c0, wIh, wHh, bIh, bHh,
+                out finalHidden, out finalCell, returnSequences);
+        }
+
+        finalHidden = Tensor<T>.Empty();
+        finalCell = Tensor<T>.Empty();
+        return base.LstmSequenceForward(input, h0, c0, wIh, wHh, bIh, bHh, returnSequences);
     }
 
     // Fused GPU BPTT backward for LstmSequenceForward. Uploads the host-saved forward caches (gates,
@@ -5839,15 +6385,27 @@ public partial class DirectGpuTensorEngine
         if (kWeight is null) throw new ArgumentNullException(nameof(kWeight));
         if (vWeight is null) throw new ArgumentNullException(nameof(vWeight));
         if (outWeight is null) throw new ArgumentNullException(nameof(outWeight));
+        if (mask is not null)
+            GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
 
-        // GPU path: float, rank-3 input, divisible heads, no mask (masked attention defers to base for
-        // now), inference only. Anything else uses the validated CPU base.
-        if (typeof(T) != typeof(float) || input.Rank != 3 || numHeads <= 0 || mask is not null
+        // GPU path: float, rank-3 input and divisible heads. Anything else uses the validated CPU base.
+        if (typeof(T) != typeof(float) || input.Rank != 3 || numHeads <= 0
             || input._shape[2] % numHeads != 0 || !TryGetBackend(out var backend))
             return base.MultiHeadAttentionForward(input, qWeight, kWeight, vWeight, outWeight, numHeads, mask);
 
         int B = input._shape[0], S = input._shape[1], D = input._shape[2];
         int H = numHeads, d = D / H;
+        if (mask is not null)
+        {
+            if (mask.Rank != 4)
+                throw new ArgumentException("Attention mask must be rank 4.", nameof(mask));
+            int[] target = { B, H, S, S };
+            for (int axis = 0; axis < target.Length; axis++)
+                if (mask._shape[axis] != 1 && mask._shape[axis] != target[axis])
+                    throw new ArgumentException(
+                        $"Attention mask axis {axis} has extent {mask._shape[axis]}; expected 1 or {target[axis]}.",
+                        nameof(mask));
+        }
         if (qWeight.Rank != 2 || qWeight._shape[0] != D || qWeight._shape[1] != D ||
             kWeight.Rank != 2 || kWeight._shape[0] != D || kWeight._shape[1] != D ||
             vWeight.Rank != 2 || vWeight._shape[0] != D || vWeight._shape[1] != D ||
@@ -5879,7 +6437,38 @@ public partial class DirectGpuTensorEngine
                 var kbh = TensorSlice(kh, new[] { bh, 0, 0 }, new[] { 1, S, d }).Reshape(new[] { S, d });
                 var vbh = TensorSlice(vh, new[] { bh, 0, 0 }, new[] { 1, S, d }).Reshape(new[] { S, d });
                 var scores = TensorMultiplyScalar(TensorMatMulTransposed(qbh, kbh), scaleT);  // [S,S] = (q·kᵀ)·scale
-                var attn = SoftmaxLastAxisGpu(backend, scores);                                // softmax over keys
+                Tensor<T> attn;
+                if (mask is null)
+                {
+                    attn = SoftmaxLastAxisGpu(backend, scores);                                // softmax over keys
+                }
+                else
+                {
+                    int b = bh / H;
+                    int h = bh % H;
+                    var headMaskData = new bool[S * S];
+                    for (int q = 0; q < S; q++)
+                        for (int k = 0; k < S; k++)
+                            headMaskData[q * S + k] = mask[
+                                mask._shape[0] == 1 ? 0 : b,
+                                mask._shape[1] == 1 ? 0 : h,
+                                mask._shape[2] == 1 ? 0 : q,
+                                mask._shape[3] == 1 ? 0 : k];
+
+                    using var headMask = new Tensor<bool>(headMaskData, new[] { S, S });
+                    var fillData = new T[S * S];
+                    for (int i = 0; i < fillData.Length; i++)
+                        fillData[i] = (T)(object)float.NegativeInfinity;
+                    using var fill = new Tensor<T>(fillData, new[] { S, S });
+                    var maskedScores = ((IEngine)this).TensorWhere(headMask, scores, fill);
+                    var rawAttention = SoftmaxLastAxisGpu(backend, maskedScores);
+
+                    // A row whose mask is entirely false makes softmax(-inf,...) undefined. Select
+                    // through the same mask once more so those rows—and every masked element—are
+                    // exactly zero, matching the CPU contract without a host-side score readback.
+                    using var zeros = new Tensor<T>(new T[S * S], new[] { S, S });
+                    attn = ((IEngine)this).TensorWhere(headMask, rawAttention, zeros);
+                }
                 headOuts[bh] = TensorMatMul(attn, vbh).Reshape(new[] { 1, S, d });            // [1,S,d]
             }
 
@@ -6125,6 +6714,8 @@ public partial class DirectGpuTensorEngine
     Tensor<T> IEngine.ScaledDotProductAttention<T>(Tensor<T> query, Tensor<T> key, Tensor<T> value,
         Tensor<bool>? mask, double? scale, out Tensor<T> attentionWeights, double softcap)
     {
+        if (mask is not null)
+            GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         // GPU SDPA kernel: [batch, numHeads, seqQ/seqK, headDim]. Non-float, wrong rank, or unequal
         // Q/K/V feature depths defer to the base (CPU) implementation. The attention-logit soft-cap
         // (Gemma-2) is threaded into every backend kernel below.
@@ -6255,6 +6846,7 @@ public partial class DirectGpuTensorEngine
     {
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int normalizedAxis = axis < 0 ? axis + input.Rank : axis;
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || normalizedAxis < 0 || normalizedAxis >= input.Rank || !TryGetBackend(out var backend)
@@ -6299,6 +6891,7 @@ public partial class DirectGpuTensorEngine
         if (input is null) throw new ArgumentNullException(nameof(input));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (values is null) throw new ArgumentNullException(nameof(values));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int normalizedAxis = axis < 0 ? axis + input.Rank : axis;
         // Tape bail RESTORED after a gradient test caught a real defect. Recording the node here with
         // CpuEngine's ScatterBackward produced d(values) exactly correct but d(input) wrong by 3.14e-01
@@ -6352,6 +6945,8 @@ public partial class DirectGpuTensorEngine
 
     Tensor<T> IEngine.TensorScatter<T>(Tensor<T> destination, Tensor<int> indices, Tensor<T> source, int axis)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (destination is null) throw new ArgumentNullException(nameof(destination));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
         if (source is null) throw new ArgumentNullException(nameof(source));
@@ -6525,7 +7120,10 @@ public partial class DirectGpuTensorEngine
     // resident primitives used by their CpuEngine definitions.
 
     Tensor<T> IEngine.TensorIndexSelectDiff<T>(Tensor<T> source, Tensor<int> indices, int axis)
-        => TensorIndexSelect(source, indices, axis);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+        return TensorIndexSelect(source, indices, axis);
+    }
 
     Tensor<T> IEngine.TensorStackDiff<T>(Tensor<T>[] tensors, int axis)
         => TensorStack(tensors, axis);
@@ -6564,10 +7162,16 @@ public partial class DirectGpuTensorEngine
     }
 
     Tensor<int> IEngine.TensorArgMax<T>(Tensor<T> tensor, int axis)
-        => TensorArgExtremaResident(tensor, axis, findMaximum: true);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+        return TensorArgExtremaResident(tensor, axis, findMaximum: true);
+    }
 
     Tensor<int> IEngine.TensorArgMin<T>(Tensor<T> tensor, int axis)
-        => TensorArgExtremaResident(tensor, axis, findMaximum: false);
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
+        return TensorArgExtremaResident(tensor, axis, findMaximum: false);
+    }
 
     private Tensor<int> TensorArgExtremaResident<T>(Tensor<T> tensor, int axis, bool findMaximum)
     {
@@ -6617,6 +7221,7 @@ public partial class DirectGpuTensorEngine
     {
         if (embeddings is null) throw new ArgumentNullException(nameof(embeddings));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.MixedElementTypes);
         if (embeddings.Rank != 2)
             throw new ArgumentException(
                 $"Embeddings must be a 2D tensor [vocab_size, embedding_dim]. Got rank {embeddings.Rank}.");
@@ -7386,6 +7991,8 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> MaxPool3DWithTensorIndices<T>(
         Tensor<T> input, int[] poolSize, int[] stride, out Tensor<int> maxIndices)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         if (Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || input.Rank != 5 || poolSize is not { Length: 3 } || stride is not { Length: 3 }
             || !TryGetBackend(out var backend))
@@ -8048,6 +8655,8 @@ public partial class DirectGpuTensorEngine
     // spiralIndices=[V,spiralLength] (int), weights=[outC, inC*spiralLength], biases=[outC] -> [V,outC].
     Tensor<T> IEngine.SpiralConv<T>(Tensor<T> vertexFeatures, Tensor<int> spiralIndices, Tensor<T> weights, Tensor<T> biases)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || vertexFeatures.Rank != 2 || spiralIndices.Rank != 2 || weights.Rank != 2 || biases.Rank != 1
             || !TryGetBackend(out var backend) || backend is not ISpiralConvKernels gpu)
@@ -8286,6 +8895,207 @@ public partial class DirectGpuTensorEngine
         catch { return base.TensorReciprocal(tensor); }
     }
 
+    /// <inheritdoc/>
+    public override void ProjectGaussians3DTo2D<T>(
+        Tensor<T> means3D,
+        Tensor<T> covariances3D,
+        Matrix<T> viewMatrix,
+        Matrix<T> projMatrix,
+        int imageWidth,
+        int imageHeight,
+        out Tensor<T> means2D,
+        out Tensor<T> covariances2D,
+        out Tensor<T> depths,
+        out Tensor<bool> visible)
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HostBoundary);
+
+        if (means3D is null) throw new ArgumentNullException(nameof(means3D));
+        if (covariances3D is null) throw new ArgumentNullException(nameof(covariances3D));
+        if (viewMatrix is null) throw new ArgumentNullException(nameof(viewMatrix));
+        if (projMatrix is null) throw new ArgumentNullException(nameof(projMatrix));
+
+        bool packedCovariance = covariances3D.Rank == 2 && covariances3D._shape[1] == 6;
+        bool matrixCovariance = covariances3D.Rank == 3 &&
+            covariances3D._shape[1] == 3 && covariances3D._shape[2] == 3;
+        int numGaussians = means3D.Rank == 2 ? means3D._shape[0] : 0;
+        if (typeof(T) != typeof(float) || means3D.Rank != 2 || means3D._shape[1] != 3 ||
+            (!packedCovariance && !matrixCovariance) || covariances3D._shape[0] != numGaussians ||
+            viewMatrix.Rows < 4 || viewMatrix.Columns < 4 ||
+            projMatrix.Rows < 4 || projMatrix.Columns < 4 ||
+            numGaussians > int.MaxValue / 9 || !TryGetBackend(out var backend) ||
+            backend is not IRenderingGeometryBackend geometry)
+        {
+            base.ProjectGaussians3DTo2D(
+                means3D, covariances3D, viewMatrix, projMatrix, imageWidth, imageHeight,
+                out means2D, out covariances2D, out depths, out visible);
+            return;
+        }
+
+        if (numGaussians == 0)
+        {
+            means2D = new Tensor<T>(Array.Empty<T>(), new[] { 0, 2 });
+            covariances2D = new Tensor<T>(Array.Empty<T>(), new[] { 0, 3 });
+            depths = new Tensor<T>(Array.Empty<T>(), new[] { 0 });
+            visible = new Tensor<bool>(Array.Empty<bool>(), new[] { 0 });
+            return;
+        }
+
+        var contiguousMeans = means3D.IsContiguous ? means3D : (Tensor<T>)means3D.Contiguous();
+        var contiguousCovariance = covariances3D.IsContiguous
+            ? covariances3D
+            : (Tensor<T>)covariances3D.Contiguous();
+        using var meansBuffer = GetOrAllocateBuffer(backend, contiguousMeans);
+        using var covarianceBuffer = GetOrAllocateBuffer(backend, contiguousCovariance);
+        var means2DBuffer = AllocateOutputBuffer(backend, checked(numGaussians * 2));
+        var covariance2DBuffer = AllocateOutputBuffer(backend, checked(numGaussians * 3));
+        var depthsBuffer = AllocateOutputBuffer(backend, numGaussians);
+        var visibleBuffer = AllocateOutputBuffer(backend, numGaussians);
+        try
+        {
+            static float Scalar(T value) => (float)(object)value!;
+            geometry.ProjectGaussians3DTo2D(
+                meansBuffer.Buffer, covarianceBuffer.Buffer,
+                means2DBuffer.Buffer, covariance2DBuffer.Buffer,
+                depthsBuffer.Buffer, visibleBuffer.Buffer,
+                numGaussians, packedCovariance ? 6 : 9, imageWidth, imageHeight,
+                Scalar(viewMatrix[0, 0]), Scalar(viewMatrix[0, 1]),
+                Scalar(viewMatrix[0, 2]), Scalar(viewMatrix[0, 3]),
+                Scalar(viewMatrix[1, 0]), Scalar(viewMatrix[1, 1]),
+                Scalar(viewMatrix[1, 2]), Scalar(viewMatrix[1, 3]),
+                Scalar(viewMatrix[2, 0]), Scalar(viewMatrix[2, 1]),
+                Scalar(viewMatrix[2, 2]), Scalar(viewMatrix[2, 3]),
+                Scalar(projMatrix[0, 0]), Scalar(projMatrix[1, 1]));
+
+            means2D = DeferTensorResult<T>(backend, means2DBuffer.Buffer,
+                numGaussians * 2, new[] { numGaussians, 2 });
+            means2DBuffer.RelinquishOwnership();
+            covariances2D = DeferTensorResult<T>(backend, covariance2DBuffer.Buffer,
+                numGaussians * 3, new[] { numGaussians, 3 });
+            covariance2DBuffer.RelinquishOwnership();
+            depths = DeferTensorResult<T>(backend, depthsBuffer.Buffer,
+                numGaussians, new[] { numGaussians });
+            depthsBuffer.RelinquishOwnership();
+            visible = DeferTensorResult<bool>(backend, visibleBuffer.Buffer,
+                numGaussians, new[] { numGaussians });
+            visibleBuffer.RelinquishOwnership();
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            base.ProjectGaussians3DTo2D(
+                means3D, covariances3D, viewMatrix, projMatrix, imageWidth, imageHeight,
+                out means2D, out covariances2D, out depths, out visible);
+        }
+        finally
+        {
+            means2DBuffer.Dispose();
+            covariance2DBuffer.Dispose();
+            depthsBuffer.Dispose();
+            visibleBuffer.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public override (Tensor<T> positions, Tensor<T> directions, Tensor<bool> validMask, Tensor<T> tValues)
+        SampleRaysWithOccupancy<T>(
+            Tensor<T> rayOrigins,
+            Tensor<T> rayDirections,
+            Tensor<uint> occupancyBitfield,
+            int gridSize,
+            Vector<T> sceneBoundsMin,
+            Vector<T> sceneBoundsMax,
+            T nearBound,
+            T farBound,
+            int maxSamples)
+    {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
+        if (rayOrigins is null) throw new ArgumentNullException(nameof(rayOrigins));
+        if (rayDirections is null) throw new ArgumentNullException(nameof(rayDirections));
+        if (occupancyBitfield is null) throw new ArgumentNullException(nameof(occupancyBitfield));
+        if (sceneBoundsMin is null) throw new ArgumentNullException(nameof(sceneBoundsMin));
+        if (sceneBoundsMax is null) throw new ArgumentNullException(nameof(sceneBoundsMax));
+        int numRays = rayOrigins.Rank == 2 ? rayOrigins._shape[0] : 0;
+        long totalSamplesLong = (long)numRays * maxSamples;
+        long totalCellsLong = (long)gridSize * gridSize * gridSize;
+        if (typeof(T) != typeof(float) || rayOrigins.Rank != 2 || rayDirections.Rank != 2 ||
+            rayOrigins._shape[1] != 3 || rayDirections._shape[1] != 3 ||
+            rayDirections._shape[0] != numRays ||
+            sceneBoundsMin.Length < 3 || sceneBoundsMax.Length < 3 ||
+            gridSize <= 0 || maxSamples <= 0 || totalSamplesLong > int.MaxValue / 3 ||
+            totalCellsLong > int.MaxValue || !TryGetBackend(out var backend) ||
+            backend is not IRenderingGeometryBackend geometry)
+            return base.SampleRaysWithOccupancy(
+                rayOrigins, rayDirections, occupancyBitfield, gridSize,
+                sceneBoundsMin, sceneBoundsMax, nearBound, farBound, maxSamples);
+
+        int totalSamples = (int)totalSamplesLong;
+        if (totalSamples == 0)
+            return base.SampleRaysWithOccupancy(
+                rayOrigins, rayDirections, occupancyBitfield, gridSize,
+                sceneBoundsMin, sceneBoundsMax, nearBound, farBound, maxSamples);
+
+        var contiguousOrigins = rayOrigins.IsContiguous
+            ? rayOrigins
+            : (Tensor<T>)rayOrigins.Contiguous();
+        var contiguousDirections = rayDirections.IsContiguous
+            ? rayDirections
+            : (Tensor<T>)rayDirections.Contiguous();
+        using var originsBuffer = GetOrAllocateBuffer(backend, contiguousOrigins);
+        using var directionsInputBuffer = GetOrAllocateBuffer(backend, contiguousDirections);
+
+        var occupancySpan = occupancyBitfield.AsSpan();
+        var occupancyWords = new int[occupancySpan.Length];
+        for (int i = 0; i < occupancyWords.Length; i++)
+            occupancyWords[i] = unchecked((int)occupancySpan[i]);
+        using var occupancyBuffer = backend.AllocateIntBuffer(occupancyWords);
+
+        var positionsBuffer = AllocateOutputBuffer(backend, checked(totalSamples * 3));
+        var directionsBuffer = AllocateOutputBuffer(backend, checked(totalSamples * 3));
+        var maskBuffer = AllocateOutputBuffer(backend, totalSamples);
+        var tValuesBuffer = AllocateOutputBuffer(backend, totalSamples);
+        try
+        {
+            static float Scalar(T value) => (float)(object)value!;
+            geometry.SampleRaysWithOccupancy(
+                originsBuffer.Buffer, directionsInputBuffer.Buffer, occupancyBuffer,
+                positionsBuffer.Buffer, directionsBuffer.Buffer, maskBuffer.Buffer,
+                tValuesBuffer.Buffer, numRays, occupancyWords.Length, gridSize, maxSamples,
+                Scalar(sceneBoundsMin[0]), Scalar(sceneBoundsMin[1]), Scalar(sceneBoundsMin[2]),
+                Scalar(sceneBoundsMax[0]), Scalar(sceneBoundsMax[1]), Scalar(sceneBoundsMax[2]),
+                Scalar(nearBound), Scalar(farBound));
+
+            var positions = DeferTensorResult<T>(backend, positionsBuffer.Buffer,
+                totalSamples * 3, new[] { totalSamples, 3 });
+            positionsBuffer.RelinquishOwnership();
+            var directions = DeferTensorResult<T>(backend, directionsBuffer.Buffer,
+                totalSamples * 3, new[] { totalSamples, 3 });
+            directionsBuffer.RelinquishOwnership();
+            var validMask = DeferTensorResult<bool>(backend, maskBuffer.Buffer,
+                totalSamples, new[] { totalSamples });
+            maskBuffer.RelinquishOwnership();
+            var tValues = DeferTensorResult<T>(backend, tValuesBuffer.Buffer,
+                totalSamples, new[] { numRays, maxSamples });
+            tValuesBuffer.RelinquishOwnership();
+            return (positions, directions, validMask, tValues);
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.SampleRaysWithOccupancy(
+                rayOrigins, rayDirections, occupancyBitfield, gridSize,
+                sceneBoundsMin, sceneBoundsMax, nearBound, farBound, maxSamples);
+        }
+        finally
+        {
+            positionsBuffer.Dispose();
+            directionsBuffer.Dispose();
+            maskBuffer.Dispose();
+            tValuesBuffer.Dispose();
+        }
+    }
+
     // #775: 3D Gaussian-splat covariance on the new gaussian_covariance kernel. rotations [N,4]
     // (quaternion w,x,y,z), scales [N,3] -> covariances [N,6] upper triangular of R*S^2*R^T. Gather
     // over gaussians; mirrors GaussianSplattingOperations. Tape/GraphMode/non-float defer to the base.
@@ -8388,6 +9198,7 @@ public partial class DirectGpuTensorEngine
     // with an explicit outputSize and a long-enough index is taken; everything else defers to the base.
     Tensor<T> IEngine.ScatterAdd<T>(Tensor<T> source, Tensor<int> indices, int dim, int? outputSize)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
         int actualDim = dim < 0 ? source.Rank + dim : dim;
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || source.Rank < 1 || actualDim != 0 || !outputSize.HasValue || outputSize.Value <= 0
@@ -8419,6 +9230,8 @@ public partial class DirectGpuTensorEngine
     // rows in ascending order, so strict greater-than preserves CPU first-on-ties behavior.
     Tensor<T> IEngine.ScatterMax<T>(Tensor<T> source, Tensor<int> indices, out Tensor<int>? argmax, int dim, int? outputSize)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousOutput);
+
         int actualDim = dim < 0 ? source.Rank + dim : dim;
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || source.Rank < 1 || actualDim != 0 || !outputSize.HasValue || outputSize.Value <= 0
@@ -8456,6 +9269,8 @@ public partial class DirectGpuTensorEngine
     // output keeps the source shape; invalid group -> 0). Non-dim-0 / tape / GraphMode defer to base.
     Tensor<T> IEngine.ScatterSoftmax<T>(Tensor<T> source, Tensor<int> indices, int dim, int? outputSize)
     {
+        GraphMode.ThrowIfInferenceUnsupported(GraphCaptureLimitation.HeterogeneousInput);
+
         int actualDim = dim < 0 ? source.Rank + dim : dim;
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || source.Rank < 1 || actualDim != 0 || !outputSize.HasValue || outputSize.Value <= 0

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -1419,7 +1419,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // is the LIVE data regardless of the host Version snapshot — accept it. Clearing it on a version
             // mismatch (the path below) would orphan a deferred materializer registered by BindResidentBuffer →
             // a later host read fires it on a recycled buffer = #226 "buffer released before materialization".
-            if (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend)))
+            if (tensor._gpuBuffer.Handle != IntPtr.Zero
+                && (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
 
             // Stale snapshot — also clear any matching activation-cache entry so
@@ -1489,11 +1490,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <see cref="EvictActivationsCreatedAfter"/> on tape dispose, then handed to the next
     /// forward call's upload). For a CPU tensor we therefore confirm the activation cache
     /// STILL maps this tensor's key to the very same buffer; if not, the field is stale and
-    /// the caller must re-upload. GPU-resident results are not tracked by the activation
-    /// cache, so their field stays authoritative.
+    /// the caller must re-upload. A zero native handle is always dead, including for a
+    /// GPU-resident tensor whose activation-cache owner has already released its buffer.
     /// </summary>
     private bool IsCachedGpuBufferLive<T>(Tensor<T> tensor, IDirectGpuBackend backend)
     {
+        if (tensor._gpuBuffer is null || tensor._gpuBuffer.Handle == IntPtr.Zero) return false;
         if (tensor.IsGpuResident) return true;
         var key = (object?)tensor.GetBackingArrayForCacheLookupUnsafe() ?? tensor.DataVector;
         // _activationCache is a ConcurrentDictionary — this read is lock-free.
@@ -1723,7 +1725,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // buffer to UploadTensorRaw callers.
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
         {
-            if (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend)))
+            if (tensor._gpuBuffer.Handle != IntPtr.Zero
+                && (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);   // compiled step: buffers pinned, don't orphan aliases
 
             var staleArray = tensor.GetBackingArrayForCacheLookupUnsafe();
@@ -3155,7 +3158,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (eng is DirectGpuTensorEngine gpu && gpu.TryAliasResidentOutput(src, dest))
         { AliasDiag("OK aliased"); return; }
         AliasDiag(eng is DirectGpuTensorEngine ? "FELLBACK host-copy" : "not-gpu-engine");
-        src.AsSpan().CopyTo(dest.AsWritableSpan());
+        var destination = dest.AsWritableSpan();
+        if (src.IsContiguous)
+            src.AsSpan().CopyTo(destination);
+        else
+            src.CopyLogicalTo(destination);
+        dest.IncrementVersion();
     }
 
     private bool TryAliasResidentOutput<T>(Tensor<T> src, Tensor<T> dest)
@@ -3173,7 +3181,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // so the stricter gate would wrongly decline and force a host-copy that fires a deferred download = CUDA
         // 900 inside the capture. This matches GetOrAllocateContiguousInputBuffer's resolution.
         IGpuBuffer? srcBuf = null;
-        if (src._gpuBuffer is not null && ReferenceEquals(src._gpuBackend, backend))
+        if (src._gpuBuffer is not null && src._gpuBuffer.Handle != IntPtr.Zero
+            && ReferenceEquals(src._gpuBackend, backend))
         {
             srcBuf = src._gpuBuffer;
         }
@@ -4164,7 +4173,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var kC = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (kC is not null) return new OwnedBuffer(Fp16InputToFp32Stable(backend, tHalfC, tCountC, kC), ownsBuffer: false);
         }
-        if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
+        if (tensor._gpuBuffer is not null && tensor._gpuBuffer.Handle != IntPtr.Zero
+            && ReferenceEquals(tensor._gpuBackend, backend))
             return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
 
         return GetOrAllocateBuffer(backend, tensor);
@@ -5736,39 +5746,69 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     void IEngine.GroupNormInto<T>(Tensor<T> output, Tensor<T> input, int numGroups, Tensor<T> gamma, Tensor<T> beta, double epsilon, out Tensor<T> mean, out Tensor<T> variance)
     {
-        if (TryGetBackend(out var gpuBackend))
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (gamma is null) throw new ArgumentNullException(nameof(gamma));
+        if (beta is null) throw new ArgumentNullException(nameof(beta));
+
+        // Inference tracing must be handled by CpuEngine's capture scaffold. Direct execution is
+        // intentionally FP32 because every DirectGpu backend stores public numeric tensors as FP32.
+        if (Compilation.GraphMode.IsInferenceTrace || typeof(T) != typeof(float) ||
+            !output.IsContiguous || input.Rank < 2 || numGroups <= 0 ||
+            input._shape[1] % numGroups != 0 || output.Length != input.Length ||
+            !TryGetBackend(out var gpuBackend))
         {
-            try
-            {
-                var floatInput = (Tensor<float>)(object)input;
-                var floatOutput = (Tensor<float>)(object)output;
-                var floatGamma = (Tensor<float>)(object)gamma;
-                var floatBeta = (Tensor<float>)(object)beta;
+            base.GroupNormInto(output, input, numGroups, gamma, beta, epsilon, out mean, out variance);
+            return;
+        }
 
-                int batch = input.Shape._dims[0], channels = input.Shape._dims[1];
-                int spatial = input.Length / (batch * channels);
+        try
+        {
+            int batch = input._shape[0];
+            int channels = input._shape[1];
+            int spatial = input.Length / (batch * channels);
+            int statCount = batch * numGroups;
 
-                using var gpuIn = gpuBackend.AllocateBuffer(floatInput.GetDataArray());
-                using var gpuGamma = gpuBackend.AllocateBuffer(floatGamma.GetDataArray());
-                using var gpuBeta = gpuBackend.AllocateBuffer(floatBeta.GetDataArray());
-                using var gpuOut = gpuBackend.AllocateBuffer(input.Length);
-                using var gpuMean = gpuBackend.AllocateBuffer(batch * numGroups);
-                using var gpuVar = gpuBackend.AllocateBuffer(batch * numGroups);
+            using var gpuIn = GetOrAllocateBuffer(gpuBackend, input);
+            using var gpuGamma = GetWeightBufferPreferResident(gpuBackend, gamma, PersistentTensorRole.Weights);
+            using var gpuBeta = GetWeightBufferPreferResident(gpuBackend, beta, PersistentTensorRole.Biases);
+            mean = new Tensor<T>(new[] { batch, numGroups });
+            variance = new Tensor<T>(new[] { batch, numGroups });
+            IGpuBuffer gpuOut = GetOrCreateResidentBuffer(gpuBackend, output, input.Length);
+            IGpuBuffer gpuMean = GetOrCreateResidentBuffer(gpuBackend, mean, statCount);
+            IGpuBuffer gpuVariance = GetOrCreateResidentBuffer(gpuBackend, variance, statCount);
 
-                gpuBackend.GroupNorm(gpuIn, gpuOut, gpuGamma, gpuBeta, gpuMean, gpuVar,
-                    batch, numGroups, channels, spatial, (float)epsilon);
-                DownloadIntoTensor(gpuBackend, gpuOut, floatOutput);
+            // GroupNorm kernels reduce from the input while other threads write output, so an
+            // input/output alias is not generally safe. Preserve the in-place public contract by
+            // computing into a distinct temporary and copying back on the same device stream.
+            bool aliasesInput = ReferenceEquals(gpuIn.Buffer, gpuOut) ||
+                (gpuIn.Buffer.Handle != IntPtr.Zero && gpuIn.Buffer.Handle == gpuOut.Handle);
+            using var aliasOutput = aliasesInput ? AllocateOutputBuffer(gpuBackend, input.Length) : default;
+            IGpuBuffer kernelOutput = aliasesInput ? aliasOutput.Buffer : gpuOut;
 
-                mean = new Tensor<T>(new int[] { batch, numGroups });
-                variance = new Tensor<T>(new int[] { batch, numGroups });
-                DownloadIntoTensor(gpuBackend, gpuMean, (Tensor<float>)(object)mean);
-                DownloadIntoTensor(gpuBackend, gpuVar, (Tensor<float>)(object)variance);
-                return;
-            }
-            catch
-            {
-                // Fall through to CPU
-            }
+            gpuBackend.GroupNorm(
+                gpuIn.Buffer, kernelOutput, gpuGamma.Buffer, gpuBeta.Buffer,
+                gpuMean, gpuVariance,
+                batch, numGroups, channels, spatial, (float)epsilon);
+            if (aliasesInput)
+                gpuBackend.Copy(kernelOutput, 0, gpuOut, 0, input.Length);
+
+            // Backends save inverse standard deviation for their backward kernels. The public
+            // IEngine contract returns population variance, so convert invStd to variance before
+            // publishing the buffer: variance = 1 / invStd^2 - epsilon.
+            gpuBackend.Multiply(gpuVariance, gpuVariance, gpuVariance, statCount);
+            gpuBackend.Reciprocal(gpuVariance, gpuVariance, statCount);
+            gpuBackend.SubScalar(gpuVariance, gpuVariance, (float)epsilon, statCount);
+
+            BindResidentBuffer(output, gpuOut, gpuBackend);
+            BindResidentBuffer(mean, gpuMean, gpuBackend);
+            BindResidentBuffer(variance, gpuVariance, gpuBackend);
+            return;
+        }
+        catch (Exception ex)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            LogGpuFallback(nameof(IEngine.GroupNormInto), ex);
         }
         base.GroupNormInto(output, input, numGroups, gamma, beta, epsilon, out mean, out variance);
     }
@@ -8281,6 +8321,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> MaxPool2DWithTensorIndices<T>(
         Tensor<T> input, int[] poolSize, int[] stride, out Tensor<int> maxIndices)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousOutput);
+
         if (!TryGetBackend(out var backend) || input.Rank != 4
             || poolSize is not { Length: 2 } || stride is not { Length: 2 })
             return base.MaxPool2DWithTensorIndices(input, poolSize, stride, out maxIndices);
@@ -10910,6 +10953,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (weight is null) throw new ArgumentNullException(nameof(weight));
         if (bias is null) throw new ArgumentNullException(nameof(bias));
         if (targetIds is null) throw new ArgumentNullException(nameof(targetIds));
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (Compilation.GraphMode.IsActive || IsTapeActive<T>())
             return base.FusedLinearCrossEntropyWithLogits(hidden, weight, bias, targetIds);
         if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
@@ -15280,6 +15325,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     Tensor<T> IEngine.Embedding<T>(Tensor<int> indices, Tensor<T> embeddingTable)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || !TryGetBackend(out var backend))
             return base.Embedding(indices, embeddingTable);
@@ -20237,7 +20284,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // inside cuStreamCapture = CUDA 906 → the catch → CpuEngine.TensorPermuteInto → get_Memory()
                 // download → cuStreamSynchronize CUDA 900 → capture aborts (the #38 attention-transpose blocker).
                 // Matches TryAliasResidentOutput's resident-step buffer-resolution rationale.
-                if (output._gpuBuffer is not null && ReferenceEquals(output._gpuBackend, backend))
+                if (output._gpuBuffer is not null && output._gpuBuffer.Handle != IntPtr.Zero
+                    && ReferenceEquals(output._gpuBackend, backend))
                     outBuf = output._gpuBuffer;
                 else if (arr is not null)
                     lock (_activationCacheLock)
@@ -20872,6 +20920,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorGather<T>(Tensor<T> source, Tensor<int> indices, int axis)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || !TryGetBackend(out var backend) || axis != 0)
             return base.TensorGather(source, indices, axis);
@@ -20923,6 +20973,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // RecordUnary).
     public override Tensor<T> Embedding<T>(Tensor<int> indices, Tensor<T> embeddingTable)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || !TryGetBackend(out var backend))
             return base.Embedding(indices, embeddingTable);
@@ -21741,6 +21793,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> ScatterMean<T>(Tensor<T> source, Tensor<int> indices, out Tensor<int>? counts, int dim, int? outputSize)
     {
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousOutput);
+
         // #775: gather-form scatter-mean (deterministic, bit-exact with CpuEngine; the old atomic
         // backend.ScatterMean path fell back). Dim-0 float case with an explicit outputSize and a
         // long-enough index; else base. Both the mean and counts stay resident.
@@ -22391,6 +22446,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (indices is null) throw new ArgumentNullException(nameof(indices));
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         int normalizedAxis = axis < 0 ? tensor.Rank + axis : axis;
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || normalizedAxis < 0 || normalizedAxis >= tensor.Rank || !TryGetBackend(out var backend)
@@ -22440,6 +22497,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorMaskedFill<T>(Tensor<T> tensor, Tensor<bool> mask, T value)
     {
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+        if (mask is null) throw new ArgumentNullException(nameof(mask));
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || !tensor._shape.SequenceEqual(mask._shape) || !TryGetBackend(out var backend))
             return base.TensorMaskedFill(tensor, mask, value);
@@ -22466,6 +22527,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     {
         if (tensor is null) throw new ArgumentNullException(nameof(tensor));
         if (mask is null) throw new ArgumentNullException(nameof(mask));
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
         if (IsTapeActive<T>() || Compilation.GraphMode.IsActive || typeof(T) != typeof(float)
             || !tensor._shape.SequenceEqual(mask._shape) || !TryGetBackend(out var backend))
             return base.TensorMaskedFill(tensor, mask, value);
@@ -22491,32 +22554,67 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         }
     }
 
+    Tensor<T> IEngine.TensorWhere<T>(Tensor<bool> condition, Tensor<T> x, Tensor<T> y)
+    {
+        if (condition is null) throw new ArgumentNullException(nameof(condition));
+        if (x is null) throw new ArgumentNullException(nameof(x));
+        if (y is null) throw new ArgumentNullException(nameof(y));
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
+        if (!condition._shape.SequenceEqual(x._shape) || !x._shape.SequenceEqual(y._shape))
+            throw new ArgumentException("condition, x, and y must have the same shape.");
+        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
+            return base.TensorWhere(condition, x, y);
+
+        try
+        {
+            // CLR bool storage is byte-addressed, while every current device Where kernel consumes
+            // an fp32 0/1 predicate. Convert explicitly instead of reinterpreting the host bytes.
+            var predicate = new float[condition.Length];
+            for (int i = 0; i < predicate.Length; i++) predicate[i] = condition[i] ? 1f : 0f;
+            using var condBuf = new OwnedBuffer(backend.AllocateBuffer(predicate), ownsBuffer: true);
+            using var xBuf = GetOrAllocateBuffer(backend, x);
+            using var yBuf = GetOrAllocateBuffer(backend, y);
+            var outBuf = AllocateOutputBuffer(backend, x.Length);
+            backend.Where(condBuf.Buffer, xBuf.Buffer, yBuf.Buffer, outBuf.Buffer, x.Length);
+            var output = DeferTensorResult<T>(backend, outBuf.Buffer, x.Length, x.Shape.ToArray());
+
+            object[]? savedState = null;
+            if (IsTapeActive<T>())
+            {
+                var condBytes = new byte[condition.Length];
+                for (int i = 0; i < condBytes.Length; i++) condBytes[i] = condition[i] ? (byte)1 : (byte)0;
+                savedState = new object[] { condBytes };
+            }
+            Autodiff.DifferentiableOps.RecordBinary("TensorWhere", output, x, y,
+                Autodiff.BackwardFunctions<T>.WhereBackward, savedState);
+            return output;
+        }
+        catch (Exception)
+        {
+            if (ThrowOnGpuKernelFallback) throw;
+            return base.TensorWhere(condition, x, y);
+        }
+    }
+
     /// <inheritdoc/>
     public override Tensor<T> TensorWhere<T>(Tensor<Bit> condition, Tensor<T> x, Tensor<T> y)
     {
         if (condition is null) throw new ArgumentNullException(nameof(condition));
         if (x is null) throw new ArgumentNullException(nameof(x));
         if (y is null) throw new ArgumentNullException(nameof(y));
-        if (x.Length != y.Length || x.Length != condition.Length)
-            throw new ArgumentException("All tensors must have the same length.");
+        Compilation.GraphMode.ThrowIfInferenceUnsupported(
+            Compilation.GraphCaptureLimitation.HeterogeneousInput);
+        if (!condition._shape.SequenceEqual(x._shape) || !x._shape.SequenceEqual(y._shape))
+            throw new ArgumentException("condition, x, and y must have the same shape.");
         // Bit masks ARE GPU-resident: PackMaskResident finishes through FinishGpuOp, which DEFERS the
         // download and keeps the device buffer cached. That buffer holds exactly the float 0/1 the
         // where_select kernel reads, because it is the output of the comparison kernel that produced the
         // mask (see equals_kernel). So the resident case can and should run on-device.
         //
-        // The guard is residency, not type. A Tensor<Bit> built on the HOST has no cached buffer; uploading
-        // its Bit[] storage and reinterpreting it as float selects on garbage — that is what broke 10
-        // comparison ops (TensorIsNan/IsInf/IsFinite, TensorEqScalar, TensorLogicalAnd/Not/Or/Xor,
-        // TensorIsIn) when where_select was first added. Requiring an already-resident condition keeps those
-        // correct on the CPU path while letting the comparison -> where chain stay on the device.
-        // MEASURED 2026-07-20 for the comparison family (TensorIsNan/IsInf/IsFinite, TensorEq,
-        // TensorLogicalAnd/Not/Or/Xor): the mask arriving here reports
-        //     arr=Bit[]  cached=False  tensorBuf=False  IsGpuResident=False
-        // i.e. it is NOT resident by any measure, so this gate cannot fire for them and they stay on the
-        // CPU path. Those ops sit at "launches 1/2" on the residency worklist, and the missing launch is NOT
-        // this Where — the chain has already left the device before it. Fixing them means making the
-        // PRODUCING comparison op keep its mask resident; this gate is then already in place to carry the
-        // mask through.
+        // A Tensor<Bit> built on the HOST has no cached fp32 buffer; uploading its Bit[] storage and
+        // reinterpreting it as float selects on garbage. Host masks therefore take the explicit 0/1
+        // conversion below, while masks produced by comparison kernels reuse their resident fp32 encoding.
         // Residency for a Bit mask lives in the ACTIVATION CACHE, keyed by backing array — FinishGpuOp
         // registers it there and defers the download; it is NOT exposed through Tensor.TryGetGpuBuffer(),
         // which stays null for these. Probe the cache directly, or this always falls back and the
@@ -22531,37 +22629,53 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // and WhereBackward matches `Tensor<T>` or `byte[]` and otherwise falls through — a Tensor<Bit> is
         // neither when T is float, so the backward silently took the wrong branch. Recording the same
         // byte[] encoding CpuEngine uses makes the two paths agree.
-        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend)
-            || condArr is null || !IsDeviceResidentArray(condArr))
+        if (typeof(T) != typeof(float) || !TryGetBackend(out var backend))
             return base.TensorWhere(condition, x, y);
 
         try
         {
-            using var condBuf = GetOrAllocateBuffer(backend, condition);
-            using var xBuf = GetOrAllocateBuffer(backend, x);
-            using var yBuf = GetOrAllocateBuffer(backend, y);
-            var outBuf = AllocateOutputBuffer(backend, x.Length);
-            backend.Where(condBuf.Buffer, xBuf.Buffer, yBuf.Buffer, outBuf.Buffer, x.Length);
-            var output = DeferTensorResult<T>(backend, outBuf.Buffer, x.Length, x.Shape.ToArray());
-            // Same byte[] 0/1 encoding CpuEngine records. WhereBackward accepts Tensor<T> or byte[];
-            // handing it a Tensor<Bit> matches neither and falls through to the wrong branch.
-            //
-            // Build it ONLY when a tape will consume it. Indexing the mask element-by-element pulls a
-            // GPU-resident Bit tensor back to the host, and this line was the single call site behind
-            // ALL 11 entries on the internal-readback worklist (every comparison op reaches Where, each
-            // showing 1 transfer before materialization). RecordBinary returns immediately when no tape
-            // is recording, so with no tape the array was pure waste that also broke residency. With a
-            // tape it is built exactly as before, so backward behaviour is unchanged.
-            object[]? savedState = null;
-            if (IsTapeActive<T>())
+            OwnedBuffer condBuf;
+            if (condArr is not null && IsDeviceResidentArray(condArr))
             {
-                var condBytes = new byte[condition.Length];
-                for (int i = 0; i < condBytes.Length; i++) condBytes[i] = (bool)condition[i] ? (byte)1 : (byte)0;
-                savedState = new object[] { condBytes };
+                // Comparison kernels already encode resident Bit predicates as fp32 0/1.
+                condBuf = GetOrAllocateBuffer(backend, condition);
             }
-            Autodiff.DifferentiableOps.RecordBinary("TensorWhere", output, x, y,
-                Autodiff.BackwardFunctions<T>.WhereBackward, savedState);
-            return output;
+            else
+            {
+                // AiDotNet Bit is not an fp32 storage type. Upload an explicit predicate buffer
+                // for host-created masks instead of reinterpreting its managed representation.
+                var predicate = new float[condition.Length];
+                for (int i = 0; i < predicate.Length; i++)
+                    predicate[i] = (bool)condition[i] ? 1f : 0f;
+                condBuf = new OwnedBuffer(backend.AllocateBuffer(predicate), ownsBuffer: true);
+            }
+            using (condBuf)
+            {
+                using var xBuf = GetOrAllocateBuffer(backend, x);
+                using var yBuf = GetOrAllocateBuffer(backend, y);
+                var outBuf = AllocateOutputBuffer(backend, x.Length);
+                backend.Where(condBuf.Buffer, xBuf.Buffer, yBuf.Buffer, outBuf.Buffer, x.Length);
+                var output = DeferTensorResult<T>(backend, outBuf.Buffer, x.Length, x.Shape.ToArray());
+                // Same byte[] 0/1 encoding CpuEngine records. WhereBackward accepts Tensor<T> or byte[];
+                // handing it a Tensor<Bit> matches neither and falls through to the wrong branch.
+                //
+                // Build it ONLY when a tape will consume it. Indexing the mask element-by-element pulls a
+                // GPU-resident Bit tensor back to the host, and this line was the single call site behind
+                // ALL 11 entries on the internal-readback worklist (every comparison op reaches Where, each
+                // showing 1 transfer before materialization). RecordBinary returns immediately when no tape
+                // is recording, so with no tape the array was pure waste that also broke residency. With a
+                // tape it is built exactly as before, so backward behaviour is unchanged.
+                object[]? savedState = null;
+                if (IsTapeActive<T>())
+                {
+                    var condBytes = new byte[condition.Length];
+                    for (int i = 0; i < condBytes.Length; i++) condBytes[i] = (bool)condition[i] ? (byte)1 : (byte)0;
+                    savedState = new object[] { condBytes };
+                }
+                Autodiff.DifferentiableOps.RecordBinary("TensorWhere", output, x, y,
+                    Autodiff.BackwardFunctions<T>.WhereBackward, savedState);
+                return output;
+            }
         }
         catch (Exception)
         {
@@ -25330,6 +25444,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (tensor._gpuBufferIsSplitComplex
             && tensor.IsContiguous && tensor._storageOffset == 0
             && tensor._gpuBuffer is not null
+            && tensor._gpuBuffer.Handle != IntPtr.Zero
             && ReferenceEquals(tensor._gpuBackend, backend)
             && (ResidentStepActive
                 || (tensor._gpuBufferVersion == tensor.Version
@@ -26524,6 +26639,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> NativeMagnitudeAndPhase<T>(Tensor<Complex<T>> input, out Tensor<T> phase)
     {
+        if (Compilation.GraphMode.IsActive)
+            return base.NativeMagnitudeAndPhase(input, out phase);
         if (!TryGetBackend(out var backend)) return base.NativeMagnitudeAndPhase(input, out phase);
         try
         {

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -4260,6 +4260,24 @@ public interface IEngine
         bool returnSequences = false);
 
     /// <summary>
+    /// Fused LSTM sequence forward that also returns the final hidden and cell states for
+    /// chunked or streaming inference.
+    /// </summary>
+    /// <param name="finalHidden">Receives the final hidden state <c>[batch, hidden]</c>.</param>
+    /// <param name="finalCell">Receives the final cell state <c>[batch, hidden]</c>.</param>
+    Tensor<T> LstmSequenceForward<T>(
+        Tensor<T> input,
+        Tensor<T>? h0,
+        Tensor<T>? c0,
+        Tensor<T> wIh,
+        Tensor<T> wHh,
+        Tensor<T>? bIh,
+        Tensor<T>? bHh,
+        out Tensor<T> finalHidden,
+        out Tensor<T> finalCell,
+        bool returnSequences = false);
+
+    /// <summary>
     /// Fused RWKV-7 "Goose" time-mixing WKV recurrence over a whole sequence in a single op
     /// (forward + custom autodiff backward). Replaces the per-timestep tape micro-ops a decomposed
     /// <c>RWKV7Block</c> loop records, which is the dominant training cost on long sequences

--- a/src/AiDotNet.Tensors/Engines/MeshConvolutionOperations.cs
+++ b/src/AiDotNet.Tensors/Engines/MeshConvolutionOperations.cs
@@ -453,10 +453,23 @@ public static class MeshConvolutionOperations
         Tensor<T> biases,
         T diffusionTime)
     {
-        var numOps = MathHelper.GetNumericOperations<T>();
+        if (vertexFeatures is null) throw new ArgumentNullException(nameof(vertexFeatures));
+        if (laplacian is null) throw new ArgumentNullException(nameof(laplacian));
+        if (weights is null) throw new ArgumentNullException(nameof(weights));
+        if (biases is null) throw new ArgumentNullException(nameof(biases));
+        if (vertexFeatures.Rank != 2)
+            throw new ArgumentException("Vertex features must have shape [numVertices, inputChannels].", nameof(vertexFeatures));
         int numVertices = vertexFeatures._shape[0];
         int inputChannels = vertexFeatures._shape[1];
+        if (laplacian.Rank != 2 || laplacian._shape[0] != numVertices || laplacian._shape[1] != numVertices)
+            throw new ArgumentException("Laplacian must have shape [numVertices, numVertices].", nameof(laplacian));
+        if (weights.Rank != 2 || weights._shape[1] != inputChannels)
+            throw new ArgumentException("Weights must have shape [outputChannels, inputChannels].", nameof(weights));
         int outputChannels = weights._shape[0];
+        if (biases.Rank != 1 || biases._shape[0] != outputChannels)
+            throw new ArgumentException("Biases must have shape [outputChannels].", nameof(biases));
+
+        var numOps = MathHelper.GetNumericOperations<T>();
 
         double t = numOps.ToDouble(diffusionTime);
         double t2 = t * t / 2.0;
@@ -613,10 +626,24 @@ public static class MeshConvolutionOperations
         Tensor<T> weights,
         T diffusionTime)
     {
-        var numOps = MathHelper.GetNumericOperations<T>();
-        int numVertices = outputGradient._shape[0];
-        int outputChannels = outputGradient._shape[1];
+        if (outputGradient is null) throw new ArgumentNullException(nameof(outputGradient));
+        if (vertexFeatures is null) throw new ArgumentNullException(nameof(vertexFeatures));
+        if (laplacian is null) throw new ArgumentNullException(nameof(laplacian));
+        if (weights is null) throw new ArgumentNullException(nameof(weights));
+        if (vertexFeatures.Rank != 2)
+            throw new ArgumentException("Vertex features must have shape [numVertices, inputChannels].", nameof(vertexFeatures));
+        int featureVertices = vertexFeatures._shape[0];
         int inputChannels = vertexFeatures._shape[1];
+        if (outputGradient.Rank != 2 || outputGradient._shape[0] != featureVertices)
+            throw new ArgumentException("Output gradient must have shape [numVertices, outputChannels].", nameof(outputGradient));
+        int outputChannels = outputGradient._shape[1];
+        if (laplacian.Rank != 2 || laplacian._shape[0] != featureVertices || laplacian._shape[1] != featureVertices)
+            throw new ArgumentException("Laplacian must have shape [numVertices, numVertices].", nameof(laplacian));
+        if (weights.Rank != 2 || weights._shape[0] != outputChannels || weights._shape[1] != inputChannels)
+            throw new ArgumentException("Weights must have shape [outputChannels, inputChannels].", nameof(weights));
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int numVertices = featureVertices;
 
         double t = numOps.ToDouble(diffusionTime);
         double t2 = t * t / 2.0;

--- a/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
+++ b/src/AiDotNet.Tensors/Engines/Optimization/MemoryPlanningPass.cs
@@ -31,6 +31,17 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
     public bool IsEnabled => true; // Always beneficial
 
     public CompiledStep<T>[]? TryOptimize<T>(CompiledStep<T>[] steps, IEngine engine)
+        => TryOptimize(steps, engine, protectedOutput: null);
+
+    /// <summary>
+    /// Plans buffer reuse while preserving the storage selected as the compiled plan's output.
+    /// An explicit output can be an internal branch rather than the final scheduled step, or a
+    /// view sharing a producer's storage, so its backing storage must remain live through replay.
+    /// </summary>
+    internal CompiledStep<T>[]? TryOptimize<T>(
+        CompiledStep<T>[] steps,
+        IEngine engine,
+        Tensor<T>? protectedOutput)
     {
         if (steps.Length < 4) return null; // Not worth the overhead for tiny plans
 
@@ -70,6 +81,22 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
                 lastUse[step.Inputs[j]] = i;
         }
 
+        if (protectedOutput is not null)
+        {
+            // A pure-view output is not necessarily a step output by identity. Protect every
+            // produced tensor that shares its TensorStorage so a later operation cannot recycle
+            // the selected output through an alias before Execute() returns it.
+            for (int i = 0; i < steps.Length; i++)
+            {
+                Tensor<T> produced = steps[i].OutputBuffer;
+                if (ReferenceEquals(produced, protectedOutput) ||
+                    ReferenceEquals(produced._storage, protectedOutput._storage))
+                {
+                    lastUse[produced] = steps.Length - 1;
+                }
+            }
+        }
+
         // Phase 2: Greedy buffer reuse via dead-pool
         // Walk steps again. After each step, check if any tensor's lifetime
         // just ended (lastUse == current step). If so, add it to the dead
@@ -101,7 +128,7 @@ internal sealed class MemoryPlanningPass : ICpuOptimizationPass
                 // the output tensor now shares that memory.
                 if (CanRebind(output, donor))
                 {
-                    output.RebindStorageFrom(donor);
+                    output.RebindStorageFromGraph(donor);
                     rebindMap[output] = donor;
                     reusedCount++;
                 }

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -51,7 +51,7 @@ internal interface IStreamingDroppable
 /// Represents a base class for multi-dimensional arrays of numeric values used in machine learning and AI computations.
 /// </summary>
 /// <typeparam name="T">The numeric type of the tensor elements (e.g., float, double, int).</typeparam>
-public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
+public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorStorageLeaseSource
 {
     private bool _disposed;
     // ================================================================
@@ -70,6 +70,35 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// usual "views share storage, storage itself is immutable" invariant.
     /// </remarks>
     internal TensorStorage<T> _storage;
+
+    /// <summary>
+    /// Reference identity of the backing storage. Views expose the same identity even though
+    /// they are distinct tensor objects, allowing lifetime planners to reason about aliases.
+    /// </summary>
+    internal object StorageIdentity => _storage;
+
+    object ITensorStorageLeaseSource.StorageIdentity => _storage;
+
+    TensorStorageLease ITensorStorageLeaseSource.AcquireStorageLease()
+    {
+        // RebindStorageFrom can replace _storage. Acquire the exact storage observed by this
+        // attempt; if a concurrent rebind released it first, retry against the newly published
+        // storage rather than retaining an obsolete, already-dead allocation.
+        while (true)
+        {
+            var storage = _storage;
+            try
+            {
+                return new TensorStorageLease<T>(storage);
+            }
+            catch (ObjectDisposedException) when (!ReferenceEquals(storage, _storage))
+            {
+            }
+        }
+    }
+
+    void ITensorStorageLeaseSource.SetTapePinned(bool pinned)
+        => _pinnedByTape = pinned;
 
     /// <summary>
     /// Direct reference to underlying Vector for backward compatibility with existing engine code.
@@ -417,7 +446,22 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// leading to use-after-free when <paramref name="source"/> was disposed.
     /// </para>
     /// </remarks>
+    internal bool SharesStorageWith(TensorBase<T> other)
+        => other is not null && ReferenceEquals(_storage, other._storage);
+
     internal void RebindStorageFrom(TensorBase<T> source)
+        => RebindStorageFromCore(source, graphOwnsStorage: false);
+
+    /// <summary>
+    /// Graph-planner rebind for a tensor whose public owner may already have disposed it.
+    /// A disposed tensor no longer owns a storage reference, so the planner must update its
+    /// metadata without releasing the graph lease as though it were still the tensor's ref.
+    /// Both old and new storages are independently retained by the active graph scope.
+    /// </summary>
+    internal void RebindStorageFromGraph(TensorBase<T> source)
+        => RebindStorageFromCore(source, graphOwnsStorage: true);
+
+    private void RebindStorageFromCore(TensorBase<T> source, bool graphOwnsStorage)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
 
@@ -457,6 +501,16 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
         // (shouldn't happen with current code, but preserves source-of-truth).
         if (ReferenceEquals(_storage, source._storage))
         {
+            _data = source._data;
+            return;
+        }
+
+        if (graphOwnsStorage && _disposed)
+        {
+            // Dispose already released this Tensor object's reference. The scope lease owns the
+            // old storage and the plan snapshot will acquire the new one after optimization;
+            // changing either refcount here would steal or manufacture a tensor-owner reference.
+            _storage = source._storage;
             _data = source._data;
             return;
         }
@@ -1033,7 +1087,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable
     /// <returns>The GPU buffer, or null when no GPU mapping exists.</returns>
     public Engines.DirectGpu.IGpuBuffer? TryGetGpuBuffer()
     {
-        if (_gpuBuffer is not null) return _gpuBuffer;
+        if (_gpuBuffer is not null && _gpuBuffer.Handle != IntPtr.Zero) return _gpuBuffer;
         // GpuPinned / GpuOffload tensors carry a device pointer set by
         // WeightRegistry.RegisterWeight. Wrap it on demand for caller use.
         if (OffloadDevicePointer != IntPtr.Zero

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorageLease.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorageLease.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading;
+
+namespace AiDotNet.Tensors.LinearAlgebra;
+
+/// <summary>
+/// Type-erased source for a reference-counted tensor-storage lease. Lazy graphs use this
+/// contract to retain mixed-element-type operands without reflection or element-type strings.
+/// </summary>
+internal interface ITensorStorageLeaseSource
+{
+    object StorageIdentity { get; }
+    TensorStorageLease AcquireStorageLease();
+    void SetTapePinned(bool pinned);
+}
+
+/// <summary>
+/// Type-safe access to tensor-bearing values hidden inside an opaque saved-state object.
+/// </summary>
+internal interface ISavedStateTensorContainer
+{
+    IReadOnlyList<object> SavedStateValues { get; }
+}
+
+internal interface ISavedStateTensorVisitor
+{
+    void Visit(ITensorStorageLeaseSource tensor);
+}
+
+/// <summary>
+/// Walks the tensor-bearing shapes supported by saved state: direct tensors, nested
+/// reference-type arrays, and explicit tensor containers such as AutogradContext.
+/// Primitive arrays are deliberately ignored.
+/// </summary>
+internal static class SavedStateTensorTraversal
+{
+    internal static void Visit<TVisitor>(object[]? savedState, ref TVisitor visitor)
+        where TVisitor : struct, ISavedStateTensorVisitor
+    {
+        if (savedState is null) return;
+        VisitValues(savedState, ref visitor);
+    }
+
+    private static void VisitValues<TVisitor>(IReadOnlyList<object> values, ref TVisitor visitor)
+        where TVisitor : struct, ISavedStateTensorVisitor
+    {
+        for (int i = 0; i < values.Count; i++)
+            VisitValue(values[i], ref visitor);
+    }
+
+    private static void VisitValue<TVisitor>(object? value, ref TVisitor visitor)
+        where TVisitor : struct, ISavedStateTensorVisitor
+    {
+        if (value is ITensorStorageLeaseSource tensor)
+        {
+            visitor.Visit(tensor);
+            return;
+        }
+
+        // Tensor<T>[] is covariant with object[]; primitive arrays are not and are skipped.
+        if (value is object[] nested)
+        {
+            VisitValues(nested, ref visitor);
+            return;
+        }
+
+        if (value is ISavedStateTensorContainer container)
+            VisitValues(container.SavedStateValues, ref visitor);
+    }
+}
+
+/// <summary>A type-erased, independently disposable reference to one tensor storage.</summary>
+internal abstract class TensorStorageLease : IDisposable
+{
+    internal abstract object StorageIdentity { get; }
+    public abstract void Dispose();
+}
+
+/// <summary>Strong reference-counted lease over a closed generic tensor storage.</summary>
+internal sealed class TensorStorageLease<T> : TensorStorageLease
+{
+    private TensorStorage<T>? _storage;
+
+    internal TensorStorageLease(TensorStorage<T> storage)
+    {
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        storage.AddRef();
+    }
+
+    internal override object StorageIdentity =>
+        _storage ?? throw new ObjectDisposedException(nameof(TensorStorageLease<T>));
+
+    public override void Dispose()
+    {
+        Interlocked.Exchange(ref _storage, null)?.Release();
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests.OpParityGen/OpParityTestGenerator.cs
+++ b/tests/AiDotNet.Tensors.Tests.OpParityGen/OpParityTestGenerator.cs
@@ -25,6 +25,14 @@ namespace AiDotNet.Tensors.Tests.OpParityGen
         {
             var opNames = context.CompilationProvider.Select(static (compilation, _) => GetTensorReturningOps(compilation));
             context.RegisterSourceOutput(opNames, static (spc, names) => spc.AddSource("GeneratedOpParityTests.g.cs", Emit(names)));
+
+            var outputContracts = context.CompilationProvider.Select(static (compilation, _) => GetTensorOutputContracts(compilation));
+            context.RegisterSourceOutput(outputContracts, static (spc, contracts) =>
+                spc.AddSource("GeneratedTensorOutputContractTests.g.cs", EmitOutputContracts(contracts)));
+
+            var captureContracts = context.CompilationProvider.Select(static (compilation, _) => GetGraphCaptureContracts(compilation));
+            context.RegisterSourceOutput(captureContracts, static (spc, contracts) =>
+                spc.AddSource("GeneratedGraphCaptureSignatureTests.g.cs", EmitGraphCaptureContracts(contracts)));
         }
 
         private static IReadOnlyList<string> GetTensorReturningOps(Compilation compilation)
@@ -37,12 +45,204 @@ namespace AiDotNet.Tensors.Tests.OpParityGen
             {
                 if (member.DeclaredAccessibility != Accessibility.Public) continue;
                 if (member.MethodKind != MethodKind.Ordinary) continue;
-                var rt = member.ReturnType as INamedTypeSymbol;
-                // Tensor<T> — the op surface the parity scaffold covers.
-                if (rt is { IsGenericType: true, Name: "Tensor" }) names.Add(member.Name);
+                if (ContainsTensor(member.ReturnType) ||
+                    member.Parameters.Any(parameter =>
+                        parameter.RefKind == RefKind.Out && ContainsTensor(parameter.Type)))
+                    names.Add(member.Name);
             }
             return names.ToList();
         }
+
+        private static IReadOnlyList<OutputContractSpec> GetTensorOutputContracts(Compilation compilation)
+        {
+            var engine = compilation.GetTypeByMetadataName(EngineMetadataName);
+            if (engine is null) return System.Array.Empty<OutputContractSpec>();
+
+            var contracts = new List<OutputContractSpec>();
+            foreach (var method in engine.GetMembers().OfType<IMethodSymbol>())
+            {
+                if (method.DeclaredAccessibility != Accessibility.Public ||
+                    method.MethodKind != MethodKind.Ordinary)
+                    continue;
+
+                var tensorOutputs = new List<ITypeSymbol>();
+                bool returnedContainer = CollectTensorElementTypes(method.ReturnType, tensorOutputs);
+                int returnedTensorCount = tensorOutputs.Count;
+                var outTensorElements = method.Parameters
+                    .Where(parameter => parameter.RefKind == RefKind.Out)
+                    .SelectMany(parameter =>
+                    {
+                        var elements = new List<ITypeSymbol>();
+                        CollectTensorElementTypes(parameter.Type, elements);
+                        return elements;
+                    })
+                    .ToList();
+                tensorOutputs.AddRange(outTensorElements);
+
+                bool returnedMultiple = returnedContainer || returnedTensorCount > 1;
+                if (tensorOutputs.Count < 2 && !returnedMultiple)
+                    continue;
+
+                bool homogeneous = tensorOutputs.All(element => IsMethodElementType(method, element!));
+
+                contracts.Add(new OutputContractSpec(
+                    method.Name,
+                    homogeneous,
+                    BuildOverloadSuffix(method)));
+            }
+
+            return contracts
+                .GroupBy(contract => contract.Name, System.StringComparer.Ordinal)
+                .OrderBy(group => group.Key, System.StringComparer.Ordinal)
+                .SelectMany(group =>
+                {
+                    var overloads = group.OrderBy(contract => contract.OverloadSuffix, System.StringComparer.Ordinal).ToList();
+                    if (overloads.Count == 1)
+                        return new[] { overloads[0].WithoutOverloadId() };
+                    return overloads.Select(contract => contract.WithOverloadId(
+                        Sanitize(contract.Name + "_" + contract.OverloadSuffix)));
+                })
+                .ToList();
+        }
+
+        private static IReadOnlyList<GraphCaptureContractSpec> GetGraphCaptureContracts(Compilation compilation)
+        {
+            var engine = compilation.GetTypeByMetadataName(EngineMetadataName);
+            if (engine is null) return System.Array.Empty<GraphCaptureContractSpec>();
+
+            var methods = engine.GetMembers().OfType<IMethodSymbol>()
+                .Where(method => method.DeclaredAccessibility == Accessibility.Public &&
+                                 method.MethodKind == MethodKind.Ordinary)
+                .ToList();
+            var overloadCounts = methods
+                .GroupBy(method => method.Name, System.StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.Count(), System.StringComparer.Ordinal);
+
+            var contracts = new List<GraphCaptureContractSpec>();
+            foreach (var method in methods)
+            {
+                var inputElements = new List<ITypeSymbol>();
+                foreach (var parameter in method.Parameters.Where(parameter => parameter.RefKind != RefKind.Out))
+                    CollectTensorElementTypes(parameter.Type, inputElements);
+
+                var outputElements = new List<ITypeSymbol>();
+                CollectTensorElementTypes(method.ReturnType, outputElements);
+                foreach (var parameter in method.Parameters.Where(parameter => parameter.RefKind == RefKind.Out))
+                    CollectTensorElementTypes(parameter.Type, outputElements);
+
+                if (inputElements.Count == 0 && outputElements.Count == 0)
+                    continue;
+
+                var allElements = inputElements.Concat(outputElements).ToList();
+                var methodTypeParameters = allElements
+                    .OfType<ITypeParameterSymbol>()
+                    .Where(parameter => method.TypeParameters.Any(candidate =>
+                        SymbolEqualityComparer.Default.Equals(candidate, parameter)))
+                    .Distinct<ITypeParameterSymbol>(SymbolEqualityComparer.Default)
+                    .ToList();
+
+                GraphCaptureConstraintKind? constraint = null;
+                if (methodTypeParameters.Count > 1)
+                {
+                    constraint = GraphCaptureConstraintKind.MixedElementTypes;
+                }
+                else if (methodTypeParameters.Count == 1)
+                {
+                    ITypeSymbol primary = methodTypeParameters[0];
+                    if (inputElements.Any(element => !SymbolEqualityComparer.Default.Equals(element, primary)))
+                        constraint = GraphCaptureConstraintKind.HeterogeneousInput;
+                    else if (outputElements.Any(element => !SymbolEqualityComparer.Default.Equals(element, primary)))
+                        constraint = GraphCaptureConstraintKind.HeterogeneousOutput;
+                }
+
+                if (constraint is null)
+                    continue;
+
+                string suffix = BuildGraphCaptureOverloadSuffix(method);
+                string? overloadId = overloadCounts[method.Name] > 1
+                    ? Sanitize(method.Name + "_" + suffix)
+                    : null;
+                contracts.Add(new GraphCaptureContractSpec(method.Name, constraint.Value, suffix, overloadId));
+            }
+
+            return contracts
+                .OrderBy(contract => contract.Name, System.StringComparer.Ordinal)
+                .ThenBy(contract => contract.OverloadSuffix, System.StringComparer.Ordinal)
+                .ToList();
+        }
+
+        private static string BuildOverloadSuffix(IMethodSymbol method)
+        {
+            if (method.Parameters.Length == 0) return "NoParameters";
+            return string.Join("_", method.Parameters.Select(parameter => TypeToken(parameter.Type)));
+        }
+
+        private static string BuildGraphCaptureOverloadSuffix(IMethodSymbol method)
+        {
+            if (method.Parameters.Length == 0) return "NoParameters";
+            return string.Join("_", method.Parameters.Select(parameter =>
+            {
+                string prefix = parameter.RefKind == RefKind.Out ? "Out_" :
+                    parameter.RefKind == RefKind.Ref ? "Ref_" :
+                    parameter.RefKind == RefKind.In ? "In_" : string.Empty;
+                return prefix + TypeToken(parameter.Type);
+            }));
+        }
+
+        private static string TypeToken(ITypeSymbol type)
+        {
+            if (type is IArrayTypeSymbol array)
+                return TypeToken(array.ElementType) + "Array";
+            if (type is ITypeParameterSymbol parameter)
+                return parameter.Name;
+            if (type is INamedTypeSymbol named)
+            {
+                if (!named.IsGenericType) return named.Name;
+                return named.Name + "_" + string.Join("_", named.TypeArguments.Select(TypeToken));
+            }
+            return type.Name;
+        }
+
+        private static bool ContainsTensor(ITypeSymbol type)
+        {
+            var elements = new List<ITypeSymbol>();
+            CollectTensorElementTypes(type, elements);
+            return elements.Count > 0;
+        }
+
+        /// <summary>
+        /// Adds every tensor element type in a direct tensor, array, or tuple. Returns true when
+        /// the declaration is a container that can carry multiple tensors even if it has one
+        /// syntactic element type (for example Tensor&lt;T&gt;[]).
+        /// </summary>
+        private static bool CollectTensorElementTypes(ITypeSymbol type, List<ITypeSymbol> elements)
+        {
+            if (type is IArrayTypeSymbol array)
+            {
+                CollectTensorElementTypes(array.ElementType, elements);
+                return elements.Count > 0;
+            }
+
+            if (type is INamedTypeSymbol { IsGenericType: true, Name: "Tensor" } tensor)
+            {
+                elements.Add(tensor.TypeArguments[0]);
+                return false;
+            }
+
+            if (type is INamedTypeSymbol { IsTupleType: true } tuple)
+            {
+                int before = elements.Count;
+                foreach (var element in tuple.TupleElements)
+                    CollectTensorElementTypes(element.Type, elements);
+                return elements.Count > before;
+            }
+
+            return false;
+        }
+
+        private static bool IsMethodElementType(IMethodSymbol method, ITypeSymbol element)
+            => element is ITypeParameterSymbol parameter &&
+               method.TypeParameters.Any(candidate => SymbolEqualityComparer.Default.Equals(candidate, parameter));
 
         private static SourceText Emit(IReadOnlyList<string> opNames)
         {
@@ -70,6 +270,128 @@ namespace AiDotNet.Tensors.Tests.OpParityGen
             sb.AppendLine("}");
             sb.AppendLine("#endif");
             return SourceText.From(sb.ToString(), Encoding.UTF8);
+        }
+
+        private static SourceText EmitOutputContracts(IReadOnlyList<OutputContractSpec> contracts)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("// <auto-generated/> Tensor output-contract tests. Do not edit.");
+            sb.AppendLine("#if !NETFRAMEWORK");
+            sb.AppendLine("using Xunit;");
+            sb.AppendLine();
+            sb.AppendLine("namespace AiDotNet.Tensors.Tests.Engines.OpParity");
+            sb.AppendLine("{");
+            sb.AppendLine("    /// <summary>Generated identity for methods whose multi-output overloads need distinct coverage.</summary>");
+            sb.AppendLine("    public enum TensorOutputOverload");
+            sb.AppendLine("    {");
+            sb.AppendLine("        Unspecified,");
+            foreach (var contract in contracts.Where(contract => contract.OverloadId is not null))
+                sb.AppendLine($"        {contract.OverloadId},");
+            sb.AppendLine("    }");
+            sb.AppendLine();
+            sb.AppendLine("    /// <summary>Generated from every IEngine signature with multiple tensor results.</summary>");
+            sb.AppendLine("    public sealed class GeneratedTensorOutputContractTests");
+            sb.AppendLine("    {");
+            foreach (var contract in contracts)
+            {
+                string method = contract.OverloadId ?? Sanitize(contract.Name);
+                string expectation = contract.IsHomogeneous
+                    ? "TensorOutputContract.HomogeneousMultiple"
+                    : "TensorOutputContract.HeterogeneousMultiple";
+                string overload = contract.OverloadId is null
+                    ? "TensorOutputOverload.Unspecified"
+                    : $"TensorOutputOverload.{contract.OverloadId}";
+                sb.AppendLine("        [Fact]");
+                sb.AppendLine($"        public void OutputContract_{method}() => GeneratedOpParitySupport.VerifyTensorOutputContract(\"{contract.Name}\", {expectation}, {overload});");
+            }
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            sb.AppendLine("#endif");
+            return SourceText.From(sb.ToString(), Encoding.UTF8);
+        }
+
+        private static SourceText EmitGraphCaptureContracts(IReadOnlyList<GraphCaptureContractSpec> contracts)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("// <auto-generated/> Heterogeneous graph-capture signature tests. Do not edit.");
+            sb.AppendLine("#if !NETFRAMEWORK");
+            sb.AppendLine("using Xunit;");
+            sb.AppendLine();
+            sb.AppendLine("namespace AiDotNet.Tensors.Tests.Engines.OpParity");
+            sb.AppendLine("{");
+            sb.AppendLine("    /// <summary>Generated identity for heterogeneous IEngine overloads.</summary>");
+            sb.AppendLine("    public enum GraphCaptureSignatureOverload");
+            sb.AppendLine("    {");
+            sb.AppendLine("        Unspecified,");
+            foreach (var contract in contracts.Where(contract => contract.OverloadId is not null))
+                sb.AppendLine($"        {contract.OverloadId},");
+            sb.AppendLine("    }");
+            sb.AppendLine();
+            sb.AppendLine("    /// <summary>Generated from tensor element types in every public IEngine signature.</summary>");
+            sb.AppendLine("    public sealed class GeneratedGraphCaptureSignatureTests");
+            sb.AppendLine("    {");
+            foreach (var contract in contracts)
+            {
+                string method = contract.OverloadId ?? Sanitize(contract.Name);
+                string overload = contract.OverloadId is null
+                    ? "GraphCaptureSignatureOverload.Unspecified"
+                    : $"GraphCaptureSignatureOverload.{contract.OverloadId}";
+                sb.AppendLine("        [Fact]");
+                sb.AppendLine($"        public void CaptureContract_{method}() => GeneratedOpParitySupport.VerifyGraphCaptureSignature(\"{contract.Name}\", GraphCaptureSignatureConstraint.{contract.Constraint}, {overload});");
+            }
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            sb.AppendLine("#endif");
+            return SourceText.From(sb.ToString(), Encoding.UTF8);
+        }
+
+        private sealed class OutputContractSpec
+        {
+            internal OutputContractSpec(string name, bool isHomogeneous, string overloadSuffix, string? overloadId = null)
+            {
+                Name = name;
+                IsHomogeneous = isHomogeneous;
+                OverloadSuffix = overloadSuffix;
+                OverloadId = overloadId;
+            }
+
+            internal string Name { get; }
+            internal bool IsHomogeneous { get; }
+            internal string OverloadSuffix { get; }
+            internal string? OverloadId { get; }
+
+            internal OutputContractSpec WithoutOverloadId() =>
+                new OutputContractSpec(Name, IsHomogeneous, OverloadSuffix);
+
+            internal OutputContractSpec WithOverloadId(string overloadId) =>
+                new OutputContractSpec(Name, IsHomogeneous, OverloadSuffix, overloadId);
+        }
+
+        private enum GraphCaptureConstraintKind
+        {
+            HeterogeneousInput,
+            HeterogeneousOutput,
+            MixedElementTypes,
+        }
+
+        private sealed class GraphCaptureContractSpec
+        {
+            internal GraphCaptureContractSpec(
+                string name,
+                GraphCaptureConstraintKind constraint,
+                string overloadSuffix,
+                string? overloadId)
+            {
+                Name = name;
+                Constraint = constraint;
+                OverloadSuffix = overloadSuffix;
+                OverloadId = overloadId;
+            }
+
+            internal string Name { get; }
+            internal GraphCaptureConstraintKind Constraint { get; }
+            internal string OverloadSuffix { get; }
+            internal string? OverloadId { get; }
         }
 
         private static string Sanitize(string name)

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
@@ -18,6 +18,64 @@ public class BackwardBugFixTests
 {
     private readonly CpuEngine _engine = new();
 
+    [Fact]
+    public void ComplexNormalize_Backward_IncludesNormDenominatorPath()
+    {
+        var real = new Tensor<double>(new[] { 0.7, -1.2, 0.3, 1.6 }, new[] { 2, 2 });
+        var imag = new Tensor<double>(new[] { -0.4, 0.9, 1.1, -0.2 }, new[] { 2, 2 });
+        var realWeight = new Tensor<double>(new[] { 0.2, -0.7, 1.3, 0.5 }, new[] { 2, 2 });
+        var imagWeight = new Tensor<double>(new[] { -0.6, 0.4, 0.8, -1.1 }, new[] { 2, 2 });
+
+        double[] realAnalytical;
+        double[] imagAnalytical;
+        using (var tape = new GradientTape<double>())
+        {
+            var normalized = _engine.ComplexNormalize(real, imag);
+            var weightedReal = _engine.TensorMultiply(normalized.real, realWeight);
+            var weightedImag = _engine.TensorMultiply(normalized.imag, imagWeight);
+            var loss = _engine.ReduceSum(_engine.TensorAdd(weightedReal, weightedImag), null);
+            var gradients = tape.ComputeGradients(loss, new[] { real, imag });
+            realAnalytical = gradients[real].ToArray();
+            imagAnalytical = gradients[imag].ToArray();
+        }
+
+        double Loss()
+        {
+            var normalized = _engine.ComplexNormalize(real, imag);
+            double sum = 0.0;
+            for (int i = 0; i < real.Length; i++)
+                sum += normalized.real[i] * realWeight[i] + normalized.imag[i] * imagWeight[i];
+            return sum;
+        }
+
+        const double step = 1e-5;
+        for (int i = 0; i < real.Length; i++)
+        {
+            double original = real[i];
+            real[i] = original + step;
+            double plus = Loss();
+            real[i] = original - step;
+            double minus = Loss();
+            real[i] = original;
+            double finite = (plus - minus) / (2.0 * step);
+            Assert.True(Math.Abs(finite - realAnalytical[i]) < 1e-6,
+                $"real[{i}] gradient is {realAnalytical[i]:G10}; finite difference is {finite:G10}.");
+        }
+
+        for (int i = 0; i < imag.Length; i++)
+        {
+            double original = imag[i];
+            imag[i] = original + step;
+            double plus = Loss();
+            imag[i] = original - step;
+            double minus = Loss();
+            imag[i] = original;
+            double finite = (plus - minus) / (2.0 * step);
+            Assert.True(Math.Abs(finite - imagAnalytical[i]) < 1e-6,
+                $"imag[{i}] gradient is {imagAnalytical[i]:G10}; finite difference is {finite:G10}.");
+        }
+    }
+
     // ================================================================
     // Issue #144: OctonionMatMulTensor backward
     // ================================================================

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardStorageReleasePlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardStorageReleasePlanTests.cs
@@ -1,0 +1,79 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class BackwardStorageReleasePlanTests
+{
+    [Fact]
+    public void AliasStorage_IsReleasedAfterFinalSavedStateUse_NotAliasStep()
+    {
+        using var saved = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        using var alias = saved.Reshape(new[] { 4 });
+        using var laterOutput = new Tensor<float>(new[] { 5f }, new[] { 1 });
+
+        var steps = new[]
+        {
+            new BackwardStep<float>
+            {
+                Output = alias,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!
+            },
+            new BackwardStep<float>
+            {
+                Output = laterOutput,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!,
+                SavedState = new object[] { saved }
+            }
+        };
+
+        var plan = BackwardStorageReleasePlan<float>.Create(steps, steps.Length);
+
+        Assert.False(plan.IsStorageScheduledAfterStep(alias, 0));
+        Assert.True(plan.IsStorageScheduledAfterStep(alias, 1));
+    }
+
+    [Fact]
+    public void NestedAndContextSavedTensors_ExtendStorageLifetimeAndArePinned()
+    {
+        using var saved = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        using var alias = saved.Reshape(new[] { 4 });
+        using var laterOutput = new Tensor<float>(new[] { 5f }, new[] { 1 });
+        var context = new AutogradContext();
+        context.SaveForBackward(saved);
+        var savedState = new object[] { new object[] { context } };
+
+        var entry = new TapeEntry<float> { SavedState = savedState };
+        DifferentiableOps.PinSavedStateTensors(ref entry);
+        Assert.True(entry.SavedStatePinsHeld);
+        Assert.True(saved._pinnedByTape);
+
+        var steps = new[]
+        {
+            new BackwardStep<float>
+            {
+                Output = alias,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!
+            },
+            new BackwardStep<float>
+            {
+                Output = laterOutput,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!,
+                SavedState = savedState
+            }
+        };
+        var plan = BackwardStorageReleasePlan<float>.Create(steps, steps.Length);
+
+        Assert.False(plan.IsStorageScheduledAfterStep(saved, 0));
+        Assert.True(plan.IsStorageScheduledAfterStep(saved, 1));
+
+        DifferentiableOps.UnpinSavedStateTensors(ref entry);
+        Assert.False(entry.SavedStatePinsHeld);
+        Assert.False(saved._pinnedByTape);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// Verifies that fused Linear+Activation ops produce identical gradients
 /// to the equivalent unfused (separate MatMul + Add + Activation) ops.
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class FusedLinearGradientTests : IDisposable
 {
     // PR #333's GPU auto-detect ModuleInitializer flips AiDotNetEngine.Current

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
@@ -11,6 +11,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 // op that replaces the ~6-primitive batch=1 BN training fallback. Forward must equal
 // BatchNormInference; backward must equal the exact closed-form gradient of a linear loss
 // L = Σ(y ⊙ w), since y = gamma·(x-mean)·inv + beta is affine in x/gamma/beta.
+[Collection("EngineCurrentGlobalState")]
 public class BatchNormAffineGradientTests
 {
     private readonly CpuEngine _engine = new CpuEngine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
@@ -54,6 +54,33 @@ public class DeterministicParallelGemmContractTests
     public void Gemm_Double_BitIdentical_AcrossThreadCounts(int m, int n, int k)
         => AssertBitIdenticalAcrossThreadCounts<double>(m, n, k, seed: 22);
 
+    [Fact]
+    public void StreamingFloat_NAxisNonDivisibleWidth_IsBitIdenticalAcrossPartitions()
+    {
+        const int m = 2;
+        const int n = 704;
+        const int k = 257;
+        var a = RandomArray<float>(m * k, seed: 31);
+        var b = RandomArray<float>(k * n, seed: 32);
+        var serial = new float[m * n];
+        var parallel = new float[m * n];
+
+        StreamingStrategy.Run(a, k, false, b, n, false, serial, n, m, n, k,
+            new BlasOptions<float> { NumThreads = 1 });
+        StreamingStrategy.Run(a, k, false, b, n, false, parallel, n, m, n, k,
+            new BlasOptions<float> { NumThreads = 32 });
+
+        for (int i = 0; i < serial.Length; i++)
+        {
+            if (!BitIdentical(serial[i], parallel[i]))
+            {
+                Assert.Fail(
+                    $"N-axis SIMD-tile partitioning changed FP32 reduction semantics at index {i}: " +
+                    $"serial={serial[i]} parallel={parallel[i]}.");
+            }
+        }
+    }
+
     private static void AssertBitIdenticalAcrossThreadCounts<T>(int m, int n, int k, int seed)
         where T : unmanaged
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/AsyncChainTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/AsyncChainTests.cs
@@ -16,6 +16,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// validation at chain time, and proper rejection of disposed /
 /// foreign / shape-mismatched plans.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class AsyncChainTests : IDisposable
 {
     // PR #333's GPU auto-detect ModuleInitializer flips AiDotNetEngine.Current

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 
+[Collection("CompilationGlobalState")]
 public class CompilationComponentTests
 {
     private const float Tolerance = 1e-5f;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBackwardReplayBufferLivenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBackwardReplayBufferLivenessTests.cs
@@ -29,6 +29,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// each subsequent step inside its OWN fresh per-step arena, checking the trained parameter's
 /// gradient stays non-zero and finite on every replay step.</para>
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class CompiledBackwardReplayBufferLivenessTests
 {
     private readonly ITestOutputHelper _o;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
@@ -66,6 +66,99 @@ public sealed class CompiledInferenceStorageContractTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Compile_RetainsCompositeTemporaryStorageAfterTemporaryIsDisposed()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+
+        Tensor<float> capturedOutput;
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.EnableInference())
+        {
+            // Composite implementations routinely scope intermediates with using. Disposing the
+            // Tensor object must not release storage that a recorded downstream node still reads.
+            {
+                using var temporary = engine.TensorAdd(input, input);
+                capturedOutput = engine.TensorMultiply(temporary, input);
+            }
+
+            plan = scope.CompileInference(capturedOutput, input);
+        }
+
+        using (plan)
+        using (capturedOutput)
+        {
+            Assert.Equal(new[] { 2f, 8f }, plan.Execute().AsSpan().ToArray());
+
+            new[] { 3f, 4f }.AsSpan().CopyTo(input.AsWritableSpan());
+            Assert.Equal(new[] { 18f, 32f }, plan.Execute().AsSpan().ToArray());
+        }
+    }
+
+    [Fact]
+    public void CompiledPlan_OwnsStorageUntilPlanDispose()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, -2f }, new[] { 2 });
+
+        Tensor<float> capturedOutput;
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.EnableInference())
+        {
+            capturedOutput = engine.TensorAdd(input, input);
+            plan = scope.CompileInference(capturedOutput, input);
+        }
+
+        var outputStorage = capturedOutput._storage;
+        Assert.Equal(2, outputStorage.RefCount); // tensor owner + compiled-plan lease
+
+        capturedOutput.Dispose();
+        Assert.Equal(1, outputStorage.RefCount); // compiled plan remains the sole owner
+        Assert.Equal(new[] { 2f, -4f }, plan.Execute().AsSpan().ToArray());
+
+        plan.Dispose();
+        Assert.Equal(0, outputStorage.RefCount);
+    }
+
+    [Fact]
+    public void Compile_IsTerminalAndRestoresParentBeforeLexicalDispose()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        using var parent = GraphMode.Enable();
+        var child = GraphMode.EnableInference();
+
+        var output = engine.TensorAdd(input, input);
+        using var plan = child.CompileInference(output, input);
+
+        Assert.Same(parent, GraphMode.Current);
+        child.Dispose();
+        Assert.Same(parent, GraphMode.Current);
+    }
+
+    [Fact]
+    public void Execute_InsideIndependentTrace_DoesNotAppendReplayOperations()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        ICompiledPlan<float> plan;
+
+        using (var scope = GraphMode.EnableInference())
+        {
+            var output = engine.TensorAdd(input, input);
+            plan = scope.CompileInference(output, input);
+        }
+
+        using (plan)
+        using (var independentTrace = GraphMode.Enable())
+        {
+            Assert.Equal(0, independentTrace.NodeCount);
+            Assert.Equal(new[] { 2f, 4f }, plan.Execute().AsSpan().ToArray());
+            Assert.Equal(0, independentTrace.NodeCount);
+        }
+    }
+
     private static void AssertSentinels(float[] backing)
     {
         Assert.Equal(999f, backing[0]);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOpaqueGpuReplayTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOpaqueGpuReplayTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class CompiledOpaqueGpuReplayTests
+{
+    [Fact]
+    public void OpaqueInferenceCapture_RecordsThroughBase_AndReplaysOnGpuBackend()
+    {
+        var state = new MockBackendState();
+        IDirectGpuBackend backend = MockDirectGpuBackend.Create(state);
+        using var directGpu = new DirectGpuEngine(backend);
+        using var engine = new DirectGpuTensorEngine(directGpu);
+        using var cache = new CompiledModelCache<float>();
+        var input = new Tensor<float>(new[] { -1.25f, -0.2f, 0.4f, 1.8f }, new[] { 2, 2 });
+
+        ICompiledPlan<float> plan = cache.GetOrCompileInference(
+            input, () => engine.NativeTanh(input));
+
+        // The outer GPU override must route the active trace to CpuEngine so the graph node is
+        // recorded. Its one suspended materialization still uses the selected GPU backend to
+        // establish the exact output shape and proves that ordinary GPU dispatch remains enabled.
+        Assert.Equal(1, state.TanhCalls);
+
+        AssertTanh(input, plan.Execute());
+        Assert.Equal(2, state.TanhCalls);
+
+        input[0] = 0.75f;
+        plan.SetInputs(new[] { input });
+        AssertTanh(input, plan.Execute());
+        Assert.Equal(3, state.TanhCalls);
+    }
+
+    private static void AssertTanh(Tensor<float> input, Tensor<float> actual)
+    {
+        float[] values = actual.ToArray();
+        Assert.Equal(input.Length, values.Length);
+        for (int i = 0; i < values.Length; i++)
+            Assert.InRange(values[i], MathF.Tanh(input[i]) - 1e-6f, MathF.Tanh(input[i]) + 1e-6f);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledPlanFinalOutputReproTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledPlanFinalOutputReproTest.cs
@@ -100,4 +100,37 @@ public class CompiledPlanFinalOutputReproTest
         var compiledOutput = plan.Execute();
         Assert.Equal(new[] { 10, 4 }, compiledOutput.Shape.ToArray());
     }
+
+    /// <summary>
+    /// A selected graph output can be an internal branch with later same-shaped work still in the
+    /// scope. Memory planning must keep the selected tensor's storage live through plan completion
+    /// instead of recycling it after its final graph consumer.
+    /// </summary>
+    [Fact]
+    public void CompiledPlan_ExplicitBranchOutput_IsNotRecycledByLaterBranch()
+    {
+        using var cache = new CompiledModelCache<float>();
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        var ones = new Tensor<float>(new[] { 1f, 1f, 1f, 1f }, new[] { 2, 2 });
+        var twos = new Tensor<float>(new[] { 2f, 2f, 2f, 2f }, new[] { 2, 2 });
+        var threes = new Tensor<float>(new[] { 3f, 3f, 3f, 3f }, new[] { 2, 2 });
+
+        Tensor<float> Forward()
+        {
+            var selected = engine.TensorAdd(input, ones);
+            var later = engine.TensorTranspose(selected);
+            later = engine.TensorMultiply(later, twos);
+            later = engine.TensorTranspose(later);
+            _ = engine.TensorAdd(later, threes);
+            return selected;
+        }
+
+        float[] expected = Forward().ToArray();
+        var plan = cache.GetOrCompileInference(input, Forward);
+        plan.SetInputs(new[] { input });
+
+        Assert.Equal(expected, plan.Execute().ToArray());
+        Assert.Equal(expected, plan.Execute().ToArray());
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledTrainingCowIsolationTests.cs
@@ -286,11 +286,12 @@ public class CompiledTrainingCowIsolationTests
         var selected = row.Slice(axis: 0, start: 0, end: 1);
         var loss = engine.ReduceSum(engine.TensorMultiply(selected, selected), null);
         using var plan = scope.CompileTraining(parameters, loss);
+        Assert.Null(GraphMode.Current);
         plan.ConfigureOptimizer(OptimizerType.SGD, 0.01f, 0.9f, 0.999f, 1e-8f, 0f);
 
         plan.Step();
 
-        Assert.Same(scope, GraphMode.Current);
+        Assert.Null(GraphMode.Current);
         var compiled = Assert.IsType<CompiledTrainingPlan<double>>(plan);
         Assert.Equal(new[] { 0.0, 0.0, 6.0, 0.0 }, compiled.Gradients[0].ToArray());
         Assert.Equal(1.0, parameter[0]);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ExecuteIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ExecuteIntoTests.cs
@@ -13,6 +13,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// rebind storage so every Replay reads and writes the caller's buffers
 /// instead of the plan's compile-time allocations.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class ExecuteIntoTests : IDisposable
 {
     // Same engine-pinning rationale as AsyncChainTests / GroupNormOpTests:

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16HeteroScratchFreeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16HeteroScratchFreeTests.cs
@@ -72,7 +72,7 @@ public class Fp16HeteroScratchFreeTests
         {
             var (order, loss) = CaptureHetero(gpu);
             gpu.ClearActivationCache(); // isolate this run's cache accounting from the capture + the other run
-            var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             // Replicate the real Step condition: eviction suspended for the whole forward+backward (#226), so
             // without the scratch-free the per-op backward scratch genuinely accumulates in the cache.
             gpu.SuspendActivationEviction();
@@ -106,7 +106,7 @@ public class Fp16HeteroScratchFreeTests
         {
             var (order, loss) = CaptureHetero(gpu);
             gpu.ClearActivationCache();
-            var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             gpu.SuspendActivationEviction();
             try
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16InCaptureForwardParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16InCaptureForwardParityTests.cs
@@ -452,12 +452,12 @@ public class Fp16InCaptureForwardParityTests
             var order = plan.Fp16HeteroOrderForTest!;
             var loss = plan.LossOutput;
 
-            var unpaged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var unpaged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             GpuMemoryTracker.ResetPeak();
             unpaged.Forward();
             long unpagedPeak = GpuMemoryTracker.PeakBytes;
 
-            var paged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: true);
+            using var paged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: true);
             GpuMemoryTracker.ResetPeak();
             paged.Forward();
             long pagedPeak = GpuMemoryTracker.PeakBytes;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
@@ -57,5 +57,6 @@ public sealed class LazyGraphCompilerPerformanceTests
         public void Realize(IEngine engine) => IsRealized = true;
         public ILazyNode[] GetInputNodes() => _inputs;
         public void ClearOutputLazySource() { }
+        public void AddStorageLeases(TensorStorageLeaseSet leases) { }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionAdamTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionAdamTests.cs
@@ -43,7 +43,7 @@ public class MixedPrecisionAdamTests
             return _engine.ReduceSum(sq);
         };
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 128f, DynamicLossScale = false });
         var pars = new[] { W };

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledBackwardTests.cs
@@ -79,7 +79,7 @@ public class MixedPrecisionCompiledBackwardTests
             {
                 var sp = new LazyTensorScope(null);
                 var lossP = BuildGraph(sp, x, W);
-                var plan = MixedPrecisionCompiledPlan.Compile(lossP, _engine);
+                using var plan = MixedPrecisionCompiledPlan.Compile(lossP, _engine);
                 plan.Forward();
                 var gp = plan.Backward();
                 Assert.True(gp.Fp32.TryGetValue(x, out var gx1), "compiled grad for x missing");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledForwardTests.cs
@@ -71,7 +71,7 @@ public class MixedPrecisionCompiledForwardTests
                 }
                 finally { GraphMode.SetCurrent(null); }
             }
-            var plan = MixedPrecisionCompiledPlan.Compile(yPlan, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(yPlan, _engine);
 
             var out1 = plan.Forward().ToArray();
             AssertClose(ref1, out1, "initial replay vs fresh trace");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledScaleGpuTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledScaleGpuTests.cs
@@ -89,7 +89,7 @@ public class MixedPrecisionCompiledScaleGpuTests
                 finally { GraphMode.SetCurrent(null); }
             }
 
-            var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
             var pars = new List<Tensor<float>>(W);
 
             float first = 0, last = 0; int nan = 0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledStepTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledStepTests.cs
@@ -63,7 +63,7 @@ public class MixedPrecisionCompiledStepTests
                 finally { GraphMode.SetCurrent(null); }
             }
 
-            var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
             var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
                 new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 256f, DynamicLossScale = false });
             var pars = new[] { W };

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionComputeGradientsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionComputeGradientsTests.cs
@@ -55,7 +55,7 @@ public class MixedPrecisionComputeGradientsTests
         const int B = 8, d = 6;
         var (forward, _, _, W) = BuildLinearProblem(B, d);
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 128f, DynamicLossScale = false });
         var pars = new[] { W };
@@ -92,7 +92,7 @@ public class MixedPrecisionComputeGradientsTests
     {
         const int B = 8, d = 6;
         var (forward, _, _, W) = BuildLinearProblem(B, d);
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var pars = new[] { W };
 
         var r = plan.ComputeGradients(pars, scaler: null);
@@ -116,8 +116,8 @@ public class MixedPrecisionComputeGradientsTests
         var (fwdA, _, _, wA) = BuildLinearProblem(B, d);
         var (fwdB, _, _, wB) = BuildLinearProblem(B, d);
 
-        var planA = MixedPrecisionCompiledPlan.Trace(fwdA, _engine);
-        var planB = MixedPrecisionCompiledPlan.Trace(fwdB, _engine);
+        using var planA = MixedPrecisionCompiledPlan.Trace(fwdA, _engine);
+        using var planB = MixedPrecisionCompiledPlan.Trace(fwdB, _engine);
 
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 1024f, DynamicLossScale = false });
@@ -146,7 +146,7 @@ public class MixedPrecisionComputeGradientsTests
     {
         const int B = 8, d = 6;
         var (forward, x, t, W) = BuildLinearProblem(B, d);
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
 
         var grad = plan.ComputeGradients(new[] { W }, scaler: null).Gradients[0];
         Assert.NotNull(grad);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionFp16WeightStorageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionFp16WeightStorageTests.cs
@@ -81,7 +81,7 @@ public class MixedPrecisionFp16WeightStorageTests
             });
         loss.LazySource = nloss;
 
-        var plan = MixedPrecisionCompiledPlan.Compile(loss, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Compile(loss, _engine);
 
         // Register the fp32 master for the fp16 storage weight.
         var masters = new MasterWeights();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPagingTests.cs
@@ -53,7 +53,7 @@ public class MixedPrecisionPagingTests
         float[] gxRef, gw1Ref, gw2Ref;
         MixedPrecisionCompiledPlan.PagingTestOverride = false;
         {
-            var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
             plan.Forward();
             var g = plan.Backward();
             Assert.Equal(0, plan.PageOutCount);
@@ -65,7 +65,7 @@ public class MixedPrecisionPagingTests
         MixedPrecisionCompiledPlan.PagingTestOverride = true;
         try
         {
-            var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
             plan.Forward();
             var g = plan.Backward();
             pageOuts = plan.PageOutCount;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPublicApiTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPublicApiTests.cs
@@ -47,7 +47,7 @@ public class MixedPrecisionPublicApiTests
             return _engine.ReduceSum(sq);
         };
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var pars = new[] { W };
 
         float first = 0, last = 0; int bad = 0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
@@ -17,6 +17,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// assert that EVERY declared input is re-bound on replay, and that a tensor the graph never
 /// reads is rejected (fail-closed) rather than silently baked.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputCompiledInferenceTests : IDisposable
 {
     // GetOrCompileInference captures AiDotNetEngine.Current as the plan's execution engine;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -19,6 +19,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// input is compared against an equally-mutated oracle. These tests snapshot inputs BEFORE Execute and
 /// reuse the same instances across calls.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputReplayAliasingTests : IDisposable
 {
     private readonly IEngine _priorEngine = AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
@@ -13,6 +13,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// directly. If the multi-input replay re-binds correctly the compiled output must match
 /// eager for every (x, t) pair.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputSecondaryConsumerReproTests : IDisposable
 {
     private readonly IEngine _prior = AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
@@ -161,6 +161,7 @@ public sealed class OperationReorderingPassTests
         public void Realize(IEngine engine) { }
         public ILazyNode[] GetInputNodes() => _inputs;
         public void ClearOutputLazySource() { }
+        public void AddStorageLeases(TensorStorageLeaseSet leases) { }
         public override string ToString() => Name;
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation.Ops;
 /// Group Normalization. Validates forward parity with the eager engine path,
 /// backward gradient correctness, attribute access, and factory round-trip.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class GroupNormOpTests
 {
     // ── Forward parity: GroupNormOp produces same result as eager engine ─────

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -29,6 +29,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// compile + step, so the loss tensor is allocated from a padded slot.
 /// </para>
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class PoolPaddedLossReadoutTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
@@ -16,6 +16,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation.Serialization;
 /// Validates SaveAsync → LoadInferenceAsync round-trip produces plans whose
 /// Execute() returns bitwise-identical outputs to the original.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class InferencePlanSerializationTests : IDisposable
 {
     // PR #333's GPU auto-detect ModuleInitializer makes plan compilation
@@ -381,5 +382,50 @@ public class InferencePlanSerializationTests : IDisposable
         Assert.False(plan.IsCompatibleWith(info));
 
         plan.Dispose();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task SaveLoad_GroupedQueryAttention_PreservesSelectedOutput(
+        bool isCausal, bool selectAttentionWeights)
+    {
+        var engine = new CpuEngine();
+        var query = Tensor<float>.CreateRandom([1, 4, 3, 2]);
+        var key = Tensor<float>.CreateRandom([1, 2, 3, 2]);
+        var value = Tensor<float>.CreateRandom([1, 2, 3, 2]);
+
+        CompiledInferencePlan<float> original;
+        using (var scope = GraphMode.EnableInference())
+        {
+            var output = engine.GroupedQueryAttention(
+                query, key, value, numQueriesPerKV: 2, scale: 0.5,
+                isCausal, out var attentionWeights);
+            var selectedOutput = selectAttentionWeights ? attentionWeights : output;
+            original = scope.CompileInference(selectedOutput, new[] { query, key, value });
+        }
+
+        using var stream = new MemoryStream();
+        await original.SaveAsync(stream);
+        stream.Position = 0;
+        var loaded = (CompiledInferencePlan<float>?)
+            await CompiledPlanLoader.LoadInferenceAsync<float>(stream, engine);
+        Assert.NotNull(loaded);
+
+        var replayInputs = new[]
+        {
+            Tensor<float>.CreateRandom([1, 4, 3, 2]),
+            Tensor<float>.CreateRandom([1, 2, 3, 2]),
+            Tensor<float>.CreateRandom([1, 2, 3, 2])
+        };
+        original.SetInputs(replayInputs);
+        loaded!.SetInputs(replayInputs);
+
+        Assert.Equal(Snapshot(original.Execute()), Snapshot(loaded.Execute()));
+
+        original.Dispose();
+        loaded.Dispose();
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/StepIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/StepIntoTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// contract as the inference plan: caller owns the loss / input buffers,
 /// the plan copies in + out, kernels stay compile-time-specialised.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class StepIntoTests : IDisposable
 {
     // Same engine-pinning rationale as AsyncChainTests / ExecuteIntoTests:

--- a/tests/AiDotNet.Tensors.Tests/Engines/CompiledTrainingPlanRebindingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/CompiledTrainingPlanRebindingTests.cs
@@ -10,6 +10,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// Tests that CompiledTrainingPlan.Step() sees in-place parameter updates.
 /// Repro for: compiled plan returning constant loss after SGD updates.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class CompiledTrainingPlanRebindingTests : IDisposable
 {
     // PR #333's [ModuleInitializer] auto-promotes AiDotNetEngine.Current to a

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -28,6 +27,50 @@ public class Conv2DImplicitGemmParityTests
         return t;
     }
 
+    [Fact]
+    public void RowBlockedIm2Col_IsBitIdentical_ToFullIm2Col()
+    {
+        const int channels = 320;
+        const int height = 32;
+        const int width = 32;
+        const int kernelSize = 3;
+        const int padding = 1;
+        const int outputHeight = 32;
+        const int outputWidth = 32;
+        const int rowsPerBlock = 22;
+        const int colH = channels * kernelSize * kernelSize;
+        const int colW = outputHeight * outputWidth;
+
+        var input = Rand(new[] { 1, channels, height, width }, 101);
+        var full = new float[colH * colW];
+        AiDotNet.Tensors.Helpers.Im2ColHelper.Im2ColChannelParallel(
+            input.AsSpan(), full,
+            channels, height, width,
+            kernelSize, kernelSize, 1, 1, padding, padding, 1, 1,
+            outputHeight, outputWidth);
+
+        for (int ohStart = 0; ohStart < outputHeight; ohStart += rowsPerBlock)
+        {
+            int ohEnd = Math.Min(ohStart + rowsPerBlock, outputHeight);
+            int blockWidth = (ohEnd - ohStart) * outputWidth;
+            var block = new float[colH * blockWidth];
+            AiDotNet.Tensors.Helpers.Im2ColHelper.Im2ColRowBlockFloat(
+                input.AsSpan(), block,
+                channels, height, width,
+                kernelSize, kernelSize, 1, 1, padding, padding, 1, 1,
+                outputHeight, outputWidth, ohStart, ohEnd);
+
+            int fullColumnOffset = ohStart * outputWidth;
+            for (int row = 0; row < colH; row++)
+            {
+                var expected = full.AsSpan(row * colW + fullColumnOffset, blockWidth);
+                var actual = block.AsSpan(row * blockWidth, blockWidth);
+                Assert.True(expected.SequenceEqual(actual),
+                    $"blocked im2col diverged in row {row}, output rows [{ohStart}, {ohEnd})");
+            }
+        }
+    }
+
     [Theory]
     // batch, inC, outC, k, hw, stride, pad, dilation
     [InlineData(1, 256, 256, 3, 16, 1, 1, 1)]   // canonical diffusion ResBlock 3×3
@@ -39,11 +82,9 @@ public class Conv2DImplicitGemmParityTests
     [InlineData(1, 256, 256, 3, 16, 1, 2, 2)]   // dilation 2
     [InlineData(1, 512, 256, 1, 16, 1, 0, 1)]   // 1×1 high-channel (routes to full path)
     [InlineData(1, 256, 300, 5, 12, 1, 2, 1)]   // 5×5, non-power-of-two outC
-    public async Task FusedConv_IsBitIdentical_ToFullIm2Col(
+    public void FusedConv_IsBitIdentical_ToFullIm2Col(
         int batch, int inC, int outC, int k, int hw, int stride, int pad, int dilation)
     {
-        await Task.Yield();
-
         var e = new CpuEngine();
         var x = Rand(new[] { batch, inC, hw, hw }, 101);
         var kernel = Rand(new[] { outC, inC, k, k }, 202);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
@@ -343,7 +343,7 @@ public class DeterministicByDefaultTests
     }
 
     [Fact]
-    public async Task SetCurrent_OnOneThread_DoesNotLeakToAnotherThread()
+    public void SetCurrent_OnOneThread_DoesNotLeakToAnotherThread()
     {
         // The core thread-local invariant: thread A's override must not change
         // what thread B sees. Without this, "thread-local" would be a lie.
@@ -360,13 +360,14 @@ public class DeterministicByDefaultTests
             using var mayExit     = new ManualResetEventSlim(false);
             bool parkedObservation = false;
 
-            var parked = Task.Run(() =>
+            var parked = new Thread(() =>
             {
                 parkedReady.Set();
                 mayExit.Wait();
                 // Record the thread-local accessor's value from the parked thread.
                 parkedObservation = BlasProvider.IsDeterministicMode;
             });
+            parked.Start();
 
             parkedReady.Wait();
             // Main thread installs a thread-local override.
@@ -375,7 +376,7 @@ public class DeterministicByDefaultTests
 
             // Release the parked thread.
             mayExit.Set();
-            await parked.ConfigureAwait(false);
+            parked.Join();
 
             // The parked thread never installed an override of its own, so it
             // must still see the process-wide value (true), not main's override.

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectOpenClContextConcurrencyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/DirectOpenClContextConcurrencyTests.cs
@@ -27,6 +27,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
 using Xunit;
 
@@ -125,4 +126,99 @@ public class DirectOpenClContextConcurrencyTests
         // Re-entrant Dispose() is a no-op contract.
         ctx.Dispose();
     }
+
+    [SkippableFact]
+    public void BufferPool_DoesNotRecycleAllocationAcrossUnorderedThreadQueues()
+    {
+        Skip.IfNot(OpenClPresent(), "No OpenCL GPU device available on this host.");
+        using var backend = new OpenClBackend(deviceIndex: 0);
+
+        IntPtr queueABuffer = IntPtr.Zero;
+        IntPtr queueBBuffer = IntPtr.Zero;
+        Exception? workerFailure = null;
+        var firstReturned = new ManualResetEventSlim(false);
+
+        var threadA = new Thread(() =>
+        {
+            try
+            {
+                using (var first = backend.AllocateBuffer(64))
+                    queueABuffer = first.Handle;
+
+                // The same queue must retain the fast reuse path.
+                using (var sameQueue = backend.AllocateBuffer(64))
+                    Assert.Equal(queueABuffer, sameQueue.Handle);
+            }
+            catch (Exception ex)
+            {
+                workerFailure = ex;
+            }
+            finally
+            {
+                firstReturned.Set();
+            }
+        }) { IsBackground = true };
+
+        var threadB = new Thread(() =>
+        {
+            try
+            {
+                firstReturned.Wait();
+                using var differentQueue = backend.AllocateBuffer(64);
+                queueBBuffer = differentQueue.Handle;
+            }
+            catch (Exception ex)
+            {
+                workerFailure = ex;
+            }
+        }) { IsBackground = true };
+
+        threadA.Start();
+        threadB.Start();
+        Assert.True(threadA.Join(TimeSpan.FromSeconds(30)));
+        Assert.True(threadB.Join(TimeSpan.FromSeconds(30)));
+        Assert.Null(workerFailure);
+        Assert.NotEqual(IntPtr.Zero, queueABuffer);
+        Assert.NotEqual(IntPtr.Zero, queueBBuffer);
+        Assert.NotEqual(queueABuffer, queueBBuffer);
+    }
+
+    [SkippableFact]
+    public void AsyncTransfer_CrossQueueDependencyAndHostPins_PreserveData()
+    {
+        Skip.IfNot(OpenClPresent(), "No OpenCL GPU device available on this host.");
+        using var backend = new OpenClBackend(deviceIndex: 0);
+        using var producer = backend.CreateStream(GpuStreamType.HostToDevice);
+        using var consumer = backend.CreateStream(GpuStreamType.Compute);
+        const int length = 262_144;
+        using var buffer = backend.AllocateBuffer(length);
+        var destination = new float[length];
+
+        QueueTemporarySpanUpload(backend, buffer, producer, length);
+        backend.DownloadBufferAsync(buffer, destination, consumer);
+
+        // The span upload owns a staged array that is reachable only through the pending host-transfer
+        // pin after QueueTemporarySpanUpload returns. A compacting collection before either queue is
+        // synchronized exercises that lifetime, while the download on a different queue exercises the
+        // automatically inserted producer-event dependency.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        consumer.Synchronize();
+
+        for (int i = 0; i < destination.Length; i++)
+            Assert.Equal(ExpectedValue(i), destination[i]);
+    }
+
+    private static void QueueTemporarySpanUpload(
+        OpenClBackend backend,
+        AiDotNet.Tensors.Engines.DirectGpu.IGpuBuffer buffer,
+        IGpuStream stream,
+        int length)
+    {
+        var source = new float[length];
+        for (int i = 0; i < source.Length; i++) source[i] = ExpectedValue(i);
+        backend.UploadBufferAsync(source.AsSpan(), buffer, stream);
+    }
+
+    private static float ExpectedValue(int index)
+        => ((index * 17) % 1009 - 504) / 32f;
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuBufferPoolAffinityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuBufferPoolAffinityTests.cs
@@ -1,0 +1,53 @@
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+public sealed class GpuBufferPoolAffinityTests
+{
+    [Fact]
+    public void Rent_DoesNotCrossAffinityDomains()
+    {
+        using var pool = new GpuBufferPool<FakeBuffer>(maxPerSize: 4, maxSize: 1024);
+        var queueA = GpuBufferPoolAffinity.ForNativeQueue(new IntPtr(1));
+        var queueB = GpuBufferPoolAffinity.ForNativeQueue(new IntPtr(2));
+        var buffer = new FakeBuffer(64);
+
+        pool.Return(buffer, queueA);
+
+        Assert.False(pool.TryRent(64, queueB, out _));
+        Assert.True(pool.TryRent(64, queueA, out var rented));
+        Assert.Same(buffer, rented);
+    }
+
+    [Fact]
+    public void Capacity_RemainsSharedAcrossAffinityDomains()
+    {
+        using var pool = new GpuBufferPool<FakeBuffer>(maxPerSize: 1, maxSize: 1024);
+        var queueA = GpuBufferPoolAffinity.ForNativeQueue(new IntPtr(1));
+        var queueB = GpuBufferPoolAffinity.ForNativeQueue(new IntPtr(2));
+        var first = new FakeBuffer(64);
+        var excess = new FakeBuffer(64);
+
+        pool.Return(first, queueA);
+        pool.Return(excess, queueB);
+
+        Assert.Equal(1, excess.ReleaseCount);
+        Assert.False(pool.TryRent(64, queueB, out _));
+        Assert.True(pool.TryRent(64, queueA, out var rented));
+        Assert.Same(first, rented);
+    }
+
+    private sealed class FakeBuffer : IGpuBuffer, IPoolableGpuBuffer
+    {
+        internal FakeBuffer(int size) => Size = size;
+        public int Size { get; }
+        public long SizeInBytes => Size * sizeof(float);
+        public IntPtr Handle => new(1);
+        internal int ReleaseCount { get; private set; }
+        public void MarkRented() { }
+        public void Release() => ReleaseCount++;
+        public void Dispose() => Release();
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Tests.Engines.OpParity;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -535,6 +536,7 @@ public sealed class GpuCpuAutoDifferentialTests : IDisposable
             string key = Key(m);
             if (IsAutoTestableOnCpu(m, out _)) continue;          // gets a real GPU-vs-CPU check
             if (IsNonDeterministic(m.Name)) continue;             // legitimately non-differentiable
+            if (GeneratedOpParitySupport.HasGeneratedHomogeneousOutputCoverage(m)) continue;
             if (DedicatedlyCovered.Contains(key)) continue;       // has a hand-written dedicated test
             uncovered.Add(key);
         }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -69,6 +69,7 @@ internal sealed class MockBackendState
     public int ScalarMinCalls { get; set; }
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
+    public int TanhCalls { get; set; }
     public List<string> OptimizerCalls { get; } = new();
 }
 
@@ -183,6 +184,15 @@ public class MockDirectGpuBackend : DispatchProxy
                 var output = (MockGpuBuffer)args[2]!;
                 int size = (int)args[3]!;
                 for (int i = 0; i < size; i++) output.Data[i] = left.Data[i] * right.Data[i];
+                return null!;
+            }
+            case "Tanh":
+            {
+                _state.TanhCalls++;
+                var input = (MockGpuBuffer)args[0]!;
+                var output = (MockGpuBuffer)args[1]!;
+                int size = (int)args[2]!;
+                for (int i = 0; i < size; i++) output.Data[i] = MathF.Tanh(input.Data[i]);
                 return null!;
             }
             case "Min" when args.Length == 2:

--- a/tests/AiDotNet.Tensors.Tests/Engines/Einsum/Parity210ExpBesselFrexpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Einsum/Parity210ExpBesselFrexpTests.cs
@@ -81,4 +81,27 @@ public class Parity210ExpBesselFrexpTests
         Assert.True(Close(-0.5f, m[0]));
         Assert.Equal(4, e[0]);
     }
+
+    [Fact]
+    public void Frexp_NonFiniteValues_ArePreservedWithZeroExponent()
+    {
+        var x = T(new[] { float.PositiveInfinity, float.NegativeInfinity, float.NaN }, 3);
+        var (mantissa, exponent) = E.TensorFrexp(x);
+
+        Assert.Equal(float.PositiveInfinity, mantissa[0]);
+        Assert.Equal(float.NegativeInfinity, mantissa[1]);
+        Assert.True(float.IsNaN(mantissa[2]));
+        Assert.Equal(new[] { 0, 0, 0 }, exponent.ToArray());
+    }
+
+    [Fact]
+    public void Frexp_Subnormal_ReconstructsInput()
+    {
+        float value = float.Epsilon;
+        var x = T(new[] { value }, 1);
+        var (mantissa, exponent) = E.TensorFrexp(x);
+
+        Assert.InRange(MathF.Abs(mantissa[0]), 0.5f, 1f);
+        Assert.Equal(value, mantissa[0] * (float)Math.Pow(2.0, exponent[0]));
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/GpuAutoDetectCorrectnessGateTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GpuAutoDetectCorrectnessGateTests.cs
@@ -17,12 +17,15 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// absent one falls back to a correct CPU engine. Before the gate, a "present but wrong" backend
 /// would be adopted and fail this assertion.
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class GpuAutoDetectCorrectnessGateTests
 {
     [Fact]
     public void AutoDetect_LeavesActiveEngineComputingCorrectly()
     {
         var prior = AiDotNetEngine.Current;
+        var isolatedBaseline = new CpuEngine();
+        AiDotNetEngine.Current = isolatedBaseline;
         try
         {
             // Adopts the GPU only if it passes the correctness probe; otherwise stays on CPU.
@@ -41,7 +44,14 @@ public class GpuAutoDetectCorrectnessGateTests
         }
         finally
         {
+            var detected = AiDotNetEngine.Current;
             AiDotNetEngine.Current = prior;
+            if (!ReferenceEquals(detected, prior) &&
+                !ReferenceEquals(detected, isolatedBaseline) &&
+                detected is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue319TrainingLoopPerfTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue319TrainingLoopPerfTests.cs
@@ -30,12 +30,15 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
-public class Issue319TrainingLoopPerfTests
+[Collection("EngineCurrentGlobalState")]
+public class Issue319TrainingLoopPerfTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
+    private readonly IEngine _priorEngine;
     public Issue319TrainingLoopPerfTests(ITestOutputHelper output)
     {
         _output = output;
+        _priorEngine = AiDotNetEngine.Current;
         // Reset shared engine + caches so alloc-counting probes aren't
         // contaminated by pooled tensors / AutoTracer state from earlier
         // tests in the same process. The perf-regression assertions use
@@ -46,6 +49,8 @@ public class Issue319TrainingLoopPerfTests
         AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
         AiDotNet.Tensors.Engines.Autodiff.TensorPool<float>.Clear();
     }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
 
     [Fact]
     public void TensorAdd_BroadcastBiasGradientReducesTheSequenceAxis()

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue338PhaseGCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue338PhaseGCoverageTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
+[Collection("EngineCurrentGlobalState")]
 public class Issue338PhaseGCoverageTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// contracting over a big dimension (V≈50257), on AVX2-no-AVX512 hardware with OpenBLAS NOT loaded (managed
 /// AVX2 fallback). Env-gated TENSORS_RUN_REPRO=1. A clean run prints "ALL OK".
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class Issue471CpuMatmulCrashRepro
 {
     private readonly ITestOutputHelper _o;
@@ -23,16 +24,9 @@ public class Issue471CpuMatmulCrashRepro
         Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
             "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
 
-        // ResetToCpu() mutates AiDotNetEngine.Current — a shared process-wide
-        // singleton. xUnit test order is nondeterministic, so without restoring
-        // the previous selection the GPU repros below could silently run on CPU
-        // and miss the hardware path they exist to cover. Capture-and-restore
-        // around the CPU-specific body keeps this test isolated.
-        var previousEngine = AiDotNetEngine.Current;
-        AiDotNetEngine.ResetToCpu();
-        try
-        {
-            var eng = AiDotNetEngine.Current;
+        // This is a CPU-specific repro, so use an explicit local engine. ResetToCpu disposes
+        // a globally selected GPU and restoring that same reference would publish a dead engine.
+        var eng = new CpuEngine();
             _o.WriteLine($"engine={eng.Name}");
             const int d = 128;
             foreach (int V in new[] { 1000, 10000, 30000, 50257 })
@@ -58,11 +52,6 @@ public class Issue471CpuMatmulCrashRepro
             }
             _o.WriteLine("ALL OK — no crash");
             Assert.True(true);
-        }
-        finally
-        {
-            AiDotNetEngine.Current = previousEngine;
-        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/MlpForwardTests.cs
@@ -140,22 +140,6 @@ public class MlpForwardTests
     }
 
     [Fact]
-    public void MlpForward_UnderGraphMode_Throws()
-    {
-        var rng = new Random(1);
-        var input = MakeRandom(rng, 2, 4);
-        var weights = new List<Tensor<float>> { MakeRandom(rng, 4, 3) };
-        var biases = new List<Tensor<float>?> { MakeRandom(rng, 3) };
-
-        using (GraphMode.Enable())
-        {
-            Assert.Throws<InvalidOperationException>(() =>
-                _engine.MlpForward(input, weights, biases,
-                    FusedActivationType.ReLU, FusedActivationType.None));
-        }
-    }
-
-    [Fact]
     public void MlpForward_MismatchedBiasCount_Throws()
     {
         var rng = new Random(1);

--- a/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
@@ -22,7 +22,11 @@ public class NativeComplexFftBlittableTests
     private readonly ITestOutputHelper _output;
     public NativeComplexFftBlittableTests(ITestOutputHelper output) => _output = output;
 
-    private static CpuEngine Cpu() => (AiDotNetEngine.Current as CpuEngine) ?? new CpuEngine();
+    // This fixture verifies the CPU blittable FFT implementation itself. DirectGpuTensorEngine
+    // derives from CpuEngine, so accepting AiDotNetEngine.Current here can silently select the
+    // GPU override and its speed-first FP32 conversion for double inputs. Use an exact CPU engine
+    // so the FP64 assertions cannot depend on process-wide backend selection or test order.
+    private static CpuEngine Cpu() => new CpuEngine();
 
     private static Tensor<double> RandD(int b, int n, int seed)
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
@@ -33,8 +33,7 @@ public class OneDnnProviderTests
         Skip.IfNot(OneDnnProvider.IsAvailable,
             "dnnl.dll not deployed for this runtime; oneDNN optional accelerator inactive.");
 
-        AiDotNetEngine.ResetToCpu();
-        var eng = AiDotNetEngine.Current;
+        var eng = new CpuEngine();
 
         // 1 batch, 1 in-channel, 3x3 input; one 2x2 kernel; stride 1, no pad → 2x2 output.
         // input:            kernel:

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/BackendCompletenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/BackendCompletenessTests.cs
@@ -155,17 +155,17 @@ public sealed class BackendCompletenessTests
     }
 
     [Fact]
-    public void EveryGpuReadbackAllowance_HasAContractReason()
+    public void EveryGpuReadbackContract_IsDefined()
     {
-        var undocumented = OpParityRegistry.All()
-            .Where(op => op.GpuAllowedReadbacks > 0 && string.IsNullOrWhiteSpace(op.GpuReadbackReason))
+        var invalid = OpParityRegistry.All()
+            .Where(op => !Enum.IsDefined(typeof(GpuReadbackContract), op.GpuReadbackContract))
             .Select(op => op.Name)
             .OrderBy(name => name, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.True(undocumented.Length == 0,
-            "GPU readback allowances must identify the synchronous host contract that requires them: " +
-            string.Join(", ", undocumented));
+        Assert.True(invalid.Length == 0,
+            "GPU readback policies must use a defined GpuReadbackContract value: " +
+            string.Join(", ", invalid));
     }
 
     // ---- helpers ---------------------------------------------------------------------------

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GeneratedOpParitySupport.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GeneratedOpParitySupport.cs
@@ -7,6 +7,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.OpParity;
@@ -23,7 +25,116 @@ public static class GeneratedOpParitySupport
         var cases = ByMethod[opMethod].ToList();
         Skip.If(cases.Count == 0, $"NEEDS SPEC: IEngine.{opMethod} has no CPU-vs-GPU parity case yet.");
         foreach (var c in cases)
-            OpParityHarness.CheckForward(c, fx);
+        {
+            switch (c.TensorOutputContract)
+            {
+                case TensorOutputContract.HomogeneousMultiple:
+                    OpParityHarness.CheckMultipleOutputs(c, fx);
+                    break;
+                case TensorOutputContract.HeterogeneousMultiple:
+                    OpParityHarness.CheckHeterogeneousOutputs(c, fx);
+                    break;
+                default:
+                    OpParityHarness.CheckForward(c, fx);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called by source-generated tests for every IEngine operation with more than one tensor
+    /// result. The registry must explicitly describe the tuple and, when homogeneous, expose every
+    /// result through the executable multi-output delegates.
+    /// </summary>
+    public static void VerifyTensorOutputContract(
+        string opMethod,
+        TensorOutputContract expected,
+        TensorOutputOverload expectedOverload)
+    {
+        var cases = ByMethod[opMethod].ToList();
+        Assert.NotEmpty(cases);
+        Assert.Contains(cases, op =>
+            op.TensorOutputContract == expected &&
+            (expectedOverload == TensorOutputOverload.Unspecified ||
+                op.TensorOutputOverload == expectedOverload) &&
+            (expected == TensorOutputContract.HomogeneousMultiple
+                ? op.HasMultipleOutputs
+                : op.HasHeterogeneousOutputs));
+    }
+
+    /// <summary>
+    /// Lets reflection-driven GPU coverage consume the same generated multi-output contract
+    /// scaffold. No method signature is copied into a string allowlist: the reflected method
+    /// must itself expose homogeneous tensor outputs, and the typed registry contract must
+    /// provide executable delegates for every result.
+    /// </summary>
+    public static bool HasGeneratedHomogeneousOutputCoverage(MethodInfo method)
+    {
+        if (method is null || !method.IsGenericMethodDefinition || method.GetGenericArguments().Length != 1)
+            return false;
+
+        var tensorElementTypes = new List<System.Type>();
+        CollectTensorElementTypes(method.ReturnType, tensorElementTypes);
+        foreach (var parameter in method.GetParameters())
+        {
+            if (parameter.IsOut)
+                CollectTensorElementTypes(parameter.ParameterType, tensorElementTypes);
+        }
+
+        if (tensorElementTypes.Count < 2)
+            return false;
+
+        var methodElementType = method.GetGenericArguments()[0];
+        if (tensorElementTypes.Any(elementType => elementType != methodElementType))
+            return false;
+
+        return ByMethod[method.Name].Any(op =>
+            op.TensorOutputContract == TensorOutputContract.HomogeneousMultiple &&
+            op.HasMultipleOutputs);
+    }
+
+    private static void CollectTensorElementTypes(System.Type type, ICollection<System.Type> output)
+    {
+        if (type.IsByRef)
+        {
+            CollectTensorElementTypes(type.GetElementType()!, output);
+            return;
+        }
+
+        if (type.IsArray)
+        {
+            CollectTensorElementTypes(type.GetElementType()!, output);
+            return;
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Tensor<>))
+        {
+            output.Add(type.GetGenericArguments()[0]);
+            return;
+        }
+
+    }
+
+    /// <summary>
+    /// Called by source-generated tests for every IEngine overload whose tensor operands/results
+    /// do not all share one element type. The registry must classify the exact overload so its
+    /// executable graph-capture case proves that compilation fails closed.
+    /// </summary>
+    public static void VerifyGraphCaptureSignature(
+        string opMethod,
+        GraphCaptureSignatureConstraint expected,
+        GraphCaptureSignatureOverload expectedOverload)
+    {
+        var cases = ByMethod[opMethod].ToList();
+        Assert.NotEmpty(cases);
+        bool found = cases.Any(op =>
+            op.GraphCaptureSignatureConstraint == expected &&
+            (expectedOverload == GraphCaptureSignatureOverload.Unspecified ||
+                op.GraphCaptureSignatureOverload == expectedOverload));
+        Assert.True(found,
+            $"IEngine.{opMethod} requires {expected}/{expectedOverload}; registered cases: " +
+            string.Join(", ", cases.Select(op =>
+                $"{op.Name}={op.GraphCaptureSignatureConstraint}/{op.GraphCaptureSignatureOverload}")));
     }
 }
 #endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GpuResidencyProbeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GpuResidencyProbeTests.cs
@@ -124,7 +124,7 @@ public sealed class GpuResidencyProbeTests
             if (internalReadbacks > op.GpuAllowedReadbacks)
                 readbacks.Add($"{op.Name}\t{op.Category}\t{internalReadbacks} transfers\t" +
                     $"{internalReadbackBytes} bytes\tallowance {op.GpuAllowedReadbacks}\t" +
-                    string.Join("; ", internalReadbackSites));
+                    $"{op.GpuReadbackDescription}\t{string.Join("; ", internalReadbackSites)}");
 
             if (op.GpuProbeExpectation == GpuProbeExpectation.HostContract)
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GraphCaptureParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/GraphCaptureParityTests.cs
@@ -1,0 +1,385 @@
+// Copyright (c) AiDotNet. All rights reserved.
+#if !NETFRAMEWORK
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.OpParity;
+
+/// <summary>
+/// Registry-derived graph-capture contract. Every required case is compiled once, its exact leaf
+/// tensors are changed, and replay is compared with an eager invocation whose <see cref="OpInput"/>
+/// values receive the same deterministic change. An eager computation hidden behind a later lazy
+/// projection therefore fails as stale rather than passing a superficial LazySource assertion.
+/// </summary>
+[Collection("OpParity")]
+public sealed class GraphCaptureParityTests
+{
+    private static readonly IReadOnlyDictionary<string, OpCase> Cases =
+        OpParityRegistry.All().ToDictionary(o => o.Name);
+
+    public static IEnumerable<object[]> ForwardCases =>
+        OpParityRegistry.All()
+            .Where(o => o.GraphCaptureExpectation != GraphCaptureExpectation.BackwardKernel)
+            .Where(o => ParityShard.Include(o.Name))
+            .Select(o => new object[] { o.Name });
+
+    public static IEnumerable<object[]> MultiOutputCases =>
+        OpParityRegistry.All()
+            .Where(o => o.HasMultipleOutputs &&
+                        o.GraphCaptureExpectation == GraphCaptureExpectation.Required)
+            .Where(o => ParityShard.Include(o.Name))
+            .Select(o => new object[] { o.Name });
+
+    [SkippableTheory]
+    [MemberData(nameof(ForwardCases))]
+    public void Forward_CompiledReplayReflectsLiveInputs(string opName)
+    {
+        var op = Cases[opName];
+        var engine = new CpuEngine();
+
+        if (op.GraphCaptureExpectation == GraphCaptureExpectation.NonDeterministic)
+        {
+            VerifyNonDeterministicCaptureIsSafe(op, engine);
+            return;
+        }
+
+        if (op.GraphCaptureExpectation == GraphCaptureExpectation.InputIndependent)
+        {
+            VerifyInputIndependentContract(op, engine);
+            return;
+        }
+
+        if (op.GraphCaptureSignatureConstraint != GraphCaptureSignatureConstraint.None ||
+            op.GraphCaptureExpectation is GraphCaptureExpectation.DataDependentOutputShape or
+            GraphCaptureExpectation.HeterogeneousInput or
+            GraphCaptureExpectation.HeterogeneousOutput or
+            GraphCaptureExpectation.MixedElementTypes or
+            GraphCaptureExpectation.HostBoundary or
+            GraphCaptureExpectation.Stateful)
+        {
+            VerifyCaptureIsRejected(op, engine);
+            return;
+        }
+
+        GraphMutationProfile mutation = SelectMutation(op, engine, out float[] eagerChanged);
+
+        var snapshots = new List<FloatInputSnapshot>();
+        CompiledInferencePlan<float> plan;
+        using (var graphScope = GraphMode.EnableInference())
+        using (OpInput.CaptureFloatInputSnapshots(snapshots))
+        {
+            var graphOutput = op.RunFloat(engine);
+            Assert.NotNull(graphOutput.LazySource);
+            Assert.NotEmpty(snapshots);
+            Assert.Contains(snapshots, snapshot => snapshot.Role == GraphInputRole.MutableValue);
+            plan = graphScope.CompileInference(
+                graphOutput,
+                snapshots.Select(snapshot => snapshot.Tensor).ToArray());
+        }
+
+        using (plan)
+        {
+            foreach (var snapshot in snapshots)
+            {
+                var destination = snapshot.Tensor.AsWritableSpan();
+                if (snapshot.Role == GraphInputRole.MutableValue)
+                {
+                    var mutated = (float[])snapshot.InitialValues.Clone();
+                    OpInput.ApplyGraphMutation(
+                        mutated, snapshot.InitialValues, mutation, snapshot.MutableOrdinal);
+                    mutated.AsSpan().CopyTo(destination);
+                }
+                else
+                {
+                    snapshot.InitialValues.AsSpan().CopyTo(destination);
+                }
+            }
+
+            float[] compiledChanged = plan.Execute().ToArray();
+            Assert.Equal(eagerChanged.Length, compiledChanged.Length);
+            Assert.True(
+                ParityMath.Within(compiledChanged, eagerChanged, op.Fwd, out var delta),
+                $"{op.Name}: compiled replay did not reflect live inputs. {delta.Describe()}");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MultiOutputCases))]
+    public void MultipleOutputs_CompiledReplayReflectsLiveInputs(string opName)
+    {
+        var op = Cases[opName];
+        var engine = new CpuEngine();
+
+        Tensor<float>[] eagerOriginal = op.RunFloatOutputs!(engine);
+        GraphMutationProfile mutation = SelectOutputMutation(op, engine, eagerOriginal, out Tensor<float>[] eagerChanged);
+
+        Assert.True(eagerOriginal.Length > 1, $"{op.Name}: a multi-output contract must expose at least two outputs.");
+        Assert.Equal(eagerOriginal.Length, eagerChanged.Length);
+
+        for (int outputIndex = 0; outputIndex < eagerOriginal.Length; outputIndex++)
+        {
+            Assert.Equal(eagerOriginal[outputIndex].Shape.ToArray(), eagerChanged[outputIndex].Shape.ToArray());
+            bool bitExact = ParityMath.BitExact(
+                eagerOriginal[outputIndex].ToArray(), eagerChanged[outputIndex].ToArray(), out _);
+            if (OutputDependency(op, outputIndex) == GraphOutputDependency.MutableInput)
+                Assert.False(bitExact,
+                    $"{op.Name} output[{outputIndex}]: the generated value mutation did not change the eager result.");
+            else
+                Assert.True(bitExact,
+                    $"{op.Name} output[{outputIndex}]: an input-independent result changed with mutable tensor inputs.");
+
+            var snapshots = new List<FloatInputSnapshot>();
+            CompiledInferencePlan<float> plan;
+            using (var graphScope = GraphMode.EnableInference())
+            using (OpInput.CaptureFloatInputSnapshots(snapshots))
+            {
+                Tensor<float>[] graphOutputs = op.RunFloatOutputs!(engine);
+                Assert.Equal(eagerOriginal.Length, graphOutputs.Length);
+                Assert.All(graphOutputs, output => Assert.NotNull(output.LazySource));
+                Assert.NotEmpty(snapshots);
+                Assert.Contains(snapshots, snapshot => snapshot.Role == GraphInputRole.MutableValue);
+                plan = graphScope.CompileInference(
+                    graphOutputs[outputIndex],
+                    snapshots.Select(snapshot => snapshot.Tensor).ToArray());
+            }
+
+            using (plan)
+            {
+                foreach (var snapshot in snapshots)
+                {
+                    var destination = snapshot.Tensor.AsWritableSpan();
+                    if (snapshot.Role == GraphInputRole.MutableValue)
+                    {
+                        var mutated = (float[])snapshot.InitialValues.Clone();
+                        OpInput.ApplyGraphMutation(
+                            mutated, snapshot.InitialValues, mutation, snapshot.MutableOrdinal);
+                        mutated.AsSpan().CopyTo(destination);
+                    }
+                    else
+                    {
+                        snapshot.InitialValues.AsSpan().CopyTo(destination);
+                    }
+                }
+
+                Tensor<float> compiledChanged = plan.Execute();
+                Assert.Equal(eagerChanged[outputIndex].Shape.ToArray(), compiledChanged.Shape.ToArray());
+                Assert.True(
+                    ParityMath.Within(
+                        compiledChanged.ToArray(), eagerChanged[outputIndex].ToArray(), op.Fwd, out var delta),
+                    $"{op.Name} output[{outputIndex}]: compiled replay did not reflect live inputs. {delta.Describe()}");
+            }
+        }
+    }
+
+    private static readonly GraphMutationProfile[] MutationProfiles =
+    {
+        GraphMutationProfile.RotateValues,
+        GraphMutationProfile.AlternatingScale,
+        GraphMutationProfile.Affine,
+        GraphMutationProfile.ContractTowardZero,
+        GraphMutationProfile.FirstMutableInput,
+        GraphMutationProfile.SentinelPattern
+    };
+
+    private static GraphMutationProfile SelectMutation(
+        OpCase op,
+        IEngine engine,
+        out float[] eagerChanged)
+    {
+        float[] eagerOriginal = op.RunFloat(engine).ToArray();
+        foreach (GraphMutationProfile candidate in MutationProfiles)
+        {
+            try
+            {
+                using (OpInput.UseGraphMutation(candidate))
+                    eagerChanged = op.RunFloat(engine).ToArray();
+
+                if (eagerOriginal.Length == eagerChanged.Length &&
+                    PreservesFiniteDomain(eagerOriginal, eagerChanged) &&
+                    !ParityMath.BitExact(eagerOriginal, eagerChanged, out _))
+                    return candidate;
+            }
+            catch (ArgumentException)
+            {
+                // This mutation violated an operation-specific input domain. Try the next
+                // deterministic profile; the chosen profile still has to replay exactly.
+            }
+        }
+
+        eagerChanged = eagerOriginal;
+        throw new Xunit.Sdk.XunitException(
+            $"{op.Name}: none of the typed graph mutations changed the eager result. " +
+            "Mark true constants/metadata with a typed GraphCaptureExpectation, or make numeric " +
+            "OpInput.From data explicitly mutable with OpInput.MutableFrom.");
+    }
+
+    private static GraphMutationProfile SelectOutputMutation(
+        OpCase op,
+        IEngine engine,
+        Tensor<float>[] eagerOriginal,
+        out Tensor<float>[] eagerChanged)
+    {
+        foreach (GraphMutationProfile candidate in MutationProfiles)
+        {
+            try
+            {
+                Tensor<float>[] candidateOutputs;
+                using (OpInput.UseGraphMutation(candidate))
+                    candidateOutputs = op.RunFloatOutputs!(engine);
+
+                bool everyOutputSatisfied = eagerOriginal.Length == candidateOutputs.Length;
+                for (int outputIndex = 0;
+                     everyOutputSatisfied && outputIndex < eagerOriginal.Length;
+                     outputIndex++)
+                {
+                    float[] before = eagerOriginal[outputIndex].ToArray();
+                    float[] after = candidateOutputs[outputIndex].ToArray();
+                    bool bitExact = ParityMath.BitExact(before, after, out _);
+                    everyOutputSatisfied = before.Length == after.Length &&
+                        PreservesFiniteDomain(before, after) &&
+                        (OutputDependency(op, outputIndex) == GraphOutputDependency.MutableInput
+                            ? !bitExact
+                            : bitExact);
+                }
+
+                if (everyOutputSatisfied)
+                {
+                    eagerChanged = candidateOutputs;
+                    return candidate;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // See SelectMutation: domain-invalid probes are discarded, never accepted.
+            }
+        }
+
+        eagerChanged = eagerOriginal;
+        throw new Xunit.Sdk.XunitException(
+            $"{op.Name}: no typed graph mutation satisfied every homogeneous output dependency.");
+    }
+
+    private static GraphOutputDependency OutputDependency(OpCase op, int outputIndex)
+    {
+        GraphOutputDependency[]? dependencies = op.GraphOutputDependencies;
+        return dependencies is not null && outputIndex < dependencies.Length
+            ? dependencies[outputIndex]
+            : GraphOutputDependency.MutableInput;
+    }
+
+    private static bool PreservesFiniteDomain(float[] before, float[] after)
+    {
+        for (int i = 0; i < before.Length; i++)
+            if (float.IsFinite(before[i]) && !float.IsFinite(after[i]))
+                return false;
+        return true;
+    }
+
+    private static void VerifyCaptureIsRejected(OpCase op, IEngine engine)
+    {
+        var snapshots = new List<FloatInputSnapshot>();
+        try
+        {
+            using var scope = GraphMode.EnableInference();
+            using var capture = OpInput.CaptureFloatInputSnapshots(snapshots);
+            Tensor<float> output = op.RunFloat(engine);
+            using CompiledInferencePlan<float> unexpected = scope.CompileInference(
+                output,
+                snapshots.Select(snapshot => snapshot.Tensor).ToArray());
+        }
+        catch (NotSupportedException)
+        {
+            return;
+        }
+
+        string captureContract = op.GraphCaptureSignatureConstraint != GraphCaptureSignatureConstraint.None
+            ? $"signature constraint {op.GraphCaptureSignatureConstraint}"
+            : $"capture expectation {op.GraphCaptureExpectation}";
+        throw new Xunit.Sdk.XunitException(
+            $"{op.Name}: {captureContract} must fail closed during inference capture.");
+    }
+
+    private static void VerifyInputIndependentContract(OpCase op, IEngine engine)
+    {
+        float[] baseline = op.RunFloat(engine).ToArray();
+        foreach (GraphMutationProfile mutation in MutationProfiles)
+        {
+            float[] candidate;
+            using (OpInput.UseGraphMutation(mutation))
+                candidate = op.RunFloat(engine).ToArray();
+            Assert.True(
+                ParityMath.BitExact(baseline, candidate, out _),
+                $"{op.Name}: InputIndependent result changed under {mutation}.");
+        }
+
+        var snapshots = new List<FloatInputSnapshot>();
+        using var scope = GraphMode.EnableInference();
+        using var capture = OpInput.CaptureFloatInputSnapshots(snapshots);
+        _ = op.RunFloat(engine);
+        scope.MarkCompiled();
+    }
+
+    private static void VerifyNonDeterministicCaptureIsSafe(OpCase op, IEngine engine)
+    {
+        var snapshots = new List<FloatInputSnapshot>();
+        using var scope = GraphMode.EnableInference();
+        using var capture = OpInput.CaptureFloatInputSnapshots(snapshots);
+        _ = op.RunFloat(engine);
+        scope.MarkCompiled();
+    }
+}
+
+/// <summary>
+/// Generated invariant over the complete parity registry: whenever an operation elects to record
+/// a graph node, the placeholder shape must already equal its eager result shape. This catches
+/// incorrect capture metadata without requiring a hand-maintained list of graph-aware operations.
+/// </summary>
+[Collection("OpParity")]
+public sealed class GraphRecordedOutputShapeTests
+{
+    private static readonly IReadOnlyDictionary<string, OpCase> Cases =
+        OpParityRegistry.All().ToDictionary(o => o.Name);
+
+    public static IEnumerable<object[]> CasesInShard =>
+        OpParityRegistry.All()
+            .Where(o => ParityShard.Include(o.Name))
+            .Select(o => new object[] { o.Name });
+
+    [Theory]
+    [MemberData(nameof(CasesInShard))]
+    public void RecordedOutputShape_MatchesEagerOutput(string opName)
+    {
+        var op = Cases[opName];
+        var engine = new CpuEngine();
+        int[] eagerShape = op.RunFloat(engine).Shape.ToArray();
+
+        Tensor<float> graphOutput;
+        try
+        {
+            using var scope = GraphMode.EnableInference();
+            graphOutput = op.RunFloat(engine);
+
+            // This invariant deliberately inspects capture metadata before execution. Marking the
+            // scope complete prevents a malformed, undersized placeholder from throwing during
+            // Dispose and replacing the more useful shape assertion below.
+            scope.MarkCompiled();
+        }
+        catch (NotSupportedException)
+        {
+            return;
+        }
+
+        if (graphOutput.LazySource is null)
+            return;
+
+        Assert.Equal(eagerShape, graphOutput.Shape.ToArray());
+    }
+}
+
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/IEngineOpInventory.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/IEngineOpInventory.cs
@@ -1,7 +1,7 @@
 // Copyright (c) AiDotNet. All rights reserved.
 // CPU-vs-GPU op-parity scaffold (Tensors #775). Full-surface op enumeration.
 // Reflects the IEngine surface at runtime so the parity scaffold auto-syncs with it — every
-// tensor-returning op is enumerated, and coverage is measured against this ground truth. (A
+// tensor-producing op is enumerated, and coverage is measured against this ground truth. (A
 // Roslyn source generator could emit the same inventory at compile time; reflection gives the
 // identical auto-sync with far less machinery and is the recommended mechanism here.)
 #if !NETFRAMEWORK
@@ -15,12 +15,13 @@ namespace AiDotNet.Tensors.Tests.Engines.OpParity;
 
 public static class IEngineOpInventory
 {
-    /// <summary>Distinct names of every public <see cref="IEngine"/> method that returns a
-    /// <c>Tensor&lt;T&gt;</c> — the op surface the parity scaffold must eventually cover.</summary>
-    public static IReadOnlyList<string> TensorReturningOps() =>
+    /// <summary>Distinct names of every public <see cref="IEngine"/> method that produces a
+    /// tensor through its return value or an out parameter — the op surface the parity scaffold
+    /// must eventually cover.</summary>
+    public static IReadOnlyList<string> TensorProducingOps() =>
         typeof(IEngine)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .Where(IsTensorReturning)
+            .Where(IsTensorProducing)
             .Select(m => m.Name)
             .Distinct(System.StringComparer.Ordinal)
             .OrderBy(n => n, System.StringComparer.Ordinal)
@@ -31,19 +32,24 @@ public static class IEngineOpInventory
     public static int TotalPublicMethodOverloads() =>
         typeof(IEngine).GetMethods(BindingFlags.Public | BindingFlags.Instance).Length;
 
-    private static bool IsTensorReturning(MethodInfo m) => ProducesTensor(m.ReturnType);
+    private static bool IsTensorProducing(MethodInfo method) =>
+        ProducesTensor(method.ReturnType) ||
+        method.GetParameters().Any(parameter => parameter.IsOut && ProducesTensor(parameter.ParameterType));
 
     /// <summary>A return type "produces a tensor" if it is a bare <c>Tensor&lt;T&gt;</c>, an ARRAY of
     /// them (<c>Tensor&lt;T&gt;[]</c>), or a tuple carrying at least one — so multi-output ops like
     /// split / unstack / meshgrid enter the coverage denominator instead of silently hiding parity gaps.</summary>
     private static bool ProducesTensor(System.Type rt)
     {
+        if (rt.IsByRef && rt.GetElementType() is { } referenced) return ProducesTensor(referenced);
         // Tensor<T> reflects as the open/closed generic named "Tensor`1".
         if (rt.IsGenericType && rt.Name == "Tensor`1") return true;
         // Tensor<T>[] (or jagged arrays of tensors).
         if (rt.IsArray && rt.GetElementType() is { } el && ProducesTensor(el)) return true;
         // (Value)Tuple<...> with a tensor in any slot — split/unstack/meshgrid-style multi-returns.
-        if (rt.IsGenericType && rt.FullName is { } fn && fn.StartsWith("System.ValueTuple`", System.StringComparison.Ordinal))
+        if (rt.IsGenericType &&
+            rt.GetGenericTypeDefinition().FullName is { } fn &&
+            fn.StartsWith("System.ValueTuple`", System.StringComparison.Ordinal))
             return rt.GetGenericArguments().Any(ProducesTensor);
         return false;
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpCase.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpCase.cs
@@ -17,6 +17,131 @@ public enum GpuProbeExpectation
 }
 
 /// <summary>
+/// Type-safe classification of readbacks that are inherent in a synchronous public API contract.
+/// This is deliberately semantic rather than operation-name based: fixed-shape tensor results must
+/// remain readback-free, while a host-owned dynamic shape or legacy CLR output may require one
+/// metadata transfer.
+/// </summary>
+public enum GpuReadbackContract
+{
+    None = 0,
+    DynamicResultShape,
+    LegacyHostOutput
+}
+
+/// <summary>
+/// Type-safe graph-capture contract for registry cases. Cases opt into a replay or rejection
+/// contract explicitly; the registry-wide output-shape invariant independently examines every
+/// operation that actually records a node, including cases not yet assessed for live replay.
+/// </summary>
+public enum GraphCaptureExpectation
+{
+    Required = 0,
+    InputIndependent,
+    DataDependentOutputShape,
+    HeterogeneousInput,
+    HeterogeneousOutput,
+    MixedElementTypes,
+    NonDeterministic,
+    HostBoundary,
+    Stateful,
+    BackwardKernel
+}
+
+/// <summary>
+/// Element-type limitation of an IEngine signature. This is independent of execution phase: a
+/// backward kernel can also have heterogeneous inputs, and both facts must remain expressible.
+/// </summary>
+public enum GraphCaptureSignatureConstraint
+{
+    None = 0,
+    HeterogeneousInput,
+    HeterogeneousOutput,
+    MixedElementTypes
+}
+
+/// <summary>Whether an input contains replayable numeric data or fixed structural metadata.</summary>
+public enum GraphInputRole
+{
+    MutableValue = 0,
+    FixedMetadata
+}
+
+/// <summary>Type-safe deterministic probes used to prove that compiled replay reads live inputs.</summary>
+internal enum GraphMutationProfile
+{
+    RotateValues,
+    AlternatingScale,
+    Affine,
+    ContractTowardZero,
+    FirstMutableInput,
+    SentinelPattern
+}
+
+/// <summary>Complete tensor-valued result shape of an <see cref="IEngine"/> operation.</summary>
+public enum TensorOutputContract
+{
+    SingleTensor,
+    HomogeneousMultiple,
+    HeterogeneousMultiple
+}
+
+/// <summary>Type-safe comparison semantics for an individual numeric tensor output.</summary>
+public enum TensorOutputComparison
+{
+    Numeric,
+    WrappedRadians
+}
+
+/// <summary>Whether one homogeneous result is expected to depend on mutable tensor inputs.</summary>
+public enum GraphOutputDependency
+{
+    MutableInput = 0,
+    InputIndependent
+}
+
+internal sealed class FloatInputSnapshot
+{
+    internal Tensor<float> Tensor { get; }
+    internal float[] InitialValues { get; }
+    internal GraphInputRole Role { get; }
+    internal int MutableOrdinal { get; }
+
+    internal FloatInputSnapshot(
+        Tensor<float> tensor,
+        float[] initialValues,
+        GraphInputRole role,
+        int mutableOrdinal)
+    {
+        Tensor = tensor;
+        InitialValues = initialValues;
+        Role = role;
+        MutableOrdinal = mutableOrdinal;
+    }
+}
+
+/// <summary>
+/// Complete result of an operation that mixes floating outputs with typed metadata tensors.
+/// Empty arrays are valid; at least one metadata array must be non-empty for a heterogeneous case.
+/// </summary>
+public sealed class HeterogeneousTensorOutputs<T>
+{
+    public Tensor<T>[] Numeric { get; }
+    public Tensor<int>[] Integers { get; }
+    public Tensor<bool>[] Booleans { get; }
+
+    public HeterogeneousTensorOutputs(
+        Tensor<T>[] numeric,
+        Tensor<int>[]? integers = null,
+        Tensor<bool>[]? booleans = null)
+    {
+        Numeric = numeric ?? throw new ArgumentNullException(nameof(numeric));
+        Integers = integers ?? Array.Empty<Tensor<int>>();
+        Booleans = booleans ?? Array.Empty<Tensor<bool>>();
+    }
+}
+
+/// <summary>
 /// A deterministic tensor input shared between the float run, the GPU float run, and the double
 /// ORACLE run. The SAME numeric samples (generated once as double[]) feed all three, so any
 /// difference is the op's numerics — not the input. <see cref="F"/> materializes a fresh
@@ -28,10 +153,22 @@ public sealed class OpInput
     [ThreadStatic]
     private static List<Tensor<float>>? s_floatInputCapture;
 
+    [ThreadStatic]
+    private static List<FloatInputSnapshot>? s_floatInputSnapshotCapture;
+
+    [ThreadStatic]
+    private static GraphMutationContext? s_graphMutation;
+
     private readonly double[] _data;
+    private readonly GraphInputRole _graphInputRole;
     public int[] Shape { get; }
 
-    private OpInput(double[] data, int[] shape) { _data = data; Shape = shape; }
+    private OpInput(double[] data, int[] shape, GraphInputRole graphInputRole)
+    {
+        _data = data;
+        Shape = shape;
+        _graphInputRole = graphInputRole;
+    }
 
     /// <summary>Uniform samples in [lo, hi] from a fixed seed. Deterministic across runs/engines.</summary>
     public static OpInput Rand(int seed, int[] shape, double lo = -1.0, double hi = 1.0)
@@ -42,7 +179,7 @@ public sealed class OpInput
         var rng = new Random(seed);
         var data = new double[n];
         for (int i = 0; i < n; i++) data[i] = lo + rng.NextDouble() * (hi - lo);
-        return new OpInput(data, (int[])shape.Clone());
+        return new OpInput(data, (int[])shape.Clone(), GraphInputRole.MutableValue);
     }
 
     [ThreadStatic]
@@ -75,9 +212,9 @@ public sealed class OpInput
     /// failing, and reports the count, so the gap stays visible instead of silently passing.
     /// </para>
     /// <para>
-    /// Only <see cref="Rand"/> and <see cref="RandPositive"/> are rewritten. <see cref="From"/>
-    /// carries structured values — indices, masks, permutations — whose length and meaning are tied
-    /// to the exact shape the spec chose, so resizing it would produce nonsense rather than coverage.
+    /// Only <see cref="Rand"/> and <see cref="RandPositive"/> are rewritten. Explicit-value inputs
+    /// carry values whose length and meaning are tied to the exact shape the spec chose, so resizing
+    /// them would produce nonsense rather than coverage.
     /// </para>
     /// </remarks>
     internal static IDisposable UseShapePolicy(Func<int[], int[]> policy)
@@ -117,15 +254,51 @@ public sealed class OpInput
     public static OpInput RandPositive(int seed, int[] shape, double lo = 0.1, double hi = 4.0)
         => Rand(seed, shape, lo, hi);
 
-    /// <summary>Explicit data (row-major) — for ops needing structured values (indices, masks).</summary>
-    public static OpInput From(double[] data, int[] shape) => new OpInput((double[])data.Clone(), shape);
+    /// <summary>Explicit mutable numeric data in row-major order.</summary>
+    public static OpInput From(double[] data, int[] shape)
+        => new OpInput((double[])data.Clone(), shape, GraphInputRole.MutableValue);
+
+    /// <summary>
+    /// Explicit structural metadata encoded in the operation's numeric element type. Graph probes
+    /// preserve these values exactly; use this only for indices, masks, and fixed selectors.
+    /// </summary>
+    public static OpInput FixedFrom(double[] data, int[] shape)
+        => new OpInput((double[])data.Clone(), shape, GraphInputRole.FixedMetadata);
+
+    /// <summary>
+    /// Explicit alias that emphasizes that graph replay probes may transform these numeric values.
+    /// </summary>
+    public static OpInput MutableFrom(double[] data, int[] shape)
+        => From(data, shape);
 
     public Tensor<float> F()
     {
-        var f = new float[_data.Length];
-        for (int i = 0; i < _data.Length; i++) f[i] = (float)_data[i];
+        var initial = new float[_data.Length];
+        for (int i = 0; i < _data.Length; i++)
+            initial[i] = (float)_data[i];
+
+        int mutableOrdinal = -1;
+        if (_graphInputRole == GraphInputRole.MutableValue)
+        {
+            if (s_graphMutation is not null)
+                mutableOrdinal = s_graphMutation.NextMutableOrdinal++;
+            else if (s_floatInputSnapshotCapture is not null)
+            {
+                mutableOrdinal = 0;
+                for (int i = 0; i < s_floatInputSnapshotCapture.Count; i++)
+                    if (s_floatInputSnapshotCapture[i].Role == GraphInputRole.MutableValue)
+                        mutableOrdinal++;
+            }
+        }
+
+        var f = (float[])initial.Clone();
+        if (s_graphMutation is not null && mutableOrdinal >= 0)
+            ApplyGraphMutation(f, initial, s_graphMutation.Profile, mutableOrdinal);
+
         var tensor = new Tensor<float>(f, (int[])Shape.Clone());
         s_floatInputCapture?.Add(tensor);
+        s_floatInputSnapshotCapture?.Add(
+            new FloatInputSnapshot(tensor, initial, _graphInputRole, mutableOrdinal));
         return tensor;
     }
 
@@ -142,6 +315,58 @@ public sealed class OpInput
         return new FloatInputCaptureScope(previous);
     }
 
+    internal static IDisposable CaptureFloatInputSnapshots(List<FloatInputSnapshot> destination)
+    {
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        var previous = s_floatInputSnapshotCapture;
+        s_floatInputSnapshotCapture = destination;
+        return new FloatInputSnapshotCaptureScope(previous);
+    }
+
+    internal static IDisposable UseGraphMutation(GraphMutationProfile profile)
+    {
+        var previous = s_graphMutation;
+        s_graphMutation = new GraphMutationContext(profile);
+        return new GraphMutationScope(previous);
+    }
+
+    internal static void ApplyGraphMutation(
+        float[] destination,
+        float[] source,
+        GraphMutationProfile profile,
+        int mutableOrdinal)
+    {
+        for (int i = 0; i < destination.Length; i++)
+        {
+            float value = source[i];
+            destination[i] = profile switch
+            {
+                GraphMutationProfile.RotateValues =>
+                    source.Length == 0 ? value : source[(i + 1) % source.Length],
+                GraphMutationProfile.AlternatingScale =>
+                    value * ((i & 1) == 0 ? 0.625f : 1.375f),
+                GraphMutationProfile.Affine =>
+                    value * 1.125f + 0.0625f + (i % 5) * 0.0078125f,
+                GraphMutationProfile.ContractTowardZero => value * 0.5f,
+                GraphMutationProfile.FirstMutableInput => mutableOrdinal == 0
+                    ? value * 0.75f + 0.25f + (i % 3) * 0.125f
+                    : value,
+                GraphMutationProfile.SentinelPattern => (i % 3) == 0
+                    ? 0.5f
+                    : value * 0.875f - 0.125f,
+                _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, null)
+            };
+        }
+    }
+
+    private sealed class GraphMutationContext
+    {
+        internal GraphMutationProfile Profile { get; }
+        internal int NextMutableOrdinal { get; set; }
+
+        internal GraphMutationContext(GraphMutationProfile profile) => Profile = profile;
+    }
+
     private sealed class FloatInputCaptureScope : IDisposable
     {
         private List<Tensor<float>>? _previous;
@@ -151,6 +376,32 @@ public sealed class OpInput
         public void Dispose()
         {
             s_floatInputCapture = _previous;
+            _previous = null;
+        }
+    }
+
+    private sealed class FloatInputSnapshotCaptureScope : IDisposable
+    {
+        private List<FloatInputSnapshot>? _previous;
+
+        internal FloatInputSnapshotCaptureScope(List<FloatInputSnapshot>? previous) => _previous = previous;
+
+        public void Dispose()
+        {
+            s_floatInputSnapshotCapture = _previous;
+            _previous = null;
+        }
+    }
+
+    private sealed class GraphMutationScope : IDisposable
+    {
+        private GraphMutationContext? _previous;
+
+        internal GraphMutationScope(GraphMutationContext? previous) => _previous = previous;
+
+        public void Dispose()
+        {
+            s_graphMutation = _previous;
             _previous = null;
         }
     }
@@ -201,6 +452,53 @@ public sealed class OpCase
     public Func<IEngine, Tensor<double>> RunDouble { get; }
     public ParityTol Fwd { get; }
 
+    /// <summary>
+    /// Complete tensor-valued result contract for operations with multiple homogeneous outputs.
+    /// The ordinary delegates remain the primary output used by coverage/residency probes; these
+    /// delegates prevent auxiliary outputs or backward gradients from being silently discarded.
+    /// </summary>
+    public Func<IEngine, Tensor<float>[]>? RunFloatOutputs { get; init; }
+    public Func<IEngine, Tensor<double>[]>? RunDoubleOutputs { get; init; }
+    public bool HasMultipleOutputs => RunFloatOutputs is not null && RunDoubleOutputs is not null;
+
+    public Func<IEngine, HeterogeneousTensorOutputs<float>>? RunFloatHeterogeneousOutputs { get; init; }
+    public Func<IEngine, HeterogeneousTensorOutputs<double>>? RunDoubleHeterogeneousOutputs { get; init; }
+    public bool HasHeterogeneousOutputs =>
+        RunFloatHeterogeneousOutputs is not null && RunDoubleHeterogeneousOutputs is not null;
+
+    /// <summary>
+    /// Typed declaration of whether the operation returns one tensor, multiple tensors of the
+    /// generic element type, or a heterogeneous tuple such as values plus integer indices.
+    /// </summary>
+    public TensorOutputContract TensorOutputContract { get; init; }
+
+    /// <summary>
+    /// Generated overload identity. Required only when an IEngine method has more than one
+    /// multi-output overload; the default cannot satisfy an overload-specific invariant.
+    /// </summary>
+    public TensorOutputOverload TensorOutputOverload { get; init; }
+
+    /// <summary>
+    /// Generated overload identity for an IEngine signature that mixes tensor element types.
+    /// Required when the method name is overloaded so a classification cannot be satisfied by a
+    /// case exercising a different overload.
+    /// </summary>
+    public GraphCaptureSignatureOverload GraphCaptureSignatureOverload { get; init; }
+
+    public GraphCaptureSignatureConstraint GraphCaptureSignatureConstraint { get; internal set; }
+
+    /// <summary>
+    /// Per-output graph dependency contract. Omitted entries default to
+    /// <see cref="GraphOutputDependency.MutableInput"/>.
+    /// </summary>
+    public GraphOutputDependency[]? GraphOutputDependencies { get; init; }
+
+    /// <summary>
+    /// Optional per-numeric-output semantics. Omitted entries use ordinary numeric comparison;
+    /// when supplied, the list must describe every numeric output in order.
+    /// </summary>
+    public IReadOnlyList<TensorOutputComparison>? TensorOutputComparisons { get; init; }
+
     public Func<IEngine, Tensor<float>>? RunFloatGrad { get; }
     public Func<IEngine, Tensor<double>>? RunDoubleGrad { get; }
     public ParityTol BwdTol { get; }
@@ -227,6 +525,29 @@ public sealed class OpCase
     /// </summary>
     public GpuProbeExpectation GpuProbeExpectation { get; init; }
 
+    /// <summary>Graph-capture behavior required by the generated live-input replay sweep.
+    /// Forward capture is the fail-closed default; non-forward contracts must opt out explicitly.</summary>
+    private GraphCaptureExpectation _graphCaptureExpectation = GraphCaptureExpectation.Required;
+
+    public GraphCaptureExpectation GraphCaptureExpectation
+    {
+        get => _graphCaptureExpectation;
+        internal set
+        {
+            _graphCaptureExpectation = value;
+            GraphCaptureSignatureConstraint inferred = value switch
+            {
+                GraphCaptureExpectation.HeterogeneousInput => GraphCaptureSignatureConstraint.HeterogeneousInput,
+                GraphCaptureExpectation.HeterogeneousOutput => GraphCaptureSignatureConstraint.HeterogeneousOutput,
+                GraphCaptureExpectation.MixedElementTypes => GraphCaptureSignatureConstraint.MixedElementTypes,
+                _ => GraphCaptureSignatureConstraint.None
+            };
+            if (inferred != GraphCaptureSignatureConstraint.None &&
+                GraphCaptureSignatureConstraint == GraphCaptureSignatureConstraint.None)
+                GraphCaptureSignatureConstraint = inferred;
+        }
+    }
+
     /// <summary>
     /// Minimum dispatches required before the residency probe accepts this case as GPU-covered.
     /// Cases that project a non-floating or multi-output result through another GPU primitive use
@@ -239,13 +560,28 @@ public sealed class OpCase
     public string? GpuHostContractReason { get; init; }
 
     /// <summary>
-    /// Number of readbacks inherent in the current synchronous public contract. Tensor-valued
+    /// Typed public-contract reason for an unavoidable metadata transfer. Tensor-valued
     /// alternatives must use separate zero-readback registry cases.
     /// </summary>
-    public int GpuAllowedReadbacks { get; init; }
+    public GpuReadbackContract GpuReadbackContract { get; init; }
 
-    /// <summary>Required contract-level justification for every nonzero readback allowance.</summary>
-    public string? GpuReadbackReason { get; init; }
+    public int GpuAllowedReadbacks => GpuReadbackContract switch
+    {
+        GpuReadbackContract.None => 0,
+        GpuReadbackContract.DynamicResultShape => 1,
+        GpuReadbackContract.LegacyHostOutput => 1,
+        _ => throw new InvalidOperationException($"Unknown GPU readback contract: {GpuReadbackContract}.")
+    };
+
+    public string GpuReadbackDescription => GpuReadbackContract switch
+    {
+        GpuReadbackContract.None => "No internal readback is permitted.",
+        GpuReadbackContract.DynamicResultShape =>
+            "One metadata transfer is required to construct the synchronous host-owned Tensor.Shape.",
+        GpuReadbackContract.LegacyHostOutput =>
+            "One transfer is required by the legacy host-owned output; a tensor-valued overload is the resident alternative.",
+        _ => throw new InvalidOperationException($"Unknown GPU readback contract: {GpuReadbackContract}.")
+    };
 
     public OpCase(
         string name, string category,
@@ -256,7 +592,10 @@ public sealed class OpCase
         Func<IEngine, Tensor<double>>? runDoubleGrad = null,
         ParityTol bwdTol = default,
         string? opMethod = null,
-        int gpuMinimumKernelLaunches = 1)
+        int gpuMinimumKernelLaunches = 1,
+        GraphCaptureExpectation graphCaptureExpectation = GraphCaptureExpectation.Required,
+        GraphCaptureSignatureConstraint graphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.None,
+        GraphCaptureSignatureOverload graphCaptureSignatureOverload = GraphCaptureSignatureOverload.Unspecified)
     {
         Name = name;
         // Default the covered op method to the leading identifier of the display name
@@ -270,6 +609,10 @@ public sealed class OpCase
         RunDoubleGrad = runDoubleGrad;
         BwdTol = bwdTol;
         GpuMinimumKernelLaunches = gpuMinimumKernelLaunches;
+        GraphCaptureExpectation = graphCaptureExpectation;
+        if (graphCaptureSignatureConstraint != GraphCaptureSignatureConstraint.None)
+            GraphCaptureSignatureConstraint = graphCaptureSignatureConstraint;
+        GraphCaptureSignatureOverload = graphCaptureSignatureOverload;
     }
 
     private static string LeadingIdentifier(string name)

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityCoverageTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.OpParity;
 
 /// <summary>
-/// Enumerates the ENTIRE tensor-returning IEngine op surface and audits how much of it the parity
+/// Enumerates the ENTIRE tensor-producing IEngine op surface and audits how much of it the parity
 /// registry covers, writing a coverage report (covered / pending lists + %). This is the "scaffold
 /// for all operations" spine: it makes full-surface coverage measurable and forces every registry
 /// entry to name a real IEngine op, so the registry can grow toward 100% with the gaps always visible.
@@ -20,17 +20,17 @@ namespace AiDotNet.Tensors.Tests.Engines.OpParity;
 [Collection("OpParity")]
 public sealed class OpParityCoverageTests
 {
-    /// <summary>Every registry OpMethod must be a real tensor-returning IEngine op — guards typos and
+    /// <summary>Every registry OpMethod must be a real tensor-producing IEngine op — guards typos and
     /// stale specs, and keeps the coverage denominator honest.</summary>
     [Fact]
     public void EveryRegistryCase_NamesARealIEngineOp()
     {
-        var inventory = IEngineOpInventory.TensorReturningOps().ToHashSet(StringComparer.Ordinal);
+        var inventory = IEngineOpInventory.TensorProducingOps().ToHashSet(StringComparer.Ordinal);
         foreach (var op in OpParityRegistry.All())
         {
             Assert.True(inventory.Contains(op.OpMethod),
                 $"OpCase '{op.Name}' claims to cover IEngine op '{op.OpMethod}', which is not a " +
-                $"tensor-returning IEngine method (typo, or it returns something other than Tensor<T>).");
+                $"tensor-producing IEngine method (typo, or it has no tensor return/out value).");
         }
     }
 
@@ -40,7 +40,7 @@ public sealed class OpParityCoverageTests
     [Fact]
     public void FullSurface_CoverageReport()
     {
-        var inventory = IEngineOpInventory.TensorReturningOps();
+        var inventory = IEngineOpInventory.TensorProducingOps();
         var covered = OpParityRegistry.All()
             .Select(o => o.OpMethod)
             .Distinct(StringComparer.Ordinal)
@@ -74,7 +74,7 @@ public sealed class OpParityCoverageTests
             var sb = new StringBuilder();
             double pct = inventory.Count == 0 ? 0 : 100.0 * covered.Count / inventory.Count;
             sb.AppendLine($"# CPU-vs-GPU op-parity coverage (#775)");
-            sb.AppendLine($"tensor-returning IEngine ops : {inventory.Count}");
+            sb.AppendLine($"tensor-producing IEngine ops : {inventory.Count}");
             sb.AppendLine($"covered by parity registry   : {covered.Count} ({pct:F1}%)");
             sb.AppendLine($"total public IEngine overloads: {IEngineOpInventory.TotalPublicMethodOverloads()}");
             sb.AppendLine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityHarness.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityHarness.cs
@@ -195,6 +195,206 @@ public static class OpParityHarness
         AssertResults("backward", op, fx, cpuF, cpuF2, gpuF, gpuF2, oracleD, op.BwdTol);
     }
 
+    public static void CheckMultipleOutputs(OpCase op, OpParityFixture fx)
+    {
+        if (!op.HasMultipleOutputs)
+        {
+            Skip.If(true, $"{op.Name}: no multi-output contract registered.");
+            return;
+        }
+
+        if (!fx.GpuReady)
+        {
+            if (fx.RequireGpu)
+                throw new InvalidOperationException(
+                    $"{op.Name}: GPU required (AIDOTNET_REQUIRE_GPU_TESTS=1) but no DirectGpu backend is available.", fx.GpuInitError);
+            Skip.If(true, "No DirectGpu backend (CUDA/OpenCL/HIP) available on this system.");
+            return;
+        }
+
+        if (op.GpuUnsafe)
+        {
+            fx.Record($"{op.Name}:outputs\t{op.Category}\tGPU-UNSAFE\t-\t-\t-");
+            Skip.If(true, $"GPU-UNSAFE ({op.Name} outputs): {op.KnownDivergence ?? "GPU kernel crashes/poisons the host"}. GPU execution skipped so it can't crash the run.");
+            return;
+        }
+
+        MaybeResetGpuEngine(fx);
+        var gpu = fx.Gpu!;
+
+        Tensor<float>[] cpu = op.RunFloatOutputs!(fx.Cpu);
+        Tensor<float>[] cpuAgain = op.RunFloatOutputs!(fx.Cpu);
+        Tensor<float>[] gpuResults = op.RunFloatOutputs!(gpu);
+        Tensor<float>[] gpuAgain = op.RunFloatOutputs!(gpu);
+        Tensor<double>[] oracle = op.RunDoubleOutputs!(fx.Cpu);
+
+        Assert.True(cpu.Length > 1, $"{op.Name}: a multi-output contract must expose at least two outputs.");
+        Assert.Equal(cpu.Length, cpuAgain.Length);
+        Assert.Equal(cpu.Length, gpuResults.Length);
+        Assert.Equal(cpu.Length, gpuAgain.Length);
+        Assert.Equal(cpu.Length, oracle.Length);
+
+        if (op.TensorOutputComparisons is { } outputComparisons)
+            Assert.Equal(cpu.Length, outputComparisons.Count);
+
+        for (int i = 0; i < cpu.Length; i++)
+        {
+            Assert.NotNull(cpu[i]);
+            Assert.NotNull(cpuAgain[i]);
+            Assert.NotNull(gpuResults[i]);
+            Assert.NotNull(gpuAgain[i]);
+            Assert.NotNull(oracle[i]);
+            Assert.Equal(cpu[i].Shape.ToArray(), cpuAgain[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), gpuResults[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), gpuAgain[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), oracle[i].Shape.ToArray());
+
+            TensorOutputComparison comparison = op.TensorOutputComparisons?[i] ?? TensorOutputComparison.Numeric;
+            if (comparison == TensorOutputComparison.WrappedRadians)
+            {
+                AssertWrappedRadiansResults(
+                    $"output[{i}]", op, fx,
+                    cpu[i].ToArray(), cpuAgain[i].ToArray(),
+                    gpuResults[i].ToArray(), gpuAgain[i].ToArray(),
+                    oracle[i].ToArray(), op.Fwd);
+            }
+            else
+            {
+                AssertResults(
+                    $"output[{i}]", op, fx,
+                    cpu[i].ToArray(), cpuAgain[i].ToArray(),
+                    gpuResults[i].ToArray(), gpuAgain[i].ToArray(),
+                    oracle[i].ToArray(), op.Fwd);
+            }
+        }
+    }
+
+    public static void CheckHeterogeneousOutputs(OpCase op, OpParityFixture fx)
+    {
+        if (!op.HasHeterogeneousOutputs)
+        {
+            Skip.If(true, $"{op.Name}: no heterogeneous output contract registered.");
+            return;
+        }
+
+        if (!fx.GpuReady)
+        {
+            if (fx.RequireGpu)
+                throw new InvalidOperationException(
+                    $"{op.Name}: GPU required (AIDOTNET_REQUIRE_GPU_TESTS=1) but no DirectGpu backend is available.", fx.GpuInitError);
+            Skip.If(true, "No DirectGpu backend (CUDA/OpenCL/HIP) available on this system.");
+            return;
+        }
+
+        if (op.GpuUnsafe)
+        {
+            fx.Record($"{op.Name}:outputs\t{op.Category}\tGPU-UNSAFE\t-\t-\t-");
+            Skip.If(true, $"GPU-UNSAFE ({op.Name} outputs): {op.KnownDivergence ?? "GPU kernel crashes/poisons the host"}.");
+            return;
+        }
+
+        MaybeResetGpuEngine(fx);
+        var gpu = fx.Gpu!;
+        var cpu = op.RunFloatHeterogeneousOutputs!(fx.Cpu);
+        var cpuAgain = op.RunFloatHeterogeneousOutputs!(fx.Cpu);
+        var gpuResults = op.RunFloatHeterogeneousOutputs!(gpu);
+        var gpuAgain = op.RunFloatHeterogeneousOutputs!(gpu);
+        var oracle = op.RunDoubleHeterogeneousOutputs!(fx.Cpu);
+
+        Assert.True(cpu.Integers.Length + cpu.Booleans.Length > 0,
+            $"{op.Name}: a heterogeneous contract must expose typed metadata outputs.");
+        Assert.Equal(cpu.Numeric.Length, cpuAgain.Numeric.Length);
+        Assert.Equal(cpu.Numeric.Length, gpuResults.Numeric.Length);
+        Assert.Equal(cpu.Numeric.Length, gpuAgain.Numeric.Length);
+        Assert.Equal(cpu.Numeric.Length, oracle.Numeric.Length);
+        for (int i = 0; i < cpu.Numeric.Length; i++)
+        {
+            Assert.Equal(cpu.Numeric[i].Shape.ToArray(), cpuAgain.Numeric[i].Shape.ToArray());
+            Assert.Equal(cpu.Numeric[i].Shape.ToArray(), gpuResults.Numeric[i].Shape.ToArray());
+            Assert.Equal(cpu.Numeric[i].Shape.ToArray(), gpuAgain.Numeric[i].Shape.ToArray());
+            Assert.Equal(cpu.Numeric[i].Shape.ToArray(), oracle.Numeric[i].Shape.ToArray());
+            AssertResults(
+                $"numeric-output[{i}]", op, fx,
+                cpu.Numeric[i].ToArray(), cpuAgain.Numeric[i].ToArray(),
+                gpuResults.Numeric[i].ToArray(), gpuAgain.Numeric[i].ToArray(),
+                oracle.Numeric[i].ToArray(), op.Fwd);
+        }
+
+        AssertExactMetadata(op, "integer", cpu.Integers, cpuAgain.Integers, gpuResults.Integers, gpuAgain.Integers, oracle.Integers);
+        AssertExactMetadata(op, "boolean", cpu.Booleans, cpuAgain.Booleans, gpuResults.Booleans, gpuAgain.Booleans, oracle.Booleans);
+    }
+
+    private static void AssertExactMetadata<TMetadata>(
+        OpCase op,
+        string kind,
+        Tensor<TMetadata>[] cpu,
+        Tensor<TMetadata>[] cpuAgain,
+        Tensor<TMetadata>[] gpu,
+        Tensor<TMetadata>[] gpuAgain,
+        Tensor<TMetadata>[] oracle)
+    {
+        Assert.Equal(cpu.Length, cpuAgain.Length);
+        Assert.Equal(cpu.Length, gpu.Length);
+        Assert.Equal(cpu.Length, gpuAgain.Length);
+        Assert.Equal(cpu.Length, oracle.Length);
+        for (int i = 0; i < cpu.Length; i++)
+        {
+            Assert.Equal(cpu[i].Shape.ToArray(), cpuAgain[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), gpu[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), gpuAgain[i].Shape.ToArray());
+            Assert.Equal(cpu[i].Shape.ToArray(), oracle[i].Shape.ToArray());
+            Assert.Equal(cpu[i].ToArray(), cpuAgain[i].ToArray());
+            Assert.Equal(cpu[i].ToArray(), gpu[i].ToArray());
+            Assert.Equal(cpu[i].ToArray(), gpuAgain[i].ToArray());
+            Assert.Equal(cpu[i].ToArray(), oracle[i].ToArray());
+            _ = kind;
+        }
+    }
+
+    private static void AssertWrappedRadiansResults(
+        string phase, OpCase op, OpParityFixture fx,
+        float[] cpu, float[] cpuAgain, float[] gpu, float[] gpuAgain, double[] oracle, ParityTol tolerance)
+    {
+        Assert.True(cpu.Length == cpuAgain.Length && cpu.Length == gpu.Length &&
+                    cpu.Length == gpuAgain.Length && cpu.Length == oracle.Length,
+            $"{op.Name} {phase}: wrapped-radian output lengths differ.");
+
+        double allowed = Math.Max(tolerance.AbsFloor, tolerance.Rel);
+        Assert.True(allowed > 0.0,
+            $"{op.Name} {phase}: wrapped-radian comparison requires a positive absolute or relative tolerance.");
+
+        double maxCpuGpu = 0.0;
+        double maxCpuOracle = 0.0;
+        double maxGpuOracle = 0.0;
+        int worstIndex = -1;
+        for (int i = 0; i < cpu.Length; i++)
+        {
+            Assert.False(float.IsNaN(cpu[i]) || float.IsInfinity(cpu[i]), $"{op.Name} {phase}: CPU non-finite {cpu[i]} @[{i}]");
+            Assert.False(float.IsNaN(gpu[i]) || float.IsInfinity(gpu[i]), $"{op.Name} {phase}: GPU non-finite {gpu[i]} @[{i}]");
+            Assert.False(double.IsNaN(oracle[i]) || double.IsInfinity(oracle[i]), $"{op.Name} {phase}: oracle non-finite {oracle[i]} @[{i}]");
+
+            double cpuGpu = WrappedRadiansDistance(cpu[i], gpu[i]);
+            double cpuOracle = WrappedRadiansDistance(cpu[i], oracle[i]);
+            double gpuOracle = WrappedRadiansDistance(gpu[i], oracle[i]);
+            if (cpuGpu > maxCpuGpu) { maxCpuGpu = cpuGpu; worstIndex = i; }
+            if (cpuOracle > maxCpuOracle) maxCpuOracle = cpuOracle;
+            if (gpuOracle > maxGpuOracle) maxGpuOracle = gpuOracle;
+        }
+
+        Assert.True(ParityMath.BitExact(cpu, cpuAgain, out int cpuDifference),
+            $"{op.Name} {phase}: CPU is nondeterministic — differs at [{cpuDifference}] across identical runs.");
+        Assert.True(ParityMath.BitExact(gpu, gpuAgain, out int gpuDifference),
+            $"{op.Name} {phase}: GPU is nondeterministic — differs at [{gpuDifference}] across identical runs.");
+
+        fx.Record($"{op.Name}:{phase}\t{op.Category}\twrapped-radians\t{maxCpuGpu:R}\t{worstIndex}");
+        Assert.True(maxCpuGpu <= allowed,
+            $"{op.Name} {phase}: circular phase distance {maxCpuGpu:E3} rad exceeded {allowed:E3} rad at [{worstIndex}]. " +
+            $"Oracle circular drift — CPU {maxCpuOracle:E3} rad, GPU {maxGpuOracle:E3} rad.");
+    }
+
+    private static double WrappedRadiansDistance(double left, double right) =>
+        Math.Abs(Math.IEEERemainder(left - right, 2.0 * Math.PI));
+
     private static void AssertResults(
         string phase, OpCase op, OpParityFixture fx,
         float[] cpuF, float[] cpuF2, float[] gpuF, float[] gpuF2, double[] oracleD, ParityTol tol)

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
@@ -25,7 +25,9 @@ public static class OpParityRegistry
         .Concat(NormConvBackward()).Concat(StackIndexEmbed()).Concat(FusedLinAffine()).Concat(GluCropSoftmaxBwd())
         .Concat(MoreBackward()).Concat(AudioFftSplat()).Concat(GeometryNerf()).Concat(FusedRoiLoss())
         .Concat(Conv3DBoxIou()).Concat(SortConvInterp()).Concat(AttentionFused())
-        .Concat(ScalarShapePad()).Concat(ComplexReal()).Concat(TensorMathBatch())
+        .Concat(ScalarShapePad())
+        .Concat(WithGraphExpectation(ComplexReal(), GraphCaptureExpectation.MixedElementTypes))
+        .Concat(TensorMathBatch())
         .Concat(FusedConvMlp()).Concat(GatherScatterPool()).Concat(SdpaScatterUnique())
         .Concat(RecurrentScans()).Concat(MoreScansComplex()).Concat(AudioSpectral())
         .Concat(ReduceBackwardMisc()).Concat(DeformMesh()).Concat(DeformGridScatterBwd())
@@ -36,42 +38,952 @@ public static class OpParityRegistry
         .Concat(ShBwdCtcSpectralBatch()).Concat(MaxPoolBwdAudio()).Concat(FoldReorderUnique())
         .Concat(ConjReorderNdIfft()).Concat(MaskedSelectScatter()).Concat(IrfftBatch())
         .Concat(ResidentLayoutEmbeddingHashBackward()).Concat(DeterministicPendingAudio())
-        .Concat(NativeComplexPending()).Concat(TensorPredicatePending()).Concat(MultiOutputPending())
-        .Concat(IntegerIndexPending()).Concat(DeterministicDiscretePending())
-        .Concat(RandomAndHostContractPending());
+        .Concat(WithGraphExpectation(NativeComplexPending(), GraphCaptureExpectation.MixedElementTypes))
+        .Concat(WithGraphExpectation(TensorPredicatePending(), GraphCaptureExpectation.MixedElementTypes))
+        .Concat(WithGraphExpectation(IntegerIndexPending(), GraphCaptureExpectation.MixedElementTypes))
+        .Concat(WithGraphExpectation(DeterministicDiscretePending(), GraphCaptureExpectation.MixedElementTypes))
+        .Concat(RandomAndHostContractPending()).Concat(OutputContractCases());
+
+    private static IEnumerable<OpCase> WithGraphExpectation(
+        IEnumerable<OpCase> cases,
+        GraphCaptureExpectation expectation)
+    {
+        foreach (OpCase op in cases)
+        {
+            op.GraphCaptureExpectation = expectation;
+            yield return op;
+        }
+    }
+
+    private static OpCase HomogeneousOutputCase(
+        string name,
+        string category,
+        string opMethod,
+        Func<IEngine, Tensor<float>[]> runFloat,
+        Func<IEngine, Tensor<double>[]> runDouble,
+        ParityTol tolerance,
+        GraphCaptureExpectation graphCaptureExpectation = GraphCaptureExpectation.Required,
+        TensorOutputComparison[]? outputComparisons = null,
+        GraphOutputDependency[]? graphOutputDependencies = null,
+        TensorOutputOverload outputOverload = TensorOutputOverload.Unspecified,
+        GraphCaptureSignatureConstraint graphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.None,
+        GraphCaptureSignatureOverload graphCaptureSignatureOverload = GraphCaptureSignatureOverload.Unspecified)
+    {
+        var op = new OpCase(
+            name,
+            category,
+            engine => ProjectMany(engine, runFloat(engine)),
+            engine => ProjectMany(engine, runDouble(engine)),
+            tolerance,
+            opMethod: opMethod,
+            gpuMinimumKernelLaunches: 2)
+        {
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = runFloat,
+            RunDoubleOutputs = runDouble,
+            GraphCaptureExpectation = graphCaptureExpectation,
+            GraphCaptureSignatureOverload = graphCaptureSignatureOverload,
+            TensorOutputComparisons = outputComparisons,
+            GraphOutputDependencies = graphOutputDependencies,
+            TensorOutputOverload = outputOverload
+        };
+        if (graphCaptureSignatureConstraint != GraphCaptureSignatureConstraint.None)
+            op.GraphCaptureSignatureConstraint = graphCaptureSignatureConstraint;
+        return op;
+    }
+
+    private static OpCase HeterogeneousOutputCase(
+        string name,
+        string category,
+        string opMethod,
+        Func<IEngine, HeterogeneousTensorOutputs<float>> runFloat,
+        Func<IEngine, HeterogeneousTensorOutputs<double>> runDouble,
+        ParityTol tolerance,
+        GraphCaptureExpectation graphCaptureExpectation = GraphCaptureExpectation.HeterogeneousOutput,
+        GraphCaptureSignatureConstraint graphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.None,
+        GpuReadbackContract gpuReadbackContract = GpuReadbackContract.None)
+    {
+        var op = new OpCase(
+            name,
+            category,
+            engine => runFloat(engine).Numeric[0],
+            engine => runDouble(engine).Numeric[0],
+            tolerance,
+            opMethod: opMethod)
+        {
+            TensorOutputContract = TensorOutputContract.HeterogeneousMultiple,
+            RunFloatHeterogeneousOutputs = runFloat,
+            RunDoubleHeterogeneousOutputs = runDouble,
+            GraphCaptureExpectation = graphCaptureExpectation,
+            GpuReadbackContract = gpuReadbackContract
+        };
+        if (graphCaptureSignatureConstraint != GraphCaptureSignatureConstraint.None)
+            op.GraphCaptureSignatureConstraint = graphCaptureSignatureConstraint;
+        return op;
+    }
+
+    public static IEnumerable<OpCase> OutputContractCases() =>
+        OutputContractShapeCases()
+            .Concat(OutputContractNormalizationCases())
+            .Concat(OutputContractBackwardCases())
+            .Concat(OutputContractSignalCases())
+            .Concat(OutputContractGeometryCases())
+            .Concat(OutputContractIndexCases());
+
+    private static IEnumerable<OpCase> OutputContractShapeCases()
+    {
+        var split = OpInput.Rand(7000, new[] { 4, 6 });
+        yield return HomogeneousOutputCase("TensorSplit[all-outputs]", "shape", "TensorSplit",
+            e => e.TensorSplit(split.F(), 3, 1),
+            e => e.TensorSplit(split.D(), 3, 1), ParityTol.Exact);
+        yield return HomogeneousOutputCase("TensorHSplit[all-outputs]", "shape", "TensorHSplit",
+            e => e.TensorHSplit(split.F(), 3),
+            e => e.TensorHSplit(split.D(), 3), ParityTol.Exact);
+
+        var uneven = OpInput.Rand(7001, new[] { 4, 7 });
+        yield return HomogeneousOutputCase("TensorTensorSplit[all-outputs]", "shape", "TensorTensorSplit",
+            e => e.TensorTensorSplit(uneven.F(), 3, 1),
+            e => e.TensorTensorSplit(uneven.D(), 3, 1), ParityTol.Exact,
+            outputOverload: TensorOutputOverload.TensorTensorSplit_Tensor_T_Int32_Int32);
+        yield return HomogeneousOutputCase("TensorTensorSplit[indices;all-outputs]", "shape", "TensorTensorSplit",
+            e => e.TensorTensorSplit(uneven.F(), new[] { 2, 5 }, 1),
+            e => e.TensorTensorSplit(uneven.D(), new[] { 2, 5 }, 1), ParityTol.Exact,
+            outputOverload: TensorOutputOverload.TensorTensorSplit_Tensor_T_Int32Array_Int32);
+
+        var vertical = OpInput.Rand(7002, new[] { 6, 4 });
+        yield return HomogeneousOutputCase("TensorVSplit[all-outputs]", "shape", "TensorVSplit",
+            e => e.TensorVSplit(vertical.F(), 3),
+            e => e.TensorVSplit(vertical.D(), 3), ParityTol.Exact);
+
+        var depth = OpInput.Rand(7003, new[] { 2, 3, 6 });
+        yield return HomogeneousOutputCase("TensorDSplit[all-outputs]", "shape", "TensorDSplit",
+            e => e.TensorDSplit(depth.F(), 3),
+            e => e.TensorDSplit(depth.D(), 3), ParityTol.Exact);
+
+        var unstack = OpInput.Rand(7004, new[] { 2, 3, 4 });
+        yield return HomogeneousOutputCase("TensorUnstack[all-outputs]", "shape", "TensorUnstack",
+            e => e.TensorUnstack(unstack.F(), 1),
+            e => e.TensorUnstack(unstack.D(), 1), ParityTol.Exact);
+
+        var broadcastA = OpInput.Rand(7005, new[] { 2, 1, 3 });
+        var broadcastB = OpInput.Rand(7006, new[] { 1, 4, 1 });
+        yield return HomogeneousOutputCase("TensorBroadcastTensors[all-outputs]", "shape", "TensorBroadcastTensors",
+            e => e.TensorBroadcastTensors(new[] { broadcastA.F(), broadcastB.F() }),
+            e => e.TensorBroadcastTensors(new[] { broadcastA.D(), broadcastB.D() }), ParityTol.Exact);
+
+        var gridX = OpInput.From(new[] { -1.0, 0.0, 2.0 }, new[] { 3 });
+        var gridY = OpInput.From(new[] { 10.0, 20.0, 30.0, 40.0 }, new[] { 4 });
+        yield return HomogeneousOutputCase("TensorMeshgrid[all-outputs]", "shape", "TensorMeshgrid",
+            e => e.TensorMeshgrid(new[] { gridX.F(), gridY.F() }, "xy"),
+            e => e.TensorMeshgrid(new[] { gridX.D(), gridY.D() }, "xy"), ParityTol.Exact,
+            outputOverload: TensorOutputOverload.TensorMeshgrid_Tensor_TArray_String);
+        yield return HomogeneousOutputCase("TensorMeshgrid[two-input;all-outputs]", "shape", "TensorMeshgrid",
+            e =>
+            {
+                var result = e.TensorMeshgrid(gridX.F(), gridY.F());
+                return new[] { result.X, result.Y };
+            },
+            e =>
+            {
+                var result = e.TensorMeshgrid(gridX.D(), gridY.D());
+                return new[] { result.X, result.Y };
+            }, ParityTol.Exact,
+            outputOverload: TensorOutputOverload.TensorMeshgrid_Tensor_T_Tensor_T);
+
+        var complexAReal = OpInput.Rand(7010, new[] { 2, 3 });
+        var complexAImag = OpInput.Rand(7011, new[] { 2, 3 });
+        var complexBReal = OpInput.Rand(7012, new[] { 3, 4 });
+        var complexBImag = OpInput.Rand(7013, new[] { 3, 4 });
+        yield return HomogeneousOutputCase("ComplexMatMul[all-outputs]", "complex", "ComplexMatMul",
+            e =>
+            {
+                var result = e.ComplexMatMul(complexAReal.F(), complexAImag.F(), complexBReal.F(), complexBImag.F());
+                return new[] { result.real, result.imag };
+            },
+            e =>
+            {
+                var result = e.ComplexMatMul(complexAReal.D(), complexAImag.D(), complexBReal.D(), complexBImag.D());
+                return new[] { result.real, result.imag };
+            }, ParityTol.Accum(2e-3));
+
+        var complexReal = OpInput.Rand(7014, new[] { 3, 5 });
+        var complexImag = OpInput.Rand(7015, new[] { 3, 5 });
+        yield return HomogeneousOutputCase("ComplexNormalize[all-outputs]", "complex", "ComplexNormalize",
+            e =>
+            {
+                var result = e.ComplexNormalize(complexReal.F(), complexImag.F());
+                return new[] { result.real, result.imag };
+            },
+            e =>
+            {
+                var result = e.ComplexNormalize(complexReal.D(), complexImag.D());
+                return new[] { result.real, result.imag };
+            }, ParityTol.Accum(2e-3));
+    }
+
+    private static IEnumerable<OpCase> OutputContractNormalizationCases()
+    {
+        var matrix = OpInput.Rand(7040, new[] { 4, 16 });
+        var matrixGamma = OpInput.Rand(7041, new[] { 16 }, 0.5, 1.5);
+        var matrixBeta = OpInput.Rand(7042, new[] { 16 }, -0.2, 0.2);
+
+        yield return HomogeneousOutputCase("LayerNorm[all-outputs]", "norm", "LayerNorm",
+            e =>
+            {
+                var result = e.LayerNorm(matrix.F(), matrixGamma.F(), matrixBeta.F(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            },
+            e =>
+            {
+                var result = e.LayerNorm(matrix.D(), matrixGamma.D(), matrixBeta.D(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            }, ParityTol.Accum(1e-3));
+
+        yield return HomogeneousOutputCase("RMSNorm[all-outputs]", "norm", "RMSNorm",
+            e =>
+            {
+                var result = e.RMSNorm(matrix.F(), matrixGamma.F(), 1e-5, out var rms);
+                return new[] { result, rms };
+            },
+            e =>
+            {
+                var result = e.RMSNorm(matrix.D(), matrixGamma.D(), 1e-5, out var rms);
+                return new[] { result, rms };
+            }, ParityTol.Accum(1e-3));
+
+        var image = OpInput.Rand(7050, new[] { 2, 4, 3, 3 });
+        var imageGamma = OpInput.Rand(7051, new[] { 4 }, 0.5, 1.5);
+        var imageBeta = OpInput.Rand(7052, new[] { 4 }, -0.2, 0.2);
+        yield return HomogeneousOutputCase("BatchNorm[all-outputs]", "norm", "BatchNorm",
+            e =>
+            {
+                var result = e.BatchNorm(image.F(), imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            },
+            e =>
+            {
+                var result = e.BatchNorm(image.D(), imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            }, ParityTol.Accum(1e-3));
+
+        yield return HomogeneousOutputCase("GroupNorm[all-outputs]", "norm", "GroupNorm",
+            e =>
+            {
+                var result = e.GroupNorm(image.F(), 2, imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            },
+            e =>
+            {
+                var result = e.GroupNorm(image.D(), 2, imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            }, ParityTol.Accum(1e-3));
+
+        yield return HomogeneousOutputCase("GroupNormInto[all-outputs]", "norm", "GroupNormInto",
+            e =>
+            {
+                var output = new Tensor<float>(new float[image.Shape.Aggregate(1, (a, b) => a * b)], image.Shape);
+                e.GroupNormInto(output, image.F(), 2, imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                return new[] { output, mean, variance };
+            },
+            e =>
+            {
+                var output = new Tensor<double>(new double[image.Shape.Aggregate(1, (a, b) => a * b)], image.Shape);
+                e.GroupNormInto(output, image.D(), 2, imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                return new[] { output, mean, variance };
+            }, ParityTol.Accum(1e-3));
+
+        yield return HomogeneousOutputCase("InstanceNorm[all-outputs]", "norm", "InstanceNorm",
+            e =>
+            {
+                var result = e.InstanceNorm(image.F(), imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            },
+            e =>
+            {
+                var result = e.InstanceNorm(image.D(), imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                return new[] { result, mean, variance };
+            }, ParityTol.Accum(1e-3));
+
+        var runningMean = OpInput.Rand(7053, new[] { 4 }, -0.2, 0.2);
+        var runningVariance = OpInput.RandPositive(7054, new[] { 4 }, 0.5, 1.5);
+        yield return HomogeneousOutputCase("FusedBatchNorm[all-outputs]", "norm", "FusedBatchNorm",
+            e =>
+            {
+                var result = e.FusedBatchNorm(image.F(), imageGamma.F(), imageBeta.F(), runningMean.F(), runningVariance.F(),
+                    1e-5, 0.1, false, FusedActivationType.None, out var saveMean, out var saveVariance);
+                return new[] { result, saveMean, saveVariance };
+            },
+            e =>
+            {
+                var result = e.FusedBatchNorm(image.D(), imageGamma.D(), imageBeta.D(), runningMean.D(), runningVariance.D(),
+                    1e-5, 0.1, false, FusedActivationType.None, out var saveMean, out var saveVariance);
+                return new[] { result, saveMean, saveVariance };
+            }, ParityTol.Accum(1e-3));
+
+        yield return HomogeneousOutputCase("Dropout[all-outputs;eval]", "random", "Dropout",
+            e =>
+            {
+                var result = e.Dropout(matrix.F(), 0.25, false, out var mask);
+                return new[] { result, mask };
+            },
+            e =>
+            {
+                var result = e.Dropout(matrix.D(), 0.25, false, out var mask);
+                return new[] { result, mask };
+            }, ParityTol.Exact,
+            graphOutputDependencies: new[]
+            {
+                GraphOutputDependency.MutableInput,
+                GraphOutputDependency.InputIndependent
+            });
+    }
+
+    private static IEnumerable<OpCase> OutputContractBackwardCases()
+    {
+        var matrix = OpInput.Rand(7070, new[] { 4, 16 });
+        var matrixGamma = OpInput.Rand(7071, new[] { 16 }, 0.5, 1.5);
+        var matrixBeta = OpInput.Rand(7072, new[] { 16 }, -0.2, 0.2);
+        var matrixGradient = OpInput.Rand(7073, new[] { 4, 16 });
+
+        yield return HomogeneousOutputCase("LayerNormBackward[all-outputs]", "norm-bwd", "LayerNormBackward",
+            e =>
+            {
+                e.LayerNorm(matrix.F(), matrixGamma.F(), matrixBeta.F(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.LayerNormBackward(matrixGradient.F(), matrix.F(), matrixGamma.F(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            },
+            e =>
+            {
+                e.LayerNorm(matrix.D(), matrixGamma.D(), matrixBeta.D(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.LayerNormBackward(matrixGradient.D(), matrix.D(), matrixGamma.D(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        yield return HomogeneousOutputCase("RMSNormBackward[all-outputs]", "norm-bwd", "RMSNormBackward",
+            e =>
+            {
+                e.RMSNorm(matrix.F(), matrixGamma.F(), 1e-5, out var rms);
+                var inputGradient = e.RMSNormBackward(matrixGradient.F(), matrix.F(), matrixGamma.F(), rms,
+                    1e-5, out var gammaGradient);
+                return new[] { inputGradient, gammaGradient };
+            },
+            e =>
+            {
+                e.RMSNorm(matrix.D(), matrixGamma.D(), 1e-5, out var rms);
+                var inputGradient = e.RMSNormBackward(matrixGradient.D(), matrix.D(), matrixGamma.D(), rms,
+                    1e-5, out var gammaGradient);
+                return new[] { inputGradient, gammaGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var image = OpInput.Rand(7080, new[] { 2, 4, 3, 3 });
+        var imageGamma = OpInput.Rand(7081, new[] { 4 }, 0.5, 1.5);
+        var imageBeta = OpInput.Rand(7082, new[] { 4 }, -0.2, 0.2);
+        var imageGradient = OpInput.Rand(7083, new[] { 2, 4, 3, 3 });
+
+        yield return HomogeneousOutputCase("BatchNormBackward[all-outputs]", "norm-bwd", "BatchNormBackward",
+            e =>
+            {
+                e.BatchNorm(image.F(), imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.BatchNormBackward(imageGradient.F(), image.F(), imageGamma.F(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            },
+            e =>
+            {
+                e.BatchNorm(image.D(), imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.BatchNormBackward(imageGradient.D(), image.D(), imageGamma.D(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        yield return HomogeneousOutputCase("GroupNormBackward[all-outputs]", "norm-bwd", "GroupNormBackward",
+            e =>
+            {
+                e.GroupNorm(image.F(), 2, imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.GroupNormBackward(imageGradient.F(), image.F(), 2, imageGamma.F(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            },
+            e =>
+            {
+                e.GroupNorm(image.D(), 2, imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.GroupNormBackward(imageGradient.D(), image.D(), 2, imageGamma.D(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        yield return HomogeneousOutputCase("InstanceNormBackward[all-outputs]", "norm-bwd", "InstanceNormBackward",
+            e =>
+            {
+                e.InstanceNorm(image.F(), imageGamma.F(), imageBeta.F(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.InstanceNormBackward(imageGradient.F(), image.F(), imageGamma.F(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            },
+            e =>
+            {
+                e.InstanceNorm(image.D(), imageGamma.D(), imageBeta.D(), 1e-5, out var mean, out var variance);
+                var inputGradient = e.InstanceNormBackward(imageGradient.D(), image.D(), imageGamma.D(), mean, variance,
+                    1e-5, out var gammaGradient, out var betaGradient);
+                return new[] { inputGradient, gammaGradient, betaGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var linearInput = OpInput.Rand(7090, new[] { 4, 8 });
+        var linearWeights = OpInput.Rand(7091, new[] { 8, 6 });
+        var linearPreActivation = OpInput.Rand(7092, new[] { 4, 6 });
+        var linearGradient = OpInput.Rand(7093, new[] { 4, 6 });
+        yield return HomogeneousOutputCase("FusedLinearBackward[all-outputs]", "matmul-bwd", "FusedLinearBackward",
+            e =>
+            {
+                var inputGradient = e.FusedLinearBackward(linearGradient.F(), linearInput.F(), linearWeights.F(),
+                    linearPreActivation.F(), FusedActivationType.None, out var weightGradient, out var biasGradient);
+                return new[] { inputGradient, weightGradient, biasGradient! };
+            },
+            e =>
+            {
+                var inputGradient = e.FusedLinearBackward(linearGradient.D(), linearInput.D(), linearWeights.D(),
+                    linearPreActivation.D(), FusedActivationType.None, out var weightGradient, out var biasGradient);
+                return new[] { inputGradient, weightGradient, biasGradient! };
+            }, ParityTol.Accum(1e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var preluInput = OpInput.Rand(7100, new[] { 3, 4 }, -2.0, 2.0);
+        var preluAlpha = OpInput.RandPositive(7101, new[] { 4 }, 0.1, 0.4);
+        var preluGradient = OpInput.Rand(7102, new[] { 3, 4 });
+        yield return HomogeneousOutputCase("PReLUBackward[all-outputs]", "activation-bwd", "PReLUBackward",
+            e =>
+            {
+                var result = e.PReLUBackward(preluGradient.F(), preluInput.F(), preluAlpha.F());
+                return new[] { result.inputGrad, result.alphaGrad };
+            },
+            e =>
+            {
+                var result = e.PReLUBackward(preluGradient.D(), preluInput.D(), preluAlpha.D());
+                return new[] { result.inputGrad, result.alphaGrad };
+            }, ParityTol.Accum(1e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var rbfInput = OpInput.Rand(7110, new[] { 4, 5 });
+        var rbfCenters = OpInput.Rand(7111, new[] { 3, 5 });
+        var rbfEpsilons = OpInput.RandPositive(7112, new[] { 3 }, 0.5, 1.5);
+        var rbfGradient = OpInput.Rand(7113, new[] { 4, 3 });
+        yield return HomogeneousOutputCase("RBFKernelBackward[all-outputs]", "kernel-bwd", "RBFKernelBackward",
+            e =>
+            {
+                var input = rbfInput.F(); var centers = rbfCenters.F(); var epsilons = rbfEpsilons.F();
+                var output = e.RBFKernel(input, centers, epsilons);
+                var result = e.RBFKernelBackward(rbfGradient.F(), input, centers, epsilons, output);
+                return new[] { result.gradInput, result.gradCenters, result.gradEpsilons };
+            },
+            e =>
+            {
+                var input = rbfInput.D(); var centers = rbfCenters.D(); var epsilons = rbfEpsilons.D();
+                var output = e.RBFKernel(input, centers, epsilons);
+                var result = e.RBFKernelBackward(rbfGradient.D(), input, centers, epsilons, output);
+                return new[] { result.gradInput, result.gradCenters, result.gradEpsilons };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var boxesA = OpInput.From(new double[] { 0, 0, 2, 2, 1, 1, 3, 4, 0, 1, 4, 3 }, new[] { 3, 4 });
+        var boxesB = OpInput.From(new double[] { 0, 0, 2, 3, 1, 0, 3, 3 }, new[] { 2, 4 });
+        var boxGradient = OpInput.Rand(7120, new[] { 3, 2 });
+
+        Tensor<float>[] BoxFloat(IEngine e, Func<IEngine, Tensor<float>, Tensor<float>, Tensor<float>, (Tensor<float>, Tensor<float>)> run)
+        {
+            var result = run(e, boxGradient.F(), boxesA.F(), boxesB.F());
+            return new[] { result.Item1, result.Item2 };
+        }
+        Tensor<double>[] BoxDouble(IEngine e, Func<IEngine, Tensor<double>, Tensor<double>, Tensor<double>, (Tensor<double>, Tensor<double>)> run)
+        {
+            var result = run(e, boxGradient.D(), boxesA.D(), boxesB.D());
+            return new[] { result.Item1, result.Item2 };
+        }
+
+        yield return HomogeneousOutputCase("BoxIouBackward[all-outputs]", "box-bwd", "BoxIouBackward",
+            e => BoxFloat(e, (engine, gradient, a, b) => engine.BoxIouBackward(gradient, a, b)),
+            e => BoxDouble(e, (engine, gradient, a, b) => engine.BoxIouBackward(gradient, a, b)),
+            ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+        yield return HomogeneousOutputCase("GeneralizedBoxIouBackward[all-outputs]", "box-bwd", "GeneralizedBoxIouBackward",
+            e => BoxFloat(e, (engine, gradient, a, b) => engine.GeneralizedBoxIouBackward(gradient, a, b)),
+            e => BoxDouble(e, (engine, gradient, a, b) => engine.GeneralizedBoxIouBackward(gradient, a, b)),
+            ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+        yield return HomogeneousOutputCase("DistanceBoxIouBackward[all-outputs]", "box-bwd", "DistanceBoxIouBackward",
+            e => BoxFloat(e, (engine, gradient, a, b) => engine.DistanceBoxIouBackward(gradient, a, b)),
+            e => BoxDouble(e, (engine, gradient, a, b) => engine.DistanceBoxIouBackward(gradient, a, b)),
+            ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+        yield return HomogeneousOutputCase("CompleteBoxIouBackward[all-outputs]", "box-bwd", "CompleteBoxIouBackward",
+            e => BoxFloat(e, (engine, gradient, a, b) => engine.CompleteBoxIouBackward(gradient, a, b)),
+            e => BoxDouble(e, (engine, gradient, a, b) => engine.CompleteBoxIouBackward(gradient, a, b)),
+            ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var vertexFeatures = OpInput.Rand(7130, new[] { 5, 3 });
+        var laplacian = OpInput.Rand(7131, new[] { 5, 5 }, -0.25, 0.25);
+        var diffusionWeights = OpInput.Rand(7132, new[] { 4, 3 });
+        var diffusionGradient = OpInput.Rand(7133, new[] { 5, 4 });
+        yield return HomogeneousOutputCase("DiffusionConvBackward[all-outputs]", "conv-bwd", "DiffusionConvBackward",
+            e =>
+            {
+                var result = e.DiffusionConvBackward(diffusionGradient.F(), vertexFeatures.F(), laplacian.F(), diffusionWeights.F(), 0.5f);
+                return new[] { result.inputGrad, result.weightGrad, result.biasGrad };
+            },
+            e =>
+            {
+                var result = e.DiffusionConvBackward(diffusionGradient.D(), vertexFeatures.D(), laplacian.D(), diffusionWeights.D(), 0.5);
+                return new[] { result.inputGrad, result.weightGrad, result.biasGrad };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var rotations = OpInput.Rand(7140, new[] { 3, 4 }, -1.0, 1.0);
+        var scales = OpInput.RandPositive(7141, new[] { 3, 3 }, 0.2, 1.5);
+        var covarianceGradient = OpInput.Rand(7142, new[] { 3, 3, 3 });
+        yield return HomogeneousOutputCase("ComputeGaussianCovarianceBackward[all-outputs]", "geometry-bwd", "ComputeGaussianCovarianceBackward",
+            e =>
+            {
+                e.ComputeGaussianCovarianceBackward(rotations.F(), scales.F(), covarianceGradient.F(), out var rotationGradient, out var scaleGradient);
+                return new[] { rotationGradient, scaleGradient };
+            },
+            e =>
+            {
+                e.ComputeGaussianCovarianceBackward(rotations.D(), scales.D(), covarianceGradient.D(), out var rotationGradient, out var scaleGradient);
+                return new[] { rotationGradient, scaleGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var hashPositions = OpInput.Rand(7150, new[] { 5, 3 }, 0.0, 1.0);
+        var hashTable0 = OpInput.Rand(7151, new[] { 16, 2 });
+        var hashTable1 = OpInput.Rand(7152, new[] { 16, 2 });
+        var hashGradient = OpInput.Rand(7153, new[] { 5, 4 });
+        yield return HomogeneousOutputCase("MultiresolutionHashEncodingBackward[all-outputs]", "encoding-bwd", "MultiresolutionHashEncodingBackward",
+            e => e.MultiresolutionHashEncodingBackward(hashPositions.F(), new[] { hashTable0.F(), hashTable1.F() }, new[] { 4, 8 }, 2, hashGradient.F()),
+            e => e.MultiresolutionHashEncodingBackward(hashPositions.D(), new[] { hashTable0.D(), hashTable1.D() }, new[] { 4, 8 }, 2, hashGradient.D()),
+            ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+    }
+
+    private static IEnumerable<OpCase> OutputContractSignalCases()
+    {
+        var real = OpInput.Rand(7170, new[] { 16 });
+        var imaginary = OpInput.Rand(7171, new[] { 16 });
+
+        yield return HomogeneousOutputCase("FFT[all-outputs]", "complex", "FFT",
+            e =>
+            {
+                e.FFT(real.F(), imaginary.F(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            },
+            e =>
+            {
+                e.FFT(real.D(), imaginary.D(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            }, ParityTol.Accum(4e-3));
+
+        yield return HomogeneousOutputCase("IFFT[all-outputs]", "complex", "IFFT",
+            e =>
+            {
+                e.IFFT(real.F(), imaginary.F(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            },
+            e =>
+            {
+                e.IFFT(real.D(), imaginary.D(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            }, ParityTol.Accum(4e-3));
+
+        var real2D = OpInput.Rand(7172, new[] { 4, 4 });
+        var imaginary2D = OpInput.Rand(7173, new[] { 4, 4 });
+        yield return HomogeneousOutputCase("FFT2D[all-outputs]", "complex", "FFT2D",
+            e =>
+            {
+                e.FFT2D(real2D.F(), imaginary2D.F(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            },
+            e =>
+            {
+                e.FFT2D(real2D.D(), imaginary2D.D(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            }, ParityTol.Accum(5e-3));
+
+        yield return HomogeneousOutputCase("IFFT2D[all-outputs]", "complex", "IFFT2D",
+            e =>
+            {
+                e.IFFT2D(real2D.F(), imaginary2D.F(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            },
+            e =>
+            {
+                e.IFFT2D(real2D.D(), imaginary2D.D(), out var outputReal, out var outputImaginary);
+                return new[] { outputReal, outputImaginary };
+            }, ParityTol.Accum(5e-3));
+
+        var waveform = OpInput.Rand(7180, new[] { 2, 32 });
+        var window = OpInput.From(Enumerable.Range(0, 16)
+            .Select(i => 0.5 - 0.5 * Math.Cos(2.0 * Math.PI * i / 15.0)).ToArray(), new[] { 16 });
+        yield return HomogeneousOutputCase("STFT[all-outputs]", "audio", "STFT",
+            e =>
+            {
+                e.STFT(waveform.F(), 16, 4, window.F(), true, out var magnitude, out var phase);
+                return new[] { magnitude, phase };
+            },
+            e =>
+            {
+                e.STFT(waveform.D(), 16, 4, window.D(), true, out var magnitude, out var phase);
+                return new[] { magnitude, phase };
+            }, ParityTol.Accum(5e-3),
+            outputComparisons: new[] { TensorOutputComparison.Numeric, TensorOutputComparison.WrappedRadians });
+
+        var complexReal = OpInput.Rand(7181, new[] { 4, 6 });
+        var complexImaginary = OpInput.Rand(7182, new[] { 4, 6 });
+        yield return HomogeneousOutputCase("NativeMagnitudeAndPhase[all-outputs]", "complex", "NativeMagnitudeAndPhase",
+            e =>
+            {
+                var magnitude = e.NativeMagnitudeAndPhase(complexReal.CF(complexImaginary), out var phase);
+                return new[] { magnitude, phase };
+            },
+            e =>
+            {
+                var magnitude = e.NativeMagnitudeAndPhase(complexReal.CD(complexImaginary), out var phase);
+                return new[] { magnitude, phase };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.MixedElementTypes);
+
+        var nodeFeatures = OpInput.Rand(7190, new[] { 1, 4, 6 });
+        Tensor<int> EdgeSources() => new(new[] { 0, 1, 2, 3, 0, 1 }, new[] { 6 });
+        Tensor<int> EdgeTargets() => new(new[] { 1, 2, 3, 0, 2, 3 }, new[] { 6 });
+        var attentionSource = OpInput.Rand(7191, new[] { 6 });
+        var attentionTarget = OpInput.Rand(7192, new[] { 6 });
+        yield return HomogeneousOutputCase("GraphAttention[all-outputs]", "attention", "GraphAttention",
+            e =>
+            {
+                var output = e.GraphAttention(nodeFeatures.F(), EdgeSources(), EdgeTargets(), attentionSource.F(), attentionTarget.F(), 0.2, out var coefficients);
+                return new[] { output, coefficients };
+            },
+            e =>
+            {
+                var output = e.GraphAttention(nodeFeatures.D(), EdgeSources(), EdgeTargets(), attentionSource.D(), attentionTarget.D(), 0.2, out var coefficients);
+                return new[] { output, coefficients };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.HeterogeneousInput);
+    }
+
+    private static IEnumerable<OpCase> OutputContractGeometryCases()
+    {
+        yield return HomogeneousOutputCase("GenerateCameraRays[all-outputs]", "geometry", "GenerateCameraRays",
+            e =>
+            {
+                var result = e.GenerateCameraRays(
+                    new Vector<float>(new[] { 0f, 0f, -2f }),
+                    new Matrix<float>(new float[,] { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } }),
+                    3, 2, 2f);
+                return new[] { result.origins, result.directions };
+            },
+            e =>
+            {
+                var result = e.GenerateCameraRays(
+                    new Vector<double>(new[] { 0.0, 0.0, -2.0 }),
+                    new Matrix<double>(new double[,] { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } }),
+                    3, 2, 2.0);
+                return new[] { result.origins, result.directions };
+            }, ParityTol.Accum(1e-3), GraphCaptureExpectation.HostBoundary);
+
+        var rayOrigins = OpInput.From(new[] { 0.0, 0.0, -2.0, 0.25, -0.25, -2.0 }, new[] { 2, 3 });
+        var rayDirections = OpInput.From(new[] { 0.0, 0.0, 1.0, 0.1, 0.0, 0.995 }, new[] { 2, 3 });
+        yield return HomogeneousOutputCase("SampleRayPoints[all-outputs]", "geometry", "SampleRayPoints",
+            e =>
+            {
+                var result = e.SampleRayPoints(rayOrigins.F(), rayDirections.F(), 0.1f, 3f, 4, false);
+                return new[] { result.positions, result.directions, result.tValues };
+            },
+            e =>
+            {
+                var result = e.SampleRayPoints(rayOrigins.D(), rayDirections.D(), 0.1, 3.0, 4, false);
+                return new[] { result.positions, result.directions, result.tValues };
+            }, ParityTol.Accum(1e-3),
+            graphOutputDependencies: new[]
+            {
+                GraphOutputDependency.MutableInput,
+                GraphOutputDependency.MutableInput,
+                GraphOutputDependency.InputIndependent
+            });
+
+        Tensor<uint> Occupancy() => new(new[] { uint.MaxValue, uint.MaxValue }, new[] { 2 });
+        yield return HeterogeneousOutputCase("SampleRaysWithOccupancy[all-outputs]", "geometry", "SampleRaysWithOccupancy",
+            e =>
+            {
+                var result = e.SampleRaysWithOccupancy(
+                    rayOrigins.F(), rayDirections.F(), Occupancy(), 4,
+                    new Vector<float>(new[] { -1f, -1f, -1f }),
+                    new Vector<float>(new[] { 1f, 1f, 1f }), 0.1f, 4f, 4);
+                return new(new[] { result.positions, result.directions, result.tValues }, booleans: new[] { result.validMask });
+            },
+            e =>
+            {
+                var result = e.SampleRaysWithOccupancy(
+                    rayOrigins.D(), rayDirections.D(), Occupancy(), 4,
+                    new Vector<double>(new[] { -1.0, -1.0, -1.0 }),
+                    new Vector<double>(new[] { 1.0, 1.0, 1.0 }), 0.1, 4.0, 4);
+                return new(new[] { result.positions, result.directions, result.tValues }, booleans: new[] { result.validMask });
+            }, ParityTol.Accum(1e-3),
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
+
+        var means3D = OpInput.From(new[]
+        {
+            -0.25, -0.20, 2.0,
+             0.30,  0.10, 2.5,
+             0.05, -0.35, 3.0
+        }, new[] { 3, 3 });
+        var covariances3D = OpInput.From(new[]
+        {
+            1.0, 0.0, 0.0, 0.0, 1.1, 0.0, 0.0, 0.0, 0.9,
+            0.8, 0.1, 0.0, 0.1, 1.2, 0.0, 0.0, 0.0, 1.0,
+            1.3, 0.0, 0.1, 0.0, 0.7, 0.0, 0.1, 0.0, 1.1
+        }, new[] { 3, 3, 3 });
+        yield return HeterogeneousOutputCase("ProjectGaussians3DTo2D[all-outputs]", "geometry", "ProjectGaussians3DTo2D",
+            e =>
+            {
+                var identity = new Matrix<float>(new float[,]
+                {
+                    { 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 }, { 0, 0, 0, 1 }
+                });
+                e.ProjectGaussians3DTo2D(means3D.F(), covariances3D.F(), identity, identity, 16, 12,
+                    out var means2D, out var covariances2D, out var depths, out var visible);
+                return new(new[] { means2D, covariances2D, depths }, booleans: new[] { visible });
+            },
+            e =>
+            {
+                var identity = new Matrix<double>(new double[,]
+                {
+                    { 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 }, { 0, 0, 0, 1 }
+                });
+                e.ProjectGaussians3DTo2D(means3D.D(), covariances3D.D(), identity, identity, 16, 12,
+                    out var means2D, out var covariances2D, out var depths, out var visible);
+                return new(new[] { means2D, covariances2D, depths }, booleans: new[] { visible });
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.HostBoundary,
+            GraphCaptureSignatureConstraint.HeterogeneousOutput);
+
+        var means2DInput = OpInput.From(new[] { 2.5, 2.5, 5.0, 4.0, 6.5, 6.0 }, new[] { 3, 2 });
+        var covariances2DInput = OpInput.From(new[] { 2.0, 0.0, 2.0, 2.5, 0.2, 2.0, 1.8, -0.1, 2.2 }, new[] { 3, 3 });
+        var colors = OpInput.Rand(7210, new[] { 3, 3 }, 0.0, 1.0);
+        var opacities = OpInput.RandPositive(7211, new[] { 3 }, 0.3, 0.9);
+        var depths = OpInput.RandPositive(7212, new[] { 3 }, 0.5, 4.0);
+        var imageGradient = OpInput.Rand(7213, new[] { 8, 8, 3 });
+        yield return HomogeneousOutputCase("RasterizeGaussiansBackward[all-outputs]", "geometry-bwd", "RasterizeGaussiansBackward",
+            e =>
+            {
+                e.RasterizeGaussiansBackward(means2DInput.F(), covariances2DInput.F(), colors.F(), opacities.F(), depths.F(),
+                    8, 8, imageGradient.F(), 4, out var meansGradient, out var covarianceGradient,
+                    out var colorGradient, out var opacityGradient);
+                return new[] { meansGradient, covarianceGradient, colorGradient, opacityGradient };
+            },
+            e =>
+            {
+                e.RasterizeGaussiansBackward(means2DInput.D(), covariances2DInput.D(), colors.D(), opacities.D(), depths.D(),
+                    8, 8, imageGradient.D(), 4, out var meansGradient, out var covarianceGradient,
+                    out var colorGradient, out var opacityGradient);
+                return new[] { meansGradient, covarianceGradient, colorGradient, opacityGradient };
+            }, ParityTol.Accum(3e-3), GraphCaptureExpectation.BackwardKernel);
+
+        var rgbSamples = OpInput.Rand(7220, new[] { 2, 4, 3 }, 0.0, 1.0);
+        var densitySamples = OpInput.RandPositive(7221, new[] { 2, 4 }, 0.1, 1.5);
+        var tValues = OpInput.From(new[] { 0.1, 0.5, 1.0, 1.8, 0.2, 0.6, 1.1, 2.0 }, new[] { 2, 4 });
+        var renderedGradient = OpInput.Rand(7222, new[] { 2, 3 });
+        yield return HomogeneousOutputCase("VolumeRenderingBackward[all-outputs]", "geometry-bwd", "VolumeRenderingBackward",
+            e =>
+            {
+                e.VolumeRenderingBackward(rgbSamples.F(), densitySamples.F(), tValues.F(), renderedGradient.F(),
+                    out var rgbGradient, out var densityGradient);
+                return new[] { rgbGradient, densityGradient };
+            },
+            e =>
+            {
+                e.VolumeRenderingBackward(rgbSamples.D(), densitySamples.D(), tValues.D(), renderedGradient.D(),
+                    out var rgbGradient, out var densityGradient);
+                return new[] { rgbGradient, densityGradient };
+            }, ParityTol.Accum(2e-3), GraphCaptureExpectation.BackwardKernel);
+    }
+
+    private static IEnumerable<OpCase> OutputContractIndexCases()
+    {
+        var values = OpInput.From(new[]
+        {
+            4.0, -1.0, 7.0, 2.0, 5.0, 0.0,
+            3.0,  8.0, 1.0, 6.0, 9.0, -2.0
+        }, new[] { 2, 6 });
+
+        yield return HeterogeneousOutputCase("TensorFrexp[all-outputs]", "arithmetic", "TensorFrexp",
+            e =>
+            {
+                var result = e.TensorFrexp(values.F());
+                return new(new[] { result.Mantissa }, new[] { result.Exponent });
+            },
+            e =>
+            {
+                var result = e.TensorFrexp(values.D());
+                return new(new[] { result.Mantissa }, new[] { result.Exponent });
+            }, ParityTol.Ulp(2, 1e-6));
+
+        yield return HeterogeneousOutputCase("TensorSort[all-outputs]", "reduction", "TensorSort",
+            e =>
+            {
+                var result = e.TensorSort(values.F(), 1, true);
+                return new(new[] { result.Values }, new[] { result.Indices });
+            },
+            e =>
+            {
+                var result = e.TensorSort(values.D(), 1, true);
+                return new(new[] { result.Values }, new[] { result.Indices });
+            }, ParityTol.Exact);
+
+        yield return HeterogeneousOutputCase("TensorTopK[all-outputs]", "reduction", "TensorTopK",
+            e =>
+            {
+                var result = e.TensorTopK(values.F(), 3, 1, out var indices);
+                return new(new[] { result }, new[] { indices });
+            },
+            e =>
+            {
+                var result = e.TensorTopK(values.D(), 3, 1, out var indices);
+                return new(new[] { result }, new[] { indices });
+            }, ParityTol.Exact);
+
+        yield return HeterogeneousOutputCase("TopK[all-outputs]", "reduction", "TopK",
+            e =>
+            {
+                var result = e.TopK(values.F(), 3, 1, true);
+                return new(new[] { result.values }, new[] { result.indices });
+            },
+            e =>
+            {
+                var result = e.TopK(values.D(), 3, 1, true);
+                return new(new[] { result.values }, new[] { result.indices });
+            }, ParityTol.Exact);
+
+        var repeated = OpInput.From(new[] { 3.0, 1.0, 3.0, 2.0, 1.0, 1.0, 4.0 }, new[] { 7 });
+        yield return HeterogeneousOutputCase("TensorUniqueWithInfo[all-outputs]", "set", "TensorUniqueWithInfo",
+            e =>
+            {
+                var result = e.TensorUniqueWithInfo(repeated.F(), true, true, true);
+                return new(new[] { result.Values }, new[] { result.Inverse!, result.Counts! });
+            },
+            e =>
+            {
+                var result = e.TensorUniqueWithInfo(repeated.D(), true, true, true);
+                return new(new[] { result.Values }, new[] { result.Inverse!, result.Counts! });
+            }, ParityTol.Exact, GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint.HeterogeneousOutput,
+            GpuReadbackContract.DynamicResultShape);
+
+        var runs = OpInput.From(new[] { 3.0, 3.0, 1.0, 1.0, 1.0, 4.0, 2.0, 2.0 }, new[] { 8 });
+        yield return HeterogeneousOutputCase("TensorUniqueConsecutiveWithInfo[all-outputs]", "set", "TensorUniqueConsecutiveWithInfo",
+            e =>
+            {
+                var result = e.TensorUniqueConsecutiveWithInfo(runs.F(), true, true);
+                return new(new[] { result.Values }, new[] { result.Inverse!, result.Counts! });
+            },
+            e =>
+            {
+                var result = e.TensorUniqueConsecutiveWithInfo(runs.D(), true, true);
+                return new(new[] { result.Values }, new[] { result.Inverse!, result.Counts! });
+            }, ParityTol.Exact, GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint.HeterogeneousOutput,
+            GpuReadbackContract.DynamicResultShape);
+
+        var pool2 = OpInput.Rand(7020, new[] { 1, 2, 4, 4 });
+        yield return HeterogeneousOutputCase("MaxPool2DWithTensorIndices[all-outputs]", "pool", "MaxPool2DWithTensorIndices",
+            e =>
+            {
+                var result = e.MaxPool2DWithTensorIndices(pool2.F(), new[] { 2, 2 }, new[] { 2, 2 }, out var indices);
+                return new(new[] { result }, new[] { indices });
+            },
+            e =>
+            {
+                var result = e.MaxPool2DWithTensorIndices(pool2.D(), new[] { 2, 2 }, new[] { 2, 2 }, out var indices);
+                return new(new[] { result }, new[] { indices });
+            }, ParityTol.Exact);
+
+        var pool3 = OpInput.Rand(7021, new[] { 1, 2, 4, 4, 4 });
+        yield return HeterogeneousOutputCase("MaxPool3DWithTensorIndices[all-outputs]", "pool", "MaxPool3DWithTensorIndices",
+            e =>
+            {
+                var result = e.MaxPool3DWithTensorIndices(pool3.F(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out var indices);
+                return new(new[] { result }, new[] { indices });
+            },
+            e =>
+            {
+                var result = e.MaxPool3DWithTensorIndices(pool3.D(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out var indices);
+                return new(new[] { result }, new[] { indices });
+            }, ParityTol.Exact);
+
+        var reduce = OpInput.Rand(7022, new[] { 2, 3, 4 });
+        yield return HeterogeneousOutputCase("ReduceMaxWithTensorIndices[all-outputs]", "reduction", "ReduceMaxWithTensorIndices",
+            e =>
+            {
+                var result = e.ReduceMaxWithTensorIndices(reduce.F(), new[] { 0, 2 }, false, out var indices);
+                return new(new[] { result }, new[] { indices });
+            },
+            e =>
+            {
+                var result = e.ReduceMaxWithTensorIndices(reduce.D(), new[] { 0, 2 }, false, out var indices);
+                return new(new[] { result }, new[] { indices });
+            }, ParityTol.Exact);
+
+        var scatter = OpInput.From(Enumerable.Range(0, 24).Select(i => (double)(i + 1)).ToArray(), new[] { 4, 6 });
+        Tensor<int> ScatterIndices() => new(new[] { 0, 1, 2, 3 }, new[] { 4 });
+        yield return HeterogeneousOutputCase("ScatterMean[all-outputs]", "index", "ScatterMean",
+            e =>
+            {
+                var result = e.ScatterMean(scatter.F(), ScatterIndices(), out var counts, 0, 4);
+                return new(new[] { result }, new[] { counts! });
+            },
+            e =>
+            {
+                var result = e.ScatterMean(scatter.D(), ScatterIndices(), out var counts, 0, 4);
+                return new(new[] { result }, new[] { counts! });
+            }, ParityTol.Ulp(16, 1e-6));
+        yield return HeterogeneousOutputCase("ScatterMax[all-outputs]", "index", "ScatterMax",
+            e =>
+            {
+                var result = e.ScatterMax(scatter.F(), ScatterIndices(), out var argmax, 0, 4);
+                return new(new[] { result }, new[] { argmax! });
+            },
+            e =>
+            {
+                var result = e.ScatterMax(scatter.D(), ScatterIndices(), out var argmax, 0, 4);
+                return new(new[] { result }, new[] { argmax! });
+            }, ParityTol.Exact);
+    }
 
     public static IEnumerable<OpCase> RandomAndHostContractPending()
     {
         yield return new OpCase("TensorRandomUniform[4,8;range-invariant]", "random",
             e => ValidateUnitInterval(e, e.TensorRandomUniform<float>(new[] { 4, 8 })),
             e => ValidateUnitInterval(e, e.TensorRandomUniform<double>(new[] { 4, 8 })),
-            ParityTol.Exact, opMethod: "TensorRandomUniform");
+            ParityTol.Exact, opMethod: "TensorRandomUniform",
+            graphCaptureExpectation: GraphCaptureExpectation.NonDeterministic);
 
         yield return new OpCase("TensorRandomUniformRange[20000;seeded-exact]", "random",
             e => e.TensorRandomUniformRange(new[] { 20000 }, -2f, 2f, 0),
             e => e.TensorRandomUniformRange(new[] { 20000 }, -2.0, 2.0, 0),
-            ParityTol.Exact, opMethod: "TensorRandomUniformRange");
+            ParityTol.Exact, opMethod: "TensorRandomUniformRange",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         yield return new OpCase("TensorRandomNormal[4,8;std0]", "random",
             e => e.TensorRandomNormal(new[] { 4, 8 }, 1.25f, 0f),
             e => e.TensorRandomNormal(new[] { 4, 8 }, 1.25, 0.0),
-            ParityTol.Exact, opMethod: "TensorRandomNormal");
+            ParityTol.Exact, opMethod: "TensorRandomNormal",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         yield return new OpCase("TensorDropoutMask[4,8;p0;seed]", "random",
             e => e.TensorDropoutMask(new[] { 4, 8 }, 0f, 1.75f, 991),
             e => e.TensorDropoutMask(new[] { 4, 8 }, 0.0, 1.75, 991),
-            ParityTol.Exact, opMethod: "TensorDropoutMask");
+            ParityTol.Exact, opMethod: "TensorDropoutMask",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         yield return new OpCase("TensorDropoutMask[20000;p0.4;seeded-exact]", "random",
             e => e.TensorDropoutMask(new[] { 20000 }, 0.4f, 1.75f, 992),
             e => e.TensorDropoutMask(new[] { 20000 }, (double)0.4f, 1.75, 992),
-            ParityTol.Exact, opMethod: "TensorDropoutMask");
+            ParityTol.Exact, opMethod: "TensorDropoutMask",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         var singletonLogits = OpInput.Rand(6120, new[] { 4, 1 });
         yield return new OpCase("GumbelSoftmax[4,1;singleton-axis]", "random",
             e => e.GumbelSoftmax(singletonLogits.F(), 0.7, false, 1),
             e => e.GumbelSoftmax(singletonLogits.D(), 0.7, false, 1),
-            ParityTol.Exact, opMethod: "GumbelSoftmax");
+            ParityTol.Exact, opMethod: "GumbelSoftmax",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         var categoricalProbabilitiesData = new double[64];
         categoricalProbabilitiesData[0] = 1.0;
@@ -81,7 +993,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorCategoricalSample[2,32;seeded-onehot]", "random",
             e => e.TensorCategoricalSample(categoricalProbabilities.F(), -1, 42),
             e => e.TensorCategoricalSample(categoricalProbabilities.D(), -1, 42),
-            ParityTol.Exact, opMethod: "TensorCategoricalSample");
+            ParityTol.Exact, opMethod: "TensorCategoricalSample",
+            graphCaptureExpectation: GraphCaptureExpectation.NonDeterministic);
 
         var constantSamples = OpInput.From(Enumerable.Repeat(2.0, 8).ToArray(), new[] { 2, 4 });
         var importanceWeights = OpInput.From(
@@ -89,14 +1002,16 @@ public static class OpParityRegistry
         yield return new OpCase("ImportanceSampling[2,4->5;constant-t]", "random",
             e => e.ImportanceSampling(constantSamples.F(), importanceWeights.F(), 5),
             e => e.ImportanceSampling(constantSamples.D(), importanceWeights.D(), 5),
-            ParityTol.Exact, opMethod: "ImportanceSampling");
+            ParityTol.Exact, opMethod: "ImportanceSampling",
+            graphCaptureExpectation: GraphCaptureExpectation.NonDeterministic);
 
         var mapInput = OpInput.From(
             new[] { -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0 }, new[] { 2, 4 });
         yield return new OpCase("TensorMap[2,4;managed-square-plus-one]", "host-contract",
             e => e.TensorMap(mapInput.F(), x => x * x + 1f),
             e => e.TensorMap(mapInput.D(), x => x * x + 1.0),
-            ParityTol.Exact, opMethod: "TensorMap")
+            ParityTol.Exact, opMethod: "TensorMap",
+            graphCaptureExpectation: GraphCaptureExpectation.HostBoundary)
         {
             GpuProbeExpectation = GpuProbeExpectation.HostContract,
             GpuHostContractReason = "The public signature accepts an arbitrary managed Func<T,T> with no serializable expression or shader IR."
@@ -107,7 +1022,8 @@ public static class OpParityRegistry
         yield return new OpCase("ImageDecode[png;1x1]", "host-contract",
             e => ProjectBytes(e, e.ImageDecode(Png(), ImageFormat.Png)),
             e => ProjectBytesDouble(e, e.ImageDecode(Png(), ImageFormat.Png)),
-            ParityTol.Exact, opMethod: "ImageDecode")
+            ParityTol.Exact, opMethod: "ImageDecode",
+            graphCaptureExpectation: GraphCaptureExpectation.HostBoundary)
         {
             GpuProbeExpectation = GpuProbeExpectation.HostContract,
             GpuHostContractReason = "Compressed host byte[] decoding and its data-dependent HWC shape are a host codec boundary."
@@ -141,16 +1057,18 @@ public static class OpParityRegistry
             e => ProjectIndicesDouble(e, e.Nms(boxes.D(), scores.D(), 0.5), 16),
             ParityTol.Exact, opMethod: "Nms", gpuMinimumKernelLaunches: 2)
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "Nms must synchronously read its dynamic kept-index count to construct Tensor.Shape."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.HeterogeneousOutput,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
         yield return new OpCase("BatchedNms[6;2class;thr0.5]", "detection",
             e => ProjectIndices(e, e.BatchedNms(boxes.F(), scores.F(), ClassIds(), 0.5), 16),
             e => ProjectIndicesDouble(e, e.BatchedNms(boxes.D(), scores.D(), ClassIds(), 0.5), 16),
             ParityTol.Exact, opMethod: "BatchedNms", gpuMinimumKernelLaunches: 2)
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "BatchedNms must synchronously read its dynamic kept-index count to construct Tensor.Shape."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.HeterogeneousInput,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
 
         var masks = OpInput.From(new[]
@@ -168,7 +1086,8 @@ public static class OpParityRegistry
         yield return new OpCase("MasksToBoxes[2,4,5]", "detection",
             e => ProjectIndices(e, e.MasksToBoxes(masks.F()), 16),
             e => ProjectIndicesDouble(e, e.MasksToBoxes(masks.D()), 16),
-            ParityTol.Exact, opMethod: "MasksToBoxes", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "MasksToBoxes", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var histogramInput = OpInput.From(new[]
         {
@@ -178,7 +1097,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorHistogram[12;4bins]", "statistics",
             e => ProjectIndices(e, e.TensorHistogram(histogramInput.F(), 4, 0f, 4f), 32),
             e => ProjectIndicesDouble(e, e.TensorHistogram(histogramInput.D(), 4, 0.0, 4.0), 32),
-            ParityTol.Exact, opMethod: "TensorHistogram", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorHistogram", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var samples = OpInput.From(new[]
         {
@@ -196,7 +1116,8 @@ public static class OpParityRegistry
                 new[] { 0f, 0f }, new[] { 2f, 3f }), 32),
             e => ProjectIndicesDouble(e, e.TensorHistogramDD(samples.D(), new[] { 2, 3 },
                 new[] { 0.0, 0.0 }, new[] { 2.0, 3.0 }), 32),
-            ParityTol.Exact, opMethod: "TensorHistogramDD", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorHistogramDD", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         Tensor<int> BinValues() => new Tensor<int>(new[] { 0, 2, 1, 2, 5, 2, 5, 0 }, new[] { 8 });
         yield return new OpCase("TensorBinCount[8;min8]", "statistics",
@@ -204,8 +1125,8 @@ public static class OpParityRegistry
             e => ProjectIndicesDouble(e, e.TensorBinCount(BinValues(), 8), 16),
             ParityTol.Exact, opMethod: "TensorBinCount", gpuMinimumKernelLaunches: 2)
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "TensorBinCount must synchronously read its dynamic maximum and negative-input flag to construct Tensor.Shape."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
 
         var audio = OpInput.From(
@@ -213,7 +1134,8 @@ public static class OpParityRegistry
         yield return new OpCase("MuLawEncoding[9;q256]", "audio",
             e => ProjectIndices(e, e.MuLawEncoding(audio.F(), 256), 256),
             e => ProjectIndicesDouble(e, e.MuLawEncoding(audio.D(), 256), 256),
-            ParityTol.Exact, opMethod: "MuLawEncoding", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "MuLawEncoding", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         Tensor<byte> Packed() => new Tensor<byte>(new byte[]
         {
@@ -262,11 +1184,13 @@ public static class OpParityRegistry
         yield return new OpCase("TensorArgMax[3,5;ax1]", "index",
             e => ProjectIndices(e, e.TensorArgMax(extrema.F(), 1), 16),
             e => ProjectIndicesDouble(e, e.TensorArgMax(extrema.D(), 1), 16),
-            ParityTol.Exact, opMethod: "TensorArgMax", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorArgMax", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorArgMin[3,5;ax1]", "index",
             e => ProjectIndices(e, e.TensorArgMin(extrema.F(), 1), 16),
             e => ProjectIndicesDouble(e, e.TensorArgMin(extrema.D(), 1), 16),
-            ParityTol.Exact, opMethod: "TensorArgMin", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorArgMin", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var sortable = OpInput.From(new[]
         {
@@ -276,22 +1200,26 @@ public static class OpParityRegistry
         yield return new OpCase("TensorArgsort[2,8;asc]", "index",
             e => ProjectIndices(e, e.TensorArgsort(sortable.F(), 1), 16),
             e => ProjectIndicesDouble(e, e.TensorArgsort(sortable.D(), 1), 16),
-            ParityTol.Exact, opMethod: "TensorArgsort", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorArgsort", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("ArgSort[2,8;desc]", "index",
             e => ProjectIndices(e, e.ArgSort(sortable.F(), 1, true), 16),
             e => ProjectIndicesDouble(e, e.ArgSort(sortable.D(), 1, true), 16),
-            ParityTol.Exact, opMethod: "ArgSort", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "ArgSort", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var sorted = OpInput.From(new[] { -4.0, -1.0, 0.0, 2.0, 5.0, 9.0 }, new[] { 6 });
         var queries = OpInput.From(new[] { -5.0, -1.0, 1.0, 2.0, 9.0, 10.0 }, new[] { 2, 3 });
         yield return new OpCase("TensorSearchSorted[6;2,3;right]", "index",
             e => ProjectIndices(e, e.TensorSearchSorted(sorted.F(), queries.F(), true), 16),
             e => ProjectIndicesDouble(e, e.TensorSearchSorted(sorted.D(), queries.D(), true), 16),
-            ParityTol.Exact, opMethod: "TensorSearchSorted", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorSearchSorted", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorBucketize[2,3;6;left]", "index",
             e => ProjectIndices(e, e.TensorBucketize(queries.F(), sorted.F()), 16),
             e => ProjectIndicesDouble(e, e.TensorBucketize(queries.D(), sorted.D()), 16),
-            ParityTol.Exact, opMethod: "TensorBucketize", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorBucketize", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var sparse = OpInput.From(new[]
         {
@@ -304,8 +1232,9 @@ public static class OpParityRegistry
             e => ProjectIndicesDouble(e, e.TensorNonzero(sparse.D()), 16),
             ParityTol.Exact, opMethod: "TensorNonzero", gpuMinimumKernelLaunches: 2)
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "TensorNonzero must synchronously read its dynamic row count to construct Tensor.Shape."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.HeterogeneousOutput,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
 
         var vertices = OpInput.From(new[]
@@ -325,7 +1254,8 @@ public static class OpParityRegistry
         yield return new OpCase("GenerateSpiralIndices[tetra4;len3]", "index",
             e => ProjectIndices(e, e.GenerateSpiralIndices(vertices.F(), Faces(), 3), 16),
             e => ProjectIndicesDouble(e, e.GenerateSpiralIndices(vertices.D(), Faces(), 3), 16),
-            ParityTol.Exact, opMethod: "GenerateSpiralIndices", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "GenerateSpiralIndices", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     private static Tensor<float> ProjectIndices(IEngine engine, Tensor<int> indices, int vocabularySize)
@@ -355,34 +1285,41 @@ public static class OpParityRegistry
         yield return new OpCase("TensorEq[8;nan-inf]", "comparison",
             e => ProjectBits(e, e.TensorEq(equalLeft.F(), equalRight.F())),
             e => ProjectBitsDouble(e, e.TensorEq(equalLeft.D(), equalRight.D())),
-            ParityTol.Exact, opMethod: "TensorEq", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorEq", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorEqScalar[8;3]", "comparison",
             e => ProjectBits(e, e.TensorEqScalar(equalLeft.F(), 3f)),
             e => ProjectBitsDouble(e, e.TensorEqScalar(equalLeft.D(), 3.0)),
-            ParityTol.Exact, opMethod: "TensorEqScalar", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorEqScalar", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorIsClose[8;equalNan]", "comparison",
             e => ProjectBits(e, e.TensorIsClose(equalLeft.F(), equalRight.F(), 1e-5f, 1e-8f, true)),
             e => ProjectBitsDouble(e, e.TensorIsClose(equalLeft.D(), equalRight.D(), 1e-5, 1e-8, true)),
-            ParityTol.Exact, opMethod: "TensorIsClose", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorIsClose", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorIsFinite[8;nan-inf]", "comparison",
             e => ProjectBits(e, e.TensorIsFinite(equalLeft.F())),
             e => ProjectBitsDouble(e, e.TensorIsFinite(equalLeft.D())),
-            ParityTol.Exact, opMethod: "TensorIsFinite", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorIsFinite", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorIsNan[8;nan-inf]", "comparison",
             e => ProjectBits(e, e.TensorIsNan(equalLeft.F())),
             e => ProjectBitsDouble(e, e.TensorIsNan(equalLeft.D())),
-            ParityTol.Exact, opMethod: "TensorIsNan", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorIsNan", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("TensorIsInf[8;nan-inf]", "comparison",
             e => ProjectBits(e, e.TensorIsInf(equalLeft.F())),
             e => ProjectBitsDouble(e, e.TensorIsInf(equalLeft.D())),
-            ParityTol.Exact, opMethod: "TensorIsInf", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorIsInf", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var elements = OpInput.From(new[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }, new[] { 2, 3 });
         var testElements = OpInput.From(new[] { 5.0, 2.0, 9.0, 4.0 }, new[] { 4 });
         yield return new OpCase("TensorIsIn[2,3;4]", "comparison",
             e => ProjectBits(e, e.TensorIsIn(elements.F(), testElements.F())),
             e => ProjectBitsDouble(e, e.TensorIsIn(elements.D(), testElements.D())),
-            ParityTol.Exact, opMethod: "TensorIsIn", gpuMinimumKernelLaunches: 2);
+            ParityTol.Exact, opMethod: "TensorIsIn", gpuMinimumKernelLaunches: 2,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         Bit[] maskA = { true, true, false, false, true, false, true, false };
         Bit[] maskB = { true, false, true, false, false, true, true, false };
@@ -527,7 +1464,8 @@ public static class OpParityRegistry
         yield return new OpCase("NativeComplexFromPolar[2,8]", "complex",
             e => ProjectComplex(e, e.NativeComplexFromPolar(magnitudes.F(), phases.F())),
             e => ProjectComplex(e, e.NativeComplexFromPolar(magnitudes.D(), phases.D())),
-            ParityTol.Accum(2e-3), opMethod: "NativeComplexFromPolar");
+            ParityTol.Accum(2e-3), opMethod: "NativeComplexFromPolar",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("NativeComplexTopK[2,8;k5]", "complex",
             e => ProjectComplex(e, e.NativeComplexTopK(realA.CF(imaginaryA), 5)),
             e => ProjectComplex(e, e.NativeComplexTopK(realA.CD(imaginaryA), 5)),
@@ -536,7 +1474,8 @@ public static class OpParityRegistry
         yield return new OpCase("NativeComplexFFT[2,8]", "complex",
             e => ProjectComplex(e, e.NativeComplexFFT(realA.F())),
             e => ProjectComplex(e, e.NativeComplexFFT(realA.D())),
-            ParityTol.Accum(4e-3), opMethod: "NativeComplexFFT");
+            ParityTol.Accum(4e-3), opMethod: "NativeComplexFFT",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         yield return new OpCase("NativeComplexFFTComplex[2,8]", "complex",
             e => ProjectComplex(e, e.NativeComplexFFTComplex(realA.CF(imaginaryA))),
             e => ProjectComplex(e, e.NativeComplexFFTComplex(realA.CD(imaginaryA))),
@@ -550,18 +1489,21 @@ public static class OpParityRegistry
         yield return new OpCase("NativeComplexFFT2D[2,4,8]", "complex",
             e => ProjectComplex(e, e.NativeComplexFFT2D(real2D.F())),
             e => ProjectComplex(e, e.NativeComplexFFT2D(real2D.D())),
-            ParityTol.Accum(5e-3), opMethod: "NativeComplexFFT2D");
+            ParityTol.Accum(5e-3), opMethod: "NativeComplexFFT2D",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
         var realND = OpInput.Rand(6091, new[] { 4, 3, 8 });
         yield return new OpCase("NativeComplexFFTND[4,3,8;axes0,2]", "complex",
             e => ProjectComplex(e, e.NativeComplexFFTND(realND.F(), new[] { 0, 2 })),
             e => ProjectComplex(e, e.NativeComplexFFTND(realND.D(), new[] { 0, 2 })),
-            ParityTol.Accum(5e-3), opMethod: "NativeComplexFFTND");
+            ParityTol.Accum(5e-3), opMethod: "NativeComplexFFTND",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var waveform = OpInput.Rand(6092, new[] { 2, 16 });
         yield return new OpCase("NativeAnalyticSignal[2,16;2-6Hz]", "complex",
             e => ProjectComplex(e, e.NativeAnalyticSignal(waveform.F(), 2.0, 6.0, 32.0)),
             e => ProjectComplex(e, e.NativeAnalyticSignal(waveform.D(), 2.0, 6.0, 32.0)),
-            ParityTol.Accum(4e-3), opMethod: "NativeAnalyticSignal");
+            ParityTol.Accum(4e-3), opMethod: "NativeAnalyticSignal",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousOutput);
 
         var spectrumReal = OpInput.Rand(6093, new[] { 16 });
         var spectrumImaginary = OpInput.Rand(6094, new[] { 16 });
@@ -626,7 +1568,8 @@ public static class OpParityRegistry
                 cavityInput.F(), cavityFilterReal.CF(cavityFilterImaginary), 2),
             e => e.NativeBatchedCavityForward(
                 cavityInput.D(), cavityFilterReal.CD(cavityFilterImaginary), 2),
-            ParityTol.Accum(3e-3), opMethod: "NativeBatchedCavityForward");
+            ParityTol.Accum(3e-3), opMethod: "NativeBatchedCavityForward")
+        { GraphCaptureExpectation = GraphCaptureExpectation.HeterogeneousInput };
     }
 
     // Previously unregistered resident layout, embedding, and hash-grid backward paths.
@@ -643,13 +1586,15 @@ public static class OpParityRegistry
         yield return new OpCase("TensorEmbeddingLookup[6,4;2,2]", "index",
             e => e.TensorEmbeddingLookup(embeddings.F(), indices),
             e => e.TensorEmbeddingLookup(embeddings.D(), indices),
-            ParityTol.Exact, opMethod: "TensorEmbeddingLookup");
+            ParityTol.Exact, opMethod: "TensorEmbeddingLookup",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.MixedElementTypes);
 
         var embeddingGrad = OpInput.Rand(6011, new[] { 2, 2, 4 });
         yield return new OpCase("TensorEmbeddingLookupBackward[2,2,4;v6]", "index",
             e => e.TensorEmbeddingLookupBackward(embeddingGrad.F(), indices, 6, 4),
             e => e.TensorEmbeddingLookupBackward(embeddingGrad.D(), indices, 6, 4),
-            ParityTol.Accum(1e-6), opMethod: "TensorEmbeddingLookupBackward");
+            ParityTol.Accum(1e-6), opMethod: "TensorEmbeddingLookupBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.MixedElementTypes);
 
         var positions = OpInput.Rand(6020, new[] { 5, 3 }, 0.0, 1.0);
         var table0 = OpInput.Rand(6021, new[] { 16, 2 });
@@ -660,7 +1605,7 @@ public static class OpParityRegistry
                 positions.F(), new[] { table0.F(), table1.F() }, new[] { 4, 8 }, 2, outputGradient.F())),
             e => FirstHashGradient(e.MultiresolutionHashEncodingBackward(
                 positions.D(), new[] { table0.D(), table1.D() }, new[] { 4, 8 }, 2, outputGradient.D())),
-            ParityTol.Accum(1e-3), opMethod: "MultiresolutionHashEncodingBackward");
+            ParityTol.Accum(1e-3), opMethod: "MultiresolutionHashEncodingBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         var pacWaveforms = OpInput.Rand(6030, new[] { 2, 32 });
         var gammaBands = new[] { (12.0, 18.0), (18.0, 26.0) };
@@ -689,7 +1634,8 @@ public static class OpParityRegistry
         var irIn = OpInput.Rand(5900, new[] { 10 });
         yield return new OpCase("IRFFT[10->8]", "complex",
             e => e.IRFFT(irIn.F(), 8), e => e.IRFFT(irIn.D(), 8),
-            ParityTol.Accum(1e-3), opMethod: "IRFFT");
+            ParityTol.Accum(1e-3), opMethod: "IRFFT")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
     }
 
     // Masked select / scatter with a fixed Bit mask.
@@ -701,13 +1647,18 @@ public static class OpParityRegistry
         yield return new OpCase("TensorMaskedSelect[4,6;checker]", "index",
             e => e.TensorMaskedSelect(t.F(), new Tensor<Bit>((Bit[])bits.Clone(), new[] { 4, 6 })),
             e => e.TensorMaskedSelect(t.D(), new Tensor<Bit>((Bit[])bits.Clone(), new[] { 4, 6 })),
-            ParityTol.Exact, opMethod: "TensorMaskedSelect");
+            ParityTol.Exact, opMethod: "TensorMaskedSelect")
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GraphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.HeterogeneousInput
+        };
 
         var src = OpInput.Rand(5801, new[] { 12 });
         yield return new OpCase("TensorMaskedScatter[4,6;checker]", "index",
             e => e.TensorMaskedScatter(t.F(), new Tensor<Bit>((Bit[])bits.Clone(), new[] { 4, 6 }), src.F()),
             e => e.TensorMaskedScatter(t.D(), new Tensor<Bit>((Bit[])bits.Clone(), new[] { 4, 6 }), src.D()),
-            ParityTol.Exact, opMethod: "TensorMaskedScatter");
+            ParityTol.Exact, opMethod: "TensorMaskedScatter",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Complex conjugate (interleaved), reorder-to-NCHWc, N-D IFFT-real.
@@ -725,7 +1676,9 @@ public static class OpParityRegistry
         yield return new OpCase("NativeComplexIFFTNDReal[4,4]", "complex",
             e => e.NativeComplexIFFTNDReal(re2.CF(im2), new[] { 0, 1 }),
             e => e.NativeComplexIFFTNDReal(re2.CD(im2), new[] { 0, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFTNDReal");
+            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFTNDReal",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Grouped-deform mask backward, fold, reorder-to-NCHW, unique-consecutive.
@@ -740,7 +1693,7 @@ public static class OpParityRegistry
         yield return new OpCase("DeformableConv2DGroupedBackwardMask[1,4,8,8;g2]", "conv",
             e => e.DeformableConv2DGroupedBackwardMask(ggo.F(), gin.F(), gk.F(), goff.F(), gmask.F(), s, s, s, 2, 1),
             e => e.DeformableConv2DGroupedBackwardMask(ggo.D(), gin.D(), gk.D(), goff.D(), gmask.D(), s, s, s, 2, 1),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardMask");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardMask", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Fold: unfolded columns [1, C*kh*kw=8, L=4] -> [1,2,4,4] (kernel 2x2 stride 2).
         var foldIn = OpInput.Rand(5610, new[] { 1, 8, 4 });
@@ -765,8 +1718,8 @@ public static class OpParityRegistry
             e => e.TensorUniqueConsecutive(uc.F()), e => e.TensorUniqueConsecutive(uc.D()),
             ParityTol.Exact, opMethod: "TensorUniqueConsecutive")
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "One scalar cardinality is required to construct the exact-size synchronous Tensor result."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
     }
 
@@ -782,11 +1735,12 @@ public static class OpParityRegistry
         yield return new OpCase("MaxPool2DBackward[1,2,8,8]", "pool",
             e => e.MaxPool2DBackward(go2.F(), idx2F, new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }),
             e => e.MaxPool2DBackward(go2.D(), idx2D, new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }),
-            ParityTol.Exact, opMethod: "MaxPool2DBackward");
+            ParityTol.Exact, opMethod: "MaxPool2DBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("MaxPool2DBackwardWithTensorIndices[1,2,8,8]", "pool",
             e => { e.MaxPool2DWithTensorIndices(in2.F(), new[] { 2, 2 }, new[] { 2, 2 }, out var idx); return e.MaxPool2DBackwardWithTensorIndices(go2.F(), idx, new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }); },
             e => { e.MaxPool2DWithTensorIndices(in2.D(), new[] { 2, 2 }, new[] { 2, 2 }, out var idx); return e.MaxPool2DBackwardWithTensorIndices(go2.D(), idx, new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }); },
-            ParityTol.Exact, opMethod: "MaxPool2DBackwardWithTensorIndices");
+            ParityTol.Exact, opMethod: "MaxPool2DBackwardWithTensorIndices", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // 3D: input [1,2,4,4,4], pool/stride [2,2,2] -> pooled [1,2,2,2,2].
         var in3 = OpInput.Rand(5510, new[] { 1, 2, 4, 4, 4 });
@@ -796,11 +1750,12 @@ public static class OpParityRegistry
         yield return new OpCase("MaxPool3DBackward[1,2,4,4,4]", "pool",
             e => e.MaxPool3DBackward(go3.F(), idx3F, new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }),
             e => e.MaxPool3DBackward(go3.D(), idx3D, new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }),
-            ParityTol.Exact, opMethod: "MaxPool3DBackward");
+            ParityTol.Exact, opMethod: "MaxPool3DBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("MaxPool3DBackwardWithTensorIndices[1,2,4,4,4]", "pool",
             e => { e.MaxPool3DWithTensorIndices(in3.F(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out var idx); return e.MaxPool3DBackwardWithTensorIndices(go3.F(), idx, new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }); },
             e => { e.MaxPool3DWithTensorIndices(in3.D(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out var idx); return e.MaxPool3DBackwardWithTensorIndices(go3.D(), idx, new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }); },
-            ParityTol.Exact, opMethod: "MaxPool3DBackwardWithTensorIndices");
+            ParityTol.Exact, opMethod: "MaxPool3DBackwardWithTensorIndices", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // SH backward, CTC loss, batched spectral filter.
@@ -812,7 +1767,7 @@ public static class OpParityRegistry
         yield return new OpCase("EvaluateSphericalHarmonicsBackward[4,9,3;deg2]", "geometry",
             e => e.EvaluateSphericalHarmonicsBackward(shC.F(), viewDir.F(), 2, shGo.F()),
             e => e.EvaluateSphericalHarmonicsBackward(shC.D(), viewDir.D(), 2, shGo.D()),
-            ParityTol.Accum(1e-3), opMethod: "EvaluateSphericalHarmonicsBackward");
+            ParityTol.Accum(1e-3), opMethod: "EvaluateSphericalHarmonicsBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // CTC loss: logProbs [T=4, N=2, C=5] (log-softmaxed), targets flat, lengths per batch.
         var lp = OpInput.Rand(5410, new[] { 4, 2, 5 });
@@ -820,7 +1775,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorCTCLoss[T4,N2,C5]", "loss",
             e => e.TensorCTCLoss(e.TensorLogSoftmax(lp.F(), -1), targets, new[] { 4, 4 }, new[] { 2, 2 }, 0),
             e => e.TensorCTCLoss(e.TensorLogSoftmax(lp.D(), -1), targets, new[] { 4, 4 }, new[] { 2, 2 }, 0),
-            ParityTol.Accum(1e-3), opMethod: "TensorCTCLoss");
+            ParityTol.Accum(1e-3), opMethod: "TensorCTCLoss",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // Batched spectral filter: 4D input [B,C,H,W], complex filter matching [H,W].
         var sfIn = OpInput.Rand(5420, new[] { 1, 2, 4, 8 });
@@ -830,7 +1786,9 @@ public static class OpParityRegistry
         // oracle) — same GPU FFT-kernel family as NativeSpectralFilter / wideband / 2D-IFFT.
         yield return new OpCase("NativeSpectralFilterBatch[1,2,4,8]", "audio",
             e => e.NativeSpectralFilterBatch(sfIn.F(), fRe.CF(fIm)), e => e.NativeSpectralFilterBatch(sfIn.D(), fRe.CD(fIm)),
-            ParityTol.Accum(2e-3), opMethod: "NativeSpectralFilterBatch");
+            ParityTol.Accum(2e-3), opMethod: "NativeSpectralFilterBatch",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Spherical harmonics, multiresolution hash encoding, gaussian rasterization.
@@ -874,7 +1832,8 @@ public static class OpParityRegistry
         yield return new OpCase("FusedLinearMaxout[4,8;w8,12;p3]", "matmul",
             e => e.FusedLinearMaxout(mIn.F(), mW.F(), null, 3),
             e => e.FusedLinearMaxout(mIn.D(), mW.D(), null, 3),
-            ParityTol.Accum(1e-3), opMethod: "FusedLinearMaxout");
+            ParityTol.Accum(1e-3), opMethod: "FusedLinearMaxout")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         // Spectral filter: real input [4,8], complex filter [4,8] (matching spatial dims).
         var sfIn = OpInput.Rand(5210, new[] { 4, 8 });
@@ -884,7 +1843,9 @@ public static class OpParityRegistry
         // oracle (49 ULP) — same GPU FFT-kernel family as the wideband/2D-IFFT divergences.
         yield return new OpCase("NativeSpectralFilter[4,8]", "audio",
             e => e.NativeSpectralFilter(sfIn.F(), fRe.CF(fIm)), e => e.NativeSpectralFilter(sfIn.D(), fRe.CD(fIm)),
-            ParityTol.Accum(2e-3), opMethod: "NativeSpectralFilter");
+            ParityTol.Accum(2e-3), opMethod: "NativeSpectralFilter",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // BCE backward, scatter-max/softmax backward, deform-mask backward, reduce-max backward.
@@ -895,14 +1856,15 @@ public static class OpParityRegistry
         yield return new OpCase("TensorBinaryCrossEntropyBackward[4,6]", "loss",
             e => e.TensorBinaryCrossEntropyBackward(pred.F(), tgt.F(), 1e-7f),
             e => e.TensorBinaryCrossEntropyBackward(pred.D(), tgt.D(), 1e-7),
-            ParityTol.Accum(1e-3), opMethod: "TensorBinaryCrossEntropyBackward");
+            ParityTol.Accum(1e-3), opMethod: "TensorBinaryCrossEntropyBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // ScatterMax backward: gradOutput [4], argmax [4] (positions into source [6]).
         var smgo = OpInput.Rand(5110, new[] { 4 });
         yield return new OpCase("ScatterMaxBackward[4->6]", "index",
             e => e.ScatterMaxBackward(smgo.F(), new Tensor<int>(new[] { 0, 1, 2, 3 }, new[] { 4 }), new[] { 6 }, 0),
             e => e.ScatterMaxBackward(smgo.D(), new Tensor<int>(new[] { 0, 1, 2, 3 }, new[] { 4 }), new[] { 6 }, 0),
-            ParityTol.Exact, opMethod: "ScatterMaxBackward");
+            ParityTol.Exact, opMethod: "ScatterMaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // ScatterSoftmax backward: gradOutput [6], indices group ids [6]. The `output` operand MUST be
         // a real scatter-softmax (derived from the forward on the same indices) — softmax backward's
@@ -912,7 +1874,8 @@ public static class OpParityRegistry
         yield return new OpCase("ScatterSoftmaxBackward[6]", "activation",
             e => e.ScatterSoftmaxBackward(ssgo.F(), e.ScatterSoftmax(ssScore.F(), new Tensor<int>(new[] { 0, 0, 1, 1, 2, 2 }, new[] { 6 }), 0), new Tensor<int>(new[] { 0, 0, 1, 1, 2, 2 }, new[] { 6 }), 0),
             e => e.ScatterSoftmaxBackward(ssgo.D(), e.ScatterSoftmax(ssScore.D(), new Tensor<int>(new[] { 0, 0, 1, 1, 2, 2 }, new[] { 6 }), 0), new Tensor<int>(new[] { 0, 0, 1, 1, 2, 2 }, new[] { 6 }), 0),
-            ParityTol.Accum(1e-3), opMethod: "ScatterSoftmaxBackward");
+            ParityTol.Accum(1e-3), opMethod: "ScatterSoftmaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // Deformable-conv mask backward: mask channels = kh*kw*deformGroups = 9.
         var dcIn = OpInput.Rand(5130, new[] { 1, 2, 8, 8 });
@@ -924,14 +1887,14 @@ public static class OpParityRegistry
         yield return new OpCase("DeformableConv2DBackwardMask[1,3,8,8]", "conv",
             e => e.DeformableConv2DBackwardMask(dcGo.F(), dcIn.F(), dcK.F(), dcOff.F(), dcMask.F(), s1, s1, s1),
             e => e.DeformableConv2DBackwardMask(dcGo.D(), dcIn.D(), dcK.D(), dcOff.D(), dcMask.D(), s1, s1, s1),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardMask");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardMask", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // ReduceMax backward: global max, gradOutput [1], maxIndices flat position into [4,6].
         var rmgo = OpInput.Rand(5140, new[] { 1 });
         yield return new OpCase("ReduceMaxBackward[4,6;global]", "reduction",
             e => e.ReduceMaxBackward(rmgo.F(), new[] { 5 }, new[] { 4, 6 }),
             e => e.ReduceMaxBackward(rmgo.D(), new[] { 5 }, new[] { 4, 6 }),
-            ParityTol.Exact, opMethod: "ReduceMaxBackward");
+            ParityTol.Exact, opMethod: "ReduceMaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Trilinear backward, multi-head graph attention, occupancy-grid update.
@@ -943,7 +1906,7 @@ public static class OpParityRegistry
         yield return new OpCase("TensorTrilinearInterpolateBackward[4,4,4,2]", "resize",
             e => e.TensorTrilinearInterpolateBackward(tgo.F(), grid.F(), posns.F()),
             e => e.TensorTrilinearInterpolateBackward(tgo.D(), grid.D(), posns.D()),
-            ParityTol.Accum(1e-3), opMethod: "TensorTrilinearInterpolateBackward");
+            ParityTol.Accum(1e-3), opMethod: "TensorTrilinearInterpolateBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Multi-head graph attention: nodeFeatures [1,4,6], headWeights [numHeads=2, inF=6, headDim=3].
         var nf = OpInput.Rand(5010, new[] { 1, 4, 6 });
@@ -955,7 +1918,21 @@ public static class OpParityRegistry
         yield return new OpCase("MultiHeadGraphAttention[1,4,6;h2]", "attention",
             e => e.MultiHeadGraphAttention(nf.F(), eSrc, eTgt, hw.F(), aS.F(), aT.F(), 0.2, true, out _),
             e => e.MultiHeadGraphAttention(nf.D(), eSrc, eTgt, hw.D(), aS.D(), aT.D(), 0.2, true, out _),
-            ParityTol.Accum(1e-3), opMethod: "MultiHeadGraphAttention");
+            ParityTol.Accum(1e-3), opMethod: "MultiHeadGraphAttention",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput)
+        {
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.MultiHeadGraphAttention(nf.F(), eSrc, eTgt, hw.F(), aS.F(), aT.F(), 0.2, true, out var coefficients);
+                return new[] { output, coefficients };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.MultiHeadGraphAttention(nf.D(), eSrc, eTgt, hw.D(), aS.D(), aT.D(), 0.2, true, out var coefficients);
+                return new[] { output, coefficients };
+            }
+        };
 
         // Occupancy-grid update: grid [64]=(gridSize 4)^3, densities [5], positions [5,3] in [0,4).
         var occ = OpInput.Rand(5020, new[] { 64 }, 0.0, 1.0);
@@ -978,7 +1955,23 @@ public static class OpParityRegistry
         yield return new OpCase("FlashAttentionBackward[1,2,4,8]", "attention",
             e => { var o = e.FlashAttention(q.F(), k.F(), v.F(), scale, false, out var st, null); return e.FlashAttentionBackward(fgo.F(), q.F(), k.F(), v.F(), o, st, scale, false, out _, out _, out _); },
             e => { var o = e.FlashAttention(q.D(), k.D(), v.D(), scale, false, out var st, null); return e.FlashAttentionBackward(fgo.D(), q.D(), k.D(), v.D(), o, st, scale, false, out _, out _, out _); },
-            ParityTol.Accum(1e-3), opMethod: "FlashAttentionBackward");
+            ParityTol.Accum(1e-3), opMethod: "FlashAttentionBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel)
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.BackwardKernel,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.FlashAttention(q.F(), k.F(), v.F(), scale, false, out var stats, null);
+                var chained = e.FlashAttentionBackward(fgo.F(), q.F(), k.F(), v.F(), output, stats, scale, false, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.FlashAttention(q.D(), k.D(), v.D(), scale, false, out var stats, null);
+                var chained = e.FlashAttentionBackward(fgo.D(), q.D(), k.D(), v.D(), output, stats, scale, false, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            }
+        };
 
         // Fused linear + cross-entropy with integer targets.
         var hid = OpInput.Rand(4910, new[] { 4, 8 });
@@ -988,7 +1981,9 @@ public static class OpParityRegistry
         yield return new OpCase("FusedLinearCrossEntropyWithLogits[4,8;v6]", "loss",
             e => e.FusedLinearCrossEntropyWithLogits(hid.F(), wt.F(), bs.F(), tgt),
             e => e.FusedLinearCrossEntropyWithLogits(hid.D(), wt.D(), bs.D(), tgt),
-            ParityTol.Accum(1e-3), opMethod: "FusedLinearCrossEntropyWithLogits");
+            ParityTol.Accum(1e-3), opMethod: "FusedLinearCrossEntropyWithLogits",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+            graphCaptureSignatureOverload: GraphCaptureSignatureOverload.FusedLinearCrossEntropyWithLogits_Tensor_T_Tensor_T_Tensor_T_Tensor_Int32);
 
         // Trilinear interpolation: grid [D,H,W,C]=[4,4,4,2], positions [5,3] in range.
         var grid = OpInput.Rand(4920, new[] { 4, 4, 4, 2 });
@@ -996,7 +1991,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorTrilinearInterpolate[4,4,4,2;5pts]", "resize",
             e => e.TensorTrilinearInterpolate(grid.F(), posns.F()),
             e => e.TensorTrilinearInterpolate(grid.D(), posns.D()),
-            ParityTol.Accum(1e-3), opMethod: "TensorTrilinearInterpolate");
+            ParityTol.Accum(1e-3), opMethod: "TensorTrilinearInterpolate")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         // Hierarchical softmax: input [4,8], nodeWeights [numClasses-1=3, 8], numClasses 4.
         var hsIn = OpInput.Rand(4930, new[] { 4, 8 });
@@ -1004,7 +2000,8 @@ public static class OpParityRegistry
         yield return new OpCase("FusedHierarchicalSoftmax[4,8;c4]", "activation",
             e => e.FusedHierarchicalSoftmax(hsIn.F(), hsW.F(), 4),
             e => e.FusedHierarchicalSoftmax(hsIn.D(), hsW.D(), 4),
-            ParityTol.Accum(1e-3), opMethod: "FusedHierarchicalSoftmax");
+            ParityTol.Accum(1e-3), opMethod: "FusedHierarchicalSoftmax")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
     }
 
     // Attention backwards (SDPA / GQA / graph) + scatter-mean backward.
@@ -1021,7 +2018,23 @@ public static class OpParityRegistry
         yield return new OpCase("ScaledDotProductAttentionBackward[1,2,4,8]", "attention",
             e => { e.ScaledDotProductAttention(q.F(), k.F(), v.F(), (Tensor<bool>?)null, scale, out var aw); return e.ScaledDotProductAttentionBackward(sgo.F(), q.F(), k.F(), v.F(), aw, scale, out _, out _, out _); },
             e => { e.ScaledDotProductAttention(q.D(), k.D(), v.D(), (Tensor<bool>?)null, scale, out var aw); return e.ScaledDotProductAttentionBackward(sgo.D(), q.D(), k.D(), v.D(), aw, scale, out _, out _, out _); },
-            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttentionBackward");
+            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttentionBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel)
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.BackwardKernel,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                e.ScaledDotProductAttention(q.F(), k.F(), v.F(), (Tensor<bool>?)null, scale, out var weights);
+                var chained = e.ScaledDotProductAttentionBackward(sgo.F(), q.F(), k.F(), v.F(), weights, scale, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            },
+            RunDoubleOutputs = e =>
+            {
+                e.ScaledDotProductAttention(q.D(), k.D(), v.D(), (Tensor<bool>?)null, scale, out var weights);
+                var chained = e.ScaledDotProductAttentionBackward(sgo.D(), q.D(), k.D(), v.D(), weights, scale, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            }
+        };
 
         // GQA backward: q/gradOutput [1,4,4,8], k/v [1,2,4,8], attnWeights [1,4,4,4].
         var gq = OpInput.Rand(4810, new[] { 1, 4, 4, 8 });
@@ -1032,7 +2045,23 @@ public static class OpParityRegistry
         yield return new OpCase("GroupedQueryAttentionBackward[1,4,4,8]", "attention",
             e => { e.GroupedQueryAttention(gq.F(), gk.F(), gv.F(), 2, scale, false, out var aw); return e.GroupedQueryAttentionBackward(ggo.F(), gq.F(), gk.F(), gv.F(), aw, 2, scale, out _, out _, out _); },
             e => { e.GroupedQueryAttention(gq.D(), gk.D(), gv.D(), 2, scale, false, out var aw); return e.GroupedQueryAttentionBackward(ggo.D(), gq.D(), gk.D(), gv.D(), aw, 2, scale, out _, out _, out _); },
-            ParityTol.Accum(1e-3), opMethod: "GroupedQueryAttentionBackward");
+            ParityTol.Accum(1e-3), opMethod: "GroupedQueryAttentionBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel)
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.BackwardKernel,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                e.GroupedQueryAttention(gq.F(), gk.F(), gv.F(), 2, scale, false, out var weights);
+                var chained = e.GroupedQueryAttentionBackward(ggo.F(), gq.F(), gk.F(), gv.F(), weights, 2, scale, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            },
+            RunDoubleOutputs = e =>
+            {
+                e.GroupedQueryAttention(gq.D(), gk.D(), gv.D(), 2, scale, false, out var weights);
+                var chained = e.GroupedQueryAttentionBackward(ggo.D(), gq.D(), gk.D(), gv.D(), weights, 2, scale, out var gradQuery, out var gradKey, out var gradValue);
+                return new[] { chained, gradQuery, gradKey, gradValue };
+            }
+        };
 
         // Graph attention backward: nodeFeatures/gradOutput [1,4,6], edges [6], coeffs [6].
         var nf = OpInput.Rand(4820, new[] { 1, 4, 6 });
@@ -1045,14 +2074,30 @@ public static class OpParityRegistry
         yield return new OpCase("GraphAttentionBackward[1,4,6;6edges]", "attention",
             e => e.GraphAttentionBackward(ngo.F(), nf.F(), eSrc, eTgt, aSrc.F(), aTgt.F(), coeffs.F(), 0.2, out _, out _, out _),
             e => e.GraphAttentionBackward(ngo.D(), nf.D(), eSrc, eTgt, aSrc.D(), aTgt.D(), coeffs.D(), 0.2, out _, out _, out _),
-            ParityTol.Accum(1e-3), opMethod: "GraphAttentionBackward");
+            ParityTol.Accum(1e-3), opMethod: "GraphAttentionBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel)
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.BackwardKernel,
+            GraphCaptureSignatureConstraint = GraphCaptureSignatureConstraint.HeterogeneousInput,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var chained = e.GraphAttentionBackward(ngo.F(), nf.F(), eSrc, eTgt, aSrc.F(), aTgt.F(), coeffs.F(), 0.2, out var gradNodes, out var gradSource, out var gradTarget);
+                return new[] { chained, gradNodes, gradSource, gradTarget };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var chained = e.GraphAttentionBackward(ngo.D(), nf.D(), eSrc, eTgt, aSrc.D(), aTgt.D(), coeffs.D(), 0.2, out var gradNodes, out var gradSource, out var gradTarget);
+                return new[] { chained, gradNodes, gradSource, gradTarget };
+            }
+        };
 
         // Scatter-mean backward: gradOutput [4,6], indices [3], counts [4], source [3,6].
         var smgo = OpInput.Rand(4830, new[] { 4, 6 });
         yield return new OpCase("ScatterMeanBackward[4,6;idx3]", "index",
             e => e.ScatterMeanBackward(smgo.F(), new Tensor<int>(new[] { 0, 2, 3 }, new[] { 3 }), new Tensor<int>(new[] { 1, 1, 1, 1 }, new[] { 4 }), new[] { 3, 6 }, 0),
             e => e.ScatterMeanBackward(smgo.D(), new Tensor<int>(new[] { 0, 2, 3 }, new[] { 3 }), new Tensor<int>(new[] { 1, 1, 1, 1 }, new[] { 4 }), new[] { 3, 6 }, 0),
-            ParityTol.Ulp(4), opMethod: "ScatterMeanBackward");
+            ParityTol.Ulp(4), opMethod: "ScatterMeanBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Masked-fill, index-put, fused-linear backward, graph attention.
@@ -1065,7 +2110,17 @@ public static class OpParityRegistry
         yield return new OpCase("TensorMaskedFill[4,6;checker]", "index",
             e => e.TensorMaskedFill(mfT.F(), new Tensor<bool>((bool[])maskData.Clone(), new[] { 4, 6 }), 0f),
             e => e.TensorMaskedFill(mfT.D(), new Tensor<bool>((bool[])maskData.Clone(), new[] { 4, 6 }), 0.0),
-            ParityTol.Exact, opMethod: "TensorMaskedFill");
+            ParityTol.Exact, opMethod: "TensorMaskedFill",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+            graphCaptureSignatureOverload: GraphCaptureSignatureOverload.TensorMaskedFill_Tensor_T_Tensor_Boolean_T);
+
+        Bit[] bitMaskData = maskData.Select(value => value ? Bit.True : Bit.False).ToArray();
+        yield return new OpCase("TensorMaskedFill[4,6;checker-bit]", "index",
+            e => e.TensorMaskedFill(mfT.F(), new Tensor<Bit>((Bit[])bitMaskData.Clone(), new[] { 4, 6 }), 0f),
+            e => e.TensorMaskedFill(mfT.D(), new Tensor<Bit>((Bit[])bitMaskData.Clone(), new[] { 4, 6 }), 0.0),
+            ParityTol.Exact, opMethod: "TensorMaskedFill",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+            graphCaptureSignatureOverload: GraphCaptureSignatureOverload.TensorMaskedFill_Tensor_T_Tensor_Bit_T);
 
         // Index-put: advanced (row,col) indexing, no accumulate.
         var ipT = OpInput.Rand(4710, new[] { 4, 6 });
@@ -1073,7 +2128,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorIndexPut[4,6;3pts]", "index",
             e => e.TensorIndexPut(ipT.F(), new[] { new Tensor<int>(new[] { 0, 1, 2 }, new[] { 3 }), new Tensor<int>(new[] { 0, 2, 4 }, new[] { 3 }) }, ipSrc.F(), false),
             e => e.TensorIndexPut(ipT.D(), new[] { new Tensor<int>(new[] { 0, 1, 2 }, new[] { 3 }), new Tensor<int>(new[] { 0, 2, 4 }, new[] { 3 }) }, ipSrc.D(), false),
-            ParityTol.Exact, opMethod: "TensorIndexPut");
+            ParityTol.Exact, opMethod: "TensorIndexPut",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
 
         // Fused-linear backward: input [4,8], weights [8,6], preActivation/gradOutput [4,6].
         var flIn = OpInput.Rand(4720, new[] { 4, 8 });
@@ -1083,7 +2139,7 @@ public static class OpParityRegistry
         yield return new OpCase("FusedLinearBackward[4,8;w8,6]", "matmul",
             e => e.FusedLinearBackward(flGo.F(), flIn.F(), flW.F(), flPre.F(), FusedActivationType.None, out _, out _),
             e => e.FusedLinearBackward(flGo.D(), flIn.D(), flW.D(), flPre.D(), FusedActivationType.None, out _, out _),
-            ParityTol.Accum(1e-3), opMethod: "FusedLinearBackward");
+            ParityTol.Accum(1e-3), opMethod: "FusedLinearBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Graph attention: nodeFeatures [1,4,6], edges [6], attnSrc/Tgt [6].
         var nf = OpInput.Rand(4730, new[] { 1, 4, 6 });
@@ -1094,7 +2150,8 @@ public static class OpParityRegistry
         yield return new OpCase("GraphAttention[1,4,6;6edges]", "attention",
             e => e.GraphAttention(nf.F(), eSrc, eTgt, aSrc.F(), aTgt.F(), 0.2, out _),
             e => e.GraphAttention(nf.D(), eSrc, eTgt, aSrc.D(), aTgt.D(), 0.2, out _),
-            ParityTol.Accum(1e-3), opMethod: "GraphAttention");
+            ParityTol.Accum(1e-3), opMethod: "GraphAttention",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
     }
 
     // Grouped-deformable backwards, log-variance backward, scatter-reduce, equals.
@@ -1108,15 +2165,15 @@ public static class OpParityRegistry
         yield return new OpCase("DeformableConv2DGroupedBackwardInput[1,4,8,8;g2]", "conv",
             e => e.DeformableConv2DGroupedBackwardInput(ggo.F(), gin.F(), gk.F(), goff.F(), null, new[] { 1, 4, 8, 8 }, s, s, s, 2, 1),
             e => e.DeformableConv2DGroupedBackwardInput(ggo.D(), gin.D(), gk.D(), goff.D(), null, new[] { 1, 4, 8, 8 }, s, s, s, 2, 1),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DeformableConv2DGroupedBackwardKernel[1,4,8,8;g2]", "conv",
             e => e.DeformableConv2DGroupedBackwardKernel(ggo.F(), gin.F(), goff.F(), null, new[] { 4, 2, 3, 3 }, s, s, s, 2, 1),
             e => e.DeformableConv2DGroupedBackwardKernel(ggo.D(), gin.D(), goff.D(), null, new[] { 4, 2, 3, 3 }, s, s, s, 2, 1),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DeformableConv2DGroupedBackwardOffset[1,4,8,8;g2]", "conv",
             e => e.DeformableConv2DGroupedBackwardOffset(ggo.F(), gin.F(), gk.F(), goff.F(), null, s, s, s, 2, 1),
             e => e.DeformableConv2DGroupedBackwardOffset(ggo.D(), gin.D(), gk.D(), goff.D(), null, s, s, s, 2, 1),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardOffset");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DGroupedBackwardOffset", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Log-variance backward (global axes).
         var lgo = OpInput.Rand(4610, new[] { 1 });
@@ -1126,7 +2183,7 @@ public static class OpParityRegistry
         yield return new OpCase("ReduceLogVarianceBackward[4,6;global]", "reduction",
             e => e.ReduceLogVarianceBackward(lgo.F(), lin.F(), lmean.F(), lvar.F(), new[] { 0, 1 }),
             e => e.ReduceLogVarianceBackward(lgo.D(), lin.D(), lmean.D(), lvar.D(), new[] { 0, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "ReduceLogVarianceBackward");
+            ParityTol.Accum(1e-3), opMethod: "ReduceLogVarianceBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Scatter-reduce (Sum): indices and source share shape; distinct rows -> deterministic.
         var srT = OpInput.Rand(4620, new[] { 4, 6 });
@@ -1137,7 +2194,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorScatterReduce[4,6;idx3,6;sum]", "index",
             e => e.TensorScatterReduce(srT.F(), 0, new Tensor<int>((int[])srIdx.Clone(), new[] { 3, 6 }), srSrc.F(), ScatterReduceMode.Sum, true),
             e => e.TensorScatterReduce(srT.D(), 0, new Tensor<int>((int[])srIdx.Clone(), new[] { 3, 6 }), srSrc.D(), ScatterReduceMode.Sum, true),
-            ParityTol.Ulp(4), opMethod: "TensorScatterReduce");
+            ParityTol.Ulp(4), opMethod: "TensorScatterReduce",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
 
         // Elementwise equals-scalar (no exact matches -> all zeros; deterministic).
         var eqT = OpInput.Rand(4630, new[] { 4, 6 });
@@ -1157,14 +2215,16 @@ public static class OpParityRegistry
         yield return new OpCase("SpiralConvBackwardInput[6,5]", "conv",
             e => e.SpiralConvBackwardInput(go.F(), spiral, w.F(), 4),
             e => e.SpiralConvBackwardInput(go.D(), spiral, w.D(), 4),
-            ParityTol.Accum(1e-3), opMethod: "SpiralConvBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "SpiralConvBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("SpiralConvBackwardWeights[6,5]", "conv",
             e => e.SpiralConvBackwardWeights(go.F(), vf.F(), spiral),
             e => e.SpiralConvBackwardWeights(go.D(), vf.D(), spiral),
-            ParityTol.Accum(1e-3), opMethod: "SpiralConvBackwardWeights");
+            ParityTol.Accum(1e-3), opMethod: "SpiralConvBackwardWeights", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("SpiralConvBackwardBias[6,5]", "conv",
             e => e.SpiralConvBackwardBias(go.F()), e => e.SpiralConvBackwardBias(go.D()),
-            ParityTol.Ulp(8), opMethod: "SpiralConvBackwardBias");
+            ParityTol.Ulp(8), opMethod: "SpiralConvBackwardBias", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Positional-encoding backward: positions [4,3], numFrequencies 4, encoded grad [4, 3*2*4=24].
         var pos = OpInput.Rand(4510, new[] { 4, 3 });
@@ -1172,7 +2232,7 @@ public static class OpParityRegistry
         yield return new OpCase("PositionalEncodingBackward[4,3;freq4]", "encoding",
             e => e.PositionalEncodingBackward(pos.F(), encGrad.F(), 4),
             e => e.PositionalEncodingBackward(pos.D(), encGrad.D(), 4),
-            ParityTol.Accum(1e-3), opMethod: "PositionalEncodingBackward");
+            ParityTol.Accum(1e-3), opMethod: "PositionalEncodingBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Complex IFFT-to-real, magnitude+phase, spiral conv.
@@ -1182,7 +2242,9 @@ public static class OpParityRegistry
         var im1 = OpInput.Rand(4401, new[] { 8 });
         yield return new OpCase("NativeComplexIFFTReal[8]", "complex",
             e => e.NativeComplexIFFTReal(re1.CF(im1)), e => e.NativeComplexIFFTReal(re1.CD(im1)),
-            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFTReal");
+            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFTReal",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var re2 = OpInput.Rand(4410, new[] { 4, 4 });
         var im2 = OpInput.Rand(4411, new[] { 4, 4 });
@@ -1190,14 +2252,18 @@ public static class OpParityRegistry
         // the 1D NativeComplexIFFTReal passes, so it's the 2D GPU FFT kernel.
         yield return new OpCase("NativeComplexIFFT2DReal[4,4]", "complex",
             e => e.NativeComplexIFFT2DReal(re2.CF(im2)), e => e.NativeComplexIFFT2DReal(re2.CD(im2)),
-            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFT2DReal");
+            ParityTol.Accum(1e-3), opMethod: "NativeComplexIFFT2DReal",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var reM = OpInput.Rand(4420, new[] { 4, 6 });
         var imM = OpInput.Rand(4421, new[] { 4, 6 });
         yield return new OpCase("NativeMagnitudeAndPhase[4,6]", "complex",
             e => e.NativeMagnitudeAndPhase(reM.CF(imM), out _),
             e => e.NativeMagnitudeAndPhase(reM.CD(imM), out _),
-            ParityTol.Accum(1e-3), opMethod: "NativeMagnitudeAndPhase");
+            ParityTol.Accum(1e-3), opMethod: "NativeMagnitudeAndPhase",
+            graphCaptureExpectation: GraphCaptureExpectation.MixedElementTypes,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // SpiralConv: vertexFeatures [6,4], spiralIndices [6,3] int, weights [Cout=5, Cin*L=12], biases [5].
         var vf = OpInput.Rand(4430, new[] { 6, 4 });
@@ -1207,7 +2273,8 @@ public static class OpParityRegistry
         yield return new OpCase("SpiralConv[6,4;spiral6,3]", "conv",
             e => e.SpiralConv(vf.F(), spiral, sw.F(), sb.F()),
             e => e.SpiralConv(vf.D(), spiral, sw.D(), sb.D()),
-            ParityTol.Accum(1e-3), opMethod: "SpiralConv");
+            ParityTol.Accum(1e-3), opMethod: "SpiralConv",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
     }
 
     // Position-sensitive RoI, octonion ops, std/var backwards.
@@ -1246,11 +2313,11 @@ public static class OpParityRegistry
         yield return new OpCase("StdBackward[4,6;global]", "reduction",
             e => e.StdBackward(bgo.F(), bin.F(), e.ReduceMean(bin.F(), new[] { 0, 1 }, false), e.TensorSqrt(e.ReduceVariance(bin.F(), new[] { 0, 1 }, false)), System.Array.Empty<int>()),
             e => e.StdBackward(bgo.D(), bin.D(), e.ReduceMean(bin.D(), new[] { 0, 1 }, false), e.TensorSqrt(e.ReduceVariance(bin.D(), new[] { 0, 1 }, false)), System.Array.Empty<int>()),
-            ParityTol.Accum(1e-3), opMethod: "StdBackward");
+            ParityTol.Accum(1e-3), opMethod: "StdBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("VarBackward[4,6;global]", "reduction",
             e => e.VarBackward(bgo.F(), bin.F(), e.ReduceMean(bin.F(), new[] { 0, 1 }, false), System.Array.Empty<int>()),
             e => e.VarBackward(bgo.D(), bin.D(), e.ReduceMean(bin.D(), new[] { 0, 1 }, false), System.Array.Empty<int>()),
-            ParityTol.Accum(1e-3), opMethod: "VarBackward");
+            ParityTol.Accum(1e-3), opMethod: "VarBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Locally-connected conv (+ backwards), grouped deformable conv, 3D max-pool-with-indices.
@@ -1268,14 +2335,14 @@ public static class OpParityRegistry
         yield return new OpCase("LocallyConnectedConv2DBackwardInput[1,2,2,2]", "conv",
             e => e.LocallyConnectedConv2DBackwardInput(lcGo.F(), lcW.F(), new[] { 1, 1, 3, 3 }, lcStride),
             e => e.LocallyConnectedConv2DBackwardInput(lcGo.D(), lcW.D(), new[] { 1, 1, 3, 3 }, lcStride),
-            ParityTol.Accum(1e-3), opMethod: "LocallyConnectedConv2DBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "LocallyConnectedConv2DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("LocallyConnectedConv2DBackwardWeights[1,2,2,2]", "conv",
             e => e.LocallyConnectedConv2DBackwardWeights(lcGo.F(), lcIn.F(), new[] { 2, 2, 2, 1, 2, 2 }, lcStride),
             e => e.LocallyConnectedConv2DBackwardWeights(lcGo.D(), lcIn.D(), new[] { 2, 2, 2, 1, 2, 2 }, lcStride),
-            ParityTol.Accum(1e-3), opMethod: "LocallyConnectedConv2DBackwardWeights");
+            ParityTol.Accum(1e-3), opMethod: "LocallyConnectedConv2DBackwardWeights", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("LocallyConnectedConv2DBackwardBias[1,2,2,2]", "conv",
             e => e.LocallyConnectedConv2DBackwardBias(lcGo.F()), e => e.LocallyConnectedConv2DBackwardBias(lcGo.D()),
-            ParityTol.Ulp(8), opMethod: "LocallyConnectedConv2DBackwardBias");
+            ParityTol.Ulp(8), opMethod: "LocallyConnectedConv2DBackwardBias", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Grouped deformable conv: input [1,4,8,8], kernel [4,2,3,3] (groups=2), offset [1,18,8,8].
         var gdIn = OpInput.Rand(4210, new[] { 1, 4, 8, 8 });
@@ -1293,13 +2360,14 @@ public static class OpParityRegistry
             e => e.MaxPool3DWithIndices(mp3.D(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out _),
             ParityTol.Exact, opMethod: "MaxPool3DWithIndices")
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "The legacy CLR multidimensional-array out parameter is host-owned; MaxPool3DWithTensorIndices is the resident replacement."
+            GraphCaptureExpectation = GraphCaptureExpectation.HeterogeneousOutput,
+            GpuReadbackContract = GpuReadbackContract.LegacyHostOutput
         };
         yield return new OpCase("MaxPool3DWithTensorIndices[1,2,4,4,4;2x2x2]", "pool",
             e => e.MaxPool3DWithTensorIndices(mp3.F(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out _),
             e => e.MaxPool3DWithTensorIndices(mp3.D(), new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, out _),
-            ParityTol.Exact, opMethod: "MaxPool3DWithTensorIndices");
+            ParityTol.Exact, opMethod: "MaxPool3DWithTensorIndices",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousOutput);
     }
 
     // Deformable-conv backwards, grid-sample backwards, scatter-add backward.
@@ -1312,15 +2380,15 @@ public static class OpParityRegistry
         yield return new OpCase("DeformableConv2DBackwardInput[1,3,8,8]", "conv",
             e => e.DeformableConv2DBackwardInput(dcGo.F(), dcIn.F(), dcK.F(), dcOff.F(), null, new[] { 1, 2, 8, 8 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
             e => e.DeformableConv2DBackwardInput(dcGo.D(), dcIn.D(), dcK.D(), dcOff.D(), null, new[] { 1, 2, 8, 8 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DeformableConv2DBackwardKernel[1,3,8,8]", "conv",
             e => e.DeformableConv2DBackwardKernel(dcGo.F(), dcIn.F(), dcOff.F(), null, new[] { 3, 2, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
             e => e.DeformableConv2DBackwardKernel(dcGo.D(), dcIn.D(), dcOff.D(), null, new[] { 3, 2, 3, 3 }, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DeformableConv2DBackwardOffset[1,3,8,8]", "conv",
             e => e.DeformableConv2DBackwardOffset(dcGo.F(), dcIn.F(), dcK.F(), dcOff.F(), null, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
             e => e.DeformableConv2DBackwardOffset(dcGo.D(), dcIn.D(), dcK.D(), dcOff.D(), null, new[] { 1, 1 }, new[] { 1, 1 }, new[] { 1, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardOffset");
+            ParityTol.Accum(1e-3), opMethod: "DeformableConv2DBackwardOffset", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Grid-sample backwards (NHWC): input [1,4,4,2], grid [1,4,4,2], gradOutput [1,4,4,2].
         // NCHW: input/gradOutput [N,C,H,W], grid [N,outH,outW,2] (outH=outW=4 -> gradOutput [1,2,4,4]).
@@ -1330,11 +2398,11 @@ public static class OpParityRegistry
         yield return new OpCase("GridSampleBackwardInput[1,2,4,4]", "grid",
             e => e.GridSampleBackwardInput(gsGo.F(), gsGrid.F(), new[] { 1, 2, 4, 4 }),
             e => e.GridSampleBackwardInput(gsGo.D(), gsGrid.D(), new[] { 1, 2, 4, 4 }),
-            ParityTol.Accum(1e-3), opMethod: "GridSampleBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "GridSampleBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("GridSampleBackwardGrid[1,2,4,4]", "grid",
             e => e.GridSampleBackwardGrid(gsGo.F(), gsIn.F(), gsGrid.F()),
             e => e.GridSampleBackwardGrid(gsGo.D(), gsIn.D(), gsGrid.D()),
-            ParityTol.Accum(1e-3), opMethod: "GridSampleBackwardGrid");
+            ParityTol.Accum(1e-3), opMethod: "GridSampleBackwardGrid", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // ScatterAdd backward: gradient wrt source = gather of gradOutput at indices.
         var saGo = OpInput.Rand(4120, new[] { 4, 6 });
@@ -1342,7 +2410,8 @@ public static class OpParityRegistry
         yield return new OpCase("ScatterAddBackward[4,6;idx3]", "index",
             e => e.ScatterAddBackward(saGo.F(), new Tensor<int>((int[])saIdx.Clone(), new[] { 3 }), new[] { 3, 6 }, 0),
             e => e.ScatterAddBackward(saGo.D(), new Tensor<int>((int[])saIdx.Clone(), new[] { 3 }), new[] { 3, 6 }, 0),
-            ParityTol.Exact, opMethod: "ScatterAddBackward");
+            ParityTol.Exact, opMethod: "ScatterAddBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Deformable conv + mesh diffusion/Laplacian.
@@ -1373,7 +2442,8 @@ public static class OpParityRegistry
         yield return new OpCase("ComputeMeshLaplacian[tet4;uniform]", "geometry",
             e => e.ComputeMeshLaplacian(verts.F(), faces, LaplacianType.Uniform),
             e => e.ComputeMeshLaplacian(verts.D(), faces, LaplacianType.Uniform),
-            ParityTol.Accum(1e-3), opMethod: "ComputeMeshLaplacian");
+            ParityTol.Accum(1e-3), opMethod: "ComputeMeshLaplacian",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
     }
 
     // Mean-diff, stack, variance/softmax backwards.
@@ -1398,7 +2468,7 @@ public static class OpParityRegistry
         yield return new OpCase("ReduceVarianceBackward[4,6;ax1]", "reduction",
             e => e.ReduceVarianceBackward(vgo.F(), vin.F(), e.ReduceMean(vin.F(), new[] { 1 }, false), new[] { 1 }),
             e => e.ReduceVarianceBackward(vgo.D(), vin.D(), e.ReduceMean(vin.D(), new[] { 1 }, false), new[] { 1 }),
-            ParityTol.Accum(1e-3), opMethod: "ReduceVarianceBackward");
+            ParityTol.Accum(1e-3), opMethod: "ReduceVarianceBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Taylor/spherical softmax backwards [4,8] over last axis.
         var go = OpInput.Rand(3920, new[] { 4, 8 });
@@ -1408,11 +2478,11 @@ public static class OpParityRegistry
         yield return new OpCase("TaylorSoftmaxBackward[4,8]", "activation",
             e => e.TaylorSoftmaxBackward(go.F(), sin.F(), e.TaylorSoftmax(sin.F(), 2, -1), 2, -1),
             e => e.TaylorSoftmaxBackward(go.D(), sin.D(), e.TaylorSoftmax(sin.D(), 2, -1), 2, -1),
-            ParityTol.Accum(1e-3), opMethod: "TaylorSoftmaxBackward");
+            ParityTol.Accum(1e-3), opMethod: "TaylorSoftmaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("SphericalSoftmaxBackward[4,8]", "activation",
             e => e.SphericalSoftmaxBackward(go.F(), sin.F(), e.SphericalSoftmax(sin.F(), -1), -1),
             e => e.SphericalSoftmaxBackward(go.D(), sin.D(), e.SphericalSoftmax(sin.D(), -1), -1),
-            ParityTol.Accum(1e-3), opMethod: "SphericalSoftmaxBackward");
+            ParityTol.Accum(1e-3), opMethod: "SphericalSoftmaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // FFT-based audio features (MFCC / wideband / mel-spectrogram).
@@ -1490,14 +2560,16 @@ public static class OpParityRegistry
         yield return new OpCase("Scatter[4,6;idx6;axis1]", "index",
             e => e.Scatter(sd.F(), new Tensor<int>((int[])sIdx.Clone(), new[] { 6 }), sv.F(), 1),
             e => e.Scatter(sd.D(), new Tensor<int>((int[])sIdx.Clone(), new[] { 6 }), sv.D(), 1),
-            ParityTol.Exact, opMethod: "Scatter");
+            ParityTol.Exact, opMethod: "Scatter",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // Interleaved-complex magnitude/multiply ([...,re,im] pairs in a real tensor).
         var ca = OpInput.Rand(3740, new[] { 4, 6 });
         var cb = OpInput.Rand(3741, new[] { 4, 6 });
         yield return new OpCase("TensorComplexMagnitude[4,6]", "complex",
             e => e.TensorComplexMagnitude(ca.F()), e => e.TensorComplexMagnitude(ca.D()),
-            ParityTol.Accum(1e-3), opMethod: "TensorComplexMagnitude");
+            ParityTol.Accum(1e-3), opMethod: "TensorComplexMagnitude")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("TensorComplexMultiply[4,6]", "complex",
             e => e.TensorComplexMultiply(ca.F(), cb.F()), e => e.TensorComplexMultiply(ca.D(), cb.D()),
             ParityTol.Ulp(8), opMethod: "TensorComplexMultiply");
@@ -1560,7 +2632,7 @@ public static class OpParityRegistry
                 for (int e = 0; e < E; e++)
                     routedMaskData[((b * S) + s) * E + e] =
                         (s + e) % E == 0 ? 0.0 : 0.25 + (0.25 * ((s + e) % E));
-        var routedMask = OpInput.From(routedMaskData, new[] { B, S, E });
+        var routedMask = OpInput.FixedFrom(routedMaskData, new[] { B, S, E });
         var routedA = OpInput.Rand(3691, new[] { E, ST }, 0.1, 0.8);
         var routedB = OpInput.Rand(3692, new[] { E, ST, D });
         var routedC = OpInput.Rand(3693, new[] { E, D, ST });
@@ -1616,7 +2688,27 @@ public static class OpParityRegistry
         yield return new OpCase("LstmSequenceForward[2,4,8;hid4]", "scan",
             e => e.LstmSequenceForward(lstmIn.F(), null, null, wIh.F(), wHh.F(), null, null, false),
             e => e.LstmSequenceForward(lstmIn.D(), null, null, wIh.D(), wHh.D(), null, null, false),
-            ParityTol.Accum(1e-3), opMethod: "LstmSequenceForward");
+            ParityTol.Accum(1e-3), opMethod: "LstmSequenceForward")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+
+        yield return new OpCase("LstmSequenceForwardState[2,4,8;hid4]", "scan",
+            e => e.LstmSequenceForward(lstmIn.F(), null, null, wIh.F(), wHh.F(), null, null, out _, out _, true),
+            e => e.LstmSequenceForward(lstmIn.D(), null, null, wIh.D(), wHh.D(), null, null, out _, out _, true),
+            ParityTol.Accum(1e-3), opMethod: "LstmSequenceForward")
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.Required,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.LstmSequenceForward(lstmIn.F(), null, null, wIh.F(), wHh.F(), null, null, out var finalHidden, out var finalCell, true);
+                return new[] { output, finalHidden, finalCell };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.LstmSequenceForward(lstmIn.D(), null, null, wIh.D(), wHh.D(), null, null, out var finalHidden, out var finalCell, true);
+                return new[] { output, finalHidden, finalCell };
+            }
+        };
     }
 
     // Scaled-dot-product attention, scatter-max (all outputs covered), unique.
@@ -1629,7 +2721,21 @@ public static class OpParityRegistry
         yield return new OpCase("ScaledDotProductAttention[4,8]", "attention",
             e => e.ScaledDotProductAttention(q.F(), k.F(), val.F(), null, null, out _),
             e => e.ScaledDotProductAttention(q.D(), k.D(), val.D(), null, null, out _),
-            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttention");
+            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttention")
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.Required,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.ScaledDotProductAttention(q.F(), k.F(), val.F(), null, null, out var weights);
+                return new[] { output, weights };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.ScaledDotProductAttention(q.D(), k.D(), val.D(), null, null, out var weights);
+                return new[] { output, weights };
+            }
+        };
 
         bool[] maskData =
         [
@@ -1647,7 +2753,8 @@ public static class OpParityRegistry
                 new Tensor<bool>((bool[])maskData.Clone(), new[] { 1, 2, 4, 4 }), null, out _),
             e => e.ScaledDotProductAttention(q.D(), k.D(), val.D(),
                 new Tensor<bool>((bool[])maskData.Clone(), new[] { 1, 2, 4, 4 }), null, out _),
-            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttention");
+            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttention",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // ScatterMax: every output index covered (0..3) so no empty-group -inf; max is deterministic.
         var smSrc = OpInput.Rand(3510, new[] { 6 });
@@ -1655,7 +2762,9 @@ public static class OpParityRegistry
         yield return new OpCase("ScatterMax[6->4]", "index",
             e => e.ScatterMax(smSrc.F(), new Tensor<int>((int[])smIdx.Clone(), new[] { 6 }), out _, 0, 4),
             e => e.ScatterMax(smSrc.D(), new Tensor<int>((int[])smIdx.Clone(), new[] { 6 }), out _, 0, 4),
-            ParityTol.Exact, opMethod: "ScatterMax");
+            ParityTol.Exact, opMethod: "ScatterMax",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousOutput,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // Unique (sorted): NON-consecutive repeats must collapse. Deterministic input with dupes
         // [3,1,2,1,3,2,4,1,5,2,3,4] -> sorted-unique [1,2,3,4,5] (length 5, not the input's 12).
@@ -1664,8 +2773,8 @@ public static class OpParityRegistry
             e => e.TensorUnique(uniq.F(), true), e => e.TensorUnique(uniq.D(), true),
             ParityTol.Exact, opMethod: "TensorUnique")
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "One scalar cardinality is required to construct the exact-size synchronous Tensor result."
+            GraphCaptureExpectation = GraphCaptureExpectation.DataDependentOutputShape,
+            GpuReadbackContract = GpuReadbackContract.DynamicResultShape
         };
     }
 
@@ -1678,37 +2787,43 @@ public static class OpParityRegistry
         yield return new OpCase("Gather[4,6;idx4,3;axis1]", "index",
             e => e.Gather(src.F(), new Tensor<int>((int[])gIdx.Clone(), new[] { 4, 3 }), 1),
             e => e.Gather(src.D(), new Tensor<int>((int[])gIdx.Clone(), new[] { 4, 3 }), 1),
-            ParityTol.Exact, opMethod: "Gather");
+            ParityTol.Exact, opMethod: "Gather",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         // Axis-0 row gather (1-D indices) — exercises the dedicated GPU gather_kernel path.
         var g0Idx = new int[] { 3, 0, 2, 0, 1 };
         yield return new OpCase("Gather[4,6;idx5;axis0]", "index",
             e => e.Gather(src.F(), new Tensor<int>((int[])g0Idx.Clone(), new[] { 5 }), 0),
             e => e.Gather(src.D(), new Tensor<int>((int[])g0Idx.Clone(), new[] { 5 }), 0),
-            ParityTol.Exact, opMethod: "Gather");
+            ParityTol.Exact, opMethod: "Gather",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var dest = OpInput.Rand(3410, new[] { 4, 6 });
         var upd = OpInput.Rand(3411, new[] { 4, 3 });
         yield return new OpCase("TensorScatter[4,6;idx4,3;axis1]", "index",
             e => e.TensorScatter(dest.F(), new Tensor<int>((int[])gIdx.Clone(), new[] { 4, 3 }), upd.F(), 1),
             e => e.TensorScatter(dest.D(), new Tensor<int>((int[])gIdx.Clone(), new[] { 4, 3 }), upd.D(), 1),
-            ParityTol.Exact, opMethod: "TensorScatter");
+            ParityTol.Exact, opMethod: "TensorScatter",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
         // index_add semantics: 1-D indices select rows (axis 0); distinct rows -> deterministic.
         var addUpd = OpInput.Rand(3412, new[] { 3, 6 });
         var addIdx = new int[] { 0, 2, 3 };
         yield return new OpCase("TensorScatterAdd[4,6;idx3;axis0]", "index",
             e => e.TensorScatterAdd(dest.F(), new Tensor<int>((int[])addIdx.Clone(), new[] { 3 }), addUpd.F(), 0),
             e => e.TensorScatterAdd(dest.D(), new Tensor<int>((int[])addIdx.Clone(), new[] { 3 }), addUpd.D(), 0),
-            ParityTol.Ulp(4), opMethod: "TensorScatterAdd");
+            ParityTol.Ulp(4), opMethod: "TensorScatterAdd",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var selIdx = new int[] { 0, 2, 3 };
         yield return new OpCase("TensorIndexSelectDiff[4,6;idx3;axis0]", "index",
             e => e.TensorIndexSelectDiff(src.F(), new Tensor<int>((int[])selIdx.Clone(), new[] { 3 }), 0),
             e => e.TensorIndexSelectDiff(src.D(), new Tensor<int>((int[])selIdx.Clone(), new[] { 3 }), 0),
-            ParityTol.Exact, opMethod: "TensorIndexSelectDiff");
+            ParityTol.Exact, opMethod: "TensorIndexSelectDiff",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("TensorIndexSelectDiff[4,6;idx3;axis1]", "index",
             e => e.TensorIndexSelectDiff(src.F(), new Tensor<int>((int[])selIdx.Clone(), new[] { 3 }), 1),
             e => e.TensorIndexSelectDiff(src.D(), new Tensor<int>((int[])selIdx.Clone(), new[] { 3 }), 1),
-            ParityTol.Exact, opMethod: "TensorIndexSelectDiff");
+            ParityTol.Exact, opMethod: "TensorIndexSelectDiff",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var poolIn = OpInput.Rand(3420, new[] { 1, 2, 8, 8 });
         yield return new OpCase("MaxPool2DWithIndices[1,2,8,8;2x2]", "pool",
@@ -1716,13 +2831,13 @@ public static class OpParityRegistry
             e => e.MaxPool2DWithIndices(poolIn.D(), new[] { 2, 2 }, new[] { 2, 2 }, out _),
             ParityTol.Exact, opMethod: "MaxPool2DWithIndices")
         {
-            GpuAllowedReadbacks = 1,
-            GpuReadbackReason = "The legacy CLR multidimensional-array out parameter is host-owned; MaxPool2DWithTensorIndices is the resident replacement."
+            GpuReadbackContract = GpuReadbackContract.LegacyHostOutput
         };
         yield return new OpCase("MaxPool2DWithTensorIndices[1,2,8,8;2x2]", "pool",
             e => e.MaxPool2DWithTensorIndices(poolIn.F(), new[] { 2, 2 }, new[] { 2, 2 }, out _),
             e => e.MaxPool2DWithTensorIndices(poolIn.D(), new[] { 2, 2 }, new[] { 2, 2 }, out _),
-            ParityTol.Exact, opMethod: "MaxPool2DWithTensorIndices");
+            ParityTol.Exact, opMethod: "MaxPool2DWithTensorIndices",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousOutput);
     }
 
     // Fused conv2d/3d/transpose, convT3d backward, mel filterbank, MLP forward.
@@ -1762,17 +2877,18 @@ public static class OpParityRegistry
         yield return new OpCase("ConvTranspose3DBackwardInput[go1,3,4,4,4;k2,3,2,2,2]", "conv",
             e => e.ConvTranspose3DBackwardInput(t3Go.F(), t3K.F(), new[] { 1, 2, 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }),
             e => e.ConvTranspose3DBackwardInput(t3Go.D(), t3K.D(), new[] { 1, 2, 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }),
-            ParityTol.Accum(1e-3), opMethod: "ConvTranspose3DBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "ConvTranspose3DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("ConvTranspose3DBackwardKernel[go1,3,4,4,4;in1,2,2,2,2]", "conv",
             e => e.ConvTranspose3DBackwardKernel(t3Go.F(), t3In.F(), new[] { 2, 3, 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }),
             e => e.ConvTranspose3DBackwardKernel(t3Go.D(), t3In.D(), new[] { 2, 3, 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }),
-            ParityTol.Accum(1e-3), opMethod: "ConvTranspose3DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "ConvTranspose3DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Mel filterbank (no tensor input) — deterministic triangular filters.
         yield return new OpCase("CreateMelFilterbank[8,16]", "audio",
             e => e.CreateMelFilterbank<float>(8, 16, 16000, 0f, 8000f),
             e => e.CreateMelFilterbank<double>(8, 16, 16000, 0.0, 8000.0),
-            ParityTol.Accum(1e-3), opMethod: "CreateMelFilterbank");
+            ParityTol.Accum(1e-3), opMethod: "CreateMelFilterbank",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         // MLP forward: input [4,8] -> [8,16] -> [16,6], no bias, None activations.
         var mlpIn = OpInput.Rand(3340, new[] { 4, 8 });
@@ -1781,7 +2897,8 @@ public static class OpParityRegistry
         yield return new OpCase("MlpForward[4,8;8,16;16,6]", "matmul",
             e => e.MlpForward(mlpIn.F(), new[] { w1.F(), w2.F() }, new Tensor<float>?[] { null, null }, FusedActivationType.None, FusedActivationType.None),
             e => e.MlpForward(mlpIn.D(), new[] { w1.D(), w2.D() }, new Tensor<double>?[] { null, null }, FusedActivationType.None, FusedActivationType.None),
-            ParityTol.Accum(1e-3), opMethod: "MlpForward");
+            ParityTol.Accum(1e-3), opMethod: "MlpForward")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
     }
 
     // Assorted Tensor* math: leaky-relu, power, inner/outer, expand, CIoU loss, upsample, tri-mask, zeta.
@@ -1803,7 +2920,8 @@ public static class OpParityRegistry
         var v = OpInput.Rand(3211, new[] { 6 });
         yield return new OpCase("TensorOuterProduct[4;6]", "matmul",
             e => e.TensorOuterProduct(u.F(), v.F()), e => e.TensorOuterProduct(u.D(), v.D()),
-            ParityTol.Ulp(4), opMethod: "TensorOuterProduct");
+            ParityTol.Ulp(4), opMethod: "TensorOuterProduct")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         var row = OpInput.Rand(3220, new[] { 1, 6 });
         var like = OpInput.Rand(3221, new[] { 4, 6 });
@@ -1829,7 +2947,8 @@ public static class OpParityRegistry
 
         yield return new OpCase("TensorTriangularMask[4;lower]", "shape",
             e => e.TensorTriangularMask<float>(4, false, 0), e => e.TensorTriangularMask<double>(4, false, 0),
-            ParityTol.Exact, opMethod: "TensorTriangularMask");
+            ParityTol.Exact, opMethod: "TensorTriangularMask",
+            graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         // Hurwitz zeta zeta(x,q), x>1, q>0.
         var zx = OpInput.Rand(3240, new[] { 3, 4 }, 2.0, 4.0);
@@ -1846,13 +2965,16 @@ public static class OpParityRegistry
         var im = OpInput.Rand(3101, new[] { 4, 6 });
         yield return new OpCase("NativeComplexMagnitude[4,6]", "complex",
             e => e.NativeComplexMagnitude(re.CF(im)), e => e.NativeComplexMagnitude(re.CD(im)),
-            ParityTol.Accum(1e-3), opMethod: "NativeComplexMagnitude");
+            ParityTol.Accum(1e-3), opMethod: "NativeComplexMagnitude",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("NativeComplexMagnitudeSquared[4,6]", "complex",
             e => e.NativeComplexMagnitudeSquared(re.CF(im)), e => e.NativeComplexMagnitudeSquared(re.CD(im)),
-            ParityTol.Ulp(8), opMethod: "NativeComplexMagnitudeSquared");
+            ParityTol.Ulp(8), opMethod: "NativeComplexMagnitudeSquared",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("NativeComplexPhase[4,6]", "complex",
             e => e.NativeComplexPhase(re.CF(im)), e => e.NativeComplexPhase(re.CD(im)),
-            ParityTol.Accum(1e-3), opMethod: "NativeComplexPhase");
+            ParityTol.Accum(1e-3), opMethod: "NativeComplexPhase",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // Scalar-minus-tensor, add-scaled, at-least-Nd shape promotion, N-d pad.
@@ -1896,7 +3018,20 @@ public static class OpParityRegistry
         yield return new OpCase("FlashAttention[1,2,4,8]", "attention",
             e => e.FlashAttention(fq.F(), fk.F(), fv.F(), null, false, out _, null),
             e => e.FlashAttention(fq.D(), fk.D(), fv.D(), null, false, out _, null),
-            ParityTol.Accum(1e-3), opMethod: "FlashAttention");
+            ParityTol.Accum(1e-3), opMethod: "FlashAttention")
+        {
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.FlashAttention(fq.F(), fk.F(), fv.F(), null, false, out var stats, null);
+                return new[] { output, stats };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.FlashAttention(fq.D(), fk.D(), fv.D(), null, false, out var stats, null);
+                return new[] { output, stats };
+            }
+        };
 
         // GroupedQueryAttention: Q [1,4,4,8], K/V [1,2,4,8], 2 queries per KV head.
         var gq = OpInput.Rand(2910, new[] { 1, 4, 4, 8 });
@@ -1905,7 +3040,27 @@ public static class OpParityRegistry
         yield return new OpCase("GroupedQueryAttention[q1,4,4,8;kv1,2,4,8]", "attention",
             e => e.GroupedQueryAttention(gq.F(), gk.F(), gv.F(), 2, null, false, out _),
             e => e.GroupedQueryAttention(gq.D(), gk.D(), gv.D(), 2, null, false, out _),
-            ParityTol.Accum(1e-3), opMethod: "GroupedQueryAttention");
+            ParityTol.Accum(1e-3), opMethod: "GroupedQueryAttention")
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.Required,
+            TensorOutputContract = TensorOutputContract.HomogeneousMultiple,
+            RunFloatOutputs = e =>
+            {
+                var output = e.GroupedQueryAttention(gq.F(), gk.F(), gv.F(), 2, null, false, out var weights);
+                return new[] { output, weights };
+            },
+            RunDoubleOutputs = e =>
+            {
+                var output = e.GroupedQueryAttention(gq.D(), gk.D(), gv.D(), 2, null, false, out var weights);
+                return new[] { output, weights };
+            }
+        };
+
+        yield return new OpCase("ScaledDotProductAttentionGqa[q1,4,4,8;kv1,2,4,8;softcap1.5]", "attention",
+            e => e.ScaledDotProductAttentionGqa(gq.F(), gk.F(), gv.F(), 0.35355339059, false, 1.5),
+            e => e.ScaledDotProductAttentionGqa(gq.D(), gk.D(), gv.D(), 0.35355339059, false, 1.5),
+            ParityTol.Accum(1e-3), opMethod: "ScaledDotProductAttentionGqa")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         // MultiHeadAttentionForward: input [B,S,dModel] = [2,4,8], projections [8,8], 2 heads.
         var mhaIn = OpInput.Rand(2920, new[] { 2, 4, 8 });
@@ -1916,7 +3071,19 @@ public static class OpParityRegistry
         yield return new OpCase("MultiHeadAttentionForward[2,4,8;h2]", "attention",
             e => e.MultiHeadAttentionForward(mhaIn.F(), qw.F(), kw.F(), vw.F(), ow.F(), 2, null),
             e => e.MultiHeadAttentionForward(mhaIn.D(), qw.D(), kw.D(), vw.D(), ow.D(), 2, null),
-            ParityTol.Accum(1e-3), opMethod: "MultiHeadAttentionForward");
+            ParityTol.Accum(1e-3), opMethod: "MultiHeadAttentionForward")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+
+        bool[] mhaMaskData = Enumerable.Range(0, 2 * 2 * 4 * 4)
+            .Select(index => index % 5 != 0)
+            .ToArray();
+        yield return new OpCase("MultiHeadAttentionForward[2,4,8;h2;mask]", "attention",
+            e => e.MultiHeadAttentionForward(mhaIn.F(), qw.F(), kw.F(), vw.F(), ow.F(), 2,
+                new Tensor<bool>((bool[])mhaMaskData.Clone(), new[] { 2, 2, 4, 4 })),
+            e => e.MultiHeadAttentionForward(mhaIn.D(), qw.D(), kw.D(), vw.D(), ow.D(), 2,
+                new Tensor<bool>((bool[])mhaMaskData.Clone(), new[] { 2, 2, 4, 4 })),
+            ParityTol.Accum(1e-3), opMethod: "MultiHeadAttentionForward",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // FusedBatchNorm in eval mode (training=false) uses running stats -> deterministic identity-ish.
         var bnIn = OpInput.Rand(2930, new[] { 2, 4, 4, 4 });
@@ -1939,7 +3106,7 @@ public static class OpParityRegistry
         yield return new OpCase("Conv1DBackwardKernel[go1,3,6;in1,2,8]", "conv",
             e => e.Conv1DBackwardKernel(go1d.F(), in1d.F(), new[] { 3, 2, 3 }, 1, 0, 1),
             e => e.Conv1DBackwardKernel(go1d.D(), in1d.D(), new[] { 3, 2, 3 }, 1, 0, 1),
-            ParityTol.Accum(1e-3), opMethod: "Conv1DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "Conv1DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Depthwise conv1d backward kernel: input [1,4,8], kernelShape [4,1,3] -> out [1,4,6].
         var dwGo1 = OpInput.Rand(2820, new[] { 1, 4, 6 });
@@ -1947,7 +3114,7 @@ public static class OpParityRegistry
         yield return new OpCase("DepthwiseConv1DBackwardKernel[go1,4,6;in1,4,8]", "conv",
             e => e.DepthwiseConv1DBackwardKernel(dwGo1.F(), dwIn1.F(), new[] { 4, 1, 3 }, 1, 0),
             e => e.DepthwiseConv1DBackwardKernel(dwGo1.D(), dwIn1.D(), new[] { 4, 1, 3 }, 1, 0),
-            ParityTol.Accum(1e-3), opMethod: "DepthwiseConv1DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "DepthwiseConv1DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // ConvTranspose2D backward kernel: convT input [1,2,4,4] kernel [2,3,2,2] stride2 -> [1,3,8,8].
         var ct2Go = OpInput.Rand(2830, new[] { 1, 3, 8, 8 });
@@ -1955,7 +3122,7 @@ public static class OpParityRegistry
         yield return new OpCase("ConvTranspose2DBackwardKernel[go1,3,8,8;in1,2,4,4]", "conv",
             e => e.ConvTranspose2DBackwardKernel(ct2Go.F(), ct2In.F(), new[] { 2, 3, 2, 2 }, new[] { 2, 2 }, new[] { 0, 0 }),
             e => e.ConvTranspose2DBackwardKernel(ct2Go.D(), ct2In.D(), new[] { 2, 3, 2, 2 }, new[] { 2, 2 }, new[] { 0, 0 }),
-            ParityTol.Accum(1e-3), opMethod: "ConvTranspose2DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "ConvTranspose2DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Interpolate [1,2,4,4] -> [8,8] bilinear.
         var interpIn = OpInput.Rand(2840, new[] { 1, 2, 4, 4 });
@@ -1986,11 +3153,11 @@ public static class OpParityRegistry
         yield return new OpCase("Conv3DBackwardKernel[go1,3,3,3,3;in1,2,4,4,4]", "conv",
             e => e.Conv3DBackwardKernel(go3d.F(), in3d.F(), new[] { 3, 2, 2, 2, 2 }, new[] { 1, 1, 1 }, new[] { 0, 0, 0 }, new[] { 1, 1, 1 }),
             e => e.Conv3DBackwardKernel(go3d.D(), in3d.D(), new[] { 3, 2, 2, 2, 2 }, new[] { 1, 1, 1 }, new[] { 0, 0, 0 }, new[] { 1, 1, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "Conv3DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "Conv3DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("Conv3DBackwardInput[go1,3,3,3,3;k3,2,2,2,2]", "conv",
             e => e.Conv3DBackwardInput(go3d.F(), k3d.F(), new[] { 1, 2, 4, 4, 4 }, new[] { 1, 1, 1 }, new[] { 0, 0, 0 }, new[] { 1, 1, 1 }),
             e => e.Conv3DBackwardInput(go3d.D(), k3d.D(), new[] { 1, 2, 4, 4, 4 }, new[] { 1, 1, 1 }, new[] { 0, 0, 0 }, new[] { 1, 1, 1 }),
-            ParityTol.Accum(1e-3), opMethod: "Conv3DBackwardInput");
+            ParityTol.Accum(1e-3), opMethod: "Conv3DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // ConvTranspose3D: input [1,2,2,2,2], kernel [2,3,2,2,2] (inC,outC,kD,kH,kW), stride 2.
         var ctIn = OpInput.Rand(2710, new[] { 1, 2, 2, 2, 2 });
@@ -2006,7 +3173,7 @@ public static class OpParityRegistry
         yield return new OpCase("DepthwiseConv2DBackwardKernel[go1,4,6,6;in1,4,8,8]", "conv",
             e => e.DepthwiseConv2DBackwardKernel(dwGo.F(), dwIn.F(), new[] { 4, 1, 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }),
             e => e.DepthwiseConv2DBackwardKernel(dwGo.D(), dwIn.D(), new[] { 4, 1, 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }),
-            ParityTol.Accum(1e-3), opMethod: "DepthwiseConv2DBackwardKernel");
+            ParityTol.Accum(1e-3), opMethod: "DepthwiseConv2DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Box-IoU variants: boxesA [3,4], boxesB [2,4] in XYXY.
         var ba = OpInput.From(new double[] { 0, 0, 2, 2, 1, 1, 3, 4, 0, 1, 4, 3 }, new[] { 3, 4 });
@@ -2066,13 +3233,13 @@ public static class OpParityRegistry
 
         yield return new OpCase("PixelShuffleBackward[1,1,8,8->1,4,4,4]", "shape",
             e => e.PixelShuffleBackward(OpInput.Rand(2510, new[] { 1, 1, 8, 8 }).F(), new[] { 1, 4, 4, 4 }, 2),
-            e => e.PixelShuffleBackward(OpInput.Rand(2510, new[] { 1, 1, 8, 8 }).D(), new[] { 1, 4, 4, 4 }, 2), ParityTol.Exact, opMethod: "PixelShuffleBackward");
+            e => e.PixelShuffleBackward(OpInput.Rand(2510, new[] { 1, 1, 8, 8 }).D(), new[] { 1, 4, 4, 4 }, 2), ParityTol.Exact, opMethod: "PixelShuffleBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("UpsampleBackward[1,2,8,8->1,2,4,4]", "shape",
             e => e.UpsampleBackward(OpInput.Rand(2511, new[] { 1, 2, 8, 8 }).F(), new[] { 1, 2, 4, 4 }, 2, 2),
-            e => e.UpsampleBackward(OpInput.Rand(2511, new[] { 1, 2, 8, 8 }).D(), new[] { 1, 2, 4, 4 }, 2, 2), ParityTol.Accum(1e-3), opMethod: "UpsampleBackward");
+            e => e.UpsampleBackward(OpInput.Rand(2511, new[] { 1, 2, 8, 8 }).D(), new[] { 1, 2, 4, 4 }, 2, 2), ParityTol.Accum(1e-3), opMethod: "UpsampleBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("Upsample3DBackward[1,2,4,4,4->1,2,2,2,2]", "shape",
             e => e.Upsample3DBackward(OpInput.Rand(2512, new[] { 1, 2, 4, 4, 4 }).F(), new[] { 1, 2, 2, 2, 2 }, 2, 2, 2),
-            e => e.Upsample3DBackward(OpInput.Rand(2512, new[] { 1, 2, 4, 4, 4 }).D(), new[] { 1, 2, 2, 2, 2 }, 2, 2, 2), ParityTol.Accum(1e-3), opMethod: "Upsample3DBackward");
+            e => e.Upsample3DBackward(OpInput.Rand(2512, new[] { 1, 2, 4, 4, 4 }).D(), new[] { 1, 2, 2, 2, 2 }, 2, 2, 2), ParityTol.Accum(1e-3), opMethod: "Upsample3DBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Audio (mu-law), FFT, gaussian-splat covariance, gumbel-softmax backward.
@@ -2081,13 +3248,15 @@ public static class OpParityRegistry
         var q = new int[8]; for (int i = 0; i < 8; i++) q[i] = i * 30 + 5;
         yield return new OpCase("MuLawDecoding[idx8;q256]", "audio",
             e => e.MuLawDecoding<float>(new Tensor<int>((int[])q.Clone(), new[] { 8 }), 256),
-            e => e.MuLawDecoding<double>(new Tensor<int>((int[])q.Clone(), new[] { 8 }), 256), ParityTol.Ulp(16, 1e-6), opMethod: "MuLawDecoding");
-        yield return new OpCase("RFFT[16]", "fft", e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).F()), e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).D()), ParityTol.Accum(1e-3), opMethod: "RFFT");
+            e => e.MuLawDecoding<double>(new Tensor<int>((int[])q.Clone(), new[] { 8 }), 256), ParityTol.Ulp(16, 1e-6), opMethod: "MuLawDecoding",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
+        yield return new OpCase("RFFT[16]", "fft", e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).F()), e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).D()), ParityTol.Accum(1e-3), opMethod: "RFFT")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("Spectrogram[1,64;n16h8w16]", "audio", e => e.Spectrogram(OpInput.Rand(2401, new[] { 1, 64 }).F(), 16, 8, 16, null), e => e.Spectrogram(OpInput.Rand(2401, new[] { 1, 64 }).D(), 16, 8, 16, null), ParityTol.Accum(1e-3), opMethod: "Spectrogram");
 
         var lg = OpInput.Rand(2410, new[] { 4, 8 }, -3.0, 3.0);
         var gg = OpInput.Rand(2411, new[] { 4, 8 });
-        yield return new OpCase("GumbelSoftmaxBackward[4,8]", "activation-bwd", e => e.GumbelSoftmaxBackward(gg.F(), e.TensorSoftmax(lg.F(), -1), 1.0, -1), e => e.GumbelSoftmaxBackward(gg.D(), e.TensorSoftmax(lg.D(), -1), 1.0, -1), ParityTol.Accum(1e-3), opMethod: "GumbelSoftmaxBackward");
+        yield return new OpCase("GumbelSoftmaxBackward[4,8]", "activation-bwd", e => e.GumbelSoftmaxBackward(gg.F(), e.TensorSoftmax(lg.F(), -1), 1.0, -1), e => e.GumbelSoftmaxBackward(gg.D(), e.TensorSoftmax(lg.D(), -1), 1.0, -1), ParityTol.Accum(1e-3), opMethod: "GumbelSoftmaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         yield return new OpCase("ComputeGaussianCovariance[3,4;3,3]", "geometry",
             e => e.ComputeGaussianCovariance(OpInput.Rand(2420, new[] { 3, 4 }, -1.0, 1.0).F(), OpInput.RandPositive(2421, new[] { 3, 3 }, 0.2, 1.5).F()),
@@ -2100,34 +3269,35 @@ public static class OpParityRegistry
         var s = new[] { 4, 8 };
         var go = OpInput.Rand(2300, s);
         var inp = OpInput.Rand(2301, s, -3.0, 3.0);
-        yield return new OpCase("ThresholdBackward[4,8]", "activation-bwd", e => e.ThresholdBackward(go.F(), inp.F(), 0.0), e => e.ThresholdBackward(go.D(), inp.D(), 0.0), ParityTol.Exact, opMethod: "ThresholdBackward");
-        yield return new OpCase("ReciprocalBackward[4,8]", "activation-bwd", e => e.ReciprocalBackward(go.F(), OpInput.Rand(2302, s, 0.5, 3.0).F()), e => e.ReciprocalBackward(go.D(), OpInput.Rand(2302, s, 0.5, 3.0).D()), ParityTol.Ulp(8, 1e-6), opMethod: "ReciprocalBackward");
+        yield return new OpCase("ThresholdBackward[4,8]", "activation-bwd", e => e.ThresholdBackward(go.F(), inp.F(), 0.0), e => e.ThresholdBackward(go.D(), inp.D(), 0.0), ParityTol.Exact, opMethod: "ThresholdBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("ReciprocalBackward[4,8]", "activation-bwd", e => e.ReciprocalBackward(go.F(), OpInput.Rand(2302, s, 0.5, 3.0).F()), e => e.ReciprocalBackward(go.D(), OpInput.Rand(2302, s, 0.5, 3.0).D()), ParityTol.Ulp(8, 1e-6), opMethod: "ReciprocalBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         {
             var maskD = new double[32]; var rng = new Random(2303); for (int i = 0; i < 32; i++) maskD[i] = rng.NextDouble() < 0.5 ? 0.0 : 2.0;
-            var mask = OpInput.From(maskD, s);
-            yield return new OpCase("DropoutBackward[4,8]", "activation-bwd", e => e.DropoutBackward(go.F(), mask.F(), 0.5), e => e.DropoutBackward(go.D(), mask.D(), 0.5), ParityTol.Ulp(4, 1e-6), opMethod: "DropoutBackward");
+            var mask = OpInput.FixedFrom(maskD, s);
+            yield return new OpCase("DropoutBackward[4,8]", "activation-bwd", e => e.DropoutBackward(go.F(), mask.F(), 0.5), e => e.DropoutBackward(go.D(), mask.D(), 0.5), ParityTol.Ulp(4, 1e-6), opMethod: "DropoutBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
         // FIXED (#775): GPU CrossEntropyBackward set all kernel args but never dispatched the kernel
         // (missing Execute1D), so gradInput was never written and the GPU returned all-zero gradients.
         {
             var cep = OpInput.Rand(2304, s, -3.0, 3.0); var cet = OpInput.Rand(2305, s, 0.0, 1.0);
             yield return new OpCase("CrossEntropyBackward[4,8]", "loss-bwd",
-                e => e.CrossEntropyBackward(e.TensorSoftmax(cep.F(), -1), cet.F()), e => e.CrossEntropyBackward(e.TensorSoftmax(cep.D(), -1), cet.D()), ParityTol.Accum(1e-3), opMethod: "CrossEntropyBackward");
+                e => e.CrossEntropyBackward(e.TensorSoftmax(cep.F(), -1), cet.F()), e => e.CrossEntropyBackward(e.TensorSoftmax(cep.D(), -1), cet.D()), ParityTol.Accum(1e-3), opMethod: "CrossEntropyBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
 
         yield return new OpCase("Conv1DBackwardInput[1,8,14->1,3,16]", "conv",
             e => e.Conv1DBackwardInput(OpInput.Rand(2310, new[] { 1, 8, 14 }).F(), OpInput.Rand(2311, new[] { 8, 3, 3 }).F(), new[] { 1, 3, 16 }, 1, 0, 1),
-            e => e.Conv1DBackwardInput(OpInput.Rand(2310, new[] { 1, 8, 14 }).D(), OpInput.Rand(2311, new[] { 8, 3, 3 }).D(), new[] { 1, 3, 16 }, 1, 0, 1), ParityTol.Accum(1e-3), opMethod: "Conv1DBackwardInput");
+            e => e.Conv1DBackwardInput(OpInput.Rand(2310, new[] { 1, 8, 14 }).D(), OpInput.Rand(2311, new[] { 8, 3, 3 }).D(), new[] { 1, 3, 16 }, 1, 0, 1), ParityTol.Accum(1e-3), opMethod: "Conv1DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("ConvTranspose2DBackwardInput[1,8,8,8->1,4,4,4]", "conv",
             e => e.ConvTranspose2DBackwardInput(OpInput.Rand(2312, new[] { 1, 8, 8, 8 }).F(), OpInput.Rand(2313, new[] { 4, 8, 2, 2 }).F(), new[] { 1, 4, 4, 4 }, new[] { 2, 2 }, new[] { 0, 0 }),
-            e => e.ConvTranspose2DBackwardInput(OpInput.Rand(2312, new[] { 1, 8, 8, 8 }).D(), OpInput.Rand(2313, new[] { 4, 8, 2, 2 }).D(), new[] { 1, 4, 4, 4 }, new[] { 2, 2 }, new[] { 0, 0 }), ParityTol.Accum(1e-3), opMethod: "ConvTranspose2DBackwardInput");
+            e => e.ConvTranspose2DBackwardInput(OpInput.Rand(2312, new[] { 1, 8, 8, 8 }).D(), OpInput.Rand(2313, new[] { 4, 8, 2, 2 }).D(), new[] { 1, 4, 4, 4 }, new[] { 2, 2 }, new[] { 0, 0 }), ParityTol.Accum(1e-3), opMethod: "ConvTranspose2DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DepthwiseConv1DBackwardInput[1,4,14->1,4,16]", "conv",
             e => e.DepthwiseConv1DBackwardInput(OpInput.Rand(2314, new[] { 1, 4, 14 }).F(), OpInput.Rand(2315, new[] { 4, 1, 3 }).F(), new[] { 1, 4, 16 }, 1, 0),
-            e => e.DepthwiseConv1DBackwardInput(OpInput.Rand(2314, new[] { 1, 4, 14 }).D(), OpInput.Rand(2315, new[] { 4, 1, 3 }).D(), new[] { 1, 4, 16 }, 1, 0), ParityTol.Accum(1e-3), opMethod: "DepthwiseConv1DBackwardInput");
+            e => e.DepthwiseConv1DBackwardInput(OpInput.Rand(2314, new[] { 1, 4, 14 }).D(), OpInput.Rand(2315, new[] { 4, 1, 3 }).D(), new[] { 1, 4, 16 }, 1, 0), ParityTol.Accum(1e-3), opMethod: "DepthwiseConv1DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         yield return new OpCase("EmbeddingBackward[go4,8;v10]", "index",
             e => e.EmbeddingBackward(OpInput.Rand(2320, new[] { 4, 8 }).F(), new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), 10, 8),
-            e => e.EmbeddingBackward(OpInput.Rand(2320, new[] { 4, 8 }).D(), new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), 10, 8), ParityTol.Ulp(8, 1e-6), opMethod: "EmbeddingBackward");
+            e => e.EmbeddingBackward(OpInput.Rand(2320, new[] { 4, 8 }).D(), new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), 10, 8), ParityTol.Ulp(8, 1e-6), opMethod: "EmbeddingBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
     }
 
     // GLU-variant backward (validates the gating-half fix), crop/pad backward, softmax-variant backward.
@@ -2135,21 +3305,21 @@ public static class OpParityRegistry
     {
         var inp = OpInput.Rand(2200, new[] { 4, 16 }, -3.0, 3.0);
         var go = OpInput.Rand(2201, new[] { 4, 8 });
-        yield return new OpCase("GLUBackward[4,16]", "activation-bwd", e => e.GLUBackward(go.F(), inp.F(), -1), e => e.GLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(1e-3), opMethod: "GLUBackward");
-        yield return new OpCase("GeGLUBackward[4,16]", "activation-bwd", e => e.GeGLUBackward(go.F(), inp.F(), -1), e => e.GeGLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(2e-3), opMethod: "GeGLUBackward");
-        yield return new OpCase("SwiGLUBackward[4,16]", "activation-bwd", e => e.SwiGLUBackward(go.F(), inp.F(), -1), e => e.SwiGLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(1e-3), opMethod: "SwiGLUBackward");
-        yield return new OpCase("ReGLUBackward[4,16]", "activation-bwd", e => e.ReGLUBackward(go.F(), inp.F(), -1), e => e.ReGLUBackward(go.D(), inp.D(), -1), ParityTol.Ulp(4, 1e-6), opMethod: "ReGLUBackward");
+        yield return new OpCase("GLUBackward[4,16]", "activation-bwd", e => e.GLUBackward(go.F(), inp.F(), -1), e => e.GLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(1e-3), opMethod: "GLUBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("GeGLUBackward[4,16]", "activation-bwd", e => e.GeGLUBackward(go.F(), inp.F(), -1), e => e.GeGLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(2e-3), opMethod: "GeGLUBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("SwiGLUBackward[4,16]", "activation-bwd", e => e.SwiGLUBackward(go.F(), inp.F(), -1), e => e.SwiGLUBackward(go.D(), inp.D(), -1), ParityTol.Accum(1e-3), opMethod: "SwiGLUBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("ReGLUBackward[4,16]", "activation-bwd", e => e.ReGLUBackward(go.F(), inp.F(), -1), e => e.ReGLUBackward(go.D(), inp.D(), -1), ParityTol.Ulp(4, 1e-6), opMethod: "ReGLUBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         yield return new OpCase("CropBackward[1,2,4,4->1,2,8,8]", "shape",
             e => e.CropBackward(OpInput.Rand(2210, new[] { 1, 2, 4, 4 }).F(), new[] { 1, 2, 8, 8 }, 1, 1),
-            e => e.CropBackward(OpInput.Rand(2210, new[] { 1, 2, 4, 4 }).D(), new[] { 1, 2, 8, 8 }, 1, 1), ParityTol.Exact, opMethod: "CropBackward");
+            e => e.CropBackward(OpInput.Rand(2210, new[] { 1, 2, 4, 4 }).D(), new[] { 1, 2, 8, 8 }, 1, 1), ParityTol.Exact, opMethod: "CropBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("PadBackward[1,2,10,10->1,2,8,8]", "shape",
             e => e.PadBackward(OpInput.Rand(2211, new[] { 1, 2, 10, 10 }).F(), 1, 1, new[] { 1, 2, 8, 8 }),
-            e => e.PadBackward(OpInput.Rand(2211, new[] { 1, 2, 10, 10 }).D(), 1, 1, new[] { 1, 2, 8, 8 }), ParityTol.Exact, opMethod: "PadBackward");
+            e => e.PadBackward(OpInput.Rand(2211, new[] { 1, 2, 10, 10 }).D(), 1, 1, new[] { 1, 2, 8, 8 }), ParityTol.Exact, opMethod: "PadBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         var lg = OpInput.Rand(2220, new[] { 4, 8 }, -3.0, 3.0);
         var sgo = OpInput.Rand(2221, new[] { 4, 8 });
-        yield return new OpCase("SparsemaxBackward[4,8]", "activation-bwd", e => e.SparsemaxBackward(sgo.F(), e.Sparsemax(lg.F(), -1), -1), e => e.SparsemaxBackward(sgo.D(), e.Sparsemax(lg.D(), -1), -1), ParityTol.Accum(1e-3), opMethod: "SparsemaxBackward");
+        yield return new OpCase("SparsemaxBackward[4,8]", "activation-bwd", e => e.SparsemaxBackward(sgo.F(), e.Sparsemax(lg.F(), -1), -1), e => e.SparsemaxBackward(sgo.D(), e.Sparsemax(lg.D(), -1), -1), ParityTol.Accum(1e-3), opMethod: "SparsemaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Fused-linear activation variants + affine batchnorm.
@@ -2158,9 +3328,12 @@ public static class OpParityRegistry
         var lin = OpInput.Rand(2100, new[] { 4, 8 });
         var w = OpInput.Rand(2101, new[] { 8, 6 });
         var bias = OpInput.Rand(2102, new[] { 6 });
-        yield return new OpCase("FusedLinearSigmoid[4,8;w8,6]", "matmul", e => e.FusedLinearSigmoid(lin.F(), w.F(), bias.F()), e => e.FusedLinearSigmoid(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearSigmoid");
-        yield return new OpCase("FusedLinearTanh[4,8;w8,6]", "matmul", e => e.FusedLinearTanh(lin.F(), w.F(), bias.F()), e => e.FusedLinearTanh(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearTanh");
-        yield return new OpCase("FusedLinearSwish[4,8;w8,6]", "matmul", e => e.FusedLinearSwish(lin.F(), w.F(), bias.F()), e => e.FusedLinearSwish(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearSwish");
+        yield return new OpCase("FusedLinearSigmoid[4,8;w8,6]", "matmul", e => e.FusedLinearSigmoid(lin.F(), w.F(), bias.F()), e => e.FusedLinearSigmoid(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearSigmoid")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+        yield return new OpCase("FusedLinearTanh[4,8;w8,6]", "matmul", e => e.FusedLinearTanh(lin.F(), w.F(), bias.F()), e => e.FusedLinearTanh(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearTanh")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+        yield return new OpCase("FusedLinearSwish[4,8;w8,6]", "matmul", e => e.FusedLinearSwish(lin.F(), w.F(), bias.F()), e => e.FusedLinearSwish(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearSwish")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         var bx = OpInput.Rand(2110, new[] { 2, 4, 4, 4 });
         var bg = OpInput.Rand(2111, new[] { 4 }, 0.5, 1.5);
@@ -2186,17 +3359,20 @@ public static class OpParityRegistry
         var m = OpInput.Rand(2010, new[] { 4, 8 });
         yield return new OpCase("TensorPut[4,8;idx3]", "index",
             e => e.TensorPut(m.F(), new Tensor<int>(new[] { 0, 10, 25 }, new[] { 3 }), OpInput.Rand(2011, new[] { 3 }).F()),
-            e => e.TensorPut(m.D(), new Tensor<int>(new[] { 0, 10, 25 }, new[] { 3 }), OpInput.Rand(2011, new[] { 3 }).D()), ParityTol.Exact, opMethod: "TensorPut");
+            e => e.TensorPut(m.D(), new Tensor<int>(new[] { 0, 10, 25 }, new[] { 3 }), OpInput.Rand(2011, new[] { 3 }).D()), ParityTol.Exact, opMethod: "TensorPut",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
         yield return new OpCase("TensorIndexCopy[4,8;ax0]", "index",
             e => e.TensorIndexCopy(m.F(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(2012, new[] { 2, 8 }).F()),
-            e => e.TensorIndexCopy(m.D(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(2012, new[] { 2, 8 }).D()), ParityTol.Exact, opMethod: "TensorIndexCopy");
+            e => e.TensorIndexCopy(m.D(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(2012, new[] { 2, 8 }).D()), ParityTol.Exact, opMethod: "TensorIndexCopy",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("TensorIndexFill[4,8;ax0]", "index",
             e => e.TensorIndexFill(m.F(), 0, new Tensor<int>(new[] { 1, 3 }, new[] { 2 }), 0.5f),
-            e => e.TensorIndexFill(m.D(), 0, new Tensor<int>(new[] { 1, 3 }, new[] { 2 }), 0.5), ParityTol.Exact, opMethod: "TensorIndexFill");
+            e => e.TensorIndexFill(m.D(), 0, new Tensor<int>(new[] { 1, 3 }, new[] { 2 }), 0.5), ParityTol.Exact, opMethod: "TensorIndexFill",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
 
         yield return new OpCase("TensorEmbeddingLookupFromFloatIndices[10,8;idx4]", "index",
-            e => e.TensorEmbeddingLookupFromFloatIndices(OpInput.Rand(2020, new[] { 10, 8 }).F(), OpInput.From(new double[] { 1, 3, 0, 5 }, new[] { 4 }).F()),
-            e => e.TensorEmbeddingLookupFromFloatIndices(OpInput.Rand(2020, new[] { 10, 8 }).D(), OpInput.From(new double[] { 1, 3, 0, 5 }, new[] { 4 }).D()), ParityTol.Exact, opMethod: "TensorEmbeddingLookupFromFloatIndices");
+            e => e.TensorEmbeddingLookupFromFloatIndices(OpInput.Rand(2020, new[] { 10, 8 }).F(), OpInput.FixedFrom(new double[] { 1, 3, 0, 5 }, new[] { 4 }).F()),
+            e => e.TensorEmbeddingLookupFromFloatIndices(OpInput.Rand(2020, new[] { 10, 8 }).D(), OpInput.FixedFrom(new double[] { 1, 3, 0, 5 }, new[] { 4 }).D()), ParityTol.Exact, opMethod: "TensorEmbeddingLookupFromFloatIndices");
         yield return new OpCase("TensorCartesianProd[2.3]", "shape",
             e => e.TensorCartesianProd(new[] { OpInput.Rand(2021, new[] { 2 }).F(), OpInput.Rand(2022, new[] { 3 }).F() }),
             e => e.TensorCartesianProd(new[] { OpInput.Rand(2021, new[] { 2 }).D(), OpInput.Rand(2022, new[] { 3 }).D() }), ParityTol.Exact, opMethod: "TensorCartesianProd");
@@ -2209,7 +3385,7 @@ public static class OpParityRegistry
         // g*(s - dot(g,s)) instead of s*(g - dot(g,s)). Args corrected.
         yield return new OpCase("TensorSoftmaxBackward[4,8]", "activation-bwd",
             e => e.TensorSoftmaxBackward(e.TensorSoftmax(logits.F(), -1), sgo.F(), -1),
-            e => e.TensorSoftmaxBackward(e.TensorSoftmax(logits.D(), -1), sgo.D(), -1), ParityTol.Accum(1e-3), opMethod: "TensorSoftmaxBackward");
+            e => e.TensorSoftmaxBackward(e.TensorSoftmax(logits.D(), -1), sgo.D(), -1), ParityTol.Accum(1e-3), opMethod: "TensorSoftmaxBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Norm-family backward (forward run inline for saved stats), conv/pool backward, global-max, mse/ce bwd.
@@ -2221,16 +3397,16 @@ public static class OpParityRegistry
         var go = OpInput.Rand(1903, new[] { 4, 64 });
         yield return new OpCase("LayerNormBackward[4,64]", "norm-bwd",
             e => { e.LayerNorm(x.F(), g.F(), beta.F(), 1e-5, out var mn, out var vr); return e.LayerNormBackward(go.F(), x.F(), g.F(), mn, vr, 1e-5, out _, out _); },
-            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); return e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward");
+            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); return e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("LayerNormBackwardGradGamma[4,64]", "norm-bwd",
             e => { e.LayerNorm(x.F(), g.F(), beta.F(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.F(), x.F(), g.F(), mn, vr, 1e-5, out var gg, out _); return gg; },
-            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out var gg, out _); return gg; }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward");
+            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out var gg, out _); return gg; }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("LayerNormBackwardGradBeta[4,64]", "norm-bwd",
             e => { e.LayerNorm(x.F(), g.F(), beta.F(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.F(), x.F(), g.F(), mn, vr, 1e-5, out _, out var gb); return gb; },
-            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out _, out var gb); return gb; }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward");
+            e => { e.LayerNorm(x.D(), g.D(), beta.D(), 1e-5, out var mn, out var vr); e.LayerNormBackward(go.D(), x.D(), g.D(), mn, vr, 1e-5, out _, out var gb); return gb; }, ParityTol.Accum(2e-3), opMethod: "LayerNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("RMSNormBackward[4,64]", "norm-bwd",
             e => { e.RMSNorm(x.F(), g.F(), 1e-5, out var rms); return e.RMSNormBackward(go.F(), x.F(), g.F(), rms, 1e-5, out _); },
-            e => { e.RMSNorm(x.D(), g.D(), 1e-5, out var rms); return e.RMSNormBackward(go.D(), x.D(), g.D(), rms, 1e-5, out _); }, ParityTol.Accum(2e-3), opMethod: "RMSNormBackward");
+            e => { e.RMSNorm(x.D(), g.D(), 1e-5, out var rms); return e.RMSNormBackward(go.D(), x.D(), g.D(), rms, 1e-5, out _); }, ParityTol.Accum(2e-3), opMethod: "RMSNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         var gx = OpInput.Rand(1910, new[] { 2, 8, 4, 4 });
         var gg = OpInput.Rand(1911, new[] { 8 }, 0.5, 1.5);
@@ -2238,28 +3414,29 @@ public static class OpParityRegistry
         var ggo = OpInput.Rand(1913, new[] { 2, 8, 4, 4 });
         yield return new OpCase("GroupNormBackward[2,8,4,4;g2]", "norm-bwd",
             e => { e.GroupNorm(gx.F(), 2, gg.F(), gb.F(), 1e-5, out var mn, out var vr); return e.GroupNormBackward(ggo.F(), gx.F(), 2, gg.F(), mn, vr, 1e-5, out _, out _); },
-            e => { e.GroupNorm(gx.D(), 2, gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.GroupNormBackward(ggo.D(), gx.D(), 2, gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "GroupNormBackward");
+            e => { e.GroupNorm(gx.D(), 2, gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.GroupNormBackward(ggo.D(), gx.D(), 2, gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "GroupNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("InstanceNormBackward[2,8,4,4]", "norm-bwd",
             e => { e.InstanceNorm(gx.F(), gg.F(), gb.F(), 1e-5, out var mn, out var vr); return e.InstanceNormBackward(ggo.F(), gx.F(), gg.F(), mn, vr, 1e-5, out _, out _); },
-            e => { e.InstanceNorm(gx.D(), gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.InstanceNormBackward(ggo.D(), gx.D(), gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "InstanceNormBackward");
+            e => { e.InstanceNorm(gx.D(), gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.InstanceNormBackward(ggo.D(), gx.D(), gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "InstanceNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("BatchNormBackward[2,8,4,4]", "norm-bwd",
             e => { e.BatchNorm(gx.F(), gg.F(), gb.F(), 1e-5, out var mn, out var vr); return e.BatchNormBackward(ggo.F(), gx.F(), gg.F(), mn, vr, 1e-5, out _, out _); },
-            e => { e.BatchNorm(gx.D(), gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.BatchNormBackward(ggo.D(), gx.D(), gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "BatchNormBackward");
+            e => { e.BatchNorm(gx.D(), gg.D(), gb.D(), 1e-5, out var mn, out var vr); return e.BatchNormBackward(ggo.D(), gx.D(), gg.D(), mn, vr, 1e-5, out _, out _); }, ParityTol.Accum(2e-3), opMethod: "BatchNormBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Conv / pool backward.
         yield return new OpCase("Conv2DBackwardKernel[go1,4,6,6;in1,3,8,8]", "conv",
             e => e.Conv2DBackwardKernel(OpInput.Rand(1920, new[] { 1, 4, 6, 6 }).F(), OpInput.Rand(1921, new[] { 1, 3, 8, 8 }).F(), new[] { 4, 3, 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }),
-            e => e.Conv2DBackwardKernel(OpInput.Rand(1920, new[] { 1, 4, 6, 6 }).D(), OpInput.Rand(1921, new[] { 1, 3, 8, 8 }).D(), new[] { 4, 3, 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "Conv2DBackwardKernel");
+            e => e.Conv2DBackwardKernel(OpInput.Rand(1920, new[] { 1, 4, 6, 6 }).D(), OpInput.Rand(1921, new[] { 1, 3, 8, 8 }).D(), new[] { 4, 3, 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "Conv2DBackwardKernel", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("DepthwiseConv2DBackwardInput[1,4,8,8]", "conv",
             e => e.DepthwiseConv2DBackwardInput(OpInput.Rand(1922, new[] { 1, 4, 8, 8 }).F(), OpInput.Rand(1923, new[] { 4, 1, 3, 3 }).F(), new[] { 1, 4, 8, 8 }, new[] { 1, 1 }, new[] { 1, 1 }),
-            e => e.DepthwiseConv2DBackwardInput(OpInput.Rand(1922, new[] { 1, 4, 8, 8 }).D(), OpInput.Rand(1923, new[] { 4, 1, 3, 3 }).D(), new[] { 1, 4, 8, 8 }, new[] { 1, 1 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "DepthwiseConv2DBackwardInput");
+            e => e.DepthwiseConv2DBackwardInput(OpInput.Rand(1922, new[] { 1, 4, 8, 8 }).D(), OpInput.Rand(1923, new[] { 4, 1, 3, 3 }).D(), new[] { 1, 4, 8, 8 }, new[] { 1, 1 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "DepthwiseConv2DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("AvgPool3DBackward[1,2,2,2,2->1,2,4,4,4]", "pool",
             e => e.AvgPool3DBackward(OpInput.Rand(1924, new[] { 1, 2, 2, 2, 2 }).F(), new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }),
-            e => e.AvgPool3DBackward(OpInput.Rand(1924, new[] { 1, 2, 2, 2, 2 }).D(), new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }), ParityTol.Accum(1e-3), opMethod: "AvgPool3DBackward");
+            e => e.AvgPool3DBackward(OpInput.Rand(1924, new[] { 1, 2, 2, 2, 2 }).D(), new[] { 1, 2, 4, 4, 4 }, new[] { 2, 2, 2 }, new[] { 2, 2, 2 }, new[] { 0, 0, 0 }), ParityTol.Accum(1e-3), opMethod: "AvgPool3DBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         yield return new OpCase("GlobalMaxPool2D[1,2,8,8]", "pool", e => e.GlobalMaxPool2D(OpInput.Rand(1930, new[] { 1, 2, 8, 8 }).F()), e => e.GlobalMaxPool2D(OpInput.Rand(1930, new[] { 1, 2, 8, 8 }).D()), ParityTol.Exact, opMethod: "GlobalMaxPool2D");
         var pr = OpInput.Rand(1931, new[] { 4, 8 }); var tg = OpInput.Rand(1932, new[] { 4, 8 });
-        yield return B("MseBackward", "loss-bwd", (e, u, v) => e.MseBackward(u, v), (e, u, v) => e.MseBackward(u, v), ParityTol.Ulp(8, 1e-6), pr, tg);
+        yield return B("MseBackward", "loss-bwd", (e, u, v) => e.MseBackward(u, v), (e, u, v) => e.MseBackward(u, v), ParityTol.Ulp(8, 1e-6), pr, tg,
+            graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Slice-scatter, clamp-tensor, nan-to-num, squash-backward.
@@ -2284,7 +3461,7 @@ public static class OpParityRegistry
         var sqi = OpInput.Rand(1807, new[] { 4, 8 });
         yield return new OpCase("TensorSquashBackward[4,8]", "activation-bwd",
             e => e.TensorSquashBackward(OpInput.Rand(1808, new[] { 4, 8 }).F(), sqi.F(), e.TensorSquash(sqi.F(), -1), -1),
-            e => e.TensorSquashBackward(OpInput.Rand(1808, new[] { 4, 8 }).D(), sqi.D(), e.TensorSquash(sqi.D(), -1), -1), ParityTol.Accum(1e-3), opMethod: "TensorSquashBackward");
+            e => e.TensorSquashBackward(OpInput.Rand(1808, new[] { 4, 8 }).D(), sqi.D(), e.TensorSquash(sqi.D(), -1), -1), ParityTol.Accum(1e-3), opMethod: "TensorSquashBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
     }
 
     // Grid-sample, upsample3d/crop, depthwise-1d, conv/pool backward, IoU + CE losses.
@@ -2308,10 +3485,10 @@ public static class OpParityRegistry
 
         yield return new OpCase("Conv2DBackwardInput[1,4,6,6->1,3,8,8]", "conv",
             e => e.Conv2DBackwardInput(OpInput.Rand(1710, new[] { 1, 4, 6, 6 }).F(), OpInput.Rand(1711, new[] { 4, 3, 3, 3 }).F(), new[] { 1, 3, 8, 8 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }),
-            e => e.Conv2DBackwardInput(OpInput.Rand(1710, new[] { 1, 4, 6, 6 }).D(), OpInput.Rand(1711, new[] { 4, 3, 3, 3 }).D(), new[] { 1, 3, 8, 8 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "Conv2DBackwardInput");
+            e => e.Conv2DBackwardInput(OpInput.Rand(1710, new[] { 1, 4, 6, 6 }).D(), OpInput.Rand(1711, new[] { 4, 3, 3, 3 }).D(), new[] { 1, 3, 8, 8 }, new[] { 1, 1 }, new[] { 0, 0 }, new[] { 1, 1 }), ParityTol.Accum(1e-3), opMethod: "Conv2DBackwardInput", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("AvgPool2DBackward[1,2,4,4->1,2,8,8]", "pool",
             e => e.AvgPool2DBackward(OpInput.Rand(1712, new[] { 1, 2, 4, 4 }).F(), new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }),
-            e => e.AvgPool2DBackward(OpInput.Rand(1712, new[] { 1, 2, 4, 4 }).D(), new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }), ParityTol.Accum(1e-3), opMethod: "AvgPool2DBackward");
+            e => e.AvgPool2DBackward(OpInput.Rand(1712, new[] { 1, 2, 4, 4 }).D(), new[] { 1, 2, 8, 8 }, new[] { 2, 2 }, new[] { 2, 2 }), ParityTol.Accum(1e-3), opMethod: "AvgPool2DBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // IoU-family box losses (predicted vs target boxes [N,4]).
         var pb = OpInput.From(new double[] { 0, 0, 2, 2, 1, 1, 3, 4, 0, 1, 4, 3 }, new[] { 3, 4 });
@@ -2339,16 +3516,19 @@ public static class OpParityRegistry
 
         yield return new OpCase("TensorTake[4,8;idx5]", "index",
             e => e.TensorTake(m.F(), new Tensor<int>(new[] { 0, 7, 15, 20, 31 }, new[] { 5 })),
-            e => e.TensorTake(m.D(), new Tensor<int>(new[] { 0, 7, 15, 20, 31 }, new[] { 5 })), ParityTol.Exact, opMethod: "TensorTake");
+            e => e.TensorTake(m.D(), new Tensor<int>(new[] { 0, 7, 15, 20, 31 }, new[] { 5 })), ParityTol.Exact, opMethod: "TensorTake",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         {
             var tad = new int[32]; for (int i = 0; i < 32; i++) tad[i] = i % 8;
             yield return new OpCase("TensorTakeAlongDim[4,8;d1]", "index",
                 e => e.TensorTakeAlongDim(m.F(), new Tensor<int>((int[])tad.Clone(), new[] { 4, 8 }), 1),
-                e => e.TensorTakeAlongDim(m.D(), new Tensor<int>((int[])tad.Clone(), new[] { 4, 8 }), 1), ParityTol.Exact, opMethod: "TensorTakeAlongDim");
+                e => e.TensorTakeAlongDim(m.D(), new Tensor<int>((int[])tad.Clone(), new[] { 4, 8 }), 1), ParityTol.Exact, opMethod: "TensorTakeAlongDim",
+                graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         }
         yield return new OpCase("TensorIndexAdd[4,8;ax0]", "index",
             e => e.TensorIndexAdd(m.F(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(1603, new[] { 2, 8 }).F()),
-            e => e.TensorIndexAdd(m.D(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(1603, new[] { 2, 8 }).D()), ParityTol.Ulp(4, 1e-6), opMethod: "TensorIndexAdd");
+            e => e.TensorIndexAdd(m.D(), 0, new Tensor<int>(new[] { 0, 2 }, new[] { 2 }), OpInput.Rand(1603, new[] { 2, 8 }).D()), ParityTol.Ulp(4, 1e-6), opMethod: "TensorIndexAdd",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         var pool = OpInput.Rand(1610, new[] { 1, 2, 8, 8 });
         yield return new OpCase("TensorMaxPool2D[1,2,8,8;k2]", "pool", e => e.TensorMaxPool2D(pool.F(), 2), e => e.TensorMaxPool2D(pool.D(), 2), ParityTol.Exact, opMethod: "TensorMaxPool2D");
@@ -2373,7 +3553,8 @@ public static class OpParityRegistry
             var xe = new int[32]; for (int k = 0; k < 32; k++) xe[k] = (k % 5) - 2;
             yield return new OpCase("TensorLdexp[4,8]", "arithmetic",
                 e => e.TensorLdexp(OpInput.Rand(1510, s).F(), new Tensor<int>((int[])xe.Clone(), s)),
-                e => e.TensorLdexp(OpInput.Rand(1510, s).D(), new Tensor<int>((int[])xe.Clone(), s)), ParityTol.Ulp(2, 1e-6), opMethod: "TensorLdexp");
+                e => e.TensorLdexp(OpInput.Rand(1510, s).D(), new Tensor<int>((int[])xe.Clone(), s)), ParityTol.Ulp(2, 1e-6), opMethod: "TensorLdexp",
+                graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
         }
 
         // Scaled dot-product attention (Q,K,V same shape).
@@ -2402,8 +3583,10 @@ public static class OpParityRegistry
         var lin = OpInput.Rand(1410, new[] { 4, 8 });
         var w = OpInput.Rand(1411, new[] { 8, 6 }); // [in, out] — FusedLinear does input·weight
         var bias = OpInput.Rand(1412, new[] { 6 });
-        yield return new OpCase("FusedLinearReLU[4,8;w8,6]", "matmul", e => e.FusedLinearReLU(lin.F(), w.F(), bias.F()), e => e.FusedLinearReLU(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearReLU");
-        yield return new OpCase("FusedLinearGELU[4,8;w8,6]", "matmul", e => e.FusedLinearGELU(lin.F(), w.F(), bias.F()), e => e.FusedLinearGELU(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearGELU");
+        yield return new OpCase("FusedLinearReLU[4,8;w8,6]", "matmul", e => e.FusedLinearReLU(lin.F(), w.F(), bias.F()), e => e.FusedLinearReLU(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearReLU")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+        yield return new OpCase("FusedLinearGELU[4,8;w8,6]", "matmul", e => e.FusedLinearGELU(lin.F(), w.F(), bias.F()), e => e.FusedLinearGELU(lin.D(), w.D(), bias.D()), ParityTol.Accum(1e-3), opMethod: "FusedLinearGELU")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         var pool = OpInput.Rand(1420, new[] { 1, 2, 8, 8 });
         yield return new OpCase("AdaptiveAvgPool2D[1,2,8,8->4,4]", "pool", e => e.AdaptiveAvgPool2D(pool.F(), 4, 4), e => e.AdaptiveAvgPool2D(pool.D(), 4, 4), ParityTol.Accum(1e-3), opMethod: "AdaptiveAvgPool2D");
@@ -2412,8 +3595,14 @@ public static class OpParityRegistry
         yield return new OpCase("AvgPool3D[1,2,4,4,4;k2]", "pool", e => e.AvgPool3D(pool3.F(), 2), e => e.AvgPool3D(pool3.D(), 2), ParityTol.Accum(1e-3), opMethod: "AvgPool3D");
         yield return new OpCase("MaxPool3D[1,2,4,4,4;k2]", "pool", e => e.MaxPool3D(pool3.F(), 2), e => e.MaxPool3D(pool3.D(), 2), ParityTol.Exact, opMethod: "MaxPool3D");
 
-        yield return B("TensorBatchOuterProduct", "matmul", (e, u, v) => e.TensorBatchOuterProduct(u, v), (e, u, v) => e.TensorBatchOuterProduct(u, v), ParityTol.Ulp(2, 1e-6), OpInput.Rand(1430, new[] { 4, 3 }), OpInput.Rand(1431, new[] { 4, 5 }));
-        yield return new OpCase("TensorLinspace[0,1,8]", "misc", e => e.TensorLinspace<float>(0f, 1f, 8), e => e.TensorLinspace<double>(0.0, 1.0, 8), ParityTol.Ulp(4, 1e-6), opMethod: "TensorLinspace");
+        var batchOuterA = OpInput.Rand(1430, new[] { 4, 3 });
+        var batchOuterB = OpInput.Rand(1431, new[] { 4, 5 });
+        yield return new OpCase("TensorBatchOuterProduct[4,3]", "matmul",
+            e => e.TensorBatchOuterProduct(batchOuterA.F(), batchOuterB.F()),
+            e => e.TensorBatchOuterProduct(batchOuterA.D(), batchOuterB.D()),
+            ParityTol.Ulp(2, 1e-6), opMethod: "TensorBatchOuterProduct")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
+        yield return new OpCase("TensorLinspace[0,1,8]", "misc", e => e.TensorLinspace<float>(0f, 1f, 8), e => e.TensorLinspace<double>(0.0, 1.0, 8), ParityTol.Ulp(4, 1e-6), opMethod: "TensorLinspace", graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
     }
 
     // Scatter-reduce, top-k, more activations/losses, positional encoding, einsum.
@@ -2422,13 +3611,17 @@ public static class OpParityRegistry
         var src = OpInput.Rand(1300, new[] { 4, 8 });
         var sidx = new int[32]; for (int k = 0; k < 32; k++) sidx[k] = k % 6;
         Tensor<int> Idx() => new Tensor<int>((int[])sidx.Clone(), new[] { 4, 8 });
-        yield return new OpCase("ScatterMean[4,8->6,8]", "index", e => { var y = e.ScatterMean(src.F(), Idx(), out _, 0, 6); return y; }, e => { var y = e.ScatterMean(src.D(), Idx(), out _, 0, 6); return y; }, ParityTol.Ulp(16, 1e-6), opMethod: "ScatterMean");
+        yield return new OpCase("ScatterMean[4,8->6,8]", "index", e => { var y = e.ScatterMean(src.F(), Idx(), out _, 0, 6); return y; }, e => { var y = e.ScatterMean(src.D(), Idx(), out _, 0, 6); return y; }, ParityTol.Ulp(16, 1e-6), opMethod: "ScatterMean",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousOutput,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         // ScatterMax left pending: it fills unmapped output positions with -inf (empty-group max
         // sentinel), which the harness's finiteness check rejects; needs a spec that guarantees full
         // output coverage under the exact scatter-dim semantics.
-        yield return new OpCase("ScatterSoftmax[4,8]", "index", e => e.ScatterSoftmax(src.F(), Idx(), 0, 6), e => e.ScatterSoftmax(src.D(), Idx(), 0, 6), ParityTol.Accum(1e-3), opMethod: "ScatterSoftmax");
+        yield return new OpCase("ScatterSoftmax[4,8]", "index", e => e.ScatterSoftmax(src.F(), Idx(), 0, 6), e => e.ScatterSoftmax(src.D(), Idx(), 0, 6), ParityTol.Accum(1e-3), opMethod: "ScatterSoftmax",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
 
-        yield return new OpCase("TensorTopK[4,8;k3,ax1]", "reduction", e => { var y = e.TensorTopK(src.F(), 3, 1, out _); return y; }, e => { var y = e.TensorTopK(src.D(), 3, 1, out _); return y; }, ParityTol.Exact, opMethod: "TensorTopK");
+        yield return new OpCase("TensorTopK[4,8;k3,ax1]", "reduction", e => { var y = e.TensorTopK(src.F(), 3, 1, out _); return y; }, e => { var y = e.TensorTopK(src.D(), 3, 1, out _); return y; }, ParityTol.Exact, opMethod: "TensorTopK",
+            graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousOutput);
 
         var a = OpInput.Rand(1310, new[] { 4, 8 }, -4.0, 4.0);
         yield return U("TensorSELU", "activation", (e, t) => e.TensorSELU(t), (e, t) => e.TensorSELU(t), ParityTol.Ulp(64, 1e-6), a);
@@ -2441,7 +3634,13 @@ public static class OpParityRegistry
         var pred = OpInput.Rand(1320, new[] { 4, 8 }, 0.05, 0.95);
         var tgt = OpInput.Rand(1321, new[] { 4, 8 }, 0.0, 1.0);
         yield return new OpCase("TensorBinaryCrossEntropy[4,8]", "loss", e => e.TensorBinaryCrossEntropy(pred.F(), tgt.F(), 1e-7f), e => e.TensorBinaryCrossEntropy(pred.D(), tgt.D(), 1e-7), ParityTol.Accum(1e-3), opMethod: "TensorBinaryCrossEntropy");
-        yield return B("TensorCosineSimilarityLoss", "loss", (e, u, v) => e.TensorCosineSimilarityLoss(u, v), (e, u, v) => e.TensorCosineSimilarityLoss(u, v), ParityTol.Accum(1e-3), OpInput.Rand(1322, new[] { 4, 8 }), OpInput.Rand(1323, new[] { 4, 8 }));
+        var cosineLossA = OpInput.Rand(1322, new[] { 4, 8 });
+        var cosineLossB = OpInput.Rand(1323, new[] { 4, 8 });
+        yield return new OpCase("TensorCosineSimilarityLoss[4,8]", "loss",
+            e => e.TensorCosineSimilarityLoss(cosineLossA.F(), cosineLossB.F()),
+            e => e.TensorCosineSimilarityLoss(cosineLossA.D(), cosineLossB.D()),
+            ParityTol.Accum(1e-3), opMethod: "TensorCosineSimilarityLoss")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         yield return new OpCase("PositionalEncoding[4,3;f4]", "misc", e => e.PositionalEncoding(OpInput.Rand(1330, new[] { 4, 3 }).F(), 4), e => e.PositionalEncoding(OpInput.Rand(1330, new[] { 4, 3 }).D(), 4), ParityTol.Ulp(64, 1e-6), opMethod: "PositionalEncoding");
         yield return new OpCase("TensorEinsum[ij,jk->ik]", "matmul", e => e.TensorEinsum("ij,jk->ik", OpInput.Rand(1340, new[] { 4, 8 }).F(), OpInput.Rand(1341, new[] { 8, 6 }).F()), e => e.TensorEinsum("ij,jk->ik", OpInput.Rand(1340, new[] { 4, 8 }).D(), OpInput.Rand(1341, new[] { 8, 6 }).D()), ParityTol.Accum(1e-3), opMethod: "TensorEinsum");
@@ -2459,7 +3658,7 @@ public static class OpParityRegistry
 
         yield return U("AmplitudeToDB", "audio", (e, t) => e.AmplitudeToDB(t, 1e-10f, null), (e, t) => e.AmplitudeToDB(t, 1e-10f, null), ParityTol.Ulp(256, 1e-4), OpInput.RandPositive(1210, s, 0.1, 4.0));
         yield return U("ComputeDeltas", "audio", (e, t) => e.ComputeDeltas(t, 5), (e, t) => e.ComputeDeltas(t, 5), ParityTol.Accum(1e-3), OpInput.Rand(1211, new[] { 4, 16 }));
-        yield return new OpCase("CreateWindow[hann;16]", "audio", e => e.CreateWindow<float>("hann", 16), e => e.CreateWindow<double>("hann", 16), ParityTol.Ulp(64, 1e-6), opMethod: "CreateWindow");
+        yield return new OpCase("CreateWindow[hann;16]", "audio", e => e.CreateWindow<float>("hann", 16), e => e.CreateWindow<double>("hann", 16), ParityTol.Ulp(64, 1e-6), opMethod: "CreateWindow", graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         // Bounding boxes [x1,y1,x2,y2] with positive extent.
         var boxA = OpInput.From(new double[] { 0, 0, 2, 2, 1, 1, 3, 4, 0, 1, 5, 3 }, new[] { 3, 4 });
@@ -2471,7 +3670,8 @@ public static class OpParityRegistry
         // Distances / kernels.
         yield return B("PairwiseDistance", "reduction", (e, u, v) => e.PairwiseDistance(u, v), (e, u, v) => e.PairwiseDistance(u, v), ParityTol.Accum(1e-3), OpInput.Rand(1220, s), OpInput.Rand(1221, s));
         yield return B("PairwiseDistanceSquared", "reduction", (e, u, v) => e.PairwiseDistanceSquared(u, v), (e, u, v) => e.PairwiseDistanceSquared(u, v), ParityTol.Accum(1e-3), OpInput.Rand(1222, s), OpInput.Rand(1223, s));
-        yield return new OpCase("RBFKernel[4,8;c3]", "kernel", e => e.RBFKernel(OpInput.Rand(1230, s).F(), OpInput.Rand(1231, new[] { 3, 8 }).F(), OpInput.Rand(1232, new[] { 3 }, 0.5, 1.5).F()), e => e.RBFKernel(OpInput.Rand(1230, s).D(), OpInput.Rand(1231, new[] { 3, 8 }).D(), OpInput.Rand(1232, new[] { 3 }, 0.5, 1.5).D()), ParityTol.Accum(1e-3), opMethod: "RBFKernel");
+        yield return new OpCase("RBFKernel[4,8;c3]", "kernel", e => e.RBFKernel(OpInput.Rand(1230, s).F(), OpInput.Rand(1231, new[] { 3, 8 }).F(), OpInput.Rand(1232, new[] { 3 }, 0.5, 1.5).F()), e => e.RBFKernel(OpInput.Rand(1230, s).D(), OpInput.Rand(1231, new[] { 3, 8 }).D(), OpInput.Rand(1232, new[] { 3 }, 0.5, 1.5).D()), ParityTol.Accum(1e-3), opMethod: "RBFKernel")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
     }
 
     // Gather/scatter (int-index), complex-magnitude, histogram, and audio resample.
@@ -2481,13 +3681,31 @@ public static class OpParityRegistry
         var gidx = new int[32]; for (int k = 0; k < 32; k++) gidx[k] = k % 4;
         yield return new OpCase("TensorGather[4,8;ax0]", "index",
             e => e.TensorGather(OpInput.Rand(1100, new[] { 4, 8 }).F(), new Tensor<int>((int[])gidx.Clone(), new[] { 4, 8 }), 0),
-            e => e.TensorGather(OpInput.Rand(1100, new[] { 4, 8 }).D(), new Tensor<int>((int[])gidx.Clone(), new[] { 4, 8 }), 0), ParityTol.Exact, opMethod: "TensorGather");
+            e => e.TensorGather(OpInput.Rand(1100, new[] { 4, 8 }).D(), new Tensor<int>((int[])gidx.Clone(), new[] { 4, 8 }), 0), ParityTol.Exact, opMethod: "TensorGather",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // ScatterAdd: order-independent sum into a [6,8] output.
         var sidx = new int[32]; for (int k = 0; k < 32; k++) sidx[k] = k % 6;
         yield return new OpCase("ScatterAdd[4,8->6,8;d0]", "index",
             e => e.ScatterAdd(OpInput.Rand(1101, new[] { 4, 8 }).F(), new Tensor<int>((int[])sidx.Clone(), new[] { 4, 8 }), 0, 6),
-            e => e.ScatterAdd(OpInput.Rand(1101, new[] { 4, 8 }).D(), new Tensor<int>((int[])sidx.Clone(), new[] { 4, 8 }), 0, 6), ParityTol.Ulp(8, 1e-6), opMethod: "ScatterAdd");
+            e => e.ScatterAdd(OpInput.Rand(1101, new[] { 4, 8 }).D(), new Tensor<int>((int[])sidx.Clone(), new[] { 4, 8 }), 0, 6), ParityTol.Ulp(8, 1e-6), opMethod: "ScatterAdd")
+        {
+            GraphCaptureExpectation = GraphCaptureExpectation.HeterogeneousInput,
+            GraphCaptureSignatureOverload = GraphCaptureSignatureOverload.ScatterAdd_Tensor_T_Tensor_Int32_Int32_Nullable_Int32
+        };
+
+        var scatterInput = OpInput.Rand(1102, new[] { 4, 8 });
+        var scatterValues = OpInput.Rand(1103, new[] { 4, 8 });
+        // This overload takes a one-dimensional index vector for the selected axis; values keeps
+        // the input rank and substitutes indices.Length at that axis. Repeat index 1 to exercise
+        // accumulation rather than only validating a gather-shaped no-op case.
+        var scatterIndices = new[] { 0, 1, 1, 3 };
+        yield return new OpCase("ScatterAdd[4,8;values;d0]", "index",
+            e => e.ScatterAdd(scatterInput.F(), new Tensor<int>((int[])scatterIndices.Clone(), new[] { 4 }), scatterValues.F(), 0),
+            e => e.ScatterAdd(scatterInput.D(), new Tensor<int>((int[])scatterIndices.Clone(), new[] { 4 }), scatterValues.D(), 0),
+            ParityTol.Ulp(8, 1e-6), opMethod: "ScatterAdd",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+            graphCaptureSignatureOverload: GraphCaptureSignatureOverload.ScatterAdd_Tensor_T_Tensor_Int32_Tensor_T_Int32);
 
         // Complex magnitude squared from separate real/imag tensors.
         var re = OpInput.Rand(1110, new[] { 4, 8 });
@@ -2521,10 +3739,11 @@ public static class OpParityRegistry
             e => e.Unfold(OpInput.Rand(1002, new[] { 1, 3, 8, 8 }).D(), new[] { 3, 3 }, new[] { 1, 1 }, new[] { 0, 0 }), ParityTol.Exact, opMethod: "Unfold");
 
         var r = OpInput.Rand(1010, new[] { 4, 32 });
-        yield return new OpCase("ReduceLogVariance[4,32;ax1]", "reduction", e => e.ReduceLogVariance(r.F(), new[] { 1 }, false, 1e-8), e => e.ReduceLogVariance(r.D(), new[] { 1 }, false, 1e-8), ParityTol.Accum(1e-3), opMethod: "ReduceLogVariance");
+        yield return new OpCase("ReduceLogVariance[4,32;ax1]", "reduction", e => e.ReduceLogVariance(r.F(), new[] { 1 }, false, 1e-8), e => e.ReduceLogVariance(r.D(), new[] { 1 }, false, 1e-8), ParityTol.Accum(1e-3), opMethod: "ReduceLogVariance")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("ReduceMeanBackward[4,1->4,8]", "reduction",
             e => e.ReduceMeanBackward(OpInput.Rand(1011, new[] { 4, 1 }).F(), new[] { 4, 8 }, new[] { 1 }),
-            e => e.ReduceMeanBackward(OpInput.Rand(1011, new[] { 4, 1 }).D(), new[] { 4, 8 }, new[] { 1 }), ParityTol.Ulp(4, 1e-6), opMethod: "ReduceMeanBackward");
+            e => e.ReduceMeanBackward(OpInput.Rand(1011, new[] { 4, 1 }).D(), new[] { 4, 8 }, new[] { 1 }), ParityTol.Ulp(4, 1e-6), opMethod: "ReduceMeanBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("TensorLogCumSumExp[4,32;ax1]", "reduction", e => e.TensorLogCumSumExp(r.F(), 1), e => e.TensorLogCumSumExp(r.D(), 1), ParityTol.Accum(1e-3), opMethod: "TensorLogCumSumExp");
         yield return new OpCase("TensorCumMin[4,32;ax1]", "reduction", e => e.TensorCumMin(r.F(), 1), e => e.TensorCumMin(r.D(), 1), ParityTol.Exact, opMethod: "TensorCumMin");
 
@@ -2532,7 +3751,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorCDist[3,8x4,8]", "reduction", e => e.TensorCDist(OpInput.Rand(1021, new[] { 3, 8 }).F(), OpInput.Rand(1022, new[] { 4, 8 }).F(), 2.0), e => e.TensorCDist(OpInput.Rand(1021, new[] { 3, 8 }).D(), OpInput.Rand(1022, new[] { 4, 8 }).D(), 2.0), ParityTol.Accum(1e-3), opMethod: "TensorCDist");
 
         var sq = OpInput.Rand(1030, new[] { 4, 4 });
-        yield return new OpCase("TensorDiagonal[4,4]", "linalg", e => e.TensorDiagonal(sq.F()), e => e.TensorDiagonal(sq.D()), ParityTol.Exact, opMethod: "TensorDiagonal");
+        yield return new OpCase("TensorDiagonal[4,4]", "linalg", e => e.TensorDiagonal(sq.F()), e => e.TensorDiagonal(sq.D()), ParityTol.Exact, opMethod: "TensorDiagonal")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("TensorDiagEmbed[4]", "linalg", e => e.TensorDiagEmbed(OpInput.Rand(1031, new[] { 4 }).F(), 0), e => e.TensorDiagEmbed(OpInput.Rand(1031, new[] { 4 }).D(), 0), ParityTol.Exact, opMethod: "TensorDiagEmbed");
         yield return new OpCase("TensorBlockDiag[2x2,2]", "linalg", e => e.TensorBlockDiag(new[] { OpInput.Rand(1032, new[] { 2, 2 }).F(), OpInput.Rand(1033, new[] { 2, 2 }).F() }), e => e.TensorBlockDiag(new[] { OpInput.Rand(1032, new[] { 2, 2 }).D(), OpInput.Rand(1033, new[] { 2, 2 }).D() }), ParityTol.Exact, opMethod: "TensorBlockDiag");
         yield return new OpCase("TensorCross[4,3]", "linalg", e => e.TensorCross(OpInput.Rand(1034, new[] { 4, 3 }).F(), OpInput.Rand(1035, new[] { 4, 3 }).F(), -1), e => e.TensorCross(OpInput.Rand(1034, new[] { 4, 3 }).D(), OpInput.Rand(1035, new[] { 4, 3 }).D(), -1), ParityTol.Ulp(8, 1e-6), opMethod: "TensorCross");
@@ -2555,8 +3775,8 @@ public static class OpParityRegistry
 
         yield return new OpCase("TensorOneHot[idx4;d5]", "index",
             e => e.TensorOneHot<float>(new Tensor<int>(new[] { 0, 3, 1, 4 }, new[] { 4 }), 5),
-            e => e.TensorOneHot<double>(new Tensor<int>(new[] { 0, 3, 1, 4 }, new[] { 4 }), 5), ParityTol.Exact, opMethod: "TensorOneHot");
-        yield return new OpCase("TensorEye[5]", "shape", e => e.TensorEye<float>(5), e => e.TensorEye<double>(5), ParityTol.Exact, opMethod: "TensorEye");
+            e => e.TensorOneHot<double>(new Tensor<int>(new[] { 0, 3, 1, 4 }, new[] { 4 }), 5), ParityTol.Exact, opMethod: "TensorOneHot", graphCaptureExpectation: GraphCaptureExpectation.HeterogeneousInput);
+        yield return new OpCase("TensorEye[5]", "shape", e => e.TensorEye<float>(5), e => e.TensorEye<double>(5), ParityTol.Exact, opMethod: "TensorEye", graphCaptureExpectation: GraphCaptureExpectation.InputIndependent);
 
         var img = OpInput.Rand(902, new[] { 1, 2, 4, 4 });
         yield return new OpCase("Upsample[1,2,4,4;2x2]", "shape", e => e.Upsample(img.F(), 2, 2), e => e.Upsample(img.D(), 2, 2), ParityTol.Exact, opMethod: "Upsample");
@@ -2602,7 +3822,8 @@ public static class OpParityRegistry
         yield return new OpCase("TensorDiag[4]", "shape", e => e.TensorDiag(diag.F()), e => e.TensorDiag(diag.D()), ParityTol.Exact, opMethod: "TensorDiag");
         yield return new OpCase("TensorFliplr[4,8]", "shape", e => e.TensorFliplr(m.F()), e => e.TensorFliplr(m.D()), ParityTol.Exact, opMethod: "TensorFliplr");
         yield return new OpCase("TensorFlipud[4,8]", "shape", e => e.TensorFlipud(m.F()), e => e.TensorFlipud(m.D()), ParityTol.Exact, opMethod: "TensorFlipud");
-        yield return new OpCase("TensorRepeatElements[4,8;2,ax0]", "shape", e => e.TensorRepeatElements(m.F(), 2, 0), e => e.TensorRepeatElements(m.D(), 2, 0), ParityTol.Exact, opMethod: "TensorRepeatElements");
+        yield return new OpCase("TensorRepeatElements[4,8;2,ax0]", "shape", e => e.TensorRepeatElements(m.F(), 2, 0), e => e.TensorRepeatElements(m.D(), 2, 0), ParityTol.Exact, opMethod: "TensorRepeatElements")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
 
         // Cumulative selection.
         var rr = OpInput.Rand(820, new[] { 4, 32 });
@@ -2626,10 +3847,12 @@ public static class OpParityRegistry
         // Index / embedding (Tensor<int> indices are identical across float/double runs).
         yield return new OpCase("Embedding[idx4;table10,8]", "index",
             e => e.Embedding(new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), OpInput.Rand(710, new[] { 10, 8 }).F()),
-            e => e.Embedding(new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), OpInput.Rand(710, new[] { 10, 8 }).D()), ParityTol.Exact, opMethod: "Embedding");
+            e => e.Embedding(new Tensor<int>(new[] { 1, 3, 0, 5 }, new[] { 4 }), OpInput.Rand(710, new[] { 10, 8 }).D()), ParityTol.Exact, opMethod: "Embedding",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
         yield return new OpCase("TensorIndexSelect[6,8;ax0]", "index",
             e => e.TensorIndexSelect(OpInput.Rand(711, new[] { 6, 8 }).F(), new Tensor<int>(new[] { 0, 2, 5, 1 }, new[] { 4 }), 0),
-            e => e.TensorIndexSelect(OpInput.Rand(711, new[] { 6, 8 }).D(), new Tensor<int>(new[] { 0, 2, 5, 1 }, new[] { 4 }), 0), ParityTol.Exact, opMethod: "TensorIndexSelect");
+            e => e.TensorIndexSelect(OpInput.Rand(711, new[] { 6, 8 }).D(), new Tensor<int>(new[] { 0, 2, 5, 1 }, new[] { 4 }), 0), ParityTol.Exact, opMethod: "TensorIndexSelect",
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput);
 
         // Losses (reductions → relative tol). BCEWithLogits is the #775 loss itself.
         var pred = OpInput.Rand(720, new[] { 4, 64 });
@@ -2658,23 +3881,26 @@ public static class OpParityRegistry
 
         // FOUND (quarantined): GPU MishBackward is NONDETERMINISTIC run-to-run (racy/uninitialized
         // kernel, like the frac bug) — a real GPU bug the determinism check catches intermittently.
-        yield return new OpCase("MishBackward[4,64]", "activation-bwd", e => e.MishBackward(go.F(), inp.F()), e => e.MishBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "MishBackward");
-        yield return new OpCase("SwishBackward[4,64]", "activation-bwd", e => e.SwishBackward(go.F(), inp.F()), e => e.SwishBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SwishBackward");
-        yield return new OpCase("SoftplusBackward[4,64]", "activation-bwd", e => e.SoftplusBackward(go.F(), inp.F()), e => e.SoftplusBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SoftplusBackward");
-        yield return new OpCase("SeluBackward[4,64]", "activation-bwd", e => e.SeluBackward(go.F(), inp.F()), e => e.SeluBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SeluBackward");
-        yield return new OpCase("HardswishBackward[4,64]", "activation-bwd", e => e.HardswishBackward(go.F(), inp.F()), e => e.HardswishBackward(go.D(), inp.D()), ParityTol.Ulp(16, 1e-6), opMethod: "HardswishBackward");
-        yield return new OpCase("HardsigmoidBackward[4,64]", "activation-bwd", e => e.HardsigmoidBackward(go.F(), inp.F()), e => e.HardsigmoidBackward(go.D(), inp.D()), ParityTol.Exact, opMethod: "HardsigmoidBackward");
+        yield return new OpCase("MishBackward[4,64]", "activation-bwd", e => e.MishBackward(go.F(), inp.F()), e => e.MishBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "MishBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("SwishBackward[4,64]", "activation-bwd", e => e.SwishBackward(go.F(), inp.F()), e => e.SwishBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SwishBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("SoftplusBackward[4,64]", "activation-bwd", e => e.SoftplusBackward(go.F(), inp.F()), e => e.SoftplusBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SoftplusBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("SeluBackward[4,64]", "activation-bwd", e => e.SeluBackward(go.F(), inp.F()), e => e.SeluBackward(go.D(), inp.D()), ParityTol.Ulp(64, 1e-6), opMethod: "SeluBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("HardswishBackward[4,64]", "activation-bwd", e => e.HardswishBackward(go.F(), inp.F()), e => e.HardswishBackward(go.D(), inp.D()), ParityTol.Ulp(16, 1e-6), opMethod: "HardswishBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("HardsigmoidBackward[4,64]", "activation-bwd", e => e.HardsigmoidBackward(go.F(), inp.F()), e => e.HardsigmoidBackward(go.D(), inp.D()), ParityTol.Exact, opMethod: "HardsigmoidBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         // #775: CPU GeluBackward now evaluates its derivative via the accurate Padé sigmoid (same
         // fix family as the forward), so it matches the GPU builtin-tanh derivative tightly.
-        yield return new OpCase("GeluBackward[4,64]", "activation-bwd", e => e.GeluBackward(go.F(), inp.F()), e => e.GeluBackward(go.D(), inp.D()), ParityTol.Accum(1e-3), opMethod: "GeluBackward");
-        yield return new OpCase("Relu6Backward[4,64]", "activation-bwd", e => e.Relu6Backward(go.F(), inp.F()), e => e.Relu6Backward(go.D(), inp.D()), ParityTol.Exact, opMethod: "Relu6Backward");
-        yield return new OpCase("LeakyReluBackward[4,64]", "activation-bwd", e => e.LeakyReluBackward(go.F(), inp.F(), 0.1), e => e.LeakyReluBackward(go.D(), inp.D(), 0.1), ParityTol.Ulp(4, 1e-6), opMethod: "LeakyReluBackward");
+        yield return new OpCase("GeluBackward[4,64]", "activation-bwd", e => e.GeluBackward(go.F(), inp.F()), e => e.GeluBackward(go.D(), inp.D()), ParityTol.Accum(1e-3), opMethod: "GeluBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("Relu6Backward[4,64]", "activation-bwd", e => e.Relu6Backward(go.F(), inp.F()), e => e.Relu6Backward(go.D(), inp.D()), ParityTol.Exact, opMethod: "Relu6Backward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("LeakyReluBackward[4,64]", "activation-bwd", e => e.LeakyReluBackward(go.F(), inp.F(), 0.1), e => e.LeakyReluBackward(go.D(), inp.D(), 0.1), ParityTol.Ulp(4, 1e-6), opMethod: "LeakyReluBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         yield return new OpCase("EluBackward[4,64]", "activation-bwd",
-            e => e.EluBackward(go.F(), inp.F(), e.ELU(inp.F(), 1.0), 1.0), e => e.EluBackward(go.D(), inp.D(), e.ELU(inp.D(), 1.0), 1.0), ParityTol.Ulp(64, 1e-6), opMethod: "EluBackward");
+            e => e.EluBackward(go.F(), inp.F(), e.ELU(inp.F(), 1.0), 1.0), e => e.EluBackward(go.D(), inp.D(), e.ELU(inp.D(), 1.0), 1.0), ParityTol.Ulp(64, 1e-6), opMethod: "EluBackward", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
-        yield return new OpCase("ReLUDerivative[4,64]", "activation-bwd", e => e.ReLUDerivative(inp.F()), e => e.ReLUDerivative(inp.D()), ParityTol.Exact, opMethod: "ReLUDerivative");
-        yield return new OpCase("SigmoidDerivative[4,64]", "activation-bwd", e => e.SigmoidDerivative(OpInput.Rand(602, s, 0.1, 0.9).F()), e => e.SigmoidDerivative(OpInput.Rand(602, s, 0.1, 0.9).D()), ParityTol.Ulp(8, 1e-6), opMethod: "SigmoidDerivative");
-        yield return new OpCase("TanhDerivative[4,64]", "activation-bwd", e => e.TanhDerivative(OpInput.Rand(603, s, -0.9, 0.9).F()), e => e.TanhDerivative(OpInput.Rand(603, s, -0.9, 0.9).D()), ParityTol.Ulp(8, 1e-6), opMethod: "TanhDerivative");
+        yield return new OpCase("ReLUDerivative[4,64]", "activation-bwd", e => e.ReLUDerivative(inp.F()), e => e.ReLUDerivative(inp.D()), ParityTol.Exact,
+            opMethod: "ReLUDerivative", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("SigmoidDerivative[4,64]", "activation-bwd", e => e.SigmoidDerivative(OpInput.Rand(602, s, 0.1, 0.9).F()), e => e.SigmoidDerivative(OpInput.Rand(602, s, 0.1, 0.9).D()), ParityTol.Ulp(8, 1e-6),
+            opMethod: "SigmoidDerivative", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
+        yield return new OpCase("TanhDerivative[4,64]", "activation-bwd", e => e.TanhDerivative(OpInput.Rand(603, s, -0.9, 0.9).F()), e => e.TanhDerivative(OpInput.Rand(603, s, -0.9, 0.9).D()), ParityTol.Ulp(8, 1e-6),
+            opMethod: "TanhDerivative", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
 
         // Matmul / linear family.
         var ba = OpInput.Rand(610, new[] { 2, 4, 8 });
@@ -2689,7 +3915,8 @@ public static class OpParityRegistry
         var mmB = OpInput.Rand(616, new[] { 8, 6 });
         yield return new OpCase("TensorAddMM[4,6;4,8x8,6]", "matmul", e => e.TensorAddMM(mmIn.F(), mmA.F(), mmB.F()), e => e.TensorAddMM(mmIn.D(), mmA.D(), mmB.D()), ParityTol.Accum(1e-3), opMethod: "TensorAddMM");
         yield return new OpCase("TensorDot[4,8.8,6]", "matmul", e => e.TensorDot(mmA.F(), mmB.F(), new[] { 1 }, new[] { 0 }), e => e.TensorDot(mmA.D(), mmB.D(), new[] { 1 }, new[] { 0 }), ParityTol.Accum(1e-3), opMethod: "TensorDot");
-        yield return new OpCase("TensorOuter[4x6]", "matmul", e => e.TensorOuter(OpInput.Rand(617, new[] { 4 }).F(), OpInput.Rand(618, new[] { 6 }).F()), e => e.TensorOuter(OpInput.Rand(617, new[] { 4 }).D(), OpInput.Rand(618, new[] { 6 }).D()), ParityTol.Ulp(2, 1e-6), opMethod: "TensorOuter");
+        yield return new OpCase("TensorOuter[4x6]", "matmul", e => e.TensorOuter(OpInput.Rand(617, new[] { 4 }).F(), OpInput.Rand(618, new[] { 6 }).F()), e => e.TensorOuter(OpInput.Rand(617, new[] { 4 }).D(), OpInput.Rand(618, new[] { 6 }).D()), ParityTol.Ulp(2, 1e-6), opMethod: "TensorOuter")
+        { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("TensorKron[2,3x2,2]", "matmul", e => e.TensorKron(OpInput.Rand(619, new[] { 2, 3 }).F(), OpInput.Rand(620, new[] { 2, 2 }).F()), e => e.TensorKron(OpInput.Rand(619, new[] { 2, 3 }).D(), OpInput.Rand(620, new[] { 2, 2 }).D()), ParityTol.Ulp(2, 1e-6), opMethod: "TensorKron");
 
         // Variadic reductions over a small tensor list.
@@ -2724,9 +3951,24 @@ public static class OpParityRegistry
             var condData = new double[256];
             var rng = new Random(512);
             for (int i = 0; i < condData.Length; i++) condData[i] = rng.NextDouble() < 0.5 ? 0.0 : 1.0;
-            var cond = OpInput.From(condData, new[] { 4, 64 });
+            var cond = OpInput.FixedFrom(condData, new[] { 4, 64 });
             yield return new OpCase("TensorWhere[4,64]", "comparison",
                 e => e.TensorWhere(cond.F(), a.F(), b.F()), e => e.TensorWhere(cond.D(), a.D(), b.D()), ParityTol.Exact, opMethod: "TensorWhere");
+
+            bool[] boolCondition = condData.Select(value => value != 0.0).ToArray();
+            Bit[] bitCondition = boolCondition.Select(value => value ? Bit.True : Bit.False).ToArray();
+            yield return new OpCase("TensorWhere[4,64;bool]", "comparison",
+                e => e.TensorWhere(new Tensor<bool>((bool[])boolCondition.Clone(), new[] { 4, 64 }), a.F(), b.F()),
+                e => e.TensorWhere(new Tensor<bool>((bool[])boolCondition.Clone(), new[] { 4, 64 }), a.D(), b.D()),
+                ParityTol.Exact, opMethod: "TensorWhere",
+                graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+                graphCaptureSignatureOverload: GraphCaptureSignatureOverload.TensorWhere_Tensor_Boolean_Tensor_T_Tensor_T);
+            yield return new OpCase("TensorWhere[4,64;bit]", "comparison",
+                e => e.TensorWhere(new Tensor<Bit>((Bit[])bitCondition.Clone(), new[] { 4, 64 }), a.F(), b.F()),
+                e => e.TensorWhere(new Tensor<Bit>((Bit[])bitCondition.Clone(), new[] { 4, 64 }), a.D(), b.D()),
+                ParityTol.Exact, opMethod: "TensorWhere",
+                graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput,
+                graphCaptureSignatureOverload: GraphCaptureSignatureOverload.TensorWhere_Tensor_Bit_Tensor_T_Tensor_T);
         }
 
         // Norm family.
@@ -2819,8 +4061,10 @@ public static class OpParityRegistry
     /// <summary>Binary elementwise op: Op(a, b).</summary>
     private static OpCase B(
         string method, string cat, System.Func<IEngine, Tensor<float>, Tensor<float>, Tensor<float>> f,
-        System.Func<IEngine, Tensor<double>, Tensor<double>, Tensor<double>> d, ParityTol tol, OpInput a, OpInput b)
-        => new OpCase($"{method}[{Dims(a)}]", cat, e => f(e, a.F(), b.F()), e => d(e, a.D(), b.D()), tol, opMethod: method);
+        System.Func<IEngine, Tensor<double>, Tensor<double>, Tensor<double>> d, ParityTol tol, OpInput a, OpInput b,
+        GraphCaptureExpectation graphCaptureExpectation = GraphCaptureExpectation.Required)
+        => new OpCase($"{method}[{Dims(a)}]", cat, e => f(e, a.F(), b.F()), e => d(e, a.D(), b.D()), tol,
+            opMethod: method, graphCaptureExpectation: graphCaptureExpectation);
 
     /// <summary>
     /// Binary case with a tag in the display id, for when two cases share an IEngine method and a
@@ -2885,7 +4129,8 @@ public static class OpParityRegistry
         yield return new OpCase("ReduceMaxWithTensorIndices[2,3,4;ax0,2]", "reduction",
             e => e.ReduceMaxWithTensorIndices(residentMax.F(), new[] { 0, 2 }, false, out _),
             e => e.ReduceMaxWithTensorIndices(residentMax.D(), new[] { 0, 2 }, false, out _),
-            ParityTol.Exact, opMethod: "ReduceMaxWithTensorIndices");
+            ParityTol.Exact, opMethod: "ReduceMaxWithTensorIndices")
+        { GraphCaptureExpectation = GraphCaptureExpectation.HeterogeneousOutput };
         yield return new OpCase("ReduceMaxBackwardWithTensorIndices[2,3,4;ax0,2]", "reduction",
             e =>
             {
@@ -2899,7 +4144,9 @@ public static class OpParityRegistry
                 return e.ReduceMaxBackwardWithTensorIndices(
                     residentMaxGrad.D(), indices, new[] { 2, 3, 4 }, new[] { 0, 2 });
             },
-            ParityTol.Exact, opMethod: "ReduceMaxBackwardWithTensorIndices");
+            ParityTol.Exact, opMethod: "ReduceMaxBackwardWithTensorIndices", graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel,
+            graphCaptureSignatureConstraint: GraphCaptureSignatureConstraint.HeterogeneousInput)
+        { GraphCaptureExpectation = GraphCaptureExpectation.BackwardKernel };
     }
 
     // Second elementwise batch: the broad Tensor* unary math/activation family + softmax variants.
@@ -3025,19 +4272,22 @@ public static class OpParityRegistry
             var go = OpInput.Rand(20, new[] { 4, 64 });
             var input = OpInput.Rand(21, new[] { 4, 64 });
             yield return new OpCase("ReluBackward[4,64]", "activation-bwd",
-                e => e.ReluBackward(go.F(), input.F()), e => e.ReluBackward(go.D(), input.D()), ParityTol.Ulp(4, 1e-6));
+                e => e.ReluBackward(go.F(), input.F()), e => e.ReluBackward(go.D(), input.D()), ParityTol.Ulp(4, 1e-6),
+                graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
         {
             var go = OpInput.Rand(22, new[] { 4, 64 });
             var outp = OpInput.Rand(23, new[] { 4, 64 }, 0.05, 0.95);
             yield return new OpCase("SigmoidBackward[4,64]", "activation-bwd",
-                e => e.SigmoidBackward(go.F(), outp.F()), e => e.SigmoidBackward(go.D(), outp.D()), ParityTol.Ulp(16, 1e-6));
+                e => e.SigmoidBackward(go.F(), outp.F()), e => e.SigmoidBackward(go.D(), outp.D()), ParityTol.Ulp(16, 1e-6),
+                graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
         {
             var go = OpInput.Rand(24, new[] { 4, 64 });
             var outp = OpInput.Rand(25, new[] { 4, 64 }, -0.95, 0.95);
             yield return new OpCase("TanhBackward[4,64]", "activation-bwd",
-                e => e.TanhBackward(go.F(), outp.F()), e => e.TanhBackward(go.D(), outp.D()), ParityTol.Ulp(16, 1e-6));
+                e => e.TanhBackward(go.F(), outp.F()), e => e.TanhBackward(go.D(), outp.D()), ParityTol.Ulp(16, 1e-6),
+                graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
         {
             // Softmax backward needs a valid softmax output (rows sum to 1) as its second arg.
@@ -3046,7 +4296,7 @@ public static class OpParityRegistry
             yield return new OpCase("SoftmaxBackward[4,16]", "activation-bwd",
                 e => e.SoftmaxBackward(go.F(), e.Softmax(logits.F(), -1), -1),
                 e => e.SoftmaxBackward(go.D(), e.Softmax(logits.D(), -1), -1),
-                ParityTol.Accum(1e-3));
+                ParityTol.Accum(1e-3), graphCaptureExpectation: GraphCaptureExpectation.BackwardKernel);
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityTests.cs
@@ -21,12 +21,31 @@ public sealed class OpParityTests
         OpParityRegistry.All().ToDictionary(o => o.Name);
 
     public static IEnumerable<object[]> ForwardCases =>
-        OpParityRegistry.All().Where(o => ParityShard.Include(o.Name)).Select(o => new object[] { o.Name });
+        OpParityRegistry.All()
+            .Where(o => o.TensorOutputContract == TensorOutputContract.SingleTensor
+                && ParityShard.Include(o.Name))
+            .Select(o => new object[] { o.Name });
+
+    public static IEnumerable<object[]> MultiOutputCases =>
+        OpParityRegistry.All()
+            .Where(o => (o.HasMultipleOutputs || o.HasHeterogeneousOutputs) && ParityShard.Include(o.Name))
+            .Select(o => new object[] { o.Name });
 
     [SkippableTheory]
     [MemberData(nameof(ForwardCases))]
     public void Forward_CpuMatchesGpu(string opName)
         => OpParityHarness.CheckForward(Cases[opName], _fx);
+
+    [SkippableTheory]
+    [MemberData(nameof(MultiOutputCases))]
+    public void MultipleOutputs_CpuMatchesGpu(string opName)
+    {
+        var op = Cases[opName];
+        if (op.TensorOutputContract == TensorOutputContract.HeterogeneousMultiple)
+            OpParityHarness.CheckHeterogeneousOutputs(op, _fx);
+        else
+            OpParityHarness.CheckMultipleOutputs(op, _fx);
+    }
 
 }
 #endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityHarness.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityHarness.cs
@@ -297,7 +297,7 @@ public static class TapeGradientParityHarness
     /// </summary>
     private static (List<LeafGradientSnapshot> Leaves, long Materialisations, int LeafCount,
         bool UsesContractIdentity, int CapturedInputCount) TapeGradient(
-        IEngine engine, Func<IEngine, Tensor<float>> runFloat)
+        IEngine engine, OpCase op)
     {
         var prior = AiDotNetEngine.Current;
         AiDotNetEngine.Current = engine;
@@ -308,6 +308,8 @@ public static class TapeGradientParityHarness
         Tensor<float>? weight = null;
         Tensor<float>? weighted = null;
         Tensor<float>? loss = null;
+        Tensor<float>[]? retainedOutputs = null;
+        Tensor<float>[]? retainedFlattenedOutputs = null;
         try
         {
             AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.ResetMaterializeCount();
@@ -316,7 +318,36 @@ public static class TapeGradientParityHarness
             try
             {
                 using (OpInput.CaptureFloatInputs(capturedInputs))
-                    output = runFloat(engine);
+                {
+                    if (op.TensorOutputContract == TensorOutputContract.HomogeneousMultiple
+                        && op.RunFloatOutputs is not null)
+                    {
+                        // The ordinary forward/residency projection disposes its constituent outputs
+                        // immediately. A tape projection cannot: multi-output backward implementations
+                        // may legitimately save any constituent for the backward walk. Retain both the
+                        // outputs and their reshape views until after ComputeGradients, then release them
+                        // in this method's existing deterministic cleanup.
+                        retainedOutputs = op.RunFloatOutputs(engine);
+                        if (retainedOutputs.Length == 0)
+                        {
+                            output = new Tensor<float>(new[] { 0 });
+                        }
+                        else
+                        {
+                            retainedFlattenedOutputs = new Tensor<float>[retainedOutputs.Length];
+                            for (int i = 0; i < retainedOutputs.Length; i++)
+                            {
+                                retainedFlattenedOutputs[i] = engine.Reshape(
+                                    retainedOutputs[i], new[] { retainedOutputs[i].Length });
+                            }
+                            output = engine.TensorConcatenate(retainedFlattenedOutputs, 0);
+                        }
+                    }
+                    else
+                    {
+                        output = op.RunFloat(engine);
+                    }
+                }
 
                 // Non-uniform weighting: a constant upstream gradient can mask a wrong backward, because several
                 // different index mappings then produce the same total.
@@ -380,6 +411,10 @@ public static class TapeGradientParityHarness
                 DisposeOnce(weighted);
                 DisposeOnce(weight);
                 DisposeOnce(output);
+                if (retainedFlattenedOutputs is not null)
+                    foreach (var flattened in retainedFlattenedOutputs) DisposeOnce(flattened);
+                if (retainedOutputs is not null)
+                    foreach (var retained in retainedOutputs) DisposeOnce(retained);
                 foreach (var source in sources) DisposeOnce(source);
                 foreach (var input in capturedInputs) DisposeOnce(input);
             }
@@ -429,9 +464,9 @@ public static class TapeGradientParityHarness
         if (gpu is null) { Skip.If(true, "GPU engine unavailable after reset."); return; }
 
         var (cpuLeafList, _, cpuLeaves, cpuUsesContractIdentity, cpuCapturedInputs) =
-            TapeGradient(fx.Cpu, op.RunFloat);
+            TapeGradient(fx.Cpu, op);
         var (gpuLeafList, materialisations, gpuLeaves, gpuUsesContractIdentity, gpuCapturedInputs) =
-            TapeGradient(gpu, op.RunFloat);
+            TapeGradient(gpu, op);
 
         if (cpuLeaves == 0 && gpuLeaves == 0)
         {
@@ -517,13 +552,17 @@ public static class TapeGradientParityHarness
             + $"(CPU {cpuLeaves} leaves, GPU {gpuLeaves}).");
 
         double maxAbs = 0, maxRel = 0;
-        foreach (var (cg, gg) in pairs)
+        string? firstNonFinite = null;
+        for (int pairIndex = 0; pairIndex < pairs.Count; pairIndex++)
         {
+            var (cg, gg) = pairs[pairIndex];
             Assert.True(cg.Length == gg.Length,
                 $"{opName} tapegrad: paired leaves have identical inputs but gradients of different length "
                 + $"(CPU={cg.Length} GPU={gg.Length}) — the engines disagree about that input's gradient shape.");
             for (int i = 0; i < cg.Length; i++)
             {
+                if (firstNonFinite is null && (!float.IsFinite(cg[i]) || !float.IsFinite(gg[i])))
+                    firstNonFinite = $"leaf={pairIndex} index={i} cpu={cg[i]} gpu={gg[i]}";
                 double d = Math.Abs(cg[i] - gg[i]);
                 maxAbs = Math.Max(maxAbs, d);
                 maxRel = Math.Max(maxRel, d / Math.Max(1.0, Math.Abs(cg[i])));
@@ -550,6 +589,7 @@ public static class TapeGradientParityHarness
 
         Assert.True(maxRel <= 1e-4,
             $"{opName} tapegrad: GPU gradient diverged from CPU (maxAbs={maxAbs:E3} maxRel={maxRel:E3}). "
+            + (firstNonFinite is null ? string.Empty : $"First non-finite value: {firstNonFinite}. ")
             + "A gross mismatch means the recorded backward, its saved state, or the overload is wrong — "
             + "NOT float rounding. Scatter failed exactly this way at 3.14e-01 while both the forward and "
             + "the backward KERNEL were correct.");

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/TapeGradientParityTests.cs
@@ -21,7 +21,10 @@ public class TapeGradientParityTests
     public TapeGradientParityTests(OpParityFixture fx) => _fx = fx;
 
     public static IEnumerable<object[]> AllOps() =>
-        OpParityRegistry.All().Where(op => ParityShard.Include(op.Name)).Select(op => new object[] { op.Name });
+        OpParityRegistry.All()
+            .Where(op => op.GraphCaptureExpectation != GraphCaptureExpectation.BackwardKernel)
+            .Where(op => ParityShard.Include(op.Name))
+            .Select(op => new object[] { op.Name });
 
     [SkippableTheory]
     [MemberData(nameof(AllOps))]

--- a/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/SoftmaxForwardGpuReproTests.cs
@@ -20,6 +20,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// Both must produce a valid per-row distribution (each row in [0,1], sums to 1) matching a CPU
 /// reference. Run on native Windows so the OpenCL GPU engages.
 /// </summary>
+[Collection("DirectGpuSerial")]
 public class SoftmaxForwardGpuReproTests
 {
     private readonly ITestOutputHelper _out;
@@ -210,12 +211,12 @@ public class SoftmaxForwardGpuReproTests
 
     // GPU-resident operands for a [batch, InF] @ [InF, OutF] + bias linear layer, built via the graph.
     private static (Tensor<float> input, Tensor<float> weights, Tensor<float> bias, Tensor<float> output)
-        MakeGpuOperands(int batch, float[] a, float[] w, float[] bv)
+        MakeGpuOperands(DirectGpuTensorEngine engine, int batch, float[] a, float[] w, float[] bv)
     {
-        var input = new Tensor<float>(a, new[] { batch, InF }).Gpu();
-        var weights = new Tensor<float>(w, new[] { InF, OutF }).Gpu();
-        var bias = new Tensor<float>(bv, new[] { OutF }).Gpu();
-        var output = new Tensor<float>(new[] { batch, OutF }).Gpu();
+        var input = engine.UploadToGpu<float>(a, new[] { batch, InF }, GpuTensorRole.Input);
+        var weights = engine.UploadToGpu<float>(w, new[] { InF, OutF }, GpuTensorRole.Weight);
+        var bias = engine.UploadToGpu<float>(bv, new[] { OutF }, GpuTensorRole.Bias);
+        var output = engine.UploadToGpu<float>(new float[batch * OutF], new[] { batch, OutF }, GpuTensorRole.Output);
         return (input, weights, bias, output);
     }
 
@@ -239,7 +240,7 @@ public class SoftmaxForwardGpuReproTests
         _out.WriteLine($"Engine: {engine.Name}   batch={batch}  (deferred graph, async fused route)");
 
         var (a, w, b) = MakeInputs(batch);
-        var (input, weights, bias, output) = MakeGpuOperands(batch, a, w, b);
+        var (input, weights, bias, output) = MakeGpuOperands(engine, batch, a, w, b);
         float[] gpu;
         try
         {
@@ -279,7 +280,7 @@ public class SoftmaxForwardGpuReproTests
         _out.WriteLine($"Engine: {engine.Name}   batch={batch}  (deferred graph, separate-node route)");
 
         var (a, w, b) = MakeInputs(batch);
-        var (input, weights, bias, output) = MakeGpuOperands(batch, a, w, b);
+        var (input, weights, bias, output) = MakeGpuOperands(engine, batch, a, w, b);
         float[] gpu;
         try
         {

--- a/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/VideoWarpOperationsTests.cs
@@ -214,25 +214,6 @@ public sealed class VideoWarpOperationsTests
         AssertClose(eager, compiled, 1e-5f);
     }
 
-    [Fact]
-    public void ScaledDotProductAttention_CompiledReplay_PreservesBooleanMask()
-    {
-        var q = new Tensor<float>([1f, 0f, 0f, 1f, 1f, 1f], [1, 1, 3, 2]);
-        var mask = new Tensor<bool>(
-            [true, false, false, true, true, false, true, true, true],
-            [1, 1, 3, 3]);
-        Func<Tensor<float>> forward = () =>
-            _engine.ScaledDotProductAttention(q, q, q, mask, scale: 1.0, out _);
-        var eager = forward().GetDataArray();
-        using var cache = new CompiledModelCache<float>();
-        var plan = cache.GetOrCompileInference(q, forward);
-        plan.SetInputs([q]);
-
-        var compiled = plan.Execute().GetDataArray();
-
-        AssertClose(eager, compiled, 1e-5f);
-    }
-
     private float Loss(
         Tensor<float> input, Tensor<float> flow, Tensor<float> gradOutput, bool normalize)
     {


### PR DESCRIPTION
## Summary
- fix compiled inference/training graph scope closure, live-input replay, output copying, serialization, and tensor-storage lifetime ownership
- add type-safe, registry-generated graph-capture and multi-output invariants instead of operation-name allowlists
- fix autodiff release planning, copy-on-write isolation, GPU buffer affinity/submission lifetime, and missing backend routing
- preserve deterministic CPU behavior and production GPU execution, including exact matmul allocation behavior and isolated FP64 FFT fixtures

## Root-cause safeguards
- compiled plans retain storage leases rather than relying on wrapper reachability
- capture recording is suspended during replay and nested scopes restore their parent immediately after compilation
- GPU results copy through storage-aware paths and asynchronous OpenCL resources remain alive through completion
- graph capability and output contracts use enums and generated registry coverage
- no assertion tolerance was relaxed and no new test skip was added

## Validation
- full non-DirectGpu net10 inventory: 11,360 passed, 317 skipped, 0 failed
- focused GPU-facing net10 gate: 34 passed, 2 skipped, 0 failed
- full generated op-parity family: 2,841 passed, 191 skipped, 0 failed
- full compilation family: 961 passed, 12 skipped, 0 failed
- matmul/COW/SIMD regression family: 218 passed, 4 skipped, 0 failed
- native complex FFT fixture: 12/12 on net10 and 12/12 on net471
- library build: net10, net8, and net471 succeeded with 0 warnings and 0 errors