### PR TITLE
test: assert gemm determinism arithmetically, not just by flag

### DIFF
--- a/tests/AiDotNet.Tensors.Tests/Engines/GemmDeterminismAcrossThreadsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GemmDeterminismAcrossThreadsTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Threading;
+using AiDotNet.Tensors.Engines.Simd;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines;
+
+/// <summary>
+/// The same GEMM, run twice in one process, must return bit-identical results.
+///
+/// <para><b>What is already covered, and what is not.</b> <c>DeterministicByDefaultTests</c> asserts the
+/// determinism CONTRACT at the level of flags and options — that <c>Deterministic</c> defaults to true, that
+/// <c>BlasProvider.IsDeterministicMode</c> follows it, that a plan is reused. Nothing there runs a GEMM and
+/// compares numbers, so a dispatcher that honours every flag and still returns different arithmetic on two
+/// calls would pass all of it.</para>
+///
+/// <para><b>Why that gap is worth closing.</b> <c>BlasManaged</c> chooses between kernels on properties that
+/// are not fixed by the caller: whether pre-packed operands were supplied, the thread budget, and which ISA
+/// the CPU reports (<c>Avx.IsSupported</c>, <c>Avx2.IsSupported &amp;&amp; Nr == 16</c>). Those kernels block
+/// the reduction differently, and floating-point addition is not associative, so two "numerically equivalent"
+/// routes legitimately disagree in the last bits. The GotoGemm path documents itself as "computed by one
+/// thread in fixed K order ⇒ thread-count-independent, Deterministic/DisableAutotune-contract safe", which
+/// says plainly that being thread-count-independent is a property some paths have and not others.</para>
+///
+/// <para><b>What prompted it.</b> A consumer's Clone() test compares a model against its clone through a
+/// 22-step denoising sampler, where a last-bit disagreement compounds. It fails intermittently on shared CI
+/// and passes on idle machines — the signature of a run-to-run difference rather than a clone defect. These
+/// tests check the mechanism directly, on whatever CPU they run on, instead of relying on a long sampler to
+/// amplify it into view somewhere else.</para>
+/// </summary>
+/// <summary>Serialised: the thread-budget test mutates the process-wide ThreadPool ceiling.</summary>
+[CollectionDefinition("GemmDeterminismSerial", DisableParallelization = true)]
+public sealed class GemmDeterminismSerialCollection { }
+
+[Collection("GemmDeterminismSerial")]
+public sealed class GemmDeterminismAcrossThreadsTests
+{
+    [Theory]
+    [InlineData(64, 64, 64)]
+    [InlineData(128, 96, 112)]
+    // Large enough to clear GotoGemmFp32.ParallelMinWork, so the parallel regime is actually exercised
+    // rather than every case quietly taking one small-shape path.
+    [InlineData(256, 256, 256)]
+    public void The_same_gemm_twice_in_one_process_is_bit_identical(int m, int k, int n)
+    {
+        var a = Fill(m * k, seed: 11);
+        var b = Fill(k * n, seed: 29);
+
+        var first = new float[m * n];
+        var second = new float[m * n];
+
+#pragma warning disable CS0618 // Sgemm forwards to BlasManaged.Gemm - exactly the dispatcher under test.
+        SimdGemm.Sgemm(a, b, first, m, k, n);
+        SimdGemm.Sgemm(a, b, second, m, k, n);
+#pragma warning restore CS0618
+
+        AssertBitIdentical(first, second, $"repeat call at {m}x{k}x{n}");
+    }
+
+    [Theory]
+    [InlineData(192, 160, 176)]
+    [InlineData(256, 256, 256)]
+    public void A_gemm_is_bit_identical_regardless_of_the_thread_budget(int m, int k, int n)
+    {
+        // THE HYPOTHESIS THIS EXISTS TO TEST. A parallel reduction whose accumulation order follows the thread
+        // count is not deterministic between a quiet machine and a loaded one - and a loaded shared CI runner
+        // is exactly where the downstream symptom appears. If this fails, the determinism contract is not
+        // being honoured by whichever kernel these shapes select, and the Clone() divergence downstream needs
+        // no clone-specific explanation at all.
+        var a = Fill(m * k, seed: 7);
+        var b = Fill(k * n, seed: 13);
+
+        var baseline = RunWithMaxThreads(a, b, m, k, n, threads: 1);
+
+        foreach (var threads in new[] { 2, 4, Environment.ProcessorCount })
+        {
+            if (threads <= 1)
+            {
+                continue;
+            }
+
+            var candidate = RunWithMaxThreads(a, b, m, k, n, threads);
+            AssertBitIdentical(baseline, candidate, $"{m}x{k}x{n} at {threads} threads vs 1");
+        }
+    }
+
+    /// <summary>
+    /// Runs the GEMM with the process's worker-thread ceiling lowered, then restores it.
+    /// </summary>
+    /// <remarks>
+    /// The thread budget is changed around the call rather than passed in, because the dispatcher decides its
+    /// own parallelism from the default (all-core) budget - which is the configuration production uses and the
+    /// one whose determinism is being claimed.
+    /// </remarks>
+    private static float[] RunWithMaxThreads(float[] a, float[] b, int m, int k, int n, int threads)
+    {
+        ThreadPool.GetMaxThreads(out var workers, out var io);
+        ThreadPool.GetMinThreads(out var minWorkers, out var minIo);
+        var result = new float[m * n];
+
+        try
+        {
+            ThreadPool.SetMinThreads(Math.Min(minWorkers, threads), minIo);
+            ThreadPool.SetMaxThreads(Math.Max(1, threads), io);
+
+#pragma warning disable CS0618
+            SimdGemm.Sgemm(a, b, result, m, k, n);
+#pragma warning restore CS0618
+        }
+        finally
+        {
+            ThreadPool.SetMinThreads(minWorkers, minIo);
+            ThreadPool.SetMaxThreads(workers, io);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Bit-identical, not "close".
+    /// </summary>
+    /// <remarks>
+    /// A tolerance here would defeat the purpose: the question is not whether two runs are both approximately
+    /// correct - they are - but whether they are the SAME, because a consumer comparing a model to its clone
+    /// through an iterative sampler compounds any difference at all.
+    /// </remarks>
+    private static void AssertBitIdentical(float[] expected, float[] actual, string context)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            if (Bits(expected[i]) != Bits(actual[i]))
+            {
+                Assert.Fail(
+                    $"{context}: element {i} differs, {expected[i]:R} vs {actual[i]:R} "
+                    + $"(delta {Math.Abs((double)expected[i] - actual[i]):E3}). The dispatcher selected a "
+                    + "different accumulation order for two runs of the same multiplication.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raw bits of a float, portably.
+    /// </summary>
+    /// <remarks>
+    /// Not BitConverter.SingleToInt32Bits: this project multi-targets net471, where that overload does not
+    /// exist. GetBytes allocates, which does not matter in a test and does matter less than the build failing
+    /// on one framework nobody ran locally.
+    /// </remarks>
+    private static int Bits(float value) => BitConverter.ToInt32(BitConverter.GetBytes(value), 0);
+
+    /// <summary>Deterministic, spread across several magnitudes so reordering a sum actually shows.</summary>
+    /// <remarks>
+    /// Values all of one magnitude can sum to the same float in any order and would hide a real reordering.
+    /// </remarks>
+    private static float[] Fill(int count, int seed)
+    {
+        var rng = new Random(seed);
+        var values = new float[count];
+        for (var i = 0; i < count; i++)
+        {
+            var scale = MathF.Pow(10f, rng.Next(-3, 4));
+            values[i] = (float)((rng.NextDouble() - 0.5) * 2.0) * scale;
+        }
+
+        return values;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/GemmDeterminismAcrossThreadsTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/GemmDeterminismAcrossThreadsTests.cs
@@ -109,8 +109,17 @@ public sealed class GemmDeterminismAcrossThreadsTests
         }
         finally
         {
-            ThreadPool.SetMinThreads(minWorkers, minIo);
+            // Restore the MAXIMUM first. SetMinThreads refuses - returns false and changes nothing -
+            // when the requested minimum exceeds the current maximum, and at this point the maximum
+            // is still the small value set above. Restoring the minimum first therefore failed
+            // silently and left the pool starved for every later test in the process, since these
+            // settings are process-wide and nothing here throws to signal it.
+            //
+            // Measured on a 32-processor host with threads = 1: min went 32 -> 1, the restoring
+            // SetMinThreads returned false, and min stayed at 1 while max came back to 32767.
+            // Reversing the two restores brings min back to 32.
             ThreadPool.SetMaxThreads(workers, io);
+            ThreadPool.SetMinThreads(minWorkers, minIo);
         }
 
         return result;


### PR DESCRIPTION
DeterministicByDefaultTests covers the determinism contract at the level of
FLAGS: that Deterministic defaults to true, that BlasProvider.IsDeterministicMode
follows it, that a plan instance is reused. None of it runs a GEMM and compares
numbers, so a dispatcher that honours every flag and still returned different
arithmetic on two calls would pass the whole file.

That gap matters because BlasManaged selects between kernels on properties the
caller does not fix: whether pre-packed operands were supplied
(`options.PackedA is null && options.PackedB is null` gates the GotoGemm path),
the thread budget, and what the CPU reports (Avx.IsSupported,
Avx2.IsSupported && Nr == 16). Those kernels block the reduction differently and
floating-point addition is not associative, so two numerically equivalent routes
can disagree in the last bits. GotoGemm documents itself as "computed by one
thread in fixed K order => thread-count-independent, Deterministic/
DisableAutotune-contract safe", which states plainly that thread-count
independence is a property some paths have and others do not.

Added:
  - the same GEMM twice in one process is BIT-identical (3 shapes)
  - a GEMM is bit-identical regardless of the thread budget (2 shapes, 1 vs
    2/4/all cores)

Bit-identical rather than "close" on purpose. Both results are approximately
correct; the question is whether they are the SAME, because a consumer
comparing a model against its clone through an iterative sampler compounds any
difference at all. Inputs span several magnitudes so that reordering a sum
actually changes the result - values of one magnitude can sum identically in any
order and would hide a real reordering.

WHY: a downstream Clone() test fails intermittently on shared CI and passes on
idle machines. That signature is a run-to-run difference rather than a clone
defect, and it matches the signature already recorded in
Issue318CloneDriftDiagnosticTests - trained weights vs SetParameters-cloned
weights producing different MatMul output from byte-identical logical contents,
where "the drift persists" after PR #315.

These pass on the author's CPU, as do the Issue #318 diagnostics and the
downstream test itself. They are added so the mechanism is checked directly, in
CI, on the hardware where the symptom actually appears - rather than inferred
from a 22-step sampler amplifying it somewhere else.

Serialised via a DisableParallelization collection, matching the convention of
the other tests here that touch process-wide state: the thread-budget case
mutates the ThreadPool ceiling, which an unrelated class running in parallel
would otherwise observe.

Bits() uses BitConverter.GetBytes rather than SingleToInt32Bits because this
project multi-targets net471, where that overload does not exist.


---

## What this PR is and is not

**It is** arithmetic-level coverage for a contract that was only ever asserted at flag level, plus a CI run of that coverage on hardware I do not have.

**It is not** a fix. I could not reproduce the downstream failure anywhere I control:

| Environment | Result |
|---|---|
| Windows, this CPU, 6 runs | passes |
| Linux container, same CPU, clean tree | passes |
| `Issue318` clone-drift diagnostics, this CPU | pass |
| These new determinism tests, this CPU | pass |

Everything points to the failure needing the CI runner's specific ISA. These tests will run there.

## How to read the CI result

- **If they fail on CI** — the determinism contract is not being honoured by whichever kernel those shapes select on that hardware, the mechanism is isolated, and the downstream `Clone()` divergence needs no clone-specific explanation.
- **If they pass on CI while the downstream shard still fails** — the cause is narrower than a general GEMM ordering difference, and #318's `SetParameters`-vs-trained-buffer provenance becomes the strongest remaining lead.

Either outcome is worth the run, which is why it is a test-only PR.

## Correction worth recording

I initially proposed that `options.PackedA is null && options.PackedB is null` explained the divergence — pre-packed weights taking a different kernel than unpacked ones. That is a real gate, but the consuming library never sets those options (zero references to `PackedA`, `PackedB`, `PackingMode`, `WeightPack` or `PrePack` in its entire source), so the branch is unreachable from that path and cannot be the explanation. Recorded here so nobody re-derives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that matrix multiplication produces identical results across repeated executions.
  - Added validation that results remain consistent under different thread configurations, including larger matrix sizes.
  - Improved safeguards around deterministic numerical behavior across supported execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->