### PR TITLE
fix: preserve compiled tensor lifetimes and CPU invariants

### DIFF
--- a/src/AiDotNet.Tensors.Onnx/OnnxImporter.cs
+++ b/src/AiDotNet.Tensors.Onnx/OnnxImporter.cs
@@ -216,7 +216,7 @@ public static class OnnxImporter
         });
         try
         {
-            using var scope = GraphMode.Enable();
+            using var scope = GraphMode.EnableInference();
             // Resolve the default-domain opset version from the model's
             // opset_import list. Softmax and a handful of other translators
             // need this to pick the correct per-opset attribute defaults.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/AutogradFunction.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/AutogradFunction.cs
@@ -76,7 +76,7 @@ public abstract class AutogradFunction<T>
 /// <summary>
 /// Context object for saving tensors between forward and backward passes.
 /// </summary>
-public sealed class AutogradContext
+public sealed class AutogradContext : ISavedStateTensorContainer
 {
     private readonly List<object> _saved = [];
 
@@ -100,4 +100,6 @@ public sealed class AutogradContext
 
     /// <summary>Gets the number of saved items.</summary>
     public int SavedCount => _saved.Count;
+
+    IReadOnlyList<object> ISavedStateTensorContainer.SavedStateValues => _saved;
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardStorageReleasePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardStorageReleasePlan.cs
@@ -1,0 +1,195 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Autodiff;
+
+/// <summary>
+/// Precomputed, storage-aware release schedule for progressive GPU activation reclamation.
+/// Tensor objects are not allocation identities: reshape/transpose/slice views can all share
+/// one storage, and a saved tensor can outlive an earlier alias's backward step. The schedule
+/// therefore releases an output storage only after its final declared backward use.
+/// </summary>
+internal sealed class BackwardStorageReleasePlan<T>
+{
+    private readonly struct ReleaseCandidate
+    {
+        internal readonly object StorageIdentity;
+        internal readonly Tensor<T> Tensor;
+
+        internal ReleaseCandidate(object storageIdentity, Tensor<T> tensor)
+        {
+            StorageIdentity = storageIdentity;
+            Tensor = tensor;
+        }
+    }
+
+    private sealed class StorageUsage
+    {
+        internal readonly object Identity;
+        internal Tensor<T>? ReleaseCandidate;
+        internal int LastUse;
+
+        internal StorageUsage(object identity, int lastUse)
+        {
+            Identity = identity;
+            LastUse = lastUse;
+        }
+    }
+
+    private sealed class Builder
+    {
+        private readonly Dictionary<object, StorageUsage> _usage =
+            new(ReferenceEqualityComparer<object>.Instance);
+
+        internal void Observe(Tensor<T>? tensor, int step, bool canRelease)
+        {
+            if (tensor is null) return;
+            object identity = tensor.StorageIdentity;
+            if (!_usage.TryGetValue(identity, out var usage))
+            {
+                usage = new StorageUsage(identity, step);
+                _usage.Add(identity, usage);
+            }
+            else if (step > usage.LastUse)
+            {
+                usage.LastUse = step;
+            }
+
+            // Only graph-produced outputs are owned by progressive activation reclamation.
+            // Inputs that are leaves must never become releasable merely because they were read.
+            if (canRelease && usage.ReleaseCandidate is null)
+                usage.ReleaseCandidate = tensor;
+        }
+
+        internal BackwardStorageReleasePlan<T> Build(int stepCount)
+        {
+            var counts = new int[stepCount];
+            foreach (var usage in _usage.Values)
+            {
+                if (usage.ReleaseCandidate is not null)
+                    counts[usage.LastUse]++;
+            }
+
+            var releases = new ReleaseCandidate[]?[stepCount];
+            for (int i = 0; i < stepCount; i++)
+            {
+                if (counts[i] != 0)
+                    releases[i] = new ReleaseCandidate[counts[i]];
+            }
+
+            Array.Clear(counts, 0, counts.Length);
+            foreach (var usage in _usage.Values)
+            {
+                if (usage.ReleaseCandidate is null) continue;
+                int step = usage.LastUse;
+                releases[step]![counts[step]++] =
+                    new ReleaseCandidate(usage.Identity, usage.ReleaseCandidate);
+            }
+
+            return new BackwardStorageReleasePlan<T>(releases);
+        }
+    }
+
+    private struct SavedUseVisitor : ISavedStateTensorVisitor
+    {
+        private readonly Builder _builder;
+        private readonly int _step;
+
+        internal SavedUseVisitor(Builder builder, int step)
+        {
+            _builder = builder;
+            _step = step;
+        }
+
+        public void Visit(ITensorStorageLeaseSource tensor)
+        {
+            if (tensor is Tensor<T> typed)
+                _builder.Observe(typed, _step, canRelease: false);
+        }
+    }
+
+    private readonly ReleaseCandidate[]?[] _releasesAfterStep;
+
+    private BackwardStorageReleasePlan(ReleaseCandidate[]?[] releasesAfterStep)
+        => _releasesAfterStep = releasesAfterStep;
+
+    internal static BackwardStorageReleasePlan<T> Create(BackwardStep<T>[] steps, int count)
+    {
+        var builder = new Builder();
+        for (int i = 0; i < count; i++)
+        {
+            ref var step = ref steps[i];
+            builder.Observe(step.Output, i, canRelease: true);
+            if (step.Inputs is not null)
+            {
+                for (int j = 0; j < step.Inputs.Length; j++)
+                    builder.Observe(step.Inputs[j], i, canRelease: false);
+            }
+
+            var visitor = new SavedUseVisitor(builder, i);
+            SavedStateTensorTraversal.Visit(step.SavedState, ref visitor);
+        }
+        return builder.Build(count);
+    }
+
+    internal static BackwardStorageReleasePlan<T> Create(
+        TapeEntryArena<T> entries,
+        int[] executionOrder)
+    {
+        var builder = new Builder();
+        for (int step = 0; step < executionOrder.Length; step++)
+        {
+            ref var entry = ref entries[executionOrder[step]];
+            builder.Observe(entry.Output, step, canRelease: true);
+            if (entry.InputsOverflow is not null)
+            {
+                for (int j = 0; j < entry.InputsOverflow.Length; j++)
+                    builder.Observe(entry.InputsOverflow[j], step, canRelease: false);
+            }
+            else
+            {
+                builder.Observe(entry.Input0, step, canRelease: false);
+                if (entry.InputCount >= 2)
+                    builder.Observe(entry.Input1, step, canRelease: false);
+                if (entry.InputCount >= 3)
+                    builder.Observe(entry.Input2, step, canRelease: false);
+            }
+
+            var visitor = new SavedUseVisitor(builder, step);
+            SavedStateTensorTraversal.Visit(entry.SavedState, ref visitor);
+        }
+        return builder.Build(executionOrder.Length);
+    }
+
+    /// <summary>
+    /// Invalidates storages whose final backward use is the completed step. A changed storage
+    /// identity means replay rebinding invalidated the precomputed proof; fail closed by retaining
+    /// that activation rather than risking premature release.
+    /// </summary>
+    internal void ReleaseAfterStep(
+        int step,
+        DirectGpuTensorEngine engine,
+        HashSet<object> protectedStorages)
+    {
+        var candidates = _releasesAfterStep[step];
+        if (candidates is null) return;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            var candidate = candidates[i];
+            if (protectedStorages.Contains(candidate.StorageIdentity)) continue;
+            if (!ReferenceEquals(candidate.Tensor.StorageIdentity, candidate.StorageIdentity)) continue;
+            engine.InvalidateGpuCacheForTensor(candidate.Tensor);
+        }
+    }
+
+    internal bool IsStorageScheduledAfterStep(Tensor<T> tensor, int step)
+    {
+        var candidates = _releasesAfterStep[step];
+        if (candidates is null) return false;
+        object identity = tensor.StorageIdentity;
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            if (ReferenceEquals(candidates[i].StorageIdentity, identity)) return true;
+        }
+        return false;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledDelegateChain.cs
@@ -101,6 +101,7 @@ internal sealed class CompiledDelegateChain<T>
     // Logical step count. The backing array may be larger when rented
     // from BackwardScratch<T> — only indices [0, _count) hold live data.
     private readonly int _count;
+    private BackwardStorageReleasePlan<T>? _storageReleasePlan;
 
     internal CompiledDelegateChain(BackwardStep<T>[] steps)
         : this(steps, steps.Length)
@@ -111,6 +112,7 @@ internal sealed class CompiledDelegateChain<T>
     {
         _steps = steps;
         _count = count;
+        _storageReleasePlan = BackwardStorageReleasePlan<T>.Create(steps, count);
     }
 
     /// <summary>
@@ -151,6 +153,7 @@ internal sealed class CompiledDelegateChain<T>
             // Output, Inputs, Backward, SavedState.
             _steps[i] = default;
         }
+        _storageReleasePlan = null;
     }
 
     /// <summary>
