### PR TITLE
fix(compilation): preserve dynamic masks across graph replay

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -3924,6 +3924,17 @@ internal static class BackwardFunctions<T>
         Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
         object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
     {
+        // Eager tape entries contain only the two differentiable branches.
+        // Compiled graph nodes additionally retain the condition as input 0
+        // so its producer remains in the replay graph.
+        int branchInputOffset = inputs.Length switch
+        {
+            2 => 0,
+            3 => 1,
+            _ => throw new InvalidOperationException(
+                $"TensorWhere backward expected 2 or 3 inputs, but received {inputs.Length}.")
+        };
+
         var numOps = MathHelper.GetNumericOperations<T>();
         if (savedState[0] is Tensor<T> condTensor)
         {
@@ -3942,8 +3953,8 @@ internal static class BackwardFunctions<T>
             var ones = engine.TensorAddScalar(engine.TensorMultiplyScalar(mask, numOps.Zero), numOps.One);
             var invCond = engine.TensorSubtract(ones, mask);
             var gradY = engine.TensorMultiply(gradOutput, invCond);
-            DifferentiableOps.AccumulateGrad(grads, inputs[0], gradX, engine);
-            DifferentiableOps.AccumulateGrad(grads, inputs[1], gradY, engine);
+            DifferentiableOps.AccumulateGrad(grads, inputs[branchInputOffset], gradX, engine);
+            DifferentiableOps.AccumulateGrad(grads, inputs[branchInputOffset + 1], gradY, engine);
             return;
         }
 
@@ -3968,8 +3979,8 @@ internal static class BackwardFunctions<T>
         var invCond2 = engine.TensorSubtract(
             engine.TensorAddScalar(engine.TensorMultiplyScalar(condT, numOps.Zero), numOps.One), condT);
         var gradY2 = engine.TensorMultiply(gradOutput, invCond2);
-        DifferentiableOps.AccumulateGrad(grads, inputs[0], gradX2, engine);
-        DifferentiableOps.AccumulateGrad(grads, inputs[1], gradY2, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[branchInputOffset], gradX2, engine);
+        DifferentiableOps.AccumulateGrad(grads, inputs[branchInputOffset + 1], gradY2, engine);
     }
 
     /// <summary>MaskedFill backward: zero gradient where mask is true</summary>

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -1248,18 +1248,24 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
         // outputs were stale or uninitialized. Reject the graph until heterogeneous mutable-input
         // rebinding and type-erased compiled steps are implemented as one coherent feature.
         if (optimized.Count == 0)
-            throw new NotSupportedException(
+            throw new GraphCaptureNotSupportedException(
+                nameof(Compile),
+                GraphCaptureLimitation.NoCompilableOperations,
                 "The captured inference graph contains no compilable tensor operations.");
 
         if (optimized.Any(node => node is not LazyNode<T>))
-            throw new NotSupportedException(
+            throw new GraphCaptureNotSupportedException(
+                nameof(Compile),
+                GraphCaptureLimitation.MixedElementTypes,
                 "The captured inference graph crosses tensor element types. " +
                 "Heterogeneous compiled inference plans are not supported yet.");
 
         if (explicitOutput is not null)
         {
             if (explicitOutput.LazySource is not ILazyNode outputNode || !optimized.Contains(outputNode))
-                throw new NotSupportedException(
+                throw new GraphCaptureNotSupportedException(
+                    nameof(Compile),
+                    GraphCaptureLimitation.UnrootedOutput,
                     "The requested inference output is not rooted in the captured graph. " +
                     "An eager operation escaped graph capture, so compiling would freeze stale data.");
         }

--- a/src/AiDotNet.Tensors/Engines/Compilation/CrossTypeLazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CrossTypeLazyNode.cs
@@ -124,6 +124,13 @@ internal sealed class CrossTypeLazyNode<TIn, TOut> : ILazyNode
         Output.LazySource = null;
     }
 
+    /// <summary>Detaches this node from its output when its trace is abandoned.</summary>
+    public void RestoreOutputLazySource()
+    {
+        if (ReferenceEquals(Output.LazySource, this))
+            Output.LazySource = null;
+    }
+
     public void AddStorageLeases(TensorStorageLeaseSet leases)
     {
         leases.Add(Input);

--- a/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/GraphMode.cs
@@ -22,7 +22,9 @@ internal enum GraphCaptureLimitation : byte
     MixedElementTypes,
     HostBoundary,
     Stateful,
-    MissingBackwardContract
+    MissingBackwardContract,
+    NoCompilableOperations,
+    UnrootedOutput
 }
 
 /// <summary>
@@ -147,6 +149,10 @@ internal static class GraphMode
                 "it mutates state during execution",
             GraphCaptureLimitation.MissingBackwardContract =>
                 "it has no backward contract",
+            GraphCaptureLimitation.NoCompilableOperations =>
+                "it contains no compilable tensor operations",
+            GraphCaptureLimitation.UnrootedOutput =>
+                "its requested output is not rooted in the captured graph",
             _ => throw new ArgumentOutOfRangeException(nameof(limitation))
         };
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/ILazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/ILazyNode.cs
@@ -35,6 +35,12 @@ internal interface ILazyNode
     /// <summary>Clears the LazySource reference on the output tensor after realization.</summary>
     void ClearOutputLazySource();
 
+    /// <summary>
+    /// Detaches this node from its output when its trace is abandoned, restoring any producer
+    /// that the node temporarily replaced.
+    /// </summary>
+    void RestoreOutputLazySource();
+
     /// <summary>Adds every tensor storage structurally retained by this node.</summary>
     void AddStorageLeases(TensorStorageLeaseSet leases);
 }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
