### PR TITLE
ci(release): use NuGet trusted publishing

### DIFF
--- a/.github/TRUSTED_PUBLISHING.md
+++ b/.github/TRUSTED_PUBLISHING.md
@@ -13,7 +13,7 @@ Create the policy at [nuget.org](https://www.nuget.org/account/trustedpublishing
 | Workflow file | `automated-release.yml` |
 | Environment | Leave blank |
 
-Enter only `automated-release.yml`, not `.github/workflows/automated-release.yml`. The values are case-sensitive. The policy must authorize every package produced by the release workflow.
+Enter only `automated-release.yml`, not `.github/workflows/automated-release.yml`. NuGet matches the owner, repository, and workflow file values case-insensitively. The policy must authorize every package produced by the release workflow.
 
 See the official [NuGet trusted-publishing documentation](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
 

--- a/.github/TRUSTED_PUBLISHING.md
+++ b/.github/TRUSTED_PUBLISHING.md
@@ -13,7 +13,7 @@ Create the policy at [nuget.org](https://www.nuget.org/account/trustedpublishing
 | Workflow file | `automated-release.yml` |
 | Environment | Leave blank |
 
-Enter only `automated-release.yml`, not `.github/workflows/automated-release.yml`. NuGet matches the owner, repository, and workflow file values case-insensitively. The policy must authorize every package produced by the release workflow.
+Enter only `automated-release.yml`, not `.github/workflows/automated-release.yml`. NuGet matches the owner, repository, workflow file, and environment values case-insensitively. The policy must authorize every package produced by the release workflow.
 
 See the official [NuGet trusted-publishing documentation](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
 
@@ -22,7 +22,7 @@ See the official [NuGet trusted-publishing documentation](https://learn.microsof
 The workflow separates package production from publication:
 
 1. `version-and-build` validates the immutable release tag with read-only repository access.
-2. `pack` builds, optionally obfuscates and signs, verifies, and uploads the packages without OIDC permission.
+2. `pack` builds, optionally obfuscates and signs, verifies, and uploads the packages without OIDC permission. The immutable package artifact is retained for 30 days so publication can be retried without rebuilding it.
 3. `publish-nuget` downloads the exact immutable artifact ID emitted by `pack`. It has no checkout, build, signing, obfuscation, or package-mutation step. This is the only job with `id-token: write`.
 4. `github-release` receives only `contents: write` and attaches the same immutable artifact to the existing release.
 

--- a/.github/TRUSTED_PUBLISHING.md
+++ b/.github/TRUSTED_PUBLISHING.md
@@ -1,0 +1,41 @@
+# NuGet Trusted Publishing
+
+AiDotNet.Tensors publishes through GitHub Actions OIDC. The repository does not store a long-lived NuGet API key.
+
+## NuGet.org policy
+
+Create the policy at [nuget.org](https://www.nuget.org/account/trustedpublishing) with these exact values:
+
+| Field | Value |
+|-------|-------|
+| Owner | `ooples` |
+| Repository | `AiDotNet.Tensors` |
+| Workflow file | `automated-release.yml` |
+| Environment | Leave blank |
+
+Enter only `automated-release.yml`, not `.github/workflows/automated-release.yml`. The values are case-sensitive. The policy must authorize every package produced by the release workflow.
+
+See the official [NuGet trusted-publishing documentation](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
+
+## Security boundary
+
+The workflow separates package production from publication:
+
+1. `version-and-build` validates the immutable release tag with read-only repository access.
+2. `pack` builds, optionally obfuscates and signs, verifies, and uploads the packages without OIDC permission.
+3. `publish-nuget` downloads the exact immutable artifact ID emitted by `pack`. It has no checkout, build, signing, obfuscation, or package-mutation step. This is the only job with `id-token: write`.
+4. `github-release` receives only `contents: write` and attaches the same immutable artifact to the existing release.
+
+`NuGet/login` exchanges the publish job's OIDC identity for a temporary API key. Publishing fails if the policy does not match, the artifact is missing or its digest is invalid, or NuGet does not issue the temporary key.
+
+## Release verification
+
+Syntax and permission-boundary checks run before merge. The OIDC exchange itself can only be proven by a real release event or the manual fallback for an existing tag. For the next deliberate release, verify:
+
+1. `pack` completes with no `id-token: write` permission.
+2. `publish-nuget` downloads the artifact ID reported by `pack`.
+3. `NuGet/login` issues a temporary key without a repository NuGet secret.
+4. Every expected package is published to nuget.org.
+5. `github-release` attaches the same package set to the existing GitHub release.
+
+If the workflow filename changes, update the NuGet policy before the renamed workflow is used for a release.

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -490,7 +490,7 @@ jobs:
           name: nuget-packages-${{ github.sha }}
           path: out/*.nupkg
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
           compression-level: 0
 
   publish-nuget:

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -23,7 +23,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -490,6 +489,9 @@ jobs:
 
   publish-nuget:
     name: Publish to NuGet
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs: [version-and-build, pack]
     timeout-minutes: 10
@@ -506,9 +508,22 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Authenticate to NuGet with trusted publishing
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ooples
+
       - name: Push to NuGet
         shell: bash
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
+          set -euo pipefail
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::NuGet trusted publishing did not issue a temporary API key."
+            exit 1
+          fi
           shopt -s nullglob
           pkgs=(out/*.nupkg)
 
@@ -519,14 +534,14 @@ jobs:
 
           # Every package (including the CUDA meta + its fragment packages) is now under
           # nuget.org's 250 MB limit, so push them all. --skip-duplicate keeps a re-run of
-          # an already-published version green; a genuine push failure (bad API key,
+          # an already-published version green; a genuine push failure (authentication,
           # validation, an unexpectedly over-limit package) still fails the job under
           # `bash -e`, which is what we want — a silent skip would hide a broken release.
           for pkg in "${pkgs[@]}"; do
             size=$(stat -c%s "$pkg")
             echo "Publishing $pkg to NuGet ($((size / 1024 / 1024)) MB)..."
             dotnet nuget push "$pkg" \
-              --api-key ${{ secrets.NUGET_API_KEY }} \
+              --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate
             echo "Successfully published $pkg"

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -16,13 +16,11 @@ on:
 concurrency:
   # NEVER cancel an in-flight publish — building/packing 7 packages and pushing to NuGet must complete
   # atomically. Releases are infrequent now (only on Release-PR merge), so serialization is cheap.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: automated-release-publish
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -40,19 +38,19 @@ jobs:
       should_release: ${{ steps.version.outputs.should_release }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props') }}
@@ -73,9 +71,11 @@ jobs:
           if [ -n "$RP_TAG" ]; then
             VER="${RP_TAG#v}"
             echo "Publishing release tag $RP_TAG (version $VER)"
-            echo "version=$VER" >> "$GITHUB_OUTPUT"
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            echo "changelog=Release $RP_TAG (see the GitHub release notes)" >> "$GITHUB_OUTPUT"
+            {
+              echo "version=$VER"
+              echo "should_release=true"
+              echo "changelog=Release $RP_TAG (see the GitHub release notes)"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -151,9 +151,11 @@ jobs:
               ;;
             none)
               echo "No conventional commits found, no version bump"
-              echo "should_release=false" >> $GITHUB_OUTPUT
-              echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-              echo "changelog=No release needed - no conventional commits found" >> $GITHUB_OUTPUT
+              {
+                echo "should_release=false"
+                echo "version=$CURRENT_VERSION"
+                echo "changelog=No release needed - no conventional commits found"
+              } >> "$GITHUB_OUTPUT"
               exit 0
               ;;
           esac
@@ -246,15 +248,14 @@ jobs:
 
           echo "$CHANGELOG"
 
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "should_release=true" >> $GITHUB_OUTPUT
-
           echo "$CHANGELOG" > /tmp/changelog.txt
           {
+            echo "version=$NEW_VERSION"
+            echo "should_release=true"
             echo 'changelog<<EOF'
             cat /tmp/changelog.txt
             echo EOF
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies
         if: steps.version.outputs.should_release == 'true'
@@ -272,20 +273,22 @@ jobs:
     needs: version-and-build
     timeout-minutes: 20
     if: needs.version-and-build.outputs.should_release == 'true'
+    outputs:
+      package-artifact-id: ${{ steps.upload-packages.outputs.artifact-id }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props') }}
@@ -481,30 +484,32 @@ jobs:
           }
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        id: upload-packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nuget-packages-${{ github.sha }}
           path: out/*.nupkg
           if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
   publish-nuget:
     name: Publish to NuGet
     permissions:
-      contents: read
-      id-token: write
+      id-token: write # Required for NuGet trusted publishing.
     runs-on: ubuntu-latest
     needs: [version-and-build, pack]
     timeout-minutes: 10
     if: needs.version-and-build.outputs.should_release == 'true'
     steps:
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7.0.0
         with:
-          name: nuget-packages-${{ github.sha }}
+          artifact-ids: ${{ needs.pack.outputs.package-artifact-id }}
           path: out/
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '8.0.x'
 
@@ -549,15 +554,17 @@ jobs:
 
   github-release:
     name: Create GitHub Release
+    permissions:
+      contents: write # Required to attach packages to the existing GitHub release.
     runs-on: ubuntu-latest
-    needs: [version-and-build, publish-nuget]
+    needs: [version-and-build, pack, publish-nuget]
     timeout-minutes: 10
     if: needs.version-and-build.outputs.should_release == 'true'
     steps:
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7.0.0
         with:
-          name: nuget-packages-${{ github.sha }}
+          artifact-ids: ${{ needs.pack.outputs.package-artifact-id }}
           path: out/
 
       - name: List artifacts
@@ -571,9 +578,11 @@ jobs:
             name=$(basename "$pkg" | sed -E 's/\.[0-9]+\.[0-9]+\.[0-9]+.*\.nupkg$//')
             PKGS="${PKGS}- **${name}**\n"
           done
-          echo "list<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$PKGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "list<<EOF"
+            echo -e "$PKGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Attach packages to the release
         # release-please already created the GitHub release (with its bundled changelog) — that is


### PR DESCRIPTION
## Summary
- exchange GitHub OIDC for a short-lived NuGet credential only in the NuGet publish job
- default the workflow to read-only contents; grant GitHub-release writes only to the attachment job
- hand off packages by the exact immutable artifact ID emitted by the pack job
- pin every third-party action to an audited commit SHA
- serialize every release under one concurrency key and fail closed on missing artifacts or credentials
- document the exact nuget.org trusted-publishing policy and first-release verification

## Local proof
- `actionlint v1.7.12` structural validation: passed
- every embedded Bash block checked independently with ShellCheck v0.11.0: 7/7 passed
- semantic security/handoff contract: 13/13 passed
- `git diff --check`: passed

The contract proves workflow-wide read-only access, job-scoped OIDC, no source/build/signing/obfuscation in the credential-bearing job, exact artifact-ID transfer into both consumers, no long-lived NuGet secret, fail-closed temporary-key handling, release-only contents writes, constant release serialization, and SHA-pinned actions.

## Required nuget.org policy before merge
- Owner: `ooples`
- Repository: `AiDotNet.Tensors`
- Workflow file: `automated-release.yml`
- Environment: leave blank

The publish path is release-only, so the real OIDC exchange must be proven by the next deliberate release after this workflow and its matching nuget.org policy are both active. The verification checklist is in `.github/TRUSTED_PUBLISHING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for NuGet trusted publishing, including required policy settings, security boundaries, and release verification steps.

* **Chores**
  * Improved release workflow security with pinned actions, read-only defaults, and temporary publishing credentials.
  * Improved artifact handling and release coordination, including shorter retention and publishing verification before attaching packages to releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->