@@ -167,7 +170,8 @@ internal sealed class CompiledDelegateChain<T>
         Tensor<T> loss,
         IReadOnlyList<Tensor<T>>? sources,
         IEngine engine,
-        bool useScratch = false)
+        bool useScratch = false,
+        IReadOnlyCollection<Tensor<T>>? retainedTensors = null)
     {
         Dictionary<Tensor<T>, Tensor<T>> grads = useScratch
             ? BackwardScratch<T>.RentGrads(_count + 1)
@@ -203,26 +207,39 @@ internal sealed class CompiledDelegateChain<T>
         // Iterate only over the live range [0, _count).
         bool timing = BackwardTiming.Enabled;
 
-        // OOM fix: free each forward activation's GPU buffer on its LAST use — right after its step's backward; in
-        // reverse-topological order a step's output is fully consumed once its step runs (every consumer was an
-        // earlier step). Previously all forward activations stayed GPU-pinned for the whole backward, so the working
-        // set pegged at the card memory limit → OOM at scale (a tiny d256/L2 model OOM'd a 12 GB card past ~200K
-        // tokens). Skip the loss + sources (leaf params). Gated to the GPU engine; materialize-then-free is safe.
+        // Free graph-owned activation storages on their final declared backward use. This is storage-aware rather
+        // than tensor-object-aware because metadata views can alias a saved tensor needed by a later step. The
+        // release schedule is precomputed with the chain, preserving progressive reclamation without adding a
+        // per-replay graph scan. Loss/source/retain-grad storages remain caller-owned after backward.
         var gpuEngine = engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
-        HashSet<Tensor<T>>? freeSkip = null;
+        HashSet<object>? protectedStorages = null;
         if (gpuEngine is not null)
         {
-            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { loss };
-            if (sources is not null) foreach (var s in sources) freeSkip.Add(s);
+            protectedStorages = new HashSet<object>(ReferenceEqualityComparer<object>.Instance)
+            {
+                loss.StorageIdentity
+            };
+            if (sources is not null)
+                foreach (var source in sources) protectedStorages.Add(source.StorageIdentity);
+            if (retainedTensors is not null)
+                foreach (var retained in retainedTensors) protectedStorages.Add(retained.StorageIdentity);
         }
 
         for (int i = 0; i < _count; i++)
         {
             ref var step = ref _steps[i];
             if (!DifferentiableOps.IsGradientRequired(step.Output))
+            {
+                if (gpuEngine is not null)
+                    _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
                 continue;
+            }
             if (!grads.TryGetValue(step.Output, out var gradOutput))
+            {
+                if (gpuEngine is not null)
+                    _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
                 continue;
+            }
 
             long start = timing ? Stopwatch.GetTimestamp() : 0;
             var previousAccumulatorOwners = DifferentiableOps.BeginBackwardStep<T>();
@@ -241,8 +258,8 @@ internal sealed class CompiledDelegateChain<T>
                 BackwardTiming.Record(step.Backward.Method.Name, ticks);
             }
 
-            if (gpuEngine is not null && !freeSkip!.Contains(step.Output))
-                gpuEngine.InvalidateGpuCacheForTensor(step.Output);
+            if (gpuEngine is not null)
+                _storageReleasePlan?.ReleaseAfterStep(i, gpuEngine, protectedStorages!);
         }
 
         if (sources is not null)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -480,7 +480,7 @@ internal static class DifferentiableOps
     }
 
     /// <summary>
-    /// Issue #338 completion: pins every <see cref="Tensor{T}"/> stored in a recorded op's
+    /// Issue #338 completion: pins every tensor stored in a recorded op's
     /// saved state against pool/arena reuse, exactly as Record* pins the op's
     /// inputs. Many backward functions read tensors OUT of savedState rather than from the op's
     /// inputs — LayerNorm/BatchNorm/RMSNorm mean/variance/rms, attention weights and softmax
@@ -498,14 +498,9 @@ internal static class DifferentiableOps
         if (entry.SavedStatePinsHeld) return;
         var savedState = entry.SavedState;
         if (savedState is null) return;
-        bool pinnedAny = false;
-        for (int i = 0; i < savedState.Length; i++)
-            if (savedState[i] is Tensor<T> saved)
-            {
-                saved._pinnedByTape = true; // ref-counted increment (see TensorBase._pinnedByTape)
-                pinnedAny = true;
-            }
-        entry.SavedStatePinsHeld = pinnedAny;
+        var visitor = new SavedStatePinVisitor(pin: true);
+        SavedStateTensorTraversal.Visit(savedState, ref visitor);
+        entry.SavedStatePinsHeld = visitor.VisitedAny;
     }
 
     /// <summary>
@@ -523,10 +518,27 @@ internal static class DifferentiableOps
             entry.SavedStatePinsHeld = false;
             return;
         }
-        for (int i = 0; i < savedState.Length; i++)
-            if (savedState[i] is Tensor<T> saved)
-                saved._pinnedByTape = false; // ref-counted decrement, clamped at zero
+        var visitor = new SavedStatePinVisitor(pin: false);
+        SavedStateTensorTraversal.Visit(savedState, ref visitor);
         entry.SavedStatePinsHeld = false;