@@ -227,8 +227,16 @@ internal sealed class LazyNode<T> : ILazyNode
     /// </summary>
     public void RestoreOutputLazySource()
     {
-        if (ReferenceEquals(Output.LazySource, this))
+        // Compilation takes ownership of output materialization by clearing LazySource before
+        // later validation/specialization stages finish. If one of those stages throws, the
+        // displaced producer is still the source this in-place node must restore even though the
+        // node is no longer attached to the tensor. Reverse-order scope abandonment then walks an
+        // in-place chain back to the producer owned by the enclosing scope.
+        if (ReferenceEquals(Output.LazySource, this)
+            || (Output.LazySource is null && _externalPrerequisite is not null))
+        {
             Output.LazySource = _externalPrerequisite;
+        }
     }
 
     public void AddStorageLeases(TensorStorageLeaseSet leases)

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyNode.cs
@@ -221,6 +221,16 @@ internal sealed class LazyNode<T> : ILazyNode
         Output.LazySource = null;
     }
 
+    /// <summary>
+    /// Removes this abandoned node from its output without severing a producer from an enclosing
+    /// scope. In-place recording temporarily replaces that producer with this node.
+    /// </summary>
+    public void RestoreOutputLazySource()
+    {
+        if (ReferenceEquals(Output.LazySource, this))
+            Output.LazySource = _externalPrerequisite;
+    }
+
     public void AddStorageLeases(TensorStorageLeaseSet leases)
     {
         leases.Add(Input0);

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -398,8 +398,8 @@ internal sealed class LazyTensorScope : IDisposable
     /// </remarks>
     internal CompiledInferencePlan<T> CompileInference<T>()
     {
-        MarkCompiled();
-        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput: null);
+        return CompilePlan(
+            () => CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput: null));
     }
 
     /// <summary>
@@ -409,8 +409,8 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledInferencePlan<T> CompileInference<T>(Tensor<T> explicitOutput)
     {
-        MarkCompiled();
-        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput);
+        return CompilePlan(
+            () => CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput));
     }
 
     /// <summary>
@@ -420,8 +420,8 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledInferencePlan<T> CompileInference<T>(Tensor<T> explicitOutput, Tensor<T> input)
     {
-        MarkCompiled();
-        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, input);
+        return CompilePlan(
+            () => CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, input));
     }
 
     /// <summary>
@@ -430,8 +430,8 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledInferencePlan<T> CompileInference<T>(Tensor<T> explicitOutput, int[] inputShape)
     {
-        MarkCompiled();
-        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, inputShape);
+        return CompilePlan(
+            () => CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, inputShape));
     }
 
     /// <summary>
@@ -442,8 +442,8 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     internal CompiledInferencePlan<T> CompileInference<T>(Tensor<T> explicitOutput, Tensor<T>[] inputs)
     {
-        MarkCompiled();
-        return CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, inputs);
+        return CompilePlan(
+            () => CompiledInferencePlan<T>.Compile(this, _engine, explicitOutput, inputs));
     }
 
     /// <summary>
@@ -459,8 +459,8 @@ internal sealed class LazyTensorScope : IDisposable
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters)
     {
         EnsureTrainingParametersPrepared(parameters);
-        MarkCompiled();
-        return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss: null);
+        return CompilePlan(
+            () => CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss: null));
     }
 
     /// <summary>
@@ -470,8 +470,26 @@ internal sealed class LazyTensorScope : IDisposable
     internal CompiledTrainingPlan<T> CompileTraining<T>(Tensor<T>[] parameters, Tensor<T> explicitLoss)
     {
         EnsureTrainingParametersPrepared(parameters);
-        MarkCompiled();
-        return CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss);
+        return CompilePlan(
+            () => CompiledTrainingPlan<T>.Compile(this, _engine, parameters, explicitLoss));
+    }
+
+    /// <summary>
+    /// Completes the terminal transition from a trace to a compiled plan. Any compiler failure
+    /// abandons the trace before the original exception continues to the caller.
+    /// </summary>
+    private TPlan CompilePlan<TPlan>(Func<TPlan> compile)
+    {
+        try
+        {
+            MarkCompiled();
+            return compile();
+        }
+        catch
+        {
+            Abandon();
+            throw;
+        }
     }
 
     /// <summary>
@@ -529,8 +547,11 @@ internal sealed class LazyTensorScope : IDisposable
     /// </summary>
     private void Abandon()
     {
-        foreach (var node in _nodes)
-            node.ClearOutputLazySource();
+        // Undo in reverse recording order. Several in-place nodes can successively replace the
+        // same target's LazySource, so each one must expose its predecessor before that predecessor
+        // can restore the producer from an enclosing scope.
+        for (int i = _nodes.Count - 1; i >= 0; i--)
+            _nodes[i].RestoreOutputLazySource();
 
         _realized = true;
     }

--- a/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/LazyTensorScope.cs
@@ -521,6 +521,20 @@ internal sealed class LazyTensorScope : IDisposable
             GraphMode.SetCurrent(_parent);
     }
 
