### PR TITLE
fix(gpu): preserve lazy activation ownership

### DIFF
--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -4356,6 +4356,44 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
         var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return;
+
+        // A zero-allocation GPU result starts life with its activation-cache entry and deferred
+        // materializer keyed by DataVector. Its first host access creates a backing array, but the
+        // cache entry deliberately survives so later GPU work can reuse the resident buffer. If an
+        // in-place/resident operation subsequently binds that same tensor, host reads are now keyed
+        // by the backing array. Leaving the cache owner on DataVector while registering the new
+        // materializer on the array lets deterministic tape eviction free the vector-owned buffer
+        // without seeing the array's pending download (OpenCL CL_INVALID_MEM_OBJECT / -38).
+        //
+        // Transfer the existing cache entry to the tensor's authoritative host key. This is a pure
+        // dictionary re-key: it preserves the buffer, timestamp, byte accounting, and GPU residency,
+        // and adds no device synchronization or host transfer to the hot path.
+        var displacedEntry = RekeyActivationCacheForResidentBinding(
+            t, arr, buf, backend, out var previousVectorKey);
+
+        // Bind is an authoritative overwrite of this tensor's resident value. Supersede either
+        // historical key rather than relying on Register's intentional first-write-wins behavior;
+        // otherwise an older callback can remain attached to a buffer that no longer owns the value.
+        if (previousVectorKey is not null)
+            Helpers.DeferredArrayMaterializer.Remove(previousVectorKey);
+        Helpers.DeferredArrayMaterializer.Remove(arr);
+        if (displacedEntry is not null)
+        {
+            // The replaced array entry represented the tensor's previous resident value.
+            // Release it only after its obsolete materializer has been detached. CUDA can
+            // preserve stream ordering; other backends synchronize only on this exceptional
+            // duplicate-owner repair path, never on the normal bind path.
+            if (displacedEntry.Backend is Engines.DirectGpu.CUDA.CudaBackend cudaBackend)
+            {
+                cudaBackend.FreeBufferDeferred(displacedEntry.Buffer);
+            }
+            else
+            {
+                try { displacedEntry.Backend.Synchronize(); }
+                catch { /* best-effort: disposal must still release the stale cache owner */ }
+                displacedEntry.Dispose();
+            }
+        }
         // #3 FP16-act: this array now holds FP32 — drop any stale FP16 tag (a pooled array reused FP16→FP32).
         if (Fp16ActEnabled) _fp16ResidentArrays.TryRemove(arr, out _);
         if (s_currentForwardOp is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[arr] = s_currentForwardOp;
@@ -4366,6 +4404,84 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var conv = DirectGpuEngine.FromFloatArray<T>(f);
             System.Array.Copy(conv, (T[])a, System.Math.Min(conv.Length, ((T[])a).Length));
         });