+    }
+
+    private struct SavedStatePinVisitor : ISavedStateTensorVisitor
+    {
+        private readonly bool _pin;
+        internal bool VisitedAny;
+
+        internal SavedStatePinVisitor(bool pin)
+        {
+            _pin = pin;
+            VisitedAny = false;
+        }
+
+        public void Visit(ITensorStorageLeaseSource tensor)
+        {
+            tensor.SetTapePinned(_pin);
+            VisitedAny = true;
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -1622,7 +1622,8 @@ public sealed class GradientTape<T> : IDisposable
             // returned grads dict carries the data either way.
             if (_cachedDelegateChain is not null)
             {
-                var cachedResult = _cachedDelegateChain.Execute(loss, sources, _engine, useScratch: acquiredScratch);
+                var cachedResult = _cachedDelegateChain.Execute(
+                    loss, sources, _engine, useScratch: acquiredScratch, retainedTensors: _retainGrad);
                 HashSet<Tensor<T>>? cachedSourceSet = null;
                 if (sources is not null)
                 {
@@ -1699,7 +1700,8 @@ public sealed class GradientTape<T> : IDisposable
                 _cachedDelegateChain = chain;
 
             // Execute the chain
-            var result = chain.Execute(loss, sources, engine, useScratch: acquiredScratch);
+            var result = chain.Execute(
+                loss, sources, engine, useScratch: acquiredScratch, retainedTensors: _retainGrad);
 
             // Build rebindable plan for fresh-tape callers (closes the
             // consumer fresh-tape gap from issue #327). MUST run AFTER

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -23,6 +23,7 @@ internal sealed class OptimizedBackwardPlan<T>
     private readonly Tensor<T> _loss;
     private readonly Tensor<T>[]? _sources;
     private readonly IEngine _engine;
+    private readonly BackwardStorageReleasePlan<T> _storageReleasePlan;
 
     /// <summary>
     /// Optional reference to the owning tape's RetainGrad set. Same parity rule
@@ -54,6 +55,7 @@ internal sealed class OptimizedBackwardPlan<T>
         _sources = sources;
         _engine = engine;
         _retainGrad = retainGrad;
+        _storageReleasePlan = BackwardStorageReleasePlan<T>.Create(entries, reachableIndices);
         _ = analysis; // Retained for future backward optimization passes
     }
 
@@ -109,38 +111,42 @@ internal sealed class OptimizedBackwardPlan<T>
         _inputsBuf2 = BackwardInputBuffers<T>.Get2();
         _inputsBuf3 = BackwardInputBuffers<T>.Get3();
 
-        // OOM fix: free each forward activation's GPU buffer as soon as it is DEAD — right after its entry's backward,
-        // in reverse-topological order its output is fully consumed (every consumer was processed earlier). Previously
-        // all forward activations stayed GPU-pinned for the whole backward, pegging the card at its memory limit →
-        // OOM at scale. Skip the loss + sources/retained tensors: the loss IS an entry.Output (the loss op's
-        // output), and the caller reads its value after backward, so it must never be freed mid-walk — same
-        // contract as CompiledDelegateChain.Execute. Sources and retain-grad tensors are likewise consumed by
-        // the caller after backward and must survive too. (Gated to GPU engine; materialize-then-free is
-        // correctness-safe.)
+        // Reclaim graph-owned activation storages progressively after their final declared backward use.
+        // Storage identity, not Tensor object identity, is the lifetime unit because metadata views alias their
+        // source. Loss/source/retain-grad storages remain protected for the caller.
         var gpuEngine = _engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine;
-        HashSet<Tensor<T>>? freeSkip = null;
+        HashSet<object>? protectedStorages = null;
         if (gpuEngine is not null)
         {
-            freeSkip = new HashSet<Tensor<T>>(ReferenceEqualityComparer<Tensor<T>>.Instance) { _loss };
-            if (_sources is not null) foreach (var s in _sources) freeSkip.Add(s);
-            if (_retainGrad is not null) foreach (var r in _retainGrad) freeSkip.Add(r);
-        }
-        void FreeDeadActivation(Tensor<T> t)
-        {
-            if (gpuEngine is not null && (freeSkip is null || !freeSkip.Contains(t)))
-                gpuEngine.InvalidateGpuCacheForTensor(t);
+            protectedStorages = new HashSet<object>(ReferenceEqualityComparer<object>.Instance)
+            {
+                _loss.StorageIdentity
+            };
+            if (_sources is not null)
+                foreach (var source in _sources) protectedStorages.Add(source.StorageIdentity);
+            if (_retainGrad is not null)
+                foreach (var retained in _retainGrad) protectedStorages.Add(retained.StorageIdentity);
         }
 
         try
         {
-            foreach (int i in _reachableIndices)
+            for (int executionStep = 0; executionStep < _reachableIndices.Length; executionStep++)
             {
+                int i = _reachableIndices[executionStep];
                 ref var entry = ref _entries[i];
 
                 if (!DifferentiableOps.IsGradientRequired(entry.Output))
+                {
+                    if (gpuEngine is not null)
+                        _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                     continue;
+                }
                 if (!grads.TryGetValue(entry.Output, out var gradOutput))
+                {
+                    if (gpuEngine is not null)
+                        _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                     continue;
+                }
 
                 entry.ValidateInputVersions();
 
@@ -150,7 +156,8 @@ internal sealed class OptimizedBackwardPlan<T>
                     // Try optimized path for MatMul operations
                     if (TryOptimizedMatMulBackward(ref entry, gradOutput, cse, grads))
                     {
-                        FreeDeadActivation(entry.Output);
+                        if (gpuEngine is not null)
+                            _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
                         continue;
                     }
 
@@ -170,12 +177,14 @@ internal sealed class OptimizedBackwardPlan<T>
                     if (BackwardTiming.Enabled)
                         BackwardTiming.Record(entry.Backward.Method.Name, System.Diagnostics.Stopwatch.GetTimestamp() - _bwdStart);
 
-                    FreeDeadActivation(entry.Output);
                 }
                 finally
                 {
                     DifferentiableOps.EndBackwardStep(previousAccumulatorOwners);
                 }
+
+                if (gpuEngine is not null)
+                    _storageReleasePlan.ReleaseAfterStep(executionStep, gpuEngine, protectedStorages!);
             }
         }
         finally

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardBugFixTests.cs
@@ -18,6 +18,64 @@ public class BackwardBugFixTests
 {
     private readonly CpuEngine _engine = new();
 
+    [Fact]
+    public void ComplexNormalize_Backward_IncludesNormDenominatorPath()
+    {
+        var real = new Tensor<double>(new[] { 0.7, -1.2, 0.3, 1.6 }, new[] { 2, 2 });
+        var imag = new Tensor<double>(new[] { -0.4, 0.9, 1.1, -0.2 }, new[] { 2, 2 });
+        var realWeight = new Tensor<double>(new[] { 0.2, -0.7, 1.3, 0.5 }, new[] { 2, 2 });
+        var imagWeight = new Tensor<double>(new[] { -0.6, 0.4, 0.8, -1.1 }, new[] { 2, 2 });
+
+        double[] realAnalytical;
+        double[] imagAnalytical;
+        using (var tape = new GradientTape<double>())
+        {
+            var normalized = _engine.ComplexNormalize(real, imag);
+            var weightedReal = _engine.TensorMultiply(normalized.real, realWeight);
+            var weightedImag = _engine.TensorMultiply(normalized.imag, imagWeight);
+            var loss = _engine.ReduceSum(_engine.TensorAdd(weightedReal, weightedImag), null);
+            var gradients = tape.ComputeGradients(loss, new[] { real, imag });
+            realAnalytical = gradients[real].ToArray();
+            imagAnalytical = gradients[imag].ToArray();
+        }
+
+        double Loss()
+        {
+            var normalized = _engine.ComplexNormalize(real, imag);
+            double sum = 0.0;
+            for (int i = 0; i < real.Length; i++)
+                sum += normalized.real[i] * realWeight[i] + normalized.imag[i] * imagWeight[i];
+            return sum;
+        }
+
+        const double step = 1e-5;
+        for (int i = 0; i < real.Length; i++)
+        {
+            double original = real[i];
+            real[i] = original + step;
+            double plus = Loss();
+            real[i] = original - step;
+            double minus = Loss();
+            real[i] = original;
+            double finite = (plus - minus) / (2.0 * step);
+            Assert.True(Math.Abs(finite - realAnalytical[i]) < 1e-6,
+                $"real[{i}] gradient is {realAnalytical[i]:G10}; finite difference is {finite:G10}.");
+        }
+
+        for (int i = 0; i < imag.Length; i++)
+        {
+            double original = imag[i];
+            imag[i] = original + step;
+            double plus = Loss();
+            imag[i] = original - step;
+            double minus = Loss();
+            imag[i] = original;
+            double finite = (plus - minus) / (2.0 * step);
+            Assert.True(Math.Abs(finite - imagAnalytical[i]) < 1e-6,
+                $"imag[{i}] gradient is {imagAnalytical[i]:G10}; finite difference is {finite:G10}.");
+        }
+    }
+
     // ================================================================
     // Issue #144: OctonionMatMulTensor backward
     // ================================================================

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardStorageReleasePlanTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardStorageReleasePlanTests.cs
@@ -1,0 +1,79 @@
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class BackwardStorageReleasePlanTests
+{
+    [Fact]
+    public void AliasStorage_IsReleasedAfterFinalSavedStateUse_NotAliasStep()
+    {
+        using var saved = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        using var alias = saved.Reshape(new[] { 4 });
+        using var laterOutput = new Tensor<float>(new[] { 5f }, new[] { 1 });
+
+        var steps = new[]
+        {
+            new BackwardStep<float>
+            {
+                Output = alias,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!
+            },
+            new BackwardStep<float>
+            {
+                Output = laterOutput,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!,
+                SavedState = new object[] { saved }
+            }
+        };
+
+        var plan = BackwardStorageReleasePlan<float>.Create(steps, steps.Length);
+
+        Assert.False(plan.IsStorageScheduledAfterStep(alias, 0));
+        Assert.True(plan.IsStorageScheduledAfterStep(alias, 1));
+    }
+
+    [Fact]
+    public void NestedAndContextSavedTensors_ExtendStorageLifetimeAndArePinned()
+    {
+        using var saved = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        using var alias = saved.Reshape(new[] { 4 });
+        using var laterOutput = new Tensor<float>(new[] { 5f }, new[] { 1 });
+        var context = new AutogradContext();
+        context.SaveForBackward(saved);
+        var savedState = new object[] { new object[] { context } };
+
+        var entry = new TapeEntry<float> { SavedState = savedState };
+        DifferentiableOps.PinSavedStateTensors(ref entry);
+        Assert.True(entry.SavedStatePinsHeld);
+        Assert.True(saved._pinnedByTape);
+
+        var steps = new[]
+        {
+            new BackwardStep<float>
+            {
+                Output = alias,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!
+            },
+            new BackwardStep<float>
+            {
+                Output = laterOutput,
+                Inputs = Array.Empty<Tensor<float>>(),
+                Backward = null!,
+                SavedState = savedState
+            }
+        };
+        var plan = BackwardStorageReleasePlan<float>.Create(steps, steps.Length);
+
+        Assert.False(plan.IsStorageScheduledAfterStep(saved, 0));
+        Assert.True(plan.IsStorageScheduledAfterStep(saved, 1));
+
+        DifferentiableOps.UnpinSavedStateTensors(ref entry);
+        Assert.False(entry.SavedStatePinsHeld);
+        Assert.False(saved._pinnedByTape);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedLinearGradientTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// Verifies that fused Linear+Activation ops produce identical gradients
 /// to the equivalent unfused (separate MatMul + Add + Activation) ops.
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class FusedLinearGradientTests : IDisposable
 {
     // PR #333's GPU auto-detect ModuleInitializer flips AiDotNetEngine.Current

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
@@ -422,6 +422,55 @@ public class SavedStatePinningReproTests
     }
 
     [Fact]
+    public void TwoRecordedEntries_SharingSavedTensor_ReleaseIndependentPins()
+    {
+        TensorPool<float>.Clear();
+        var saved = Fixed(new[] { 2 }, 3f, 1f);
+        var firstTape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
+        var secondTape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
+        try
+        {
+            firstTape.Record(new TapeEntry<float>
+            {
+                OperationName = nameof(TwoRecordedEntries_SharingSavedTensor_ReleaseIndependentPins),
+                Output = Fixed(new[] { 2 }, 5f, 1f),
+                Input0 = Fixed(new[] { 2 }, 7f, 1f),
+                InputCount = 1,
+                Backward = PassThroughBackward,
+                SavedState = new object[] { saved }
+            });
+            secondTape.Record(new TapeEntry<float>
+            {
+                OperationName = nameof(TwoRecordedEntries_SharingSavedTensor_ReleaseIndependentPins),
+                Output = Fixed(new[] { 2 }, 9f, 1f),
+                Input0 = Fixed(new[] { 2 }, 11f, 1f),
+                InputCount = 1,
+                Backward = PassThroughBackward,
+                SavedState = new object[] { saved }
+            });
+
+            Assert.Equal(2, saved._pinnedByTapeCount);
+            secondTape.Dispose();
+            Assert.Equal(1, saved._pinnedByTapeCount);
+
+            TensorPool<float>.Return(saved);
+            var scratch = TensorPool<float>.Rent(ShapeOf(saved));
+            Assert.NotSame(saved, scratch);
+            TensorPool<float>.Return(scratch);
+
+            firstTape.Dispose();
+            Assert.Equal(0, saved._pinnedByTapeCount);
+            TensorPool<float>.Return(saved);
+            Assert.Same(saved, TensorPool<float>.Rent(ShapeOf(saved)));
+        }
+        finally
+        {
+            secondTape.Dispose();
+            firstTape.Dispose();
+        }
+    }
+
+    [Fact]
     public void CachedReplay_ReleasesSavedStateAndKeepsGradientsStable()
     {
         TensorPool<float>.Clear();

--- a/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BatchNormAffineGradientTests.cs
@@ -11,6 +11,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 // op that replaces the ~6-primitive batch=1 BN training fallback. Forward must equal
 // BatchNormInference; backward must equal the exact closed-form gradient of a linear loss
 // L = Σ(y ⊙ w), since y = gamma·(x-mean)·inv + beta is affine in x/gamma/beta.
+[Collection("EngineCurrentGlobalState")]
 public class BatchNormAffineGradientTests
 {
     private readonly CpuEngine _engine = new CpuEngine();

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicParallelGemmContractTests.cs
@@ -54,6 +54,95 @@ public class DeterministicParallelGemmContractTests
     public void Gemm_Double_BitIdentical_AcrossThreadCounts(int m, int n, int k)
         => AssertBitIdenticalAcrossThreadCounts<double>(m, n, k, seed: 22);
 
+    [Fact]
+    public void StreamingFloat_NAxisNonDivisibleWidth_IsBitIdenticalAcrossPartitions()
+    {
+        const int m = 2;
+        const int n = 704;
+        const int k = 257;
+
+        Assert.Equal(
+            ParallelismAxis.N,
+            StreamingStrategy.SelectParallelismAxis(m, n, k, procs: 32, isDeterministic: false));
+
+        var a = RandomArray<float>(m * k, seed: 31);
+        var b = RandomArray<float>(k * n, seed: 32);
+        var serial = new float[m * n];
+        var parallel = new float[m * n];
+
+        StreamingStrategy.Run(a, k, false, b, n, false, serial, n, m, n, k,
+            new BlasOptions<float> { NumThreads = 1 });
+        StreamingStrategy.Run(a, k, false, b, n, false, parallel, n, m, n, k,
+            new BlasOptions<float> { NumThreads = 32 });
+
+        for (int i = 0; i < serial.Length; i++)
+        {
+            if (!BitIdentical(serial[i], parallel[i]))
+            {
+                Assert.Fail(
+                    $"N-axis SIMD-tile partitioning changed FP32 reduction semantics at index {i}: " +
+                    $"serial={serial[i]} parallel={parallel[i]}.");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(16)]
+    public void StreamingNAxisPartitions_PreserveKernelTileBoundaries(int columnTileWidth)
+    {
+        const int procs = 32;
+        int n = ((procs * 2) + 5) * columnTileWidth + (columnTileWidth - 1);
+        int previousEnd = 0;
+
+        for (int partition = 0; partition < procs; partition++)
+        {
+            var (start, end) = StreamingStrategy.GetNPartitionRange(
+                n, procs, partition, columnTileWidth);
+
+            Assert.Equal(previousEnd, start);
+            Assert.True(end >= start);
+            Assert.Equal(0, start % columnTileWidth);
+            if (partition < procs - 1)
+            {
+                Assert.Equal(0, end % columnTileWidth);
+            }
+
+            previousEnd = end;
+        }
+
+        Assert.Equal(n, previousEnd);
+    }
+
+    [Fact]
+    public void StreamingColumnTileWidth_MatchesActiveKernel()
+    {
+        int expectedFloat = Avx512Streaming.IsSupported
+            ? Avx512Streaming.Fp32ColumnTileWidth
+            : Avx2Streaming.IsSupported
+                ? Avx2Streaming.Fp32ColumnTileWidth
+                : NeonStreaming.IsSupported
+                    ? NeonStreaming.Fp32ColumnTileWidth
+                    : 1;
+        int expectedDouble = Avx512Streaming.IsSupported
+            ? Avx512Streaming.Fp64ColumnTileWidth
+            : Avx2Streaming.IsSupported
+                ? Avx2Streaming.Fp64ColumnTileWidth
+                : NeonStreaming.IsSupported
+                    ? NeonStreaming.Fp64ColumnTileWidth
+                    : PortableSimdStreaming.IsSupported
+                        ? PortableSimdStreaming.Fp64ColumnTileWidth
+                        : 1;
+
+        Assert.Equal(expectedFloat, StreamingStrategy.GetColumnTileWidth<float>(transB: false));
+        Assert.Equal(expectedDouble, StreamingStrategy.GetColumnTileWidth<double>(transB: false));
+        Assert.Equal(1, StreamingStrategy.GetColumnTileWidth<float>(transB: true));
+        Assert.Equal(1, StreamingStrategy.GetColumnTileWidth<double>(transB: true));
+    }
+
     private static void AssertBitIdenticalAcrossThreadCounts<T>(int m, int n, int k, int seed)
         where T : unmanaged
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/AsyncChainTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/AsyncChainTests.cs
@@ -16,6 +16,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// validation at chain time, and proper rejection of disposed /
 /// foreign / shape-mismatched plans.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class AsyncChainTests : IDisposable
 {
     // PR #333's GPU auto-detect ModuleInitializer flips AiDotNetEngine.Current

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 
+[Collection("CompilationGlobalState")]
 public class CompilationComponentTests
 {
     private const float Tolerance = 1e-5f;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompilationComponentTests.cs
@@ -9,9 +9,12 @@ using Xunit;
 namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 
 [Collection("CompilationGlobalState")]
-public class CompilationComponentTests
+public class CompilationComponentTests : IDisposable
 {
     private const float Tolerance = 1e-5f;
+    private readonly IEngine _priorEngine = AiDotNetEngine.Current;
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
 
     #region CompiledModelCache Tests
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBackwardReplayBufferLivenessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledBackwardReplayBufferLivenessTests.cs
@@ -29,6 +29,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// each subsequent step inside its OWN fresh per-step arena, checking the trained parameter's
 /// gradient stays non-zero and finite on every replay step.</para>
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class CompiledBackwardReplayBufferLivenessTests
 {
     private readonly ITestOutputHelper _o;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledInferenceStorageContractTests.cs
@@ -66,6 +66,99 @@ public sealed class CompiledInferenceStorageContractTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Compile_RetainsCompositeTemporaryStorageAfterTemporaryIsDisposed()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+
+        Tensor<float> capturedOutput;
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.EnableInference())
+        {
+            // Composite implementations routinely scope intermediates with using. Disposing the
+            // Tensor object must not release storage that a recorded downstream node still reads.
+            {
+                using var temporary = engine.TensorAdd(input, input);
+                capturedOutput = engine.TensorMultiply(temporary, input);
+            }
+
+            plan = scope.CompileInference(capturedOutput, input);
+        }
+
+        using (plan)
+        using (capturedOutput)
+        {
+            Assert.Equal(new[] { 2f, 8f }, plan.Execute().AsSpan().ToArray());
+
+            new[] { 3f, 4f }.AsSpan().CopyTo(input.AsWritableSpan());
+            Assert.Equal(new[] { 18f, 32f }, plan.Execute().AsSpan().ToArray());
+        }
+    }
+
+    [Fact]
+    public void CompiledPlan_OwnsStorageUntilPlanDispose()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, -2f }, new[] { 2 });
+
+        Tensor<float> capturedOutput;
+        ICompiledPlan<float> plan;
+        using (var scope = GraphMode.EnableInference())
+        {
+            capturedOutput = engine.TensorAdd(input, input);
+            plan = scope.CompileInference(capturedOutput, input);
+        }
+
+        var outputStorage = capturedOutput._storage;
+        Assert.Equal(2, outputStorage.RefCount); // tensor owner + compiled-plan lease
+
+        capturedOutput.Dispose();
+        Assert.Equal(1, outputStorage.RefCount); // compiled plan remains the sole owner
+        Assert.Equal(new[] { 2f, -4f }, plan.Execute().AsSpan().ToArray());
+
+        plan.Dispose();
+        Assert.Equal(0, outputStorage.RefCount);
+    }
+
+    [Fact]
+    public void Compile_IsTerminalAndRestoresParentBeforeLexicalDispose()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        using var parent = GraphMode.Enable();
+        var child = GraphMode.EnableInference();
+
+        var output = engine.TensorAdd(input, input);
+        using var plan = child.CompileInference(output, input);
+
+        Assert.Same(parent, GraphMode.Current);
+        child.Dispose();
+        Assert.Same(parent, GraphMode.Current);
+    }
+
+    [Fact]
+    public void Execute_InsideIndependentTrace_DoesNotAppendReplayOperations()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        ICompiledPlan<float> plan;
+
+        using (var scope = GraphMode.EnableInference())
+        {
+            var output = engine.TensorAdd(input, input);
+            plan = scope.CompileInference(output, input);
+        }
+
+        using (plan)
+        using (var independentTrace = GraphMode.Enable())
+        {
+            Assert.Equal(0, independentTrace.NodeCount);
+            Assert.Equal(new[] { 2f, 4f }, plan.Execute().AsSpan().ToArray());
+            Assert.Equal(0, independentTrace.NodeCount);
+        }
+    }
+
     private static void AssertSentinels(float[] backing)
     {
         Assert.Equal(999f, backing[0]);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOpaqueGpuReplayTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledOpaqueGpuReplayTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+public sealed class CompiledOpaqueGpuReplayTests
+{
+    [Fact]
+    public void OpaqueInferenceCapture_RecordsThroughBase_AndReplaysOnGpuBackend()
+    {
+        var state = new MockBackendState();
+        IDirectGpuBackend backend = MockDirectGpuBackend.Create(state);
+        using var directGpu = new DirectGpuEngine(backend);
+        using var engine = new DirectGpuTensorEngine(directGpu);
+        using var cache = new CompiledModelCache<float>();
+        var input = new Tensor<float>(new[] { -1.25f, -0.2f, 0.4f, 1.8f }, new[] { 2, 2 });
+
+        ICompiledPlan<float> plan = cache.GetOrCompileInference(
+            input, () => engine.NativeTanh(input));
+
+        // The outer GPU override must route the active trace to CpuEngine so the graph node is
+        // recorded. Its one suspended materialization still uses the selected GPU backend to
+        // establish the exact output shape and proves that ordinary GPU dispatch remains enabled.
+        Assert.Equal(1, state.TanhCalls);
+
+        AssertTanh(input, plan.Execute());
+        Assert.Equal(2, state.TanhCalls);
+
+        input[0] = 0.75f;
+        plan.SetInputs(new[] { input });
+        AssertTanh(input, plan.Execute());
+        Assert.Equal(3, state.TanhCalls);
+    }
+
+    private static void AssertTanh(Tensor<float> input, Tensor<float> actual)
+    {
+        float[] values = actual.ToArray();
+        Assert.Equal(input.Length, values.Length);
+        for (int i = 0; i < values.Length; i++)
+            Assert.InRange(values[i], MathF.Tanh(input[i]) - 1e-6f, MathF.Tanh(input[i]) + 1e-6f);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledPlanFinalOutputReproTest.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledPlanFinalOutputReproTest.cs
@@ -100,4 +100,37 @@ public class CompiledPlanFinalOutputReproTest
         var compiledOutput = plan.Execute();
         Assert.Equal(new[] { 10, 4 }, compiledOutput.Shape.ToArray());
     }
+
+    /// <summary>
+    /// A selected graph output can be an internal branch with later same-shaped work still in the
+    /// scope. Memory planning must keep the selected tensor's storage live through plan completion
+    /// instead of recycling it after its final graph consumer.
+    /// </summary>
+    [Fact]
+    public void CompiledPlan_ExplicitBranchOutput_IsNotRecycledByLaterBranch()
+    {
+        using var cache = new CompiledModelCache<float>();
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1f, 2f, 3f, 4f }, new[] { 2, 2 });
+        var ones = new Tensor<float>(new[] { 1f, 1f, 1f, 1f }, new[] { 2, 2 });
+        var twos = new Tensor<float>(new[] { 2f, 2f, 2f, 2f }, new[] { 2, 2 });
+        var threes = new Tensor<float>(new[] { 3f, 3f, 3f, 3f }, new[] { 2, 2 });
+
+        Tensor<float> Forward()
+        {
+            var selected = engine.TensorAdd(input, ones);
+            var later = engine.TensorTranspose(selected);
+            later = engine.TensorMultiply(later, twos);
+            later = engine.TensorTranspose(later);
+            _ = engine.TensorAdd(later, threes);
+            return selected;
+        }
+
+        float[] expected = Forward().ToArray();
+        var plan = cache.GetOrCompileInference(input, Forward);
+        plan.SetInputs(new[] { input });
+
+        Assert.Equal(expected, plan.Execute().ToArray());
+        Assert.Equal(expected, plan.Execute().ToArray());
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ExecuteIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/ExecuteIntoTests.cs
@@ -13,6 +13,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// rebind storage so every Replay reads and writes the caller's buffers
 /// instead of the plan's compile-time allocations.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class ExecuteIntoTests : IDisposable
 {
     // Same engine-pinning rationale as AsyncChainTests / GroupNormOpTests:

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16HeteroScratchFreeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16HeteroScratchFreeTests.cs
@@ -72,7 +72,7 @@ public class Fp16HeteroScratchFreeTests
         {
             var (order, loss) = CaptureHetero(gpu);
             gpu.ClearActivationCache(); // isolate this run's cache accounting from the capture + the other run
-            var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             // Replicate the real Step condition: eviction suspended for the whole forward+backward (#226), so
             // without the scratch-free the per-op backward scratch genuinely accumulates in the cache.
             gpu.SuspendActivationEviction();
@@ -106,7 +106,7 @@ public class Fp16HeteroScratchFreeTests
         {
             var (order, loss) = CaptureHetero(gpu);
             gpu.ClearActivationCache();
-            var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var plan = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             gpu.SuspendActivationEviction();
             try
             {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16InCaptureForwardParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Fp16InCaptureForwardParityTests.cs
@@ -452,12 +452,12 @@ public class Fp16InCaptureForwardParityTests
             var order = plan.Fp16HeteroOrderForTest!;
             var loss = plan.LossOutput;
 
-            var unpaged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
+            using var unpaged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: false);
             GpuMemoryTracker.ResetPeak();
             unpaged.Forward();
             long unpagedPeak = GpuMemoryTracker.PeakBytes;
 
-            var paged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: true);
+            using var paged = MixedPrecisionCompiledPlan.FromCapturedOrder(gpu, order, loss, paging: true);
             GpuMemoryTracker.ResetPeak();
             paged.Forward();
             long pagedPeak = GpuMemoryTracker.PeakBytes;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionAdamTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionAdamTests.cs
@@ -43,7 +43,7 @@ public class MixedPrecisionAdamTests
             return _engine.ReduceSum(sq);
         };
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 128f, DynamicLossScale = false });
         var pars = new[] { W };

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledBackwardTests.cs
@@ -79,7 +79,7 @@ public class MixedPrecisionCompiledBackwardTests
             {
                 var sp = new LazyTensorScope(null);
                 var lossP = BuildGraph(sp, x, W);
-                var plan = MixedPrecisionCompiledPlan.Compile(lossP, _engine);
+                using var plan = MixedPrecisionCompiledPlan.Compile(lossP, _engine);
                 plan.Forward();
                 var gp = plan.Backward();
                 Assert.True(gp.Fp32.TryGetValue(x, out var gx1), "compiled grad for x missing");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledForwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledForwardTests.cs
@@ -71,7 +71,7 @@ public class MixedPrecisionCompiledForwardTests
                 }
                 finally { GraphMode.SetCurrent(null); }
             }
-            var plan = MixedPrecisionCompiledPlan.Compile(yPlan, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(yPlan, _engine);
 
             var out1 = plan.Forward().ToArray();
             AssertClose(ref1, out1, "initial replay vs fresh trace");

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledScaleGpuTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledScaleGpuTests.cs
@@ -89,7 +89,7 @@ public class MixedPrecisionCompiledScaleGpuTests
                 finally { GraphMode.SetCurrent(null); }
             }
 
-            var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
             var pars = new List<Tensor<float>>(W);
 
             float first = 0, last = 0; int nan = 0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledStepTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionCompiledStepTests.cs
@@ -63,7 +63,7 @@ public class MixedPrecisionCompiledStepTests
                 finally { GraphMode.SetCurrent(null); }
             }
 
-            var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Compile(lossT, _engine);
             var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
                 new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 256f, DynamicLossScale = false });
             var pars = new[] { W };

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionComputeGradientsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionComputeGradientsTests.cs
@@ -55,7 +55,7 @@ public class MixedPrecisionComputeGradientsTests
         const int B = 8, d = 6;
         var (forward, _, _, W) = BuildLinearProblem(B, d);
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 128f, DynamicLossScale = false });
         var pars = new[] { W };