+    /// <summary>
+    /// Discards an incomplete explicit compilation trace without executing it.
+    /// Inference and training scopes are opened to build plans, so replaying a
+    /// partial graph while an exception unwinds would introduce work and user-
+    /// visible side effects that the failed operation never requested.
+    /// </summary>
+    private void Abandon()
+    {
+        foreach (var node in _nodes)
+            node.ClearOutputLazySource();
+
+        _realized = true;
+    }
+
     public void Dispose()
     {
         if (_disposed) return;
@@ -528,9 +542,17 @@ internal sealed class LazyTensorScope : IDisposable
 
         try
         {
-            // Auto-realize on dispose if not yet done (safety net)
+            // Compatibility scopes retain the historical lazy-evaluation
+            // contract. Explicit inference/training scopes exist only to
+            // compile a plan; if compilation did not complete, abandon the
+            // partial trace instead of executing callbacks during Dispose.
             if (!_realized)
-                Realize();
+            {
+                if (_traceKind == GraphTraceKind.Compatibility)
+                    Realize();
+                else
+                    Abandon();
+            }
         }
         finally
         {

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.GraphCapture.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.GraphCapture.cs
@@ -9,6 +9,61 @@ namespace AiDotNet.Tensors.Engines;
 public partial class CpuEngine
 {
     /// <summary>
+    /// Captures a value-dependent unary comparison in any graph kind. Comparison
+    /// results are forward-only masks: they must be recomputed on every replay,
+    /// but gradients do not flow through the discontinuous predicate itself.
+    /// </summary>
+    protected Tensor<T> CaptureComparisonKernel<T>(
+        Tensor<T> input,
+        Func<IEngine, Tensor<T>> execute,
+        [CallerMemberName] string operationName = "")
+    {
+        var scope = GraphMode.Current
+            ?? throw new InvalidOperationException("Comparison capture requires an active graph scope.");
+        if (execute is null) throw new ArgumentNullException(nameof(execute));
+
+        scope.BindEngineIfUnset(this);
+        return scope.RecordUnary(
+            LazyNodeType.Custom,
+            operationName,
+            input,
+            input._shape,
+            (engine, output) =>
+            {
+                Tensor<T> result = execute(engine);
+                DirectGpuTensorEngine.CopyResultInto(engine, result, output);
+            });
+    }
+
+    /// <summary>
+    /// Captures a value-dependent binary comparison in any graph kind. The
+    /// output shape is identical to the already-validated operand shape.
+    /// </summary>
+    protected Tensor<T> CaptureComparisonKernel<T>(
+        Tensor<T> left,
+        Tensor<T> right,
+        Func<IEngine, Tensor<T>> execute,
+        [CallerMemberName] string operationName = "")
+    {
+        var scope = GraphMode.Current
+            ?? throw new InvalidOperationException("Comparison capture requires an active graph scope.");
+        if (execute is null) throw new ArgumentNullException(nameof(execute));
+
+        scope.BindEngineIfUnset(this);
+        return scope.RecordBinary(
+            LazyNodeType.Custom,
+            operationName,
+            left,
+            right,
+            left._shape,
+            (engine, output) =>
+            {
+                Tensor<T> result = execute(engine);
+                DirectGpuTensorEngine.CopyResultInto(engine, result, output);
+            });
+    }
+
+    /// <summary>
     /// Captures a kernel as one opaque inference node while preserving the public tensor operands
     /// as graph leaves. The eager trace invocation establishes the exact output shape; replay calls
     /// the engine bound to the graph, so a DirectGpuTensorEngine trace continues to dispatch to GPU

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -6480,9 +6480,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorEquals<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(
-                new[] { tensor }, engine => engine.TensorEquals(tensor, value));
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(
+                tensor, engine => engine.TensorEquals(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6502,18 +6502,17 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorEquals(a, b));
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!b.IsContiguous) b = b.Contiguous();
         if (!ShapesMatch(a._shape, b._shape))
         {
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
-
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(a, b, engine => engine.TensorEquals(a, b));
+        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!a.IsContiguous) a = a.Contiguous();
+        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!b.IsContiguous) b = b.Contiguous();
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(a._shape);
         var srcA = a.AsSpan();
@@ -6530,9 +6529,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorNotEquals<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(
-                new[] { tensor }, engine => engine.TensorNotEquals(tensor, value));
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(
+                tensor, engine => engine.TensorNotEquals(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6552,18 +6551,17 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorNotEquals(a, b));
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!b.IsContiguous) b = b.Contiguous();
         if (!ShapesMatch(a._shape, b._shape))
         {
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
-
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(a, b, engine => engine.TensorNotEquals(a, b));
+        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!a.IsContiguous) a = a.Contiguous();
+        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!b.IsContiguous) b = b.Contiguous();
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(a._shape);
         var srcA = a.AsSpan();
@@ -6581,18 +6579,17 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorGreaterThan(a, b));
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!b.IsContiguous) b = b.Contiguous();
         if (!ShapesMatch(a._shape, b._shape))
         {
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
-
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(a, b, engine => engine.TensorGreaterThan(a, b));
+        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!a.IsContiguous) a = a.Contiguous();
+        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!b.IsContiguous) b = b.Contiguous();
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(a._shape);
         var srcA = a.AsSpan();
@@ -6609,9 +6606,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorGreaterThan<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(
-                new[] { tensor }, engine => engine.TensorGreaterThan(tensor, value));
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(
+                tensor, engine => engine.TensorGreaterThan(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -6631,18 +6628,17 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (a == null) throw new ArgumentNullException(nameof(a));
         if (b == null) throw new ArgumentNullException(nameof(b));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(new[] { a, b }, engine => engine.TensorLessThan(a, b));
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!b.IsContiguous) b = b.Contiguous();
         if (!ShapesMatch(a._shape, b._shape))
         {
             throw new ArgumentException(
                 $"Tensor shapes must match. Got {FormatShape(a._shape)} and {FormatShape(b._shape)}.");
         }
-
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(a, b, engine => engine.TensorLessThan(a, b));
+        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!a.IsContiguous) a = a.Contiguous();
+        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        if (!b.IsContiguous) b = b.Contiguous();
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(a._shape);
         var srcA = a.AsSpan();
@@ -6659,9 +6655,9 @@ public partial class CpuEngine : ITensorLevelEngine
     public Tensor<T> TensorLessThan<T>(Tensor<T> tensor, T value)
     {
         if (tensor == null) throw new ArgumentNullException(nameof(tensor));
-        if (GraphMode.IsInferenceTrace)
-            return CaptureInferenceKernel(
-                new[] { tensor }, engine => engine.TensorLessThan(tensor, value));
+        if (GraphMode.IsActive)
+            return CaptureComparisonKernel(
+                tensor, engine => engine.TensorLessThan(tensor, value));
         var tensorOrig = tensor;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!tensor.IsContiguous) tensor = tensor.Contiguous();
 