+    }
+
+    private ActivationCacheEntry? RekeyActivationCacheForResidentBinding<T>(
+        Tensor<T> tensor,
+        object arrayKey,
+        IGpuBuffer buffer,
+        IDirectGpuBackend backend,
+        out object? previousVectorKey)
+    {
+        previousVectorKey = null;
+
+        // The normal array-backed path was cached correctly at creation time. Keep that common
+        // route to one lock-free dictionary read, without even touching DataVector or its guard.
+        if (_activationCache.TryGetValue(arrayKey, out var arrayEntry)
+            && ReferenceEquals(arrayEntry.Buffer, buffer)
+            && ReferenceEquals(arrayEntry.Backend, backend))
+            return null;
+
+        // Only a tensor that acquired its host array after a zero-allocation GPU result can need
+        // migration. Resolve the old identity after the common path has returned.
+        object vectorKey = tensor.DataVector;
+
+        lock (_activationCacheLock)
+        {
+            if (_activationCache.TryGetValue(arrayKey, out arrayEntry)
+                && ReferenceEquals(arrayEntry.Buffer, buffer)
+                && ReferenceEquals(arrayEntry.Backend, backend))
+                return null;
+
+            if (!_activationCache.TryGetValue(vectorKey, out var vectorEntry)
+                || !ReferenceEquals(vectorEntry.Buffer, buffer)
+                || !ReferenceEquals(vectorEntry.Backend, backend))
+                return null;
+
+            // A second entry can have been cached under the newly materialized array between the
+            // vector-keyed result's host read and this bind. The bind makes `buffer` authoritative,
+            // so atomically replace that stale array owner while moving the original entry. This
+            // restores one cache owner for one tensor and preserves the original entry's timestamp.
+            ActivationCacheEntry? displaced = null;
+            if (_activationCache.TryGetValue(arrayKey, out arrayEntry))
+            {
+                if (!_activationCache.TryRemove(arrayKey, out displaced))
+                    return null;
+            }
+
+            if (!_activationCache.TryRemove(vectorKey, out var owner))
+            {
+                if (displaced is not null)
+                    _activationCache.TryAdd(arrayKey, displaced);
+                return null;
+            }
+
+            if (!_activationCache.TryAdd(arrayKey, owner))
+            {
+                // Concurrent mutation is not expected while the engine lock is held, but restore
+                // both original owners if it occurs so accounting and lifetime remain conservative.
+                _activationCache.TryAdd(vectorKey, owner);
+                if (displaced is not null)
+                    _activationCache.TryAdd(arrayKey, displaced);
+                return null;
+            }
+
+            previousVectorKey = vectorKey;
+
+            if (displaced is not null)
+            {
+                System.Threading.Interlocked.Add(
+                    ref _currentActivationCacheBytes, -displaced.Buffer.SizeInBytes);
+                System.Threading.Interlocked.Add(
+                    ref _currentActivationManagedBytes, -displaced.ManagedBytes);
+            }
+
+            // If corrupt duplicate ownership pointed both entries at the same buffer, the surviving
+            // vector entry (now array-keyed) remains its owner; never dispose that shared handle.
+            return displaced is not null && !ReferenceEquals(displaced.Buffer, buffer)
+                ? displaced
+                : null;
+        }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/VectorBase.cs
@@ -417,6 +417,19 @@ public abstract class VectorBase<T>
     /// </summary>
     internal bool TryGetBackingArraySegmentForReadOnlyAccess(out T[]? array, out int offset)
     {
+        // Memory<T>.Empty is backed by the process-wide Array.Empty<T>() singleton. A
+        // zero-allocation GPU vector therefore has an implementation array, but it does
+        // not yet have a host backing store. Exposing that singleton as cache identity
+        // aliases every lazy tensor of the same element type to one key and sends engine
+        // code down the array-backed path before materialization. Preserve the semantic
+        // contract: no host allocation means no backing-array identity.
+        if (IsLazyAllocated)
+        {
+            array = null;
+            offset = 0;
+            return false;
+        }
+
         if (_cachedArray is not null)
         {
             array = _cachedArray;

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
@@ -176,6 +176,173 @@ public class EvictActivationsCreatedAfterLifetimeTests
     }
 
     [Fact]
+    public void BindResidentBuffer_RekeysMaterializedLazyTensorBeforeTapeEviction()
+    {
+        // A deferred GPU tensor is initially cached by DataVector. After its first host
+        // materialization it has an array, but the resident cache entry intentionally remains.
+        // A later in-place gradient accumulation binds the array-backed tensor again. The cache
+        // owner and materializer must move to the same array key before per-tape eviction, or the
+        // vector-keyed entry is freed while the array callback still points at its buffer.
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var activationCacheField = engineType.GetField(
+            "_activationCache", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DirectGpuTensorEngine activation cache field was not found.");
+        var cacheActivation = engineType.GetMethod(
+            "CacheActivation", BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[]
+            {
+                typeof(object), typeof(IGpuBuffer), typeof(int[]), typeof(IDirectGpuBackend),
+                typeof(bool), typeof(int)
+            },
+            null) ?? throw new InvalidOperationException("DirectGpuTensorEngine CacheActivation method was not found.");
+        object activationCache = activationCacheField.GetValue(engine)
+            ?? throw new InvalidOperationException("DirectGpuTensorEngine activation cache was null.");
+
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.Create(state);
+        var buffer = new MockGpuBuffer(new[] { 3f, 5f, 7f, 11f });
+        var tensor = AiDotNet.Tensors.LinearAlgebra.Tensor<float>.CreateGpuResident(
+            new[] { 1, 4 }, TensorDevice.OpenCL);
+        object vectorKey = tensor.DataVector;
+        Assert.Null(tensor.GetBackingArrayForCacheLookupUnsafe());
+
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(vectorKey, key =>
+        {
+            var values = backend.DownloadBuffer(buffer);
+            ((AiDotNet.Tensors.LinearAlgebra.VectorBase<float>)key).MaterializeBacking(values);
+        });
+        cacheActivation.Invoke(engine, new object[]
+        {
+            vectorKey, buffer, new[] { 1, 4 }, backend, false, 0
+        });
+
+        Assert.Equal(new[] { 3f, 5f, 7f, 11f }, tensor.ToArray());
+        object arrayKey = tensor.GetBackingArrayForCacheLookupUnsafe()
+            ?? throw new InvalidOperationException("Expected host materialization to create a backing array.");
+        var dictionary = (System.Collections.IDictionary)activationCache;
+        object entry = dictionary[vectorKey]
+            ?? throw new InvalidOperationException("Expected the lazy tensor cache entry to remain vector-keyed.");
+        Assert.False(dictionary.Contains(arrayKey));
+        Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(vectorKey));
+        Assert.Equal(1, state.DownloadBufferCalls);
+        Assert.Equal(buffer.SizeInBytes, engine.CurrentActivationCacheBytes);
+
+        try
+        {
+            engine.BindResidentBuffer(tensor, buffer, backend);
+
+            Assert.False(dictionary.Contains(vectorKey));
+            Assert.True(dictionary.Contains(arrayKey));
+            Assert.Same(entry, dictionary[arrayKey]);
+            Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(vectorKey));
+            Assert.True(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(arrayKey));
+            Assert.Equal(1, state.DownloadBufferCalls);
+            Assert.Equal(buffer.SizeInBytes, engine.CurrentActivationCacheBytes);
+
+            engine.EvictActivationsCreatedAfter(0L);
+
+            Assert.Equal(2, state.DownloadBufferCalls);
+            Assert.Equal(new[] { 3f, 5f, 7f, 11f }, tensor.ToArray());
+            Assert.False(AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.IsPending(arrayKey));
+            Assert.Equal(0L, engine.CurrentActivationCacheBytes);
+            Assert.Equal(1, buffer.DisposeCount);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(vectorKey);
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(arrayKey);
+        }
+    }
+
+    [Fact]
+    public void BindResidentBuffer_ReplacesCompetingArrayOwnerWithoutDoubleAccounting()
+    {
+        // Adversarial form of the lazy-to-materialized transition: another path has
+        // already cached a stale value under the new array key. The resident bind must
+        // leave exactly one authoritative owner, detach the stale materializer, and
+        // release only the displaced buffer.
+        using var engine = new DirectGpuTensorEngine();
+        var engineType = typeof(DirectGpuTensorEngine);
+        var activationCacheField = engineType.GetField(
+            "_activationCache", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DirectGpuTensorEngine activation cache field was not found.");
+        var cacheActivation = engineType.GetMethod(
+            "CacheActivation", BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[]
+            {
+                typeof(object), typeof(IGpuBuffer), typeof(int[]), typeof(IDirectGpuBackend),
+                typeof(bool), typeof(int)
+            },
+            null) ?? throw new InvalidOperationException("DirectGpuTensorEngine CacheActivation method was not found.");
+        object activationCache = activationCacheField.GetValue(engine)
+            ?? throw new InvalidOperationException("DirectGpuTensorEngine activation cache was null.");
+        var dictionary = (System.Collections.IDictionary)activationCache;
+
+        var state = new MockBackendState();
+        var backend = MockDirectGpuBackend.Create(state);
+        var residentBuffer = new MockGpuBuffer(new[] { 2f, 3f, 5f, 7f });
+        var displacedBuffer = new MockGpuBuffer(new[] { 11f, 13f, 17f, 19f });
+        var tensor = AiDotNet.Tensors.LinearAlgebra.Tensor<float>.CreateGpuResident(
+            new[] { 1, 4 }, TensorDevice.OpenCL);
+        object vectorKey = tensor.DataVector;
+
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(vectorKey, key =>
+        {
+            var values = backend.DownloadBuffer(residentBuffer);
+            ((AiDotNet.Tensors.LinearAlgebra.VectorBase<float>)key).MaterializeBacking(values);
+        });
+        cacheActivation.Invoke(engine, new object[]
+        {
+            vectorKey, residentBuffer, new[] { 1, 4 }, backend, false, 0
+        });
+        Assert.Equal(new[] { 2f, 3f, 5f, 7f }, tensor.ToArray());
+        object arrayKey = tensor.GetBackingArrayForCacheLookupUnsafe()
+            ?? throw new InvalidOperationException("Expected host materialization to create a backing array.");
+        object residentEntry = dictionary[vectorKey]
+            ?? throw new InvalidOperationException("Expected the resident vector-keyed cache entry.");
+
+        cacheActivation.Invoke(engine, new object[]
+        {
+            arrayKey, displacedBuffer, new[] { 1, 4 }, backend, false, 0
+        });
+        bool staleMaterializerRan = false;
+        AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(
+            arrayKey, _ => staleMaterializerRan = true);
+
+        try
+        {
+            Assert.Equal(residentBuffer.SizeInBytes + displacedBuffer.SizeInBytes,
+                engine.CurrentActivationCacheBytes);
+
+            engine.BindResidentBuffer(tensor, residentBuffer, backend);
+
+            Assert.False(staleMaterializerRan);
+            Assert.False(dictionary.Contains(vectorKey));
+            Assert.Single(dictionary.Keys.Cast<object>());
+            Assert.Same(residentEntry, dictionary[arrayKey]);
+            Assert.Equal(residentBuffer.SizeInBytes, engine.CurrentActivationCacheBytes);
+            Assert.Equal(1, displacedBuffer.DisposeCount);
+            Assert.Equal(0, residentBuffer.DisposeCount);
+            Assert.Equal(1, state.DownloadBufferCalls);
+
+            engine.EvictActivationsCreatedAfter(0L);
+
+            Assert.Equal(2, state.DownloadBufferCalls);
+            Assert.Equal(new[] { 2f, 3f, 5f, 7f }, tensor.ToArray());
+            Assert.Equal(1, residentBuffer.DisposeCount);
+            Assert.Equal(0L, engine.CurrentActivationCacheBytes);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(vectorKey);
+            AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Remove(arrayKey);
+        }
+    }
+
+    [Fact]
     public void EvictActivationsCreatedAfter_DiscardsPendingDownloadsWhenRequested()
     {
         using var engine = new DirectGpuTensorEngine();


### PR DESCRIPTION
## Root cause

A zero-allocation GPU tensor begins with both its deferred materializer and activation-cache owner keyed by `DataVector`. After host materialization creates a backing array, a later resident in-place bind registered the new materializer under that array but left the cache owner under `DataVector`. Tape eviction could therefore free the vector-owned GPU buffer without observing the array-keyed pending download. The later host read hit OpenCL `CL_INVALID_MEM_OBJECT` (`-38`).

The audit also found that `Memory<T>.Empty` was being exposed as a real backing-array identity for lazy vectors. Because `Array.Empty<T>()` is shared, unrelated zero-allocation tensors could appear to have the same cache key.

## Fix

- Make `VectorBase` report no backing array while storage is genuinely lazy.
- On the rare lazy-to-materialized resident transition, move the existing activation-cache entry to the authoritative array key without reallocating, downloading, changing its timestamp, or changing byte accounting.
- Detach obsolete first-write-wins materializers before registering the authoritative resident callback.
- Repair a competing stale array owner atomically, preserving stream-ordered CUDA release and synchronizing non-CUDA backends only on that exceptional repair path.
- Keep the normal array-backed bind path to one lock-free cache lookup; it does not touch `DataVector`, lock, synchronize, or transfer data.

## Before / after proof

- Before: AiDotNet's exact `Autoformer_float_trains_with_the_gpu_engine_adopted` reproducer failed on the local AMD/OpenCL device with buffer error `-38`, on both the committed baseline and the #2088 branch.
- Before the `VectorBase` fix, the strengthened lazy-transition regression failed because a zero-allocation tensor returned `Array.Empty<float>()` as a backing array.
- After: the single-model and three-instance concurrent Autoformer GPU reproducers both pass on the same AMD/OpenCL device (2/2, 7m18s).
- The focused tests prove the same cache entry and buffer survive the handoff, zero downloads occur during handoff, byte accounting remains exact, stale competing owners are disposed once, and tape eviction downloads once before freeing.

## Verification

- `dotnet build AiDotNet.Tensors.slnx --configuration Release --no-restore` — succeeds for `net471`, `net8.0`, and `net10.0` with 0 errors.
- Affected activation lifetime, deferred storage, gradient, residency, optimizer, and cleanup sweep — 147 passed, 8 CUDA-only skipped, 0 failed.
- Focused adversarial eviction suite — 7 passed, 0 failed.
- AiDotNet Autoformer AMD/OpenCL canaries — 2 passed, 0 skipped, 0 failed.
- Added null-forgiving operators: 0.
- Added string-backed state/type dispatch: 0.
- `git diff --check` — clean.

This is a prerequisite for the final package-based verification of ooples/AiDotNet#2088.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU tensor memory tracking when deferred tensors are materialized.
  * Prevented incorrect cache sharing between lazily allocated tensors.
  * Improved cleanup of stale or duplicate GPU buffers while avoiding double disposal.

* **Tests**
  * Added coverage for materialized tensors and competing cache entries during GPU activation eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->