@@ -92,7 +92,7 @@ public class MixedPrecisionComputeGradientsTests
     {
         const int B = 8, d = 6;
         var (forward, _, _, W) = BuildLinearProblem(B, d);
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var pars = new[] { W };
 
         var r = plan.ComputeGradients(pars, scaler: null);
@@ -116,8 +116,8 @@ public class MixedPrecisionComputeGradientsTests
         var (fwdA, _, _, wA) = BuildLinearProblem(B, d);
         var (fwdB, _, _, wB) = BuildLinearProblem(B, d);
 
-        var planA = MixedPrecisionCompiledPlan.Trace(fwdA, _engine);
-        var planB = MixedPrecisionCompiledPlan.Trace(fwdB, _engine);
+        using var planA = MixedPrecisionCompiledPlan.Trace(fwdA, _engine);
+        using var planB = MixedPrecisionCompiledPlan.Trace(fwdB, _engine);
 
         var scaler = new AiDotNet.Tensors.Engines.Autodiff.GradScaler(
             new AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig { LossScale = 1024f, DynamicLossScale = false });
@@ -146,7 +146,7 @@ public class MixedPrecisionComputeGradientsTests
     {
         const int B = 8, d = 6;
         var (forward, x, t, W) = BuildLinearProblem(B, d);
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
 
         var grad = plan.ComputeGradients(new[] { W }, scaler: null).Gradients[0];
         Assert.NotNull(grad);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionFp16WeightStorageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionFp16WeightStorageTests.cs
@@ -81,7 +81,7 @@ public class MixedPrecisionFp16WeightStorageTests
             });
         loss.LazySource = nloss;
 