@@ -35640,6 +35636,9 @@ public partial class CpuEngine : ITensorLevelEngine
     {
         if (condition == null) throw new ArgumentNullException(nameof(condition));
         if (x == null) throw new ArgumentNullException(nameof(x));
+        if (y == null) throw new ArgumentNullException(nameof(y));
+        if (!condition._shape.SequenceEqual(x._shape) || !condition._shape.SequenceEqual(y._shape))
+            throw new ArgumentException("All tensors must have the same shape");
 
         if (GraphMode.IsActive)
         {
@@ -35647,22 +35646,25 @@ public partial class CpuEngine : ITensorLevelEngine
             if (scope != null)
             {
                 var cc = condition; var cx = x; var cy = y;
+                BackwardFunction<T>? backwardFn = GraphMode.IsInferenceTrace
+                    ? null
+                    : BackwardFunctions<T>.WhereBackward;
+                object[]? savedState = GraphMode.IsInferenceTrace
+                    ? null
+                    : new object[] { condition };
                 return scope.RecordVariadic(LazyNodeType.Custom, "TensorWhere",
                     new[] { condition, x, y }, x._shape,
-                    (eng, output) => { var r = eng.TensorWhere(cc, cx, cy); DirectGpuTensorEngine.CopyResultInto(eng, r, output); });
+                    (eng, output) => { var r = eng.TensorWhere(cc, cx, cy); DirectGpuTensorEngine.CopyResultInto(eng, r, output); },
+                    backwardFn,
+                    savedState);
             }
         }
-        if (y == null) throw new ArgumentNullException(nameof(y));
         var yOrig = y;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!y.IsContiguous) y = y.Contiguous();
         var xOrig = x;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!x.IsContiguous) x = x.Contiguous();
         var conditionOrig = condition;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
         if (!condition.IsContiguous) condition = condition.Contiguous();
-
-        // All tensors must have the same shape (or be broadcastable, but we'll require same shape for simplicity)
-        if (!condition._shape.SequenceEqual(x._shape) || !condition._shape.SequenceEqual(y._shape))
-            throw new ArgumentException("All tensors must have the same shape");
 
         var numOps = MathHelper.GetNumericOperations<T>();
         var result = AutoTensorCache.RentOrAllocate<T>(condition._shape);

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -19639,6 +19639,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     public override Tensor<T> TensorWhere<T>(Tensor<T> condition, Tensor<T> x, Tensor<T> y)
     {
+        // The base engine records the condition and both branches as graph inputs.
+        // Executing the GPU kernel while tracing would freeze the trace-time mask;
+        // replay reaches this fast path after graph capture has ended.
+        if (Compilation.GraphMode.IsActive)
+            return base.TensorWhere(condition, x, y);
+
         if (!TryGetBackend(out var backend))
             return base.TensorWhere(condition, x, y);
 
@@ -24511,7 +24517,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     Tensor<T> IEngine.TensorEquals<T>(Tensor<T> tensor, T value)
     {
-        if (!IsTapeActive<T>() && typeof(T) == typeof(float) && tensor.IsContiguous
+        if (!IsTapeActive<T>() && !Compilation.GraphMode.IsActive
+            && typeof(T) == typeof(float) && tensor.IsContiguous
             && TryGetBackend(out var backend))
         {
             try
@@ -24539,7 +24546,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     Tensor<T> IEngine.TensorNotEquals<T>(Tensor<T> tensor, T value)
     {
-        if (!IsTapeActive<T>() && typeof(T) == typeof(float) && tensor.IsContiguous
+        if (!IsTapeActive<T>() && !Compilation.GraphMode.IsActive
+            && typeof(T) == typeof(float) && tensor.IsContiguous
             && TryGetBackend(out var backend))
         {
             try
@@ -24565,7 +24573,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     Tensor<T> IEngine.TensorEquals<T>(Tensor<T> a, Tensor<T> b2)
     {
-        if (TryGetBackend(out var b) && ShapesMatch(a.Shape._dims, b2.Shape._dims))
+        if (!IsTapeActive<T>() && !Compilation.GraphMode.IsActive && typeof(T) == typeof(float)
+            && TryGetBackend(out var b) && ShapesMatch(a.Shape._dims, b2.Shape._dims))
         {
             try
             {
@@ -24582,7 +24591,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
     Tensor<T> IEngine.TensorNotEquals<T>(Tensor<T> a, Tensor<T> b2)
     {
-        if (TryGetBackend(out var b) && ShapesMatch(a.Shape._dims, b2.Shape._dims))
+        if (!IsTapeActive<T>() && !Compilation.GraphMode.IsActive && typeof(T) == typeof(float)
+            && TryGetBackend(out var b) && ShapesMatch(a.Shape._dims, b2.Shape._dims))
         {
             try
             {

--- a/src/AiDotNet.Tensors/Engines/Simd/TableDrivenSigmoid.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/TableDrivenSigmoid.cs
@@ -10,24 +10,24 @@ namespace AiDotNet.Tensors.Engines.Simd;
 /// Table-driven sigmoid with quadratic interpolation.
 ///
 /// Instead of computing 1/(1+exp(-x)) which requires expensive exp + divide,
-/// use a precomputed 258-entry lookup table covering [-8, 8] with quadratic
-/// interpolation. Outside this range, sigmoid saturates to 0 or 1.
+/// use a precomputed 514-entry lookup table covering [-16, 16] with quadratic
+/// interpolation. Outside this range, sigmoid saturates to 0 or 1 at float32 precision.
 ///
 /// Computation per element: 1 multiply (index) + 1 clamp + table load + 2 FMA
 /// Total: ~5 ops vs ~14 for exp+divide path
 ///
 /// Accuracy: max 2.1e-6 absolute error within the interpolation interval.
-/// Table: 258 entries = 1032 bytes (fits in L1 cache)
+/// Table: 514 entries = 2056 bytes (fits in L1 cache)
 /// </summary>
 internal static class TableDrivenSigmoid
 {
-    private const int TableSize = 256;
-    private const float XMin = -8.0f;
-    private const float XMax = 8.0f;
+    private const int TableSize = 512;
+    private const float XMin = -16.0f;
+    private const float XMax = 16.0f;
     private const float Step = (XMax - XMin) / TableSize; // 0.0625
     private const float InvStep = TableSize / (XMax - XMin); // 16.0
 
-    // Pre-computed sigmoid values at 258 points (256 + 2 for quadratic interpolation boundary)
+    // Pre-computed sigmoid values at 514 points (512 + 2 for quadratic interpolation boundary)
     private static readonly float[] Table = GenerateTable();
 
     private static float[] GenerateTable()
@@ -48,8 +48,8 @@ internal static class TableDrivenSigmoid
     internal static float Sigmoid(float x)
     {
         if (float.IsNaN(x)) return float.NaN;
-        if (x <= XMin) return 0f;
-        if (x >= XMax) return 1f;
+        if (x < XMin) return 0f;
+        if (x > XMax) return 1f;
 
         float t = (x - XMin) * InvStep;
         int idx = (int)t;
@@ -127,9 +127,9 @@ internal static class TableDrivenSigmoid
                     // while the scalar path returns the exact saturation values.
                     result = Avx.Max(vZero, Avx.Min(vOne, result));
                     var lowMask = Avx.Compare(
-                        x, vXMin, FloatComparisonMode.OrderedLessThanOrEqualSignaling);
+                        x, vXMin, FloatComparisonMode.OrderedLessThanSignaling);
                     var highMask = Avx.Compare(
-                        x, Vector256.Create(XMax), FloatComparisonMode.OrderedGreaterThanOrEqualSignaling);
+                        x, Vector256.Create(XMax), FloatComparisonMode.OrderedGreaterThanSignaling);
                     var nanMask = Avx.CompareNotEqual(x, x);
                     result = Avx.BlendVariable(result, vZero, lowMask);
                     result = Avx.BlendVariable(result, vOne, highMask);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
@@ -217,6 +217,55 @@ public class CompiledGraphRegressionTests
     }
 
     [Fact]
+    public void AbandonedNestedTrace_RestoresEnclosingProducerAfterInPlaceChain()
+    {
+        using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Tensor<float>? output = null;
+        ILazyNode? enclosingProducer = null;
+        int enclosingCallbackCount = 0;
+        int nestedCallbackCount = 0;
+
+        using (var enclosingScope = GraphMode.Enable())
+        {
+            output = enclosingScope.RecordUnary(
+                LazyNodeType.Custom,
+                "EnclosingProducer",
+                input,
+                input._shape,
+                (_, destination) =>
+                {
+                    enclosingCallbackCount++;
+                    destination[0] = 7f;
+                });
+            enclosingProducer = output.LazySource;
+
+            using (var nestedScope = GraphMode.EnableInference())
+            {
+                nestedScope.RecordInPlace(
+                    LazyNodeType.Custom,
+                    "NestedMutation1",
+                    output,
+                    Array.Empty<Tensor<float>>(),
+                    (_, _) => nestedCallbackCount++);
+                nestedScope.RecordInPlace(
+                    LazyNodeType.Custom,
+                    "NestedMutation2",
+                    output,
+                    Array.Empty<Tensor<float>>(),
+                    (_, _) => nestedCallbackCount++);
+            }
+
+            Assert.Same(enclosingProducer, output.LazySource);
+            Assert.Equal(0, nestedCallbackCount);
+        }
+
+        Assert.Equal(1, enclosingCallbackCount);
+        Assert.Equal(0, nestedCallbackCount);
+        Assert.Equal(7f, output![0]);
+        output.Dispose();
+    }
+
+    [Fact]
     public void CompatibilityTrace_StillExecutesRecordedCallbacksOnDispose()
     {
         using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
@@ -249,16 +298,19 @@ public class CompiledGraphRegressionTests
         using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
         using var cache = new CompiledModelCache<float>();
 
+        Tensor<float>? captured = null;
         Tensor<float>? unrooted = null;
         var error = Assert.Throws<GraphCaptureNotSupportedException>(() =>
             cache.GetOrCompileInference(input, () =>
             {
-                _ = engine.TensorAdd(input, input);
+                captured = engine.TensorAdd(input, input);
                 unrooted = new Tensor<float>(new[] { 2f }, new[] { 1 });
                 return unrooted;
             }));
 
         Assert.Equal(GraphCaptureLimitation.UnrootedOutput, error.Limitation);
+        Assert.Null(captured!.LazySource);
+        captured.Dispose();
         unrooted?.Dispose();
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
@@ -266,6 +266,62 @@ public class CompiledGraphRegressionTests
     }
 
     [Fact]
+    public void FailedCompilationAfterOutputDetach_RestoresEnclosingProducerAfterInPlaceChain()
+    {
+        using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var invalidPlanInput = new Tensor<float>(new[] { 2f }, new[] { 1 });
+        Tensor<float>? output = null;
+        ILazyNode? enclosingProducer = null;
+        int enclosingCallbackCount = 0;
+        int nestedCallbackCount = 0;
+
+        using (var enclosingScope = GraphMode.Enable())
+        {
+            output = enclosingScope.RecordUnary(
+                LazyNodeType.Custom,
+                "EnclosingProducer",
+                input,
+                input._shape,
+                (_, destination) =>
+                {
+                    enclosingCallbackCount++;
+                    destination[0] = 7f;
+                });
+            enclosingProducer = output.LazySource;
+
+            using (var nestedScope = GraphMode.EnableInference())
+            {
+                nestedScope.RecordInPlace(
+                    LazyNodeType.Custom,
+                    "NestedMutation1",
+                    output,
+                    Array.Empty<Tensor<float>>(),
+                    (_, _) => nestedCallbackCount++);
+                nestedScope.RecordInPlace(
+                    LazyNodeType.Custom,
+                    "NestedMutation2",
+                    output,
+                    Array.Empty<Tensor<float>>(),
+                    (_, _) => nestedCallbackCount++);
+
+                // Multi-input validation runs after CompiledInferencePlan has detached lazy
+                // outputs. Supplying a tensor the graph never reads forces that later stage to
+                // fail and exercises restoration from the saved enclosing producer.
+                Assert.Throws<InvalidOperationException>(() =>
+                    nestedScope.CompileInference(output, new[] { invalidPlanInput }));
+            }
+
+            Assert.Same(enclosingProducer, output.LazySource);
+            Assert.Equal(0, nestedCallbackCount);
+        }
+
+        Assert.Equal(1, enclosingCallbackCount);
+        Assert.Equal(0, nestedCallbackCount);
+        Assert.Equal(7f, output![0]);
+        output.Dispose();
+    }
+
+    [Fact]
     public void CompatibilityTrace_StillExecutesRecordedCallbacksOnDispose()
     {
         using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/CompiledGraphRegressionTests.cs
@@ -1,0 +1,291 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using System.Reflection;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Compilation;
+
+[Collection("CompilationGlobalState")]
+public class CompiledGraphRegressionTests
+{
+    public enum ComparisonKind
+    {
+        Equal,
+        NotEqual,
+        GreaterThan,
+        LessThan
+    }
+
+    public enum OperandKind
+    {
+        Tensor,
+        Scalar
+    }
+
+    [Theory]
+    [InlineData(ComparisonKind.Equal, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.Equal, OperandKind.Scalar)]
+    [InlineData(ComparisonKind.NotEqual, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.NotEqual, OperandKind.Scalar)]
+    [InlineData(ComparisonKind.GreaterThan, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.GreaterThan, OperandKind.Scalar)]
+    [InlineData(ComparisonKind.LessThan, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.LessThan, OperandKind.Scalar)]
+    public void TrainingPlan_RecomputesComparisonMaskOnReplay(
+        ComparisonKind comparisonKind,
+        OperandKind operandKind)
+    {
+        var engine = new CpuEngine();
+        float traceValue = comparisonKind is ComparisonKind.NotEqual or ComparisonKind.LessThan ? 1f : 0f;
+        float replayValue = comparisonKind == ComparisonKind.LessThan ? 0f :
+            comparisonKind == ComparisonKind.Equal ? 1f : 2f;
+        using var parameter = new Tensor<float>(new[] { traceValue }, new[] { 1 });
+        using var right = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var whenTrue = new Tensor<float>(new[] { 11f }, new[] { 1 });
+        using var whenFalse = new Tensor<float>(new[] { 22f }, new[] { 1 });
+        using var cache = new CompiledModelCache<float>();
+
+        Tensor<float> ForwardAndLoss()
+        {
+            Tensor<float> condition = (comparisonKind, operandKind) switch
+            {
+                (ComparisonKind.Equal, OperandKind.Tensor) => engine.TensorEquals(parameter, right),
+                (ComparisonKind.Equal, OperandKind.Scalar) => engine.TensorEquals(parameter, 1f),
+                (ComparisonKind.NotEqual, OperandKind.Tensor) => engine.TensorNotEquals(parameter, right),
+                (ComparisonKind.NotEqual, OperandKind.Scalar) => engine.TensorNotEquals(parameter, 1f),
+                (ComparisonKind.GreaterThan, OperandKind.Tensor) => engine.TensorGreaterThan(parameter, right),
+                (ComparisonKind.GreaterThan, OperandKind.Scalar) => engine.TensorGreaterThan(parameter, 1f),
+                (ComparisonKind.LessThan, OperandKind.Tensor) => engine.TensorLessThan(parameter, right),
+                (ComparisonKind.LessThan, OperandKind.Scalar) => engine.TensorLessThan(parameter, 1f),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+            return engine.ReduceSum(engine.TensorWhere(condition, whenTrue, whenFalse), null);
+        }
+
+        var plan = cache.GetOrCompileTraining(parameter._shape, ForwardAndLoss, new[] { parameter });
+        parameter[0] = replayValue;
+
+        float loss = plan.Step()[0];
+
+        Assert.Equal(11f, loss);
+    }
+
+    [Fact]
+    public void TrainingPlan_TensorWhereRoutesGradientUsingReplayMask()
+    {
+        var engine = new CpuEngine();
+        using var parameter = new Tensor<float>(new[] { 0.5f }, new[] { 1 });
+        using var one = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var cache = new CompiledModelCache<float>();
+
+        Tensor<float> ForwardAndLoss()
+        {
+            var reciprocal = engine.TensorDivide(one, parameter);
+            var condition = engine.TensorGreaterThan(parameter, one);
+            var selected = engine.TensorWhere(condition, reciprocal, parameter);
+            return engine.ReduceSum(selected, null);
+        }
+
+        var plan = cache.GetOrCompileTraining(parameter._shape, ForwardAndLoss, new[] { parameter });
+        parameter[0] = 2f;
+
+        float loss = plan.Step()[0];
+
+        Assert.Equal(0.5f, loss, precision: 6);
+        Assert.Equal(-0.25f, plan.Gradients[0][0], precision: 6);
+    }
+
+    [Theory]
+    [InlineData(ComparisonKind.Equal, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.Equal, OperandKind.Scalar)]
+    [InlineData(ComparisonKind.NotEqual, OperandKind.Tensor)]
+    [InlineData(ComparisonKind.NotEqual, OperandKind.Scalar)]
+    public void DirectGpuTrace_CapturesEqualityBeforeKernelDispatch(
+        ComparisonKind comparisonKind,
+        OperandKind operandKind)
+    {
+        using var directGpu = CreateMockDirectGpu(out var state);
+        using var engine = new DirectGpuTensorEngine(directGpu);
+        IEngine dispatch = engine;
+        using var parameter = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var right = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Tensor<float>? condition = null;
+
+        try
+        {
+            using (GraphMode.EnableTraining(new[] { parameter }))
+            {
+                condition = (comparisonKind, operandKind) switch
+                {
+                    (ComparisonKind.Equal, OperandKind.Tensor) => dispatch.TensorEquals(parameter, right),
+                    (ComparisonKind.Equal, OperandKind.Scalar) => dispatch.TensorEquals(parameter, 1f),
+                    (ComparisonKind.NotEqual, OperandKind.Tensor) => dispatch.TensorNotEquals(parameter, right),
+                    (ComparisonKind.NotEqual, OperandKind.Scalar) => dispatch.TensorNotEquals(parameter, 1f),
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+
+                Assert.NotNull(condition.LazySource);
+                Assert.Equal(0, state.EqualsCalls);
+                Assert.Equal(0, state.NotEqualsCalls);
+            }
+        }
+        finally
+        {
+            condition?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DirectGpuTrace_CapturesWhereBeforeKernelDispatch()
+    {
+        using var directGpu = CreateMockDirectGpu(out var state);
+        using var engine = new DirectGpuTensorEngine(directGpu);
+        IEngine dispatch = engine;
+        using var parameter = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var condition = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var whenTrue = new Tensor<float>(new[] { 11f }, new[] { 1 });
+        using var whenFalse = new Tensor<float>(new[] { 22f }, new[] { 1 });
+        Tensor<float>? selected = null;
+
+        try
+        {
+            using (GraphMode.EnableTraining(new[] { parameter }))
+            {
+                selected = dispatch.TensorWhere(condition, whenTrue, whenFalse);
+
+                Assert.NotNull(selected.LazySource);
+                Assert.Equal(0, state.WhereCalls);
+            }
+        }
+        finally
+        {
+            selected?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void FailedExplicitInferenceTrace_DoesNotExecuteRecordedCallbacksOnDispose()
+    {
+        using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Tensor<float>? output = null;
+        int callbackCount = 0;
+
+        var error = Assert.Throws<InvalidOperationException>((Action)(() =>
+        {
+            using var scope = GraphMode.EnableInference();
+            output = scope.RecordUnary(
+                LazyNodeType.Custom,
+                "SideEffectProbe",
+                input,
+                input._shape,
+                (_, _) => callbackCount++);
+            throw new InvalidOperationException("forced trace failure");
+        }));
+
+        Assert.Equal("forced trace failure", error.Message);
+        Assert.Equal(0, callbackCount);
+        Assert.False(GraphMode.IsActive);
+        output?.Dispose();
+    }
+
+    [Fact]
+    public void FailedExplicitTrainingTrace_DoesNotExecuteRecordedCallbacksOnDispose()
+    {
+        using var parameter = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Tensor<float>? output = null;
+        int callbackCount = 0;
+
+        var error = Assert.Throws<InvalidOperationException>((Action)(() =>
+        {
+            using var scope = GraphMode.EnableTraining(new[] { parameter });
+            output = scope.RecordUnary(
+                LazyNodeType.Custom,
+                "SideEffectProbe",
+                parameter,
+                parameter._shape,
+                (_, _) => callbackCount++);
+            throw new InvalidOperationException("forced trace failure");
+        }));
+
+        Assert.Equal("forced trace failure", error.Message);
+        Assert.Equal(0, callbackCount);
+        Assert.False(GraphMode.IsActive);
+        output?.Dispose();
+    }
+
+    [Fact]
+    public void CompatibilityTrace_StillExecutesRecordedCallbacksOnDispose()
+    {
+        using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        Tensor<float>? output = null;
+        int callbackCount = 0;
+
+        using (var scope = GraphMode.Enable())
+        {
+            output = scope.RecordUnary(
+                LazyNodeType.Custom,
+                "CompatibilityProbe",
+                input,
+                input._shape,
+                (_, destination) =>
+                {
+                    callbackCount++;
+                    destination[0] = 7f;
+                });
+        }
+
+        Assert.Equal(1, callbackCount);
+        Assert.Equal(7f, output![0]);
+        output.Dispose();
+    }
+
+    [Fact]
+    public void UnrootedInferenceOutput_UsesTypedCaptureLimitation()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        using var cache = new CompiledModelCache<float>();
+
+        Tensor<float>? unrooted = null;
+        var error = Assert.Throws<GraphCaptureNotSupportedException>(() =>
+            cache.GetOrCompileInference(input, () =>
+            {
+                _ = engine.TensorAdd(input, input);
+                unrooted = new Tensor<float>(new[] { 2f }, new[] { 1 });
+                return unrooted;
+            }));
+
+        Assert.Equal(GraphCaptureLimitation.UnrootedOutput, error.Limitation);
+        unrooted?.Dispose();
+    }
+
+    private static void SetField(object target, string name, object value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field not found: {name}");
+        field.SetValue(target, value);
+    }
+
+    private static DirectGpuEngine CreateMockDirectGpu(out MockBackendState state)
+    {
+        string? priorBackends = Environment.GetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS");
+        DirectGpuEngine directGpu;
+        try
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", "none");
+            directGpu = new DirectGpuEngine();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_DIRECTGPU_BACKENDS", priorBackends);
+        }
+
+        state = new MockBackendState();
+        SetField(directGpu, "_backend", MockDirectGpuBackend.Create(state));
+        SetField(directGpu, "_isAvailable", true);
+        return directGpu;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/LazyGraphCompilerPerformanceTests.cs
@@ -57,6 +57,7 @@ public sealed class LazyGraphCompilerPerformanceTests
         public void Realize(IEngine engine) => IsRealized = true;
         public ILazyNode[] GetInputNodes() => _inputs;
         public void ClearOutputLazySource() { }
+        public void RestoreOutputLazySource() { }
         public void AddStorageLeases(TensorStorageLeaseSet leases) { }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MathInvariantExpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/MathInvariantExpTests.cs
@@ -150,7 +150,7 @@ public class MathInvariantExpTests
             // For moderate inputs, sigmoid should be strictly between 0 and 1
             if (MathF.Abs(input[i]) < 15f) // float32 sigmoid saturates at ~16
                 Assert.True(output[i] > 0f && output[i] < 1f,
-                    $"sigmoid({input[i]}) = {output[i]} — must be in (0,1) for |x| < 30");
+                    $"sigmoid({input[i]}) = {output[i]} — must be in (0,1) for |x| < 15");
         }
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/OperationReorderingPassTests.cs
@@ -161,6 +161,7 @@ public sealed class OperationReorderingPassTests
         public void Realize(IEngine engine) { }
         public ILazyNode[] GetInputNodes() => _inputs;
         public void ClearOutputLazySource() { }
+        public void RestoreOutputLazySource() { }
         public void AddStorageLeases(TensorStorageLeaseSet leases) { }
         public override string ToString() => Name;
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/MockDirectGpuBackend.cs
@@ -70,6 +70,9 @@ internal sealed class MockBackendState
     public int UnaryOpCalls { get; set; }
     public int BinaryOpCalls { get; set; }
     public int TanhCalls { get; set; }
+    public int EqualsCalls { get; set; }
+    public int NotEqualsCalls { get; set; }
+    public int WhereCalls { get; set; }
     public List<string> OptimizerCalls { get; } = new();
 }
 
@@ -193,6 +196,48 @@ public class MockDirectGpuBackend : DispatchProxy
                 var output = (MockGpuBuffer)args[1]!;
                 int size = (int)args[2]!;
                 for (int i = 0; i < size; i++) output.Data[i] = MathF.Tanh(input.Data[i]);
+                return null!;
+            }
+            case "EqualsKernel":
+            {
+                _state.EqualsCalls++;
+                var left = (MockGpuBuffer)args[0]!;
+                var right = (MockGpuBuffer)args[1]!;
+                var output = (MockGpuBuffer)args[2]!;
+                int size = (int)args[3]!;
+                for (int i = 0; i < size; i++) output.Data[i] = left.Data[i] == right.Data[i] ? 1f : 0f;
+                return null!;
+            }
+            case "NotEqualScalar":
+            {
+                _state.NotEqualsCalls++;
+                var input = (MockGpuBuffer)args[0]!;
+                var output = (MockGpuBuffer)args[1]!;
+                float value = (float)args[2]!;
+                int size = (int)args[3]!;
+                for (int i = 0; i < size; i++) output.Data[i] = input.Data[i] != value ? 1f : 0f;
+                return null!;
+            }
+            case "NotEqualsKernel":
+            {
+                _state.NotEqualsCalls++;
+                var left = (MockGpuBuffer)args[0]!;
+                var right = (MockGpuBuffer)args[1]!;
+                var output = (MockGpuBuffer)args[2]!;
+                int size = (int)args[3]!;
+                for (int i = 0; i < size; i++) output.Data[i] = left.Data[i] != right.Data[i] ? 1f : 0f;
+                return null!;
+            }
+            case "Where":
+            {
+                _state.WhereCalls++;
+                var condition = (MockGpuBuffer)args[0]!;
+                var whenTrue = (MockGpuBuffer)args[1]!;
+                var whenFalse = (MockGpuBuffer)args[2]!;
+                var output = (MockGpuBuffer)args[3]!;
+                int size = (int)args[4]!;
+                for (int i = 0; i < size; i++)
+                    output.Data[i] = condition.Data[i] != 0f ? whenTrue.Data[i] : whenFalse.Data[i];
                 return null!;
             }
             case "Min" when args.Length == 2:

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/TableDrivenSigmoidTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/TableDrivenSigmoidTests.cs
@@ -16,21 +16,21 @@ public sealed class TableDrivenSigmoidTests
         float[] input =
         [
             float.NegativeInfinity,
+            -16.0f,
+            -15.999f,
+            -15.9375f,
             -8.0f,
-            -7.999f,
-            -7.9375f,
-            7.875f,
-            7.9375f,
-            7.999f,
             8.0f,
+            15.875f,
+            15.9375f,
+            15.999f,
+            16.0f,
             float.PositiveInfinity,
             float.NaN,
             -0.125f,
             0.125f,
             -3.25f,
             3.25f,
-            -1.0f,
-            1.0f,
         ];
         var output = new float[input.Length];
 
@@ -62,7 +62,7 @@ public sealed class TableDrivenSigmoidTests
         var input = new float[length];
         var output = new float[length];
         for (int i = 0; i < length; i++)
-            input[i] = 7.75f + 0.249f * i / (length - 1);
+            input[i] = 15.75f + 0.249f * i / (length - 1);
 
         fixed (float* inputPtr = input)
         fixed (float* outputPtr = output)
@@ -74,6 +74,31 @@ public sealed class TableDrivenSigmoidTests
             Assert.True(
                 MathF.Abs(expected - output[i]) <= 2.2e-6f,
                 $"index {i}, x={input[i]:R}: expected={expected:R}, actual={output[i]:R}");
+        }
+    }
+
+    [Theory]
+    [InlineData(-16f)]
+    [InlineData(-14.375474f)]
+    [InlineData(14.375474f)]
+    [InlineData(16f)]
+    public unsafe void SigmoidArray_CentralRangeDoesNotPrematurelySaturate(float value)
+    {
+        var input = new float[8];
+        var output = new float[8];
+        Array.Fill(input, value);
+
+        fixed (float* inputPtr = input)
+        fixed (float* outputPtr = output)
+            TableDrivenSigmoid.SigmoidArray(inputPtr, outputPtr, input.Length);
+
+        float expected = 1.0f / (1.0f + MathF.Exp(-value));
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.True(output[i] > 0f && output[i] < 1f,
+                $"table sigmoid({value}) = {output[i]} — central inputs must not saturate");
+            Assert.True(MathF.Abs(output[i] - expected) < 1e-6f,
+                $"table sigmoid({value}) = {output[i]}, expected {expected}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- capture numeric comparison predicates in training graphs so replay uses current tensor values
- keep `TensorWhere` conditions in the compiled graph and route gradients with the replay-time mask
- abandon incomplete explicit inference/training traces without executing callbacks during exception unwinding
- restore parent producers when nested in-place traces are abandoned, including compiler failures after output detachment
- classify deterministic inference-capture limitations with typed enum values
- prevent DirectGpu comparison and `TensorWhere` kernels from bypassing graph capture while preserving GPU execution during replay
- preserve non-saturated sigmoid tails on CPUs that select the fast table-driven path without changing its per-element operations

## Verification

- `CompiledGraphRegressionTests`: 20 passed
- full `Engines.Compilation` family: 1,003 passed, 12 skipped, 0 failed
- full `Engines.Simd` family: 316 passed, 1 skipped, 0 failed
- `AiDotNet.Tensors` Release build: net10.0, net8.0, and net471 succeeded with 0 warnings/errors
- downstream AiDotNet CI regressions: 3 passed, 0 failed against the packed assembly
- downstream affected classes: 36 passed, 1 skipped, 0 failed
- stochastic APNet regression: passed in 5 fresh processes
- verified the downstream test-output `AiDotNet.Tensors.dll` SHA-256 exactly matches the local NuGet package DLL