-        var plan = MixedPrecisionCompiledPlan.Compile(loss, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Compile(loss, _engine);
 
         // Register the fp32 master for the fp16 storage weight.
         var masters = new MasterWeights();

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPagingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPagingTests.cs
@@ -53,7 +53,7 @@ public class MixedPrecisionPagingTests
         float[] gxRef, gw1Ref, gw2Ref;
         MixedPrecisionCompiledPlan.PagingTestOverride = false;
         {
-            var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
             plan.Forward();
             var g = plan.Backward();
             Assert.Equal(0, plan.PageOutCount);
@@ -65,7 +65,7 @@ public class MixedPrecisionPagingTests
         MixedPrecisionCompiledPlan.PagingTestOverride = true;
         try
         {
-            var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+            using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
             plan.Forward();
             var g = plan.Backward();
             pageOuts = plan.PageOutCount;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPublicApiTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MixedPrecisionPublicApiTests.cs
@@ -47,7 +47,7 @@ public class MixedPrecisionPublicApiTests
             return _engine.ReduceSum(sq);
         };
 
-        var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
+        using var plan = MixedPrecisionCompiledPlan.Trace(forward, _engine);
         var pars = new[] { W };
 
         float first = 0, last = 0; int bad = 0;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputCompiledInferenceTests.cs
@@ -17,6 +17,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// assert that EVERY declared input is re-bound on replay, and that a tensor the graph never
 /// reads is rejected (fail-closed) rather than silently baked.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputCompiledInferenceTests : IDisposable
 {
     // GetOrCompileInference captures AiDotNetEngine.Current as the plan's execution engine;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputReplayAliasingTests.cs
@@ -19,6 +19,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// input is compared against an equally-mutated oracle. These tests snapshot inputs BEFORE Execute and
 /// reuse the same instances across calls.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputReplayAliasingTests : IDisposable
 {
     private readonly IEngine _priorEngine = AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MultiInputSecondaryConsumerReproTests.cs
@@ -13,6 +13,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// directly. If the multi-input replay re-binds correctly the compiled output must match
 /// eager for every (x, t) pair.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class MultiInputSecondaryConsumerReproTests : IDisposable
 {
     private readonly IEngine _prior = AiDotNetEngine.Current;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Ops/GroupNormOpTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation.Ops;
 /// Group Normalization. Validates forward parity with the eager engine path,
 /// backward gradient correctness, attribute access, and factory round-trip.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class GroupNormOpTests
 {
     // ── Forward parity: GroupNormOp produces same result as eager engine ─────

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/PoolPaddedLossReadoutTests.cs
@@ -29,6 +29,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// compile + step, so the loss tensor is allocated from a padded slot.
 /// </para>
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class PoolPaddedLossReadoutTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
@@ -700,7 +700,7 @@ public class InferencePlanSerializationTests : IDisposable
                 await CompiledPlanLoader.LoadInferenceAsync<float>(stream, engine);
             Assert.NotNull(loaded);
 
-            Tensor<float> loadedInput = Assert.IsType<Tensor<float>>(loaded!.CompiledInputTensor);
+            using Tensor<float> loadedInput = Assert.IsType<Tensor<float>>(loaded!.CompiledInputTensor);
             var leaseSource = (ITensorStorageLeaseSource)loadedInput;
             var storage = Assert.IsType<TensorStorage<float>>(leaseSource.StorageIdentity);
             int refCountWithPlan = storage.RefCount;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/Serialization/InferencePlanSerializationTests.cs
@@ -682,4 +682,38 @@ public class InferencePlanSerializationTests : IDisposable
                 output,
                 new object[] { false, LstmSequenceOptionalInputs.None }));
     }
+
+    [Fact]
+    public async Task LoadedPlan_HoldsStorageLeaseUntilDisposed()
+    {
+        var engine = new CpuEngine();
+        using var input = Tensor<float>.CreateRandom(new[] { 2, 3 });
+        using var weight = Tensor<float>.CreateRandom(new[] { 3, 4 });
+        using var original = CompileMatMulSigmoid(engine, input, weight);
+        CompiledInferencePlan<float>? loaded = null;
+        try
+        {
+            using var stream = new MemoryStream();
+            await original.SaveAsync(stream);
+            stream.Position = 0;
+            loaded = (CompiledInferencePlan<float>?)
+                await CompiledPlanLoader.LoadInferenceAsync<float>(stream, engine);
+            Assert.NotNull(loaded);
+
+            Tensor<float> loadedInput = Assert.IsType<Tensor<float>>(loaded!.CompiledInputTensor);
+            var leaseSource = (ITensorStorageLeaseSource)loadedInput;
+            var storage = Assert.IsType<TensorStorage<float>>(leaseSource.StorageIdentity);
+            int refCountWithPlan = storage.RefCount;
+            Assert.True(refCountWithPlan >= 2,
+                "The deserialized tensor owner and compiled plan must hold independent storage references.");
+
+            loaded.Dispose();
+            loaded = null;
+            Assert.Equal(refCountWithPlan - 1, storage.RefCount);
+        }
+        finally
+        {
+            loaded?.Dispose();
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/StepIntoTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/StepIntoTests.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines.Compilation;
 /// contract as the inference plan: caller owns the loss / input buffers,
 /// the plan copies in + out, kernels stay compile-time-specialised.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class StepIntoTests : IDisposable
 {
     // Same engine-pinning rationale as AsyncChainTests / ExecuteIntoTests:

--- a/tests/AiDotNet.Tensors.Tests/Engines/CompiledTrainingPlanRebindingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/CompiledTrainingPlanRebindingTests.cs
@@ -10,6 +10,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// Tests that CompiledTrainingPlan.Step() sees in-place parameter updates.
 /// Repro for: compiled plan returning constant loss after SGD updates.
 /// </summary>
+[Collection("CompilationGlobalState")]
 public class CompiledTrainingPlanRebindingTests : IDisposable
 {
     // PR #333's [ModuleInitializer] auto-promotes AiDotNetEngine.Current to a

--- a/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Conv2DImplicitGemmParityTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -28,6 +27,50 @@ public class Conv2DImplicitGemmParityTests
         return t;
     }
 
+    [Fact]
+    public void RowBlockedIm2Col_IsBitIdentical_ToFullIm2Col()
+    {
+        const int channels = 320;
+        const int height = 32;
+        const int width = 32;
+        const int kernelSize = 3;
+        const int padding = 1;
+        const int outputHeight = 32;
+        const int outputWidth = 32;
+        const int rowsPerBlock = 22;
+        const int colH = channels * kernelSize * kernelSize;
+        const int colW = outputHeight * outputWidth;
+
+        var input = Rand(new[] { 1, channels, height, width }, 101);
+        var full = new float[colH * colW];
+        AiDotNet.Tensors.Helpers.Im2ColHelper.Im2ColChannelParallel(
+            input.AsSpan(), full,
+            channels, height, width,
+            kernelSize, kernelSize, 1, 1, padding, padding, 1, 1,
+            outputHeight, outputWidth);
+
+        for (int ohStart = 0; ohStart < outputHeight; ohStart += rowsPerBlock)
+        {
+            int ohEnd = Math.Min(ohStart + rowsPerBlock, outputHeight);
+            int blockWidth = (ohEnd - ohStart) * outputWidth;
+            var block = new float[colH * blockWidth];
+            AiDotNet.Tensors.Helpers.Im2ColHelper.Im2ColRowBlockFloat(
+                input.AsSpan(), block,
+                channels, height, width,
+                kernelSize, kernelSize, 1, 1, padding, padding, 1, 1,
+                outputHeight, outputWidth, ohStart, ohEnd);
+
+            int fullColumnOffset = ohStart * outputWidth;
+            for (int row = 0; row < colH; row++)
+            {
+                var expected = full.AsSpan(row * colW + fullColumnOffset, blockWidth);
+                var actual = block.AsSpan(row * blockWidth, blockWidth);
+                Assert.True(expected.SequenceEqual(actual),
+                    $"blocked im2col diverged in row {row}, output rows [{ohStart}, {ohEnd})");
+            }
+        }
+    }
+
     [Theory]
     // batch, inC, outC, k, hw, stride, pad, dilation
     [InlineData(1, 256, 256, 3, 16, 1, 1, 1)]   // canonical diffusion ResBlock 3×3
@@ -39,11 +82,9 @@ public class Conv2DImplicitGemmParityTests
     [InlineData(1, 256, 256, 3, 16, 1, 2, 2)]   // dilation 2
     [InlineData(1, 512, 256, 1, 16, 1, 0, 1)]   // 1×1 high-channel (routes to full path)
     [InlineData(1, 256, 300, 5, 12, 1, 2, 1)]   // 5×5, non-power-of-two outC
-    public async Task FusedConv_IsBitIdentical_ToFullIm2Col(
+    public void FusedConv_IsBitIdentical_ToFullIm2Col(
         int batch, int inC, int outC, int k, int hw, int stride, int pad, int dilation)
     {
-        await Task.Yield();
-
         var e = new CpuEngine();
         var x = Rand(new[] { batch, inC, hw, hw }, 101);
         var kernel = Rand(new[] { outC, inC, k, k }, 202);

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
@@ -368,15 +368,18 @@ public class DeterministicByDefaultTests
                 parkedObservation = BlasProvider.IsDeterministicMode;
             });
             parked.Start();
-
-            parkedReady.Wait();
-            // Main thread installs a thread-local override.
-            TensorCodecOptions.SetCurrent(new TensorCodecOptions { Deterministic = false });
-            Assert.False(BlasProvider.IsDeterministicMode); // main thread sees the override
-
-            // Release the parked thread.
-            mayExit.Set();
-            parked.Join();
+            try
+            {
+                parkedReady.Wait();
+                // Main thread installs a thread-local override.
+                TensorCodecOptions.SetCurrent(new TensorCodecOptions { Deterministic = false });
+                Assert.False(BlasProvider.IsDeterministicMode); // main thread sees the override
+            }
+            finally
+            {
+                mayExit.Set();
+                parked.Join();
+            }
 
             // The parked thread never installed an override of its own, so it
             // must still see the process-wide value (true), not main's override.

--- a/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DeterministicByDefaultTests.cs
@@ -343,7 +343,7 @@ public class DeterministicByDefaultTests
     }
 
     [Fact]
-    public async Task SetCurrent_OnOneThread_DoesNotLeakToAnotherThread()
+    public void SetCurrent_OnOneThread_DoesNotLeakToAnotherThread()
     {
         // The core thread-local invariant: thread A's override must not change
         // what thread B sees. Without this, "thread-local" would be a lie.
@@ -360,13 +360,14 @@ public class DeterministicByDefaultTests
             using var mayExit     = new ManualResetEventSlim(false);
             bool parkedObservation = false;
 
-            var parked = Task.Run(() =>
+            var parked = new Thread(() =>
             {
                 parkedReady.Set();
                 mayExit.Wait();
                 // Record the thread-local accessor's value from the parked thread.
                 parkedObservation = BlasProvider.IsDeterministicMode;
             });
+            parked.Start();
 
             parkedReady.Wait();
             // Main thread installs a thread-local override.
@@ -375,7 +376,7 @@ public class DeterministicByDefaultTests
 
             // Release the parked thread.
             mayExit.Set();
-            await parked.ConfigureAwait(false);
+            parked.Join();
 
             // The parked thread never installed an override of its own, so it
             // must still see the process-wide value (true), not main's override.

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -69,6 +69,7 @@ internal sealed class MockBackendState
     public int ScalarMinCalls { get; set; }
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
+    public int TanhCalls { get; set; }
     public List<string> OptimizerCalls { get; } = new();
 }
 
@@ -183,6 +184,15 @@ public class MockDirectGpuBackend : DispatchProxy
                 var output = (MockGpuBuffer)args[2]!;
                 int size = (int)args[3]!;
                 for (int i = 0; i < size; i++) output.Data[i] = left.Data[i] * right.Data[i];
+                return null!;
+            }
+            case "Tanh":
+            {
+                _state.TanhCalls++;
+                var input = (MockGpuBuffer)args[0]!;
+                var output = (MockGpuBuffer)args[1]!;
+                int size = (int)args[2]!;
+                for (int i = 0; i < size; i++) output.Data[i] = MathF.Tanh(input.Data[i]);
                 return null!;
             }
             case "Min" when args.Length == 2:

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue319TrainingLoopPerfTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue319TrainingLoopPerfTests.cs
@@ -30,12 +30,15 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
-public class Issue319TrainingLoopPerfTests
+[Collection("EngineCurrentGlobalState")]
+public class Issue319TrainingLoopPerfTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
+    private readonly IEngine _priorEngine;
     public Issue319TrainingLoopPerfTests(ITestOutputHelper output)
     {
         _output = output;
+        _priorEngine = AiDotNetEngine.Current;
         // Reset shared engine + caches so alloc-counting probes aren't
         // contaminated by pooled tensors / AutoTracer state from earlier
         // tests in the same process. The perf-regression assertions use
@@ -46,6 +49,8 @@ public class Issue319TrainingLoopPerfTests
         AiDotNet.Tensors.Helpers.AutoTensorCache.Clear();
         AiDotNet.Tensors.Engines.Autodiff.TensorPool<float>.Clear();
     }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
 
     [Fact]
     public void TensorAdd_BroadcastBiasGradientReducesTheSequenceAxis()

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue338PhaseGCoverageTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue338PhaseGCoverageTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tensors.Tests.Engines;
 
+[Collection("EngineCurrentGlobalState")]
 public class Issue338PhaseGCoverageTests
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -27,31 +27,37 @@ public class Issue471CpuMatmulCrashRepro
         // This is a CPU-specific repro, so use an explicit local engine. ResetToCpu disposes
         // a globally selected GPU and restoring that same reference would publish a dead engine.
         var eng = new CpuEngine();
-            _o.WriteLine($"engine={eng.Name}");
-            const int d = 128;
-            foreach (int V in new[] { 1000, 10000, 30000, 50257 })
-            {
-                var aData = new double[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01;
-                var bData = new double[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01;
-                var a = new Tensor<double>(aData, new[] { d, V });
-                var b = new Tensor<double>(bData, new[] { V, d });
-                _o.WriteLine($"matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
-                var c = eng.TensorMatMul(a, b);
-                _o.WriteLine($"  OK V={V}: c[0,0]={c[0, 0]:F4} (expect {V * 0.01 * 0.01:F4})");
-            }
-            // FLOAT path (matches HE's training-readout dtype; float is the oneDNN/SimdGemm-Sgemm dispatch)
-            foreach (int V in new[] { 10000, 50257 })
-            {
-                var aData = new float[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01f;
-                var bData = new float[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01f;
-                var a = new Tensor<float>(aData, new[] { d, V });
-                var b = new Tensor<float>(bData, new[] { V, d });
-                _o.WriteLine($"FLOAT matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
-                var c = eng.TensorMatMul(a, b);
-                _o.WriteLine($"  OK float V={V}: c[0,0]={c[0, 0]:F4}");
-            }
-            _o.WriteLine("ALL OK — no crash");
-            Assert.True(true);
+        _o.WriteLine($"engine={eng.Name}");
+        const int d = 128;
+        foreach (int V in new[] { 1000, 10000, 30000, 50257 })
+        {
+            var aData = new double[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01;
+            var bData = new double[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01;
+            using var a = new Tensor<double>(aData, new[] { d, V });
+            using var b = new Tensor<double>(bData, new[] { V, d });
+            _o.WriteLine($"matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+            using var c = eng.TensorMatMul(a, b);
+            double expected = V * 0.01 * 0.01;
+            Assert.InRange(Math.Abs(c[0, 0] - expected), 0, Math.Max(1e-10, expected * 1e-10));
+            Assert.InRange(Math.Abs(c[d - 1, d - 1] - expected), 0, Math.Max(1e-10, expected * 1e-10));
+            _o.WriteLine($"  OK V={V}: c[0,0]={c[0, 0]:F4} (expect {expected:F4})");
+        }
+        // FLOAT path (matches HE's training-readout dtype; float is the oneDNN/SimdGemm-Sgemm dispatch)
+        foreach (int V in new[] { 10000, 50257 })
+        {
+            var aData = new float[d * V]; for (int i = 0; i < aData.Length; i++) aData[i] = 0.01f;
+            var bData = new float[V * d]; for (int i = 0; i < bData.Length; i++) bData[i] = 0.01f;
+            using var a = new Tensor<float>(aData, new[] { d, V });
+            using var b = new Tensor<float>(bData, new[] { V, d });
+            _o.WriteLine($"FLOAT matmul [d={d} x V={V}] x [V={V} x d={d}] ...");
+            using var c = eng.TensorMatMul(a, b);
+            float expected = V * 0.01f * 0.01f;
+            float tolerance = expected * 2e-3f;
+            Assert.InRange(MathF.Abs(c[0, 0] - expected), 0f, tolerance);
+            Assert.InRange(MathF.Abs(c[d - 1, d - 1] - expected), 0f, tolerance);
+            _o.WriteLine($"  OK float V={V}: c[0,0]={c[0, 0]:F4}");
+        }
+        _o.WriteLine("ALL OK — no crash and values are correct");
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Issue471CpuMatmulCrashRepro.cs
@@ -12,6 +12,7 @@ namespace AiDotNet.Tensors.Tests.Engines;
 /// contracting over a big dimension (V≈50257), on AVX2-no-AVX512 hardware with OpenBLAS NOT loaded (managed
 /// AVX2 fallback). Env-gated TENSORS_RUN_REPRO=1. A clean run prints "ALL OK".
 /// </summary>
+[Collection("EngineCurrentGlobalState")]
 public class Issue471CpuMatmulCrashRepro
 {
     private readonly ITestOutputHelper _o;
@@ -23,16 +24,9 @@ public class Issue471CpuMatmulCrashRepro
         Skip.IfNot(Environment.GetEnvironmentVariable("TENSORS_RUN_REPRO") == "1",
             "Env-gated #471 repro: set TENSORS_RUN_REPRO=1 to run.");
 
-        // ResetToCpu() mutates AiDotNetEngine.Current — a shared process-wide
-        // singleton. xUnit test order is nondeterministic, so without restoring
-        // the previous selection the GPU repros below could silently run on CPU
-        // and miss the hardware path they exist to cover. Capture-and-restore
-        // around the CPU-specific body keeps this test isolated.
-        var previousEngine = AiDotNetEngine.Current;
-        AiDotNetEngine.ResetToCpu();
-        try
-        {
-            var eng = AiDotNetEngine.Current;
+        // This is a CPU-specific repro, so use an explicit local engine. ResetToCpu disposes
+        // a globally selected GPU and restoring that same reference would publish a dead engine.
+        var eng = new CpuEngine();
             _o.WriteLine($"engine={eng.Name}");
             const int d = 128;
             foreach (int V in new[] { 1000, 10000, 30000, 50257 })
@@ -58,11 +52,6 @@ public class Issue471CpuMatmulCrashRepro
             }
             _o.WriteLine("ALL OK — no crash");
             Assert.True(true);
-        }
-        finally
-        {
-            AiDotNetEngine.Current = previousEngine;
-        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/NativeComplexFftBlittableTests.cs
@@ -22,7 +22,11 @@ public class NativeComplexFftBlittableTests
     private readonly ITestOutputHelper _output;
     public NativeComplexFftBlittableTests(ITestOutputHelper output) => _output = output;
 
-    private static CpuEngine Cpu() => (AiDotNetEngine.Current as CpuEngine) ?? new CpuEngine();
+    // This fixture verifies the CPU blittable FFT implementation itself. DirectGpuTensorEngine
+    // derives from CpuEngine, so accepting AiDotNetEngine.Current here can silently select the
+    // GPU override and its speed-first FP32 conversion for double inputs. Use an exact CPU engine
+    // so the FP64 assertions cannot depend on process-wide backend selection or test order.
+    private static CpuEngine Cpu() => new CpuEngine();
 
     private static Tensor<double> RandD(int b, int n, int seed)
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OneDnnProviderTests.cs
@@ -33,8 +33,7 @@ public class OneDnnProviderTests
         Skip.IfNot(OneDnnProvider.IsAvailable,
             "dnnl.dll not deployed for this runtime; oneDNN optional accelerator inactive.");
 
-        AiDotNetEngine.ResetToCpu();
-        var eng = AiDotNetEngine.Current;
+        var eng = new CpuEngine();
 
         // 1 batch, 1 in-channel, 3x3 input; one 2x2 kernel; stride 1, no pad → 2x2 output.
         // input:            kernel:


### PR DESCRIPTION
## Summary

- repairs compiled-plan storage, saved-state, view, and autodiff lifetime ownership at the tensor/storage layer
- restores copy-on-write and mutation semantics without weakening the zero-copy/read fast paths
- fixes CPU numerical and mixed-residency invariants while retaining the SIMD/pointer kernels
- keeps ONNX behavior aligned with the corrected tensor contracts
- generates parity and residency coverage from Roslyn symbols instead of maintaining string allowlists

## Validation

- full CPU suite: **9,855 passed, 408 skipped, 0 failed**
- generated parity/residency contracts: **540 passed, 35 skipped, 0 failed**
- `net10.0`, `net8.0`, and `net471` build matrix: **0 errors**
- conservative patch coverage: **59.37%** (required: 58.3%)
- exact candidate-to-commit tree equivalence and clean `git diff --check`

## Split proof

This is the 91-file core half of the replacement for #1004. #1006 is the 98-file graph/GPU integration half. Both target `main`; their 47 intentional overlaps merge without conflict into the exact 142-file validated union, with no missing or extra paths.

The merged production tree also passed the affected AiDotNet model-family sweep: **3,239 passed, 78 skipped, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compiled inference support for multi-input models, serialization, graph replay, and additional attention, MLP, LSTM, and tensor operations.
  - Added streaming LSTM inference outputs for final hidden and cell states.
  - Added inference graph capture for supported geometry and bounding-box operations.

- **Bug Fixes**
  - Improved tensor lifetime management, gradient retention, GPU memory reclamation, and mixed CPU/GPU read behavior.
  - Added validation and clearer failures for unsupported inference graph operations.
  - Improved SIMD streaming partitioning and output consistency across supported hardware.

- **Tests**
  - Expanded coverage for autodiff, compiled plans, serialization, tensor storage, mixed residency, and deterministic GEMM behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->