### PR TITLE
feat: make istft differentiable and add stftphase

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -8929,10 +8929,10 @@ internal static class BackwardFunctions<T>
     /// imaginary parts of <c>FFT(gz_f)</c>.
     /// </description></item>
     /// <item><description>
-    /// <b>Hermitian extension and the polar map.</b> The forward copied bins
-    /// <c>1 .. numFreqs-2</c> to <c>nFft-k</c> with the imaginary part negated, so each of those
-    /// bins receives two contributions while DC and Nyquist receive one. Then <c>C[k] = m
-    /// exp(I*p)</c> gives <c>dL/dm = gCRe cos(p) + gCIm sin(p)</c> and
+    /// <b>Hermitian extension and the polar map.</b> The forward copied every bin with
+    /// <c>2k &lt; nFft</c> to <c>nFft-k</c> with the imaginary part negated, so each of those bins
+    /// receives two contributions while DC - and Nyquist, when <c>nFft</c> is even - receives one.
+    /// Then <c>C[k] = m exp(I*p)</c> gives <c>dL/dm = gCRe cos(p) + gCIm sin(p)</c> and
     /// <c>dL/dp = m * (gCIm cos(p) - gCRe sin(p))</c>.
     /// </description></item>
     /// </list>
@@ -9033,7 +9033,10 @@ internal static class BackwardFunctions<T>
                     double gradReal = numOps.ToDouble(adjointReal[k]);
                     double gradImag = numOps.ToDouble(adjointImag[k]);
 
-                    if (k >= 1 && k < numFreqs - 1)
+                    // Same bound as the forward mirror, for the same reason: 2k < nFft rather than
+                    // k < numFreqs - 1, which differ exactly when nFft is odd. The fold has to track
+                    // whatever the forward copies or this stops being its transpose.
+                    if (k >= 1 && (k * 2) < nFft)
                     {
                         gradReal += numOps.ToDouble(adjointReal[nFft - k]);
                         gradImag -= numOps.ToDouble(adjointImag[nFft - k]);

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -8856,6 +8856,164 @@ internal static class BackwardFunctions<T>
     private static string Describe(object? o) => o is null ? "null" : o.GetType().Name;
 
     /// <summary>
+    /// Adjoint of <c>ISTFT</c>: maps a gradient shaped like the reconstructed waveform back onto
+    /// the magnitude and phase spectrograms it was synthesised from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The forward is four stages, and this transposes each in reverse. Writing <c>w</c> for the
+    /// window, <c>s(f)</c> for the write offset of frame <c>f</c>, and
+    /// <c>W[j] = sum_f w[j - s(f)]^2</c> for the window-sum envelope:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>
+    /// <b>Normalisation.</b> <c>y[j] = a[j] / W[j]</c> where the envelope exceeds 1e-8. <c>W</c>
+    /// depends only on the geometry, never on magnitude or phase, so its transpose is the same
+    /// division applied to the incoming gradient, under the same 1e-8 guard. Dropping that guard
+    /// would make the adjoint disagree with the forward exactly where the forward declined to
+    /// divide.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Windowed overlap-add.</b> <c>a[s(f) + i] += w[i] * z_f[i] / nFft</c>, summed over frames
+    /// and skipping out-of-range writes. The transpose of a scatter-add is a gather:
+    /// <c>gz_f[i] = w[i] * gy[s(f) + i] / nFft</c>, and zero wherever the forward wrote nothing.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Inverse DFT, real part.</b> <c>z_f[i] = Re( sum_k C[k] exp(+2*pi*I*k*i/nFft) )</c>. The
+    /// transpose of an unnormalised inverse transform is an unnormalised FORWARD one, so
+    /// <c>gCRe[k] = sum_i gz_f[i] cos(2*pi*k*i/nFft)</c> and
+    /// <c>gCIm[k] = -sum_i gz_f[i] sin(2*pi*k*i/nFft)</c>, which are exactly the real and
+    /// imaginary parts of <c>FFT(gz_f)</c>.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Hermitian extension and the polar map.</b> The forward copied bins
+    /// <c>1 .. numFreqs-2</c> to <c>nFft-k</c> with the imaginary part negated, so each of those
+    /// bins receives two contributions while DC and Nyquist receive one. Then <c>C[k] = m
+    /// exp(I*p)</c> gives <c>dL/dm = gCRe cos(p) + gCIm sin(p)</c> and
+    /// <c>dL/dp = m * (gCIm cos(p) - gCRe sin(p))</c>.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// This is the transpose of SYNTHESIS, which is a different operator from the analysis adjoint
+    /// in <see cref="MagnitudeStftAdjoint"/>: that one maps a spectrogram gradient onto a waveform,
+    /// this one maps a waveform gradient onto a spectrogram. The registry note on ISTFT records why
+    /// the two must not be substituted for one another.
+    /// </para>
+    /// <para>
+    /// The window is treated as a constant, as it is everywhere else in this file. It is a fixed
+    /// analysis choice rather than a learned parameter.
+    /// </para>
+    /// </remarks>
+    internal static void IstftBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var magnitude = inputs[0];
+        var phase = inputs[1];
+
+        RequireSavedState(nameof(IstftBackward), savedState, 5);
+        int nFft = SavedInt(nameof(IstftBackward), savedState, 0, "nFft");
+        int hopLength = SavedInt(nameof(IstftBackward), savedState, 1, "hopLength");
+        var window = SavedTensor(nameof(IstftBackward), savedState, 2, "window");
+        bool center = SavedBool(nameof(IstftBackward), savedState, 3, "center");
+        int outputLength = SavedInt(nameof(IstftBackward), savedState, 4, "outputLength");
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int numFreqs = magnitude._shape[^2];
+        int numFrames = magnitude._shape[^1];
+        int batchSize = magnitude.Length / (numFreqs * numFrames);
+
+        var gradData = gradOutput.GetDataArray();
+        var magData = magnitude.GetDataArray();
+        var phaseData = phase.GetDataArray();
+        var windowData = window.GetDataArray();
+
+        var gradMagnitude = new Tensor<T>(magnitude._shape);
+        var gradPhase = new Tensor<T>(magnitude._shape);
+        var gradMagnitudeData = gradMagnitude.GetDataArray();
+        var gradPhaseData = gradPhase.GetDataArray();
+
+        var windowSum = new double[outputLength];
+        var normalisedGrad = new double[outputLength];
+
+        // Hoisted for the reason MagnitudeStftAdjoint hoists its pair: one allocation per
+        // (batch, frame) would churn thousands of short-lived vectors on long audio. Every element
+        // is rewritten below before it is read, so nothing carries over between frames.
+        var frameGradReal = new Vector<T>(nFft);
+        var frameGradImag = new Vector<T>(nFft);
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            int specOffset = b * numFreqs * numFrames;
+            int outOffset = b * outputLength;
+
+            Array.Clear(windowSum, 0, windowSum.Length);
+            for (int frame = 0; frame < numFrames; frame++)
+            {
+                int writeStart = center ? (frame * hopLength) - (nFft / 2) : frame * hopLength;
+                for (int i = 0; i < nFft; i++)
+                {
+                    int outIdx = writeStart + i;
+                    if (outIdx >= 0 && outIdx < outputLength)
+                    {
+                        double w = numOps.ToDouble(windowData[i]);
+                        windowSum[outIdx] += w * w;
+                    }
+                }
+            }
+
+            for (int i = 0; i < outputLength; i++)
+            {
+                double g = numOps.ToDouble(gradData[outOffset + i]);
+                normalisedGrad[i] = windowSum[i] > 1e-8 ? g / windowSum[i] : g;
+            }
+
+            for (int frame = 0; frame < numFrames; frame++)
+            {
+                int writeStart = center ? (frame * hopLength) - (nFft / 2) : frame * hopLength;
+
+                for (int i = 0; i < nFft; i++)
+                {
+                    int outIdx = writeStart + i;
+                    double contribution = outIdx >= 0 && outIdx < outputLength
+                        ? normalisedGrad[outIdx] * numOps.ToDouble(windowData[i]) / nFft
+                        : 0.0;
+                    frameGradReal[i] = numOps.FromDouble(contribution);
+                    frameGradImag[i] = numOps.Zero;
+                }
+
+                var (adjointReal, adjointImag) =
+                    CpuEngine.UnnormalizedTransformForAdjoint<T>(frameGradReal, frameGradImag, inverse: false);
+
+                for (int k = 0; k < numFreqs; k++)
+                {
+                    double gradReal = numOps.ToDouble(adjointReal[k]);
+                    double gradImag = numOps.ToDouble(adjointImag[k]);
+
+                    if (k >= 1 && k < numFreqs - 1)
+                    {
+                        gradReal += numOps.ToDouble(adjointReal[nFft - k]);
+                        gradImag -= numOps.ToDouble(adjointImag[nFft - k]);
+                    }
+
+                    int idx = specOffset + (k * numFrames) + frame;
+                    double magnitudeValue = numOps.ToDouble(magData[idx]);
+                    double phaseValue = numOps.ToDouble(phaseData[idx]);
+                    double cosPhase = Math.Cos(phaseValue);
+                    double sinPhase = Math.Sin(phaseValue);
+
+                    gradMagnitudeData[idx] = numOps.FromDouble((gradReal * cosPhase) + (gradImag * sinPhase));
+                    gradPhaseData[idx] = numOps.FromDouble(
+                        magnitudeValue * ((gradImag * cosPhase) - (gradReal * sinPhase)));
+                }
+            }
+        }
+
+        DifferentiableOps.AccumulateGrad(grads, magnitude, gradMagnitude, engine);
+        DifferentiableOps.AccumulateGrad(grads, phase, gradPhase, engine);
+    }
+
+    /// <summary>
     /// Adjoint of <c>mag = |STFT(x)|</c> with <c>center: true</c>: maps a gradient shaped like
     /// the one-sided magnitude spectrogram back onto the waveform.
     /// </summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -15,6 +15,22 @@ namespace AiDotNet.Tensors.Engines.Autodiff;
 /// [B,S]) that previously threw "Destination is too short" and silently disabled
 /// the fused compiled-training path for every transformer.
 /// </summary>
+/// <summary>
+/// Which one-sided STFT output an analysis adjoint is transposing.
+/// </summary>
+/// <remarks>
+/// Magnitude and phase share every step of the adjoint except the per-bin coefficients that seed
+/// the inverse transform, so they share one implementation and differ only by this.
+/// </remarks>
+internal enum StftAdjointTarget
+{
+    /// <summary>The magnitude <c>|C[k]|</c>.</summary>
+    Magnitude,
+
+    /// <summary>The wrapped phase <c>atan2(Im C[k], Re C[k])</c>.</summary>
+    Phase
+}
+
 internal sealed class LayerNormStateRef<T>
 {
     public Tensor<T>? Mean;
@@ -8668,6 +8684,33 @@ internal static class BackwardFunctions<T>
     }
 
     /// <summary>
+    /// Adjoint of <c>StftPhase</c>: maps a gradient shaped like the one-sided phase spectrogram
+    /// back onto the waveform.
+    /// </summary>
+    /// <remarks>
+    /// The mirror image of <see cref="SpectrogramBackward"/>. That one is handed the phase it did
+    /// not return and needs it to rebuild the complex bins; this one is handed the magnitude for
+    /// the same reason, and reads the phase straight off its own output.
+    /// </remarks>
+    internal static void StftPhaseBackward(
+        Tensor<T> gradOutput, Tensor<T>[] inputs, Tensor<T> output,
+        object[] savedState, IEngine engine, Dictionary<Tensor<T>, Tensor<T>> grads)
+    {
+        var waveform = inputs[0];
+        RequireSavedState(nameof(StftPhaseBackward), savedState, 5);
+        int nFft = SavedInt(nameof(StftPhaseBackward), savedState, 0, "nFft");
+        int hopLength = SavedInt(nameof(StftPhaseBackward), savedState, 1, "hopLength");
+        var window = SavedTensor(nameof(StftPhaseBackward), savedState, 2, "window");
+        var magnitude = SavedTensor(nameof(StftPhaseBackward), savedState, 3, "magnitude");
+        int origLength = SavedInt(nameof(StftPhaseBackward), savedState, 4, "origLength");
+
+        var result = StftAnalysisAdjoint(
+            gradOutput, magnitude, output, StftAdjointTarget.Phase,
+            nFft, hopLength, window, origLength, waveform._shape);
+        DifferentiableOps.AccumulateGrad(grads, waveform, result, engine);
+    }
+
+    /// <summary>
     /// Adjoint of <c>RFFT</c>: maps a gradient shaped like the interleaved one-sided spectrum back
     /// onto the real input signal.
     /// </summary>
@@ -8721,7 +8764,7 @@ internal static class BackwardFunctions<T>
                 cImag[k] = numOps.Zero;
             }
 
-            var (re, _) = CpuEngine.UnnormalizedTransformForAdjoint<T>(cReal, cImag, inverse: true);
+            var (re, _) = CpuEngine.UnnormalizedTransform<T>(cReal, cImag, inverse: true);
 
             int outOffset = b * n;
             for (int j = 0; j < n; j++) resultData[outOffset + j] = re[j];
@@ -8780,7 +8823,7 @@ internal static class BackwardFunctions<T>
                 yImag[j] = numOps.Zero;
             }
 
-            var (re, im) = CpuEngine.UnnormalizedTransformForAdjoint<T>(yReal, yImag, inverse: false);
+            var (re, im) = CpuEngine.UnnormalizedTransform<T>(yReal, yImag, inverse: false);
 
             int outOffset = b * numFreqs * 2;
             for (int k = 0; k < numFreqs; k++)
@@ -8983,7 +9026,7 @@ internal static class BackwardFunctions<T>
                 }
 
                 var (adjointReal, adjointImag) =
-                    CpuEngine.UnnormalizedTransformForAdjoint<T>(frameGradReal, frameGradImag, inverse: false);
+                    CpuEngine.UnnormalizedTransform<T>(frameGradReal, frameGradImag, inverse: false);
 
                 for (int k = 0; k < numFreqs; k++)
                 {
@@ -9025,8 +9068,52 @@ internal static class BackwardFunctions<T>
     /// </remarks>
     private static Tensor<T> MagnitudeStftAdjoint(
         Tensor<T> gradMagnitude, Tensor<T> phase, int nFft, int hopLength,
-        Tensor<T> window, int origLength, int[] waveformShape)
+        Tensor<T> window, int origLength, int[] waveformShape) =>
+        StftAnalysisAdjoint(
+            gradMagnitude, magnitude: null, phase, StftAdjointTarget.Magnitude,
+            nFft, hopLength, window, origLength, waveformShape);
+
+    /// <summary>
+    /// Below which magnitude the phase gradient is taken to be zero.
+    /// </summary>
+    /// <remarks>
+    /// The phase derivative carries a <c>1/|C|</c> factor, so it is unbounded as the bin empties -
+    /// and at exactly zero the phase is not merely steep but undefined, which is why the forward
+    /// reports <c>atan2(0, 0) == 0</c> there. Returning zero keeps the adjoint finite. The
+    /// alternative, letting an infinity through, would poison every sample of the waveform gradient
+    /// via the inverse transform, turning one silent bin into an entirely NaN gradient.
+    /// </remarks>
+    private const double PhaseGradientMagnitudeFloor = 1e-12;
+
+    /// <summary>
+    /// Shared adjoint of a one-sided STFT analysis with <c>center: true</c>: maps a gradient shaped
+    /// like the spectrogram back onto the waveform, for either reported output.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Everything after the per-bin seed is common to both targets - the unnormalised inverse
+    /// transform, the windowing, the overlap-add onto the padded signal, and the adjoint of the
+    /// reflection padding. Only the coefficients differ, because only the outer function differs:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>Magnitude.</b> <c>d|C|/dRe = cos(p)</c> and <c>d|C|/dIm = sin(p)</c>, so the seed is
+    /// <c>g e^(i p)</c>.
+    /// </description></item>
+    /// <item><description>
+    /// <b>Phase.</b> <c>dp/dRe = -Im/|C|^2 = -sin(p)/|C|</c> and
+    /// <c>dp/dIm = Re/|C|^2 = cos(p)/|C|</c>, so the seed is <c>(g/|C|) i e^(i p)</c> - the same
+    /// direction rotated a quarter turn and scaled by the reciprocal magnitude. That reciprocal is
+    /// the only reason <paramref name="magnitude"/> is needed, and the only reason this target has
+    /// a floor.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    private static Tensor<T> StftAnalysisAdjoint(
+        Tensor<T> gradient, Tensor<T>? magnitude, Tensor<T> phase, StftAdjointTarget target,
+        int nFft, int hopLength, Tensor<T> window, int origLength, int[] waveformShape)
     {
+        var gradMagnitude = gradient;
         var numOps = MathHelper.GetNumericOperations<T>();
         int numFreqs = nFft / 2 + 1;
         int numFrames = gradMagnitude._shape[^1];
@@ -9037,6 +9124,20 @@ internal static class BackwardFunctions<T>
         var gradData = gradMagnitude.GetDataArray();
         var phaseData = phase.GetDataArray();
         var windowData = window.GetDataArray();
+        // Bound once, non-nullable, so the inner loop needs no null handling and no suppression.
+        // Empty for the magnitude target, which never indexes it.
+        var magnitudeData = Array.Empty<T>();
+        if (target == StftAdjointTarget.Phase)
+        {
+            if (magnitude is null)
+            {
+                throw new ArgumentNullException(
+                    nameof(magnitude),
+                    "StftAnalysisAdjoint: the phase adjoint needs the magnitudes, whose reciprocal scales every bin.");
+            }
+
+            magnitudeData = magnitude.GetDataArray();
+        }
 
         var result = new Tensor<T>(waveformShape);
         var resultData = result.GetDataArray();
@@ -9063,18 +9164,39 @@ internal static class BackwardFunctions<T>
                     cImag[k] = numOps.Zero;
                 }
 
-                // c[k] = g[k] * e^(i * phase[k]) over the reported one-sided bins.
+                // Seed the reported one-sided bins. See the remarks for the two coefficient forms.
                 for (int k = 0; k < numFreqs; k++)
                 {
-                    double g = numOps.ToDouble(gradData[specOffset + k * numFrames + frame]);
-                    double ph = numOps.ToDouble(phaseData[specOffset + k * numFrames + frame]);
-                    cReal[k] = numOps.FromDouble(g * Math.Cos(ph));
-                    cImag[k] = numOps.FromDouble(g * Math.Sin(ph));
+                    int binIndex = specOffset + (k * numFrames) + frame;
+                    double g = numOps.ToDouble(gradData[binIndex]);
+                    double ph = numOps.ToDouble(phaseData[binIndex]);
+                    double cosPhase = Math.Cos(ph);
+                    double sinPhase = Math.Sin(ph);
+
+                    double seedReal;
+                    double seedImag;
+                    if (target == StftAdjointTarget.Magnitude)
+                    {
+                        seedReal = g * cosPhase;
+                        seedImag = g * sinPhase;
+                    }
+                    else
+                    {
+                        double binMagnitude = numOps.ToDouble(magnitudeData[binIndex]);
+                        double reciprocal = binMagnitude > PhaseGradientMagnitudeFloor
+                            ? g / binMagnitude
+                            : 0.0;
+                        seedReal = -reciprocal * sinPhase;
+                        seedImag = reciprocal * cosPhase;
+                    }
+
+                    cReal[k] = numOps.FromDouble(seedReal);
+                    cImag[k] = numOps.FromDouble(seedImag);
                 }
 
                 // Unnormalized inverse transform: FFTCore only flips the twiddle sign, so this
                 // is exactly Σ_k c[k] e^(+2πik i/N) with no 1/N applied.
-                var (frameGrad, _) = CpuEngine.UnnormalizedTransformForAdjoint<T>(cReal, cImag, inverse: true);
+                var (frameGrad, _) = CpuEngine.UnnormalizedTransform<T>(cReal, cImag, inverse: true);
 
                 int start = frame * hopLength;
                 for (int i = 0; i < nFft; i++)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -214,7 +214,7 @@ internal static class OpRegistry
 
         // Audio element-wise / linear ops — backward wired.
         "Spectrogram", "AmplitudeToDB", "ComputeDeltas", "Resample",
-        "ISTFT",
+        "ISTFT", "StftPhase",
 
         // Mel spectrogram — |STFT|^2, mel filterbank matmul and the optional dB conversion are
         // all differentiable, so the op records one node with BackwardFunctions<T>.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OpRegistry.cs
@@ -214,6 +214,7 @@ internal static class OpRegistry
 
         // Audio element-wise / linear ops — backward wired.
         "Spectrogram", "AmplitudeToDB", "ComputeDeltas", "Resample",
+        "ISTFT",
 
         // Mel spectrogram — |STFT|^2, mel filterbank matmul and the optional dB conversion are
         // all differentiable, so the op records one node with BackwardFunctions<T>.
@@ -334,17 +335,20 @@ internal static class OpRegistry
 
         // Signal processing.
         //
-        // ISTFT is synthesis (overlap-add with window-sum normalization) and is used as a
-        // reconstruction operator, not on a training path — note it is specifically NOT the
-        // adjoint of the STFT analysis, which is why BackwardFunctions has its own
-        // MagnitudeStftAdjoint rather than delegating here.
-        //
         // GriffinLim is an iterative phase-reconstruction ALGORITHM (60 fixed-point iterations
         // by default), not a single differentiable op.
         //
         // MelSpectrogram moved to DifferentiableOps — every stage of it is differentiable and
         // mel-based objectives need the gradient.
-        "ISTFT", "GriffinLim",
+        //
+        // ISTFT moved to DifferentiableOps as well (issue #905 item 2). It was classified here on
+        // the grounds that synthesis is a reconstruction operator rather than a training-path op,
+        // and that it is specifically NOT the adjoint of STFT analysis. The second point still
+        // stands and is why BackwardFunctions keeps MagnitudeStftAdjoint separate; the first did
+        // not survive contact with STFT-consistency objectives, which are defined across the
+        // round trip and need the gradient through synthesis itself. IstftBackward is the genuine
+        // transpose of overlap-add synthesis, derived there in full.
+        "GriffinLim",
 
         // Raw transforms that emit their outputs through `out` parameters. These are
         // deliberately NOT recorded: they are primitives that the recorded ops above are built

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -392,6 +392,31 @@ public partial class CpuEngine
         return mag;
     }
 
+    /// <inheritdoc/>
+    public virtual Tensor<T> StftPhase<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
+    {
+        if (waveform == null) throw new ArgumentNullException(nameof(waveform));
+        if (GraphMode.IsInferenceTrace)
+        {
+            Tensor<T>[] inputs = window is null ? new[] { waveform } : new[] { waveform, window };
+            return CaptureInferenceKernel(
+                inputs,
+                engine => engine.StftPhase(waveform, nFft, hopLength, winLength, window));
+        }
+
+        // The mirror of Spectrogram: same STFT, the other output kept, and the discarded half
+        // saved for the backward, which needs the magnitudes to scale each bin by 1/|C|.
+        var win = window ?? HannWindow<T>(winLength);
+        STFT(waveform, nFft, hopLength, win, center: true,
+            out var mag, out var phase);
+        int origLength = waveform._shape[waveform.Rank - 1];
+        DifferentiableOps.RecordUnary(
+            "StftPhase", phase, waveform,
+            BackwardFunctions<T>.StftPhaseBackward,
+            new object[] { nFft, hopLength, win, mag, origLength });
+        return phase;
+    }
+
     private static Tensor<T> HannWindow<T>(int n)
     {
         var ops = MathHelper.GetNumericOperations<T>();

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.RoiAudio.cs
@@ -744,6 +744,14 @@ public partial class CpuEngine
         }
 
         int targetLen = (int)Math.Round(waveform._shape[waveform.Rank - 1] / rate);
-        return ISTFT(newMag, newPhase, nFft, hopLength, window, center: true, length: targetLen);
+
+        // Suppressed: ISTFT records on the tape (issue #905 item 2), but TimeStretch builds its
+        // phase by an unrecorded accumulation loop above, so a recorded synthesis here would hand
+        // back a gradient that ignores everything this op actually did. TimeStretch stays in
+        // NonDifferentiableOps and its internals must agree.
+        using (new NoGradScope<T>())
+        {
+            return ISTFT(newMag, newPhase, nFft, hopLength, window, center: true, length: targetLen);
+        }
     }
 }

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -42252,8 +42252,18 @@ public partial class CpuEngine : ITensorLevelEngine
                     imagIn[k] = numOps.FromDouble(mag * Math.Sin(ph));
                 }
 
-                // Reconstruct negative frequencies using conjugate symmetry
-                for (int k = 1; k < numFreqs - 1; k++)
+                // Reconstruct negative frequencies using conjugate symmetry.
+                //
+                // The bound is 2k < nFft, not k < numFreqs - 1. Those agree only when nFft is even,
+                // where bin nFft/2 is Nyquist and is its own conjugate so must not be mirrored. An
+                // ODD nFft has no Nyquist bin, and stopping a bin early left the top of the spectrum
+                // at zero: the inverse transform was then not of a conjugate-symmetric spectrum, its
+                // result was not real, and taking the real part discarded the difference.
+                //
+                // Measured as a STFT -> ISTFT round trip on a smooth signal, worst interior error:
+                // nFft 8 gave 4.4e-16 and nFft 16 gave 6.7e-16, against 0.055 at nFft 5 and 3.5e-3
+                // at nFft 7. IstftRoundTripTests pins all four.
+                for (int k = 1; k < numFreqs && (k * 2) < nFft; k++)
                 {
                     realIn[nFft - k] = realIn[k];
                     imagIn[nFft - k] = numOps.Negate(imagIn[k]);

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -42117,8 +42117,16 @@ public partial class CpuEngine : ITensorLevelEngine
                     frameData[i] = numOps.Multiply(paddedInputData[inputOffset + start + i], windowData[i]);
                 }
 
-                // Compute FFT
-                var (realOut, imagOut) = FFTCore<T>(frameData, inverse: false);
+                // Compute FFT.
+                //
+                // UnnormalizedTransform, not FFTCore: FFTCore zero-pads a non-power-of-two length up
+                // to the next power of two, which is a different transform -- its bins sit at
+                // k/nPadded rather than k/nFft. That was already known and documented on the helper,
+                // but only the ADJOINT had been moved onto it, so at those lengths the forward and
+                // its own transpose were computing different operators. Surfaced by
+                // DifferentiableOpsGradCheckSweep, whose reflective argument synthesis produces
+                // nFft = 6. Identical call for power-of-two lengths, which is every realistic one.
+                var (realOut, imagOut) = UnnormalizedTransform<T>(frameData, inverse: false);
 
                 // Compute magnitude and phase for positive frequencies
                 int outputOffset = batchIdx * numFreqs * numFrames;
@@ -42251,8 +42259,9 @@ public partial class CpuEngine : ITensorLevelEngine
                     imagIn[nFft - k] = numOps.Negate(imagIn[k]);
                 }
 
-                // Inverse FFT
-                var (realOut, _) = FFTCore<T>(realIn, imagIn, inverse: true);
+                // Inverse FFT. UnnormalizedTransform for the same reason as the forward in STFT:
+                // exact at every length, where FFTCore silently zero-pads to a power of two.
+                var (realOut, _) = UnnormalizedTransform<T>(realIn, imagIn, inverse: true);
                 T scale = numOps.FromDouble(1.0 / nFft);
 
                 // Overlap-add.
@@ -42666,7 +42675,19 @@ public partial class CpuEngine : ITensorLevelEngine
     }
 
     /// <summary>
-    /// Unnormalized complex inverse transform, exposed for the Spectrogram adjoint.
+    /// Real-input form of <see cref="UnnormalizedTransform{T}(Vector{T}, Vector{T}, bool)"/>.
+    /// </summary>
+    internal static (Vector<T> real, Vector<T> imag) UnnormalizedTransform<T>(Vector<T> realInput, bool inverse)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var imagInput = new Vector<T>(realInput.Length);
+        for (int i = 0; i < realInput.Length; i++)
+            imagInput[i] = numOps.Zero;
+        return UnnormalizedTransform(realInput, imagInput, inverse);
+    }
+
+    /// <summary>
+    /// Unnormalized complex transform that is exact at every length, in either direction.
     /// </summary>
     /// <remarks>
     /// Computes <c>Σ_k c[k] e^(+2πik n/N)</c> with NO 1/N factor — <see cref="FFTCore{T}(Vector{T}, Vector{T}, bool)"/>
@@ -42682,7 +42703,7 @@ public partial class CpuEngine : ITensorLevelEngine
     /// does not transpose the forward it is paired with. That is fine for the power-of-two lengths
     /// this used to see and wrong for every other one, so those route to Bluestein instead.
     /// </remarks>
-    internal static (Vector<T> real, Vector<T> imag) UnnormalizedTransformForAdjoint<T>(
+    internal static (Vector<T> real, Vector<T> imag) UnnormalizedTransform<T>(
         Vector<T> realInput, Vector<T> imagInput, bool inverse)
     {
         int n = realInput.Length;

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -42304,6 +42304,15 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
+        // Synthesis is on the tape (issue #905 item 2). An STFT-consistency objective is defined
+        // ACROSS the round trip, so a severed ISTFT leaves half of it untrainable while still
+        // running - the silent failure the issue reports. outputLength is saved rather than
+        // recomputed because the caller may have supplied it verbatim.
+        DifferentiableOps.RecordBinary(
+            "ISTFT", result, magnitude, phase,
+            BackwardFunctions<T>.IstftBackward,
+            new object[] { nFft, hopLength, window, center, outputLength });
+
         return result;
     }
 
@@ -42466,11 +42475,21 @@ public partial class CpuEngine : ITensorLevelEngine
 
         for (int iter = 0; iter < iterations; iter++)
         {
-            // Reconstruct signal from magnitude and estimated phase
-            var reconstructed = ISTFT(magnitude, phase, nFft, hopLength, window, center: true, length: length);
+            // Reconstruct signal from magnitude and estimated phase.
+            //
+            // Suppressed: ISTFT records on the tape (issue #905 item 2) but GriffinLim is an
+            // iterative ALGORITHM, not a differentiable op, and stays in NonDifferentiableOps.
+            // Without this, calling it under a tape would unroll every iteration onto that tape
+            // and pin each intermediate, making the op silently contradict its own classification.
+            Tensor<T> reconstructed;
+            Tensor<T> newPhase;
+            using (new NoGradScope<T>())
+            {
+                reconstructed = ISTFT(magnitude, phase, nFft, hopLength, window, center: true, length: length);
 
-            // Re-compute STFT to get new phase estimate
-            STFT(reconstructed, nFft, hopLength, window, center: true, out _, out var newPhase);
+                // Re-compute STFT to get new phase estimate
+                STFT(reconstructed, nFft, hopLength, window, center: true, out _, out newPhase);
+            }
 
             // Apply momentum for faster convergence
             if (previousPhase != null && momentum > 0)
@@ -42498,8 +42517,11 @@ public partial class CpuEngine : ITensorLevelEngine
             previousPhase = newPhase;
         }
 
-        // Final reconstruction
-        return ISTFT(magnitude, phase, nFft, hopLength, window, center: true, length: length);
+        // Final reconstruction, suppressed for the same reason as the iterations above.
+        using (new NoGradScope<T>())
+        {
+            return ISTFT(magnitude, phase, nFft, hopLength, window, center: true, length: length);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5243,6 +5243,72 @@ public partial class DirectGpuTensorEngine
         catch (Exception) { return base.Spectrogram(waveform, nFft, hopLength, winLength, window); }
     }
 
+    /// <summary>
+    /// GPU phase spectrogram. The same <c>StftMagPhase</c> kernel Spectrogram already runs, keeping
+    /// the output that one discards.
+    /// </summary>
+    public override Tensor<T> StftPhase<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
+    {
+        if (waveform is null) throw new ArgumentNullException(nameof(waveform));
+        if (typeof(T) != typeof(float) || nFft <= 0 || hopLength <= 0 || !TryGetBackend(out var backend))
+            return base.StftPhase(waveform, nFft, hopLength, winLength, window);
+        // Build the window (must be length nFft for STFT). Match CpuEngine.HannWindow exactly.
+        Tensor<T> win;
+        if (window is not null) win = window;
+        else
+        {
+            var warr = new T[winLength];
+            var wf = (float[])(object)warr;
+            for (int i = 0; i < winLength; i++)
+                wf[i] = (float)(0.5 - 0.5 * System.Math.Cos(2.0 * System.Math.PI * i / System.Math.Max(1, winLength - 1)));
+            win = new Tensor<T>(warr, new[] { winLength });
+        }
+        if (win.Length != nFft)
+            return base.StftPhase(waveform, nFft, hopLength, winLength, window);
+        try
+        {
+            int rank = waveform.Rank;
+            int L = waveform._shape[rank - 1];
+            int pad = nFft / 2;                 // StftPhase always uses STFT center:true
+            int Lp = L + 2 * pad;
+            int batch = L == 0 ? 0 : waveform.Length / L;
+            int numFrames = (Lp - nFft) / hopLength + 1;
+            int numFreqs = nFft / 2 + 1;
+            if (batch == 0 || numFrames <= 0 || pad >= L)   // reflect needs pad < L
+                return base.StftPhase(waveform, nFft, hopLength, winLength, window);
+            var newShape = new int[rank + 1];
+            for (int i = 0; i < rank - 1; i++) newShape[i] = waveform._shape[i];
+            newShape[rank - 1] = numFreqs;
+            newShape[rank] = numFrames;
+            int outLen = batch * numFreqs * numFrames;
+
+            var cw = waveform.IsContiguous ? waveform : (Tensor<T>)waveform.Contiguous();
+            var cwin = win.IsContiguous ? win : (Tensor<T>)win.Contiguous();
+            using var bufWave = GetOrAllocateBuffer(backend, cw);
+            using var bufWin = GetOrAllocateBuffer(backend, cwin);
+            using var bufPadded = AllocateOutputBuffer(backend, batch * Lp);
+            backend.ReflectPad1d(bufWave.Buffer, bufPadded.Buffer, batch, L, Lp, pad);
+            var bufMag = AllocateOutputBuffer(backend, outLen);
+            var bufPhase = AllocateOutputBuffer(backend, outLen);
+            backend.StftMagPhase(bufPadded.Buffer, bufWin.Buffer, bufMag.Buffer, bufPhase.Buffer, batch, Lp, nFft, hopLength, numFrames, numFreqs);
+            // Finish the compute while `bufPadded` is still alive: FinishGpuOp defers only the
+            // DOWNLOAD, so without this the padded buffer could be freed before a deferred
+            // materialization runs the kernel. Same reasoning as Spectrogram above.
+            backend.Synchronize();
+            var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
+            var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
+            var mag = new Tensor<T>(magArr, newShape);
+            var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
+            int origLength = waveform._shape[rank - 1];
+            // Mirror of the Spectrogram contract: that one saves the phase it discards, this one
+            // saves the magnitude, which the phase adjoint needs to scale each bin by 1/|C|.
+            DifferentiableOps.RecordUnary("StftPhase", phase, waveform,
+                BackwardFunctions<T>.StftPhaseBackward, new object[] { nFft, hopLength, win, mag, origLength });
+            return phase;
+        }
+        catch (Exception) { return base.StftPhase(waveform, nFft, hopLength, winLength, window); }
+    }
+
     // The 3-argument backward entry points are the adjoint of the 3-argument (narrow) GridSample
     // forward, which uses torchvision's DEFAULTS: align_corners=false, padding_mode='zeros'.
     // These passed alignCorners: true, matching the narrow CPU forward's old (size-1)/2 mapping.

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5224,21 +5224,38 @@ public partial class DirectGpuTensorEngine
             backend.ReflectPad1d(bufWave.Buffer, bufPadded.Buffer, batch, L, Lp, pad);
             var bufMag = AllocateOutputBuffer(backend, outLen);
             var bufPhase = AllocateOutputBuffer(backend, outLen);
-            backend.StftMagPhase(bufPadded.Buffer, bufWin.Buffer, bufMag.Buffer, bufPhase.Buffer, batch, Lp, nFft, hopLength, numFrames, numFreqs);
-            // Force the stft compute to finish while the intermediate `bufPadded` is still alive (it is
-            // `using` and feeds the kernel). FinishGpuOp only defers the DOWNLOAD, not the compute, so
-            // without this the padded buffer could be freed before a deferred materialization runs the
-            // kernel — a use-after-free. mag/phase still stay GPU-resident (deferred download).
-            backend.Synchronize();
-            var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
-            var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
-            var mag = new Tensor<T>(magArr, newShape);
-            var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
-            int origLength = waveform._shape[rank - 1];
-            // Same backward contract as the base (phase piped through ISTFT); no-op when no tape is active.
-            DifferentiableOps.RecordUnary("Spectrogram", mag, waveform,
-                BackwardFunctions<T>.SpectrogramBackward, new object[] { nFft, hopLength, win, phase, origLength });
-            return mag;
+            // FinishGpuOp takes ownership of the buffer it is handed, so these two are only safe to
+            // leave undisposed once it has returned for each. Anything before that - the kernel
+            // launch, the synchronize, or the first handoff - throws into the catch below, which
+            // falls back to the CPU path and would otherwise strand the allocations on the device.
+            // A repeatedly failing GPU path would then exhaust device memory rather than degrade.
+            bool magHandedOff = false;
+            bool phaseHandedOff = false;
+            try
+            {
+                backend.StftMagPhase(bufPadded.Buffer, bufWin.Buffer, bufMag.Buffer, bufPhase.Buffer, batch, Lp, nFft, hopLength, numFrames, numFreqs);
+                // Force the stft compute to finish while the intermediate `bufPadded` is still alive (it is
+                // `using` and feeds the kernel). FinishGpuOp only defers the DOWNLOAD, not the compute, so
+                // without this the padded buffer could be freed before a deferred materialization runs the
+                // kernel — a use-after-free. mag/phase still stay GPU-resident (deferred download).
+                backend.Synchronize();
+                var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
+                magHandedOff = true;
+                var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
+                phaseHandedOff = true;
+                var mag = new Tensor<T>(magArr, newShape);
+                var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
+                int origLength = waveform._shape[rank - 1];
+                // Same backward contract as the base (phase piped through ISTFT); no-op when no tape is active.
+                DifferentiableOps.RecordUnary("Spectrogram", mag, waveform,
+                    BackwardFunctions<T>.SpectrogramBackward, new object[] { nFft, hopLength, win, phase, origLength });
+                return mag;
+            }
+            finally
+            {
+                if (!magHandedOff) { bufMag.Dispose(); }
+                if (!phaseHandedOff) { bufPhase.Dispose(); }
+            }
         }
         catch (Exception) { return base.Spectrogram(waveform, nFft, hopLength, winLength, window); }
     }
@@ -5250,7 +5267,15 @@ public partial class DirectGpuTensorEngine
     public override Tensor<T> StftPhase<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null)
     {
         if (waveform is null) throw new ArgumentNullException(nameof(waveform));
-        if (typeof(T) != typeof(float) || nFft <= 0 || hopLength <= 0 || !TryGetBackend(out var backend))
+
+        // IsInferenceTrace defers to the base, which is the only implementation that calls
+        // CaptureInferenceKernel. Computing here instead would produce the right tensor and add
+        // nothing to the inference graph, so a compiled replay would reuse this trace-time result
+        // in place of the live waveform and window. GroupNorm bails on the same condition for the
+        // same reason. Note GraphCaptureParityTests cannot catch this: it builds a CpuEngine, so it
+        // exercises the base path and never reaches this override.
+        if (Compilation.GraphMode.IsInferenceTrace
+            || typeof(T) != typeof(float) || nFft <= 0 || hopLength <= 0 || !TryGetBackend(out var backend))
             return base.StftPhase(waveform, nFft, hopLength, winLength, window);
         // Build the window (must be length nFft for STFT). Match CpuEngine.HannWindow exactly.
         Tensor<T> win;
@@ -5290,21 +5315,38 @@ public partial class DirectGpuTensorEngine
             backend.ReflectPad1d(bufWave.Buffer, bufPadded.Buffer, batch, L, Lp, pad);
             var bufMag = AllocateOutputBuffer(backend, outLen);
             var bufPhase = AllocateOutputBuffer(backend, outLen);
-            backend.StftMagPhase(bufPadded.Buffer, bufWin.Buffer, bufMag.Buffer, bufPhase.Buffer, batch, Lp, nFft, hopLength, numFrames, numFreqs);
-            // Finish the compute while `bufPadded` is still alive: FinishGpuOp defers only the
-            // DOWNLOAD, so without this the padded buffer could be freed before a deferred
-            // materialization runs the kernel. Same reasoning as Spectrogram above.
-            backend.Synchronize();
-            var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
-            var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
-            var mag = new Tensor<T>(magArr, newShape);
-            var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
-            int origLength = waveform._shape[rank - 1];
-            // Mirror of the Spectrogram contract: that one saves the phase it discards, this one
-            // saves the magnitude, which the phase adjoint needs to scale each bin by 1/|C|.
-            DifferentiableOps.RecordUnary("StftPhase", phase, waveform,
-                BackwardFunctions<T>.StftPhaseBackward, new object[] { nFft, hopLength, win, mag, origLength });
-            return phase;
+            // FinishGpuOp takes ownership of the buffer it is handed, so these two are only safe to
+            // leave undisposed once it has returned for each. Anything before that - the kernel
+            // launch, the synchronize, or the first handoff - throws into the catch below, which
+            // falls back to the CPU path and would otherwise strand the allocations on the device.
+            // A repeatedly failing GPU path would then exhaust device memory rather than degrade.
+            bool magHandedOff = false;
+            bool phaseHandedOff = false;
+            try
+            {
+                backend.StftMagPhase(bufPadded.Buffer, bufWin.Buffer, bufMag.Buffer, bufPhase.Buffer, batch, Lp, nFft, hopLength, numFrames, numFreqs);
+                // Finish the compute while `bufPadded` is still alive: FinishGpuOp defers only the
+                // DOWNLOAD, so without this the padded buffer could be freed before a deferred
+                // materialization runs the kernel. Same reasoning as Spectrogram above.
+                backend.Synchronize();
+                var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
+                magHandedOff = true;
+                var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
+                phaseHandedOff = true;
+                var mag = new Tensor<T>(magArr, newShape);
+                var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
+                int origLength = waveform._shape[rank - 1];
+                // Mirror of the Spectrogram contract: that one saves the phase it discards, this one
+                // saves the magnitude, which the phase adjoint needs to scale each bin by 1/|C|.
+                DifferentiableOps.RecordUnary("StftPhase", phase, waveform,
+                    BackwardFunctions<T>.StftPhaseBackward, new object[] { nFft, hopLength, win, mag, origLength });
+                return phase;
+            }
+            finally
+            {
+                if (!magHandedOff) { bufMag.Dispose(); }
+                if (!phaseHandedOff) { bufPhase.Dispose(); }
+            }
         }
         catch (Exception) { return base.StftPhase(waveform, nFft, hopLength, winLength, window); }
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.MissingKernels.cs
@@ -5241,14 +5241,24 @@ public partial class DirectGpuTensorEngine
                 backend.Synchronize();
                 var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
                 magHandedOff = true;
-                var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
-                phaseHandedOff = true;
                 var mag = new Tensor<T>(magArr, newShape);
-                var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
-                int origLength = waveform._shape[rank - 1];
-                // Same backward contract as the base (phase piped through ISTFT); no-op when no tape is active.
-                DifferentiableOps.RecordUnary("Spectrogram", mag, waveform,
-                    BackwardFunctions<T>.SpectrogramBackward, new object[] { nFft, hopLength, win, phase, origLength });
+
+                // The companion output is only needed to seed the backward pass, and RecordUnary
+                // returns on its first line when no tape is active. Materialising it during
+                // inference therefore buys nothing and costs something: FinishGpuOp registers a
+                // pending device-to-host download and puts the buffer in the activation cache,
+                // where it can displace an activation that is actually wanted and be paid for
+                // again on eviction. Left unclaimed, the finally block below frees it outright.
+                if (DifferentiableOps.IsRecording<T>())
+                {
+                    var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
+                    phaseHandedOff = true;
+                    var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
+                    int origLength = waveform._shape[rank - 1];
+                    DifferentiableOps.RecordUnary("Spectrogram", mag, waveform,
+                        BackwardFunctions<T>.SpectrogramBackward, new object[] { nFft, hopLength, win, phase, origLength });
+                }
+
                 return mag;
             }
             finally
@@ -5329,17 +5339,28 @@ public partial class DirectGpuTensorEngine
                 // DOWNLOAD, so without this the padded buffer could be freed before a deferred
                 // materialization runs the kernel. Same reasoning as Spectrogram above.
                 backend.Synchronize();
-                var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
-                magHandedOff = true;
                 var phaseArr = FinishGpuOp<T>(backend, bufPhase, outLen);
                 phaseHandedOff = true;
-                var mag = new Tensor<T>(magArr, newShape);
-                var phase = new Tensor<T>(phaseArr, (int[])newShape.Clone());
-                int origLength = waveform._shape[rank - 1];
-                // Mirror of the Spectrogram contract: that one saves the phase it discards, this one
-                // saves the magnitude, which the phase adjoint needs to scale each bin by 1/|C|.
-                DifferentiableOps.RecordUnary("StftPhase", phase, waveform,
-                    BackwardFunctions<T>.StftPhaseBackward, new object[] { nFft, hopLength, win, mag, origLength });
+                var phase = new Tensor<T>(phaseArr, newShape);
+
+                // The companion output is only needed to seed the backward pass, and RecordUnary
+                // returns on its first line when no tape is active. Materialising it during
+                // inference therefore buys nothing and costs something: FinishGpuOp registers a
+                // pending device-to-host download and puts the buffer in the activation cache,
+                // where it can displace an activation that is actually wanted and be paid for
+                // again on eviction. Left unclaimed, the finally block below frees it outright.
+                // Mirror of the Spectrogram contract: that one saves the phase it discards, this
+                // one saves the magnitude, which the phase adjoint needs to scale each bin by 1/|C|.
+                if (DifferentiableOps.IsRecording<T>())
+                {
+                    var magArr = FinishGpuOp<T>(backend, bufMag, outLen);
+                    magHandedOff = true;
+                    var mag = new Tensor<T>(magArr, (int[])newShape.Clone());
+                    int origLength = waveform._shape[rank - 1];
+                    DifferentiableOps.RecordUnary("StftPhase", phase, waveform,
+                        BackwardFunctions<T>.StftPhaseBackward, new object[] { nFft, hopLength, win, mag, origLength });
+                }
+
                 return phase;
             }
             finally

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -12678,6 +12678,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var outputShape = magnitude.Shape._dims.Take(magnitude.Rank - 2).Append(outputLength).ToArray();
             var result = DeferTensorResult<T>(backend, resultBuffer.Buffer, totalOutput, outputShape);
             resultBuffer.RelinquishOwnership();
+
+            // Same tape contract as the base engine. Without this the GPU path would compute the
+            // right waveform and record nothing, so whether a model trained would depend on which
+            // engine happened to be current - the precise failure mode issue #905 is about.
+            Autodiff.DifferentiableOps.RecordBinary(
+                "ISTFT", result, magnitude, phase,
+                Autodiff.BackwardFunctions<T>.IstftBackward,
+                new object[] { nFft, hopLength, window, center, outputLength });
+
             return result;
         }
         catch
@@ -12820,6 +12829,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
 
             IEngine engine = this;
+
+            // GriffinLim is an iterative ALGORITHM and sits in OpRegistry.NonDifferentiableOps, so
+            // none of its internals should reach the tape. Two things would otherwise put them
+            // there: ISTFT now records (issue #905 item 2), and the momentum arithmetic below is
+            // built from TensorSubtract/TensorAdd/TensorMultiplyScalar, which have always recorded
+            // -- so on this engine a tape-active GriffinLim was already accumulating nodes for the
+            // momentum path while the CPU engine recorded nothing. One scope settles both, and
+            // makes the two engines agree.
+            using var noGrad = new Autodiff.NoGradScope<T>();
+
             var phase = new Tensor<T>(DirectGpuEngine.FromFloatArray<T>(initialPhase), magnitude.Shape.ToArray());
             Tensor<T>? previousPhase = null;
             float momentumF = (float)momentum;

--- a/src/AiDotNet.Tensors/Engines/IEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/IEngine.cs
@@ -9845,6 +9845,36 @@ public interface IEngine
     /// that returns only the magnitude half.</summary>
     Tensor<T> Spectrogram<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null);
 
+    /// <summary>Phase spectrogram <c>arg STFT(x)</c>. The phase counterpart of
+    /// <see cref="Spectrogram{T}"/>, returning the half that one discards.</summary>
+    /// <typeparam name="T">The numeric type of tensor elements.</typeparam>
+    /// <param name="waveform">Audio signal, <c>[..., samples]</c>.</param>
+    /// <param name="nFft">FFT size.</param>
+    /// <param name="hopLength">Samples between frames.</param>
+    /// <param name="winLength">Window length, used only when <paramref name="window"/> is null.</param>
+    /// <param name="window">Analysis window; a Hann window of <paramref name="winLength"/> when null.</param>
+    /// <returns>Wrapped phase in radians, <c>[..., nFft/2 + 1, frames]</c>, matching
+    /// <see cref="Spectrogram{T}"/> bin for bin.</returns>
+    /// <remarks>
+    /// <para>
+    /// Records on the gradient tape, which is the point of it (issue #905). <c>STFT</c> emits phase
+    /// through an <c>out</c> parameter and is deliberately unrecorded, so before this the only
+    /// differentiable analysis output was magnitude, and an objective over angles - the phase term
+    /// in a prediction vocoder - had no differentiable path to the quantity it was defined on.
+    /// </para>
+    /// <para>
+    /// Together with <see cref="Spectrogram{T}"/> this gives the complex analysis differentiably,
+    /// and pairs with <see cref="ISTFT{T}"/> to close the round trip: both of its inputs are now
+    /// reachable, and synthesis itself records.
+    /// </para>
+    /// <para>
+    /// The phase derivative scales as <c>1/|C|</c>, so bins with near-zero magnitude contribute an
+    /// unbounded gradient. Their phase is meaningless in any case, and the implementation reports
+    /// zero there rather than an infinity that would spread through the whole waveform gradient.
+    /// </para>
+    /// </remarks>
+    Tensor<T> StftPhase<T>(Tensor<T> waveform, int nFft, int hopLength, int winLength, Tensor<T>? window = null);
+
     /// <summary>
     /// Convert amplitude to dB: <c>20 · log10(max(x, minAmplitude))</c>.
     /// Matches torchaudio's <c>AmplitudeToDB</c> with

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/DifferentiableOpsGradCheckSweep.cs
@@ -242,6 +242,14 @@ public class DifferentiableOpsGradCheckSweep
         ["IRFFT"] = r => [SafeTensor([2 * (8 / 2 + 1)], r), 8],
         ["Spectrogram"] = r => [SafeTensor([64], r), 16, 4, 16, HannWindowFor(16)],
 
+        // StftPhase needs a waveform, not noise. Its output is WRAPPED phase, so finite differences
+        // across the atan2 branch cut measure a 2*pi jump rather than a derivative -- with
+        // SafeTensor input the numerical gradient came back as 3.14158e6, which is exactly
+        // 2*pi / (2*eps). A signal with every bin strongly excited keeps each bin away from the cut
+        // under a 1e-6 perturbation. Same nFft/hop/window coupling as Spectrogram, whose bins these
+        // must match one for one.
+        ["StftPhase"] = _ => [WellExcitedWaveform(64), 16, 4, 16, HannWindowFor(16)],
+
         // --- reductions with explicit axes. ReduceMax is overloaded 3-param / 4-param
         //     (the latter with `out int[] maxIndices`), hence the arity-keyed pair. ---
         ["ReduceMax/3"] = r => [SafeTensor([2, 3], r), new[] { 1 }, false],
@@ -397,6 +405,23 @@ public class DifferentiableOpsGradCheckSweep
         if (t == typeof(double?)) return "double?";
         if (t.IsGenericType) return t.Name + "<" + string.Join(",", t.GetGenericArguments().Select(TypeToken)) + ">";
         return t.Name;
+    }
+
+    /// <summary>
+    /// A deterministic waveform whose every STFT bin carries real energy.
+    /// </summary>
+    /// <remarks>
+    /// Phase is only well conditioned where the magnitude is not near zero -- its derivative carries
+    /// a 1/|C| factor -- and it is only finite-difference-checkable where the wrapped value stays
+    /// clear of the branch cut. Two incommensurate tones over a DC offset satisfy both, which
+    /// uniform noise in [0.35, 0.95] does not.
+    /// </remarks>
+    private static Tensor<double> WellExcitedWaveform(int n)
+    {
+        var t = new Tensor<double>([n]);
+        for (int i = 0; i < n; i++)
+            t[i] = 0.6 + Math.Sin(0.37 * i) + 0.4 * Math.Cos(1.13 * i);
+        return t;
     }
 
     /// <summary>Hann window of exactly nFft samples, matching CpuEngine's own definition.</summary>

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
@@ -358,4 +358,47 @@ public class IstftGradientTests
 
         Assert.True(moved, "the round-trip gradient is identically zero");
     }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(5)]
+    [InlineData(7)]
+    public void Istft_InvertsStft(int nFft)
+    {
+        // ISTFT(STFT(x)) must return x in the interior, where every sample is covered by a full set
+        // of overlapping frames.
+        //
+        // This is the test the gradchecks could not be: they compare the adjoint against the
+        // forward, so they pass whether or not the forward is a correct inverse. It was not, at odd
+        // nFft - the Hermitian extension stopped one bin early, which is only right when there is a
+        // Nyquist bin to leave alone. Worst interior error before the fix was 0.055 at nFft 5 and
+        // 3.5e-3 at nFft 7, against 4.4e-16 at nFft 8.
+        int hop = Math.Max(1, nFft / 4);
+        const int n = 96;
+
+        var x = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            x[i] = 0.6 + Math.Sin(0.37 * i) + (0.4 * Math.Cos(1.13 * i));
+        }
+
+        var signal = new Tensor<double>(x, new[] { n });
+
+        var w = new double[nFft];
+        for (int i = 0; i < nFft; i++)
+        {
+            w[i] = 0.5 - (0.5 * Math.Cos(2.0 * Math.PI * i / (nFft - 1)));
+        }
+
+        var window = new Tensor<double>(w, new[] { nFft });
+
+        _engine.STFT(signal, nFft, hop, window, center: true, out var magnitude, out var phase);
+        var reconstructed = _engine.ISTFT(magnitude, phase, nFft, hop, window, center: true, n);
+
+        for (int i = nFft; i < n - nFft; i++)
+        {
+            Assert.Equal(x[i], reconstructed[i], 1e-12);
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
@@ -33,6 +33,21 @@ public class IstftGradientTests
     private const int HopLength = 4;
     private const int NumFreqs = NFft / 2 + 1;
     private const int NumFrames = 3;
+    /// <summary>
+    /// Output length for a given centring, matching how ISTFT derives it when length is null.
+    /// </summary>
+    /// <remarks>
+    /// Centred synthesis drops the nFft of analysis padding, which is also what moves each frame
+    /// write offset back by nFft/2 and so makes the first frames write partly before sample zero.
+    /// That trimming is a distinct branch in both the forward and its adjoint, which is why both
+    /// settings are gradchecked below rather than only the simpler one.
+    /// </remarks>
+    private static int OutputLengthFor(bool center)
+    {
+        int length = ((NumFrames - 1) * HopLength) + NFft;
+        return center ? length - NFft : length;
+    }
+
     private const int OutputLength = ((NumFrames - 1) * HopLength) + NFft;
 
     /// <summary>
@@ -76,22 +91,23 @@ public class IstftGradientTests
     }
 
     /// <summary>Fixed, varied loss weights, so the seed gradient is not a uniform vector.</summary>
-    private static Tensor<double> LossWeights()
+    private static Tensor<double> LossWeights(bool center)
     {
-        var c = new double[OutputLength];
+        int length = OutputLengthFor(center);
+        var c = new double[length];
         for (int i = 0; i < c.Length; i++)
         {
             c[i] = 0.25 + (0.11 * ((i * 5) % 7));
         }
 
-        return new Tensor<double>(c, new[] { OutputLength });
+        return new Tensor<double>(c, new[] { length });
     }
 
-    private double Loss(Tensor<double> magnitude, Tensor<double> phase, Tensor<double> weights)
+    private double Loss(Tensor<double> magnitude, Tensor<double> phase, Tensor<double> weights, bool center)
     {
-        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: false);
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center);
         double total = 0;
-        for (int i = 0; i < OutputLength; i++)
+        for (int i = 0; i < OutputLengthFor(center); i++)
         {
             total += reconstructed[i] * weights[i];
         }
@@ -99,14 +115,14 @@ public class IstftGradientTests
         return total;
     }
 
-    private (Tensor<double> Magnitude, Tensor<double> Phase) AnalyticGradients()
+    private (Tensor<double> Magnitude, Tensor<double> Phase) AnalyticGradients(bool center)
     {
         var magnitude = Magnitudes();
         var phase = Phases();
-        var weights = LossWeights();
+        var weights = LossWeights(center);
 
         using var tape = new GradientTape<double>();
-        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: false);
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center);
         var loss = _engine.ReduceSum(_engine.TensorMultiply(reconstructed, weights), null);
         var grads = tape.ComputeGradients(loss, new[] { magnitude, phase });
 
@@ -115,11 +131,13 @@ public class IstftGradientTests
         return (grads[magnitude], grads[phase]);
     }
 
-    [Fact]
-    public void Istft_MagnitudeGradient_MatchesFiniteDifferences()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Istft_MagnitudeGradient_MatchesFiniteDifferences(bool center)
     {
-        var (analyticMagnitude, _) = AnalyticGradients();
-        var weights = LossWeights();
+        var (analyticMagnitude, _) = AnalyticGradients(center);
+        var weights = LossWeights(center);
         const double h = 1e-6;
 
         for (int j = 0; j < NumFreqs * NumFrames; j++)
@@ -129,16 +147,18 @@ public class IstftGradientTests
             plus[j] += h;
             minus[j] -= h;
 
-            var numeric = (Loss(plus, Phases(), weights) - Loss(minus, Phases(), weights)) / (2 * h);
+            var numeric = (Loss(plus, Phases(), weights, center) - Loss(minus, Phases(), weights, center)) / (2 * h);
             Assert.Equal(numeric, analyticMagnitude[j], 1e-7);
         }
     }
 
-    [Fact]
-    public void Istft_PhaseGradient_MatchesFiniteDifferences()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Istft_PhaseGradient_MatchesFiniteDifferences(bool center)
     {
-        var (_, analyticPhase) = AnalyticGradients();
-        var weights = LossWeights();
+        var (_, analyticPhase) = AnalyticGradients(center);
+        var weights = LossWeights(center);
         const double h = 1e-6;
 
         for (int j = 0; j < NumFreqs * NumFrames; j++)
@@ -148,7 +168,7 @@ public class IstftGradientTests
             plus[j] += h;
             minus[j] -= h;
 
-            var numeric = (Loss(Magnitudes(), plus, weights) - Loss(Magnitudes(), minus, weights)) / (2 * h);
+            var numeric = (Loss(Magnitudes(), plus, weights, center) - Loss(Magnitudes(), minus, weights, center)) / (2 * h);
             Assert.Equal(numeric, analyticPhase[j], 1e-7);
         }
     }
@@ -159,7 +179,7 @@ public class IstftGradientTests
         // The regression that matters. Before this change ISTFT sat in
         // OpRegistry.NonDifferentiableOps, so a loss downstream of it produced no gradient at all
         // and training proceeded quietly. A forward-only test would not have noticed.
-        var (analyticMagnitude, analyticPhase) = AnalyticGradients();
+        var (analyticMagnitude, analyticPhase) = AnalyticGradients(center: false);
 
         var magnitudeMoved = false;
         var phaseMoved = false;
@@ -201,6 +221,21 @@ public class IstftGradientTests
         {
             Assert.Equal(expected[i], withoutTape[i], 1e-12);
         }
+    }
+
+    [Fact]
+    public void GriffinLim_StaysOffTheTape()
+    {
+        // GriffinLim calls ISTFT internally and is classified non-differentiable. Now that ISTFT
+        // records, only the NoGradScope around those calls keeps that classification true - and a
+        // scope that silently stopped working would show up nowhere else, because the forward value
+        // is unaffected either way.
+        var magnitude = Magnitudes();
+
+        using var tape = new GradientTape<double>();
+        var audio = _engine.GriffinLim(magnitude, NFft, HopLength, Window(), iterations: 2, momentum: 0.0);
+
+        Assert.Null(audio.GradFn);
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
@@ -223,6 +223,102 @@ public class IstftGradientTests
         }
     }
 
+    [Theory]
+    [InlineData(5)]
+    [InlineData(7)]
+    public void Istft_GradientMatchesFiniteDifferences_AtOddNFft(int oddNFft)
+    {
+        // The Hermitian extension is where an odd length could diverge: with nFft even, bin
+        // numFreqs-1 is Nyquist and is deliberately not mirrored, whereas with nFft odd there is no
+        // Nyquist bin and the forward still stops mirroring at numFreqs-2. The adjoint folds over
+        // exactly the range the forward mirrors, so it stays the transpose either way - but that is
+        // an argument, and every other gradcheck here runs at nFft 8, so nothing had tested it.
+        //
+        // Odd lengths also exercise the Bluestein path, since they are not powers of two. Before
+        // the transform fix in this branch the forward zero-padded to the next power of two while
+        // the adjoint did not, and these cases would have failed outright.
+        const int hop = 2;
+        const int frames = 3;
+        int numFreqs = (oddNFft / 2) + 1;
+        int outputLength = ((frames - 1) * hop) + oddNFft;
+
+        var windowData = new double[oddNFft];
+        for (int i = 0; i < oddNFft; i++)
+        {
+            windowData[i] = 0.3 + (0.1 * i);
+        }
+
+        var window = new Tensor<double>(windowData, new[] { oddNFft });
+
+        Tensor<double> BuildMagnitudes()
+        {
+            var m = new double[numFreqs * frames];
+            for (int i = 0; i < m.Length; i++)
+            {
+                m[i] = 0.4 + (0.17 * ((i * 7) % 5));
+            }
+
+            return new Tensor<double>(m, new[] { numFreqs, frames });
+        }
+
+        Tensor<double> BuildPhases()
+        {
+            var p = new double[numFreqs * frames];
+            for (int i = 0; i < p.Length; i++)
+            {
+                p[i] = -2.0 + (0.31 * ((i * 3) % 11));
+            }
+
+            return new Tensor<double>(p, new[] { numFreqs, frames });
+        }
+
+        var weightData = new double[outputLength];
+        for (int i = 0; i < outputLength; i++)
+        {
+            weightData[i] = 0.25 + (0.11 * ((i * 5) % 7));
+        }
+
+        var weights = new Tensor<double>(weightData, new[] { outputLength });
+
+        double Loss(Tensor<double> magnitude, Tensor<double> phase)
+        {
+            var reconstructed = _engine.ISTFT(magnitude, phase, oddNFft, hop, window, center: false);
+            double total = 0;
+            for (int i = 0; i < outputLength; i++)
+            {
+                total += reconstructed[i] * weights[i];
+            }
+
+            return total;
+        }
+
+        var baseMagnitude = BuildMagnitudes();
+        var basePhase = BuildPhases();
+
+        using var tape = new GradientTape<double>();
+        var output = _engine.ISTFT(baseMagnitude, basePhase, oddNFft, hop, window, center: false);
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(output, weights), null);
+        var grads = tape.ComputeGradients(loss, new[] { baseMagnitude, basePhase });
+
+        const double h = 1e-6;
+        for (int j = 0; j < numFreqs * frames; j++)
+        {
+            var magPlus = BuildMagnitudes();
+            var magMinus = BuildMagnitudes();
+            magPlus[j] += h;
+            magMinus[j] -= h;
+            var magNumeric = (Loss(magPlus, BuildPhases()) - Loss(magMinus, BuildPhases())) / (2 * h);
+            Assert.Equal(magNumeric, grads[baseMagnitude][j], 1e-7);
+
+            var phasePlus = BuildPhases();
+            var phaseMinus = BuildPhases();
+            phasePlus[j] += h;
+            phaseMinus[j] -= h;
+            var phaseNumeric = (Loss(BuildMagnitudes(), phasePlus) - Loss(BuildMagnitudes(), phaseMinus)) / (2 * h);
+            Assert.Equal(phaseNumeric, grads[basePhase][j], 1e-7);
+        }
+    }
+
     [Fact]
     public void GriffinLim_StaysOffTheTape()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/IstftGradientTests.cs
@@ -1,0 +1,230 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Gradient guards for <c>ISTFT</c>, which is now on the tape (issue #905 item 2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Synthesis used to be classified non-differentiable on the grounds that it is a reconstruction
+/// operator rather than a training-path op. STFT-consistency objectives are defined across the round
+/// trip <c>|| S - STFT(ISTFT(S)) ||</c>, so that classification left half of such a loss untrainable
+/// while the training loop still ran and reported a number.
+/// </para>
+/// <para>
+/// These tests deliberately construct the engine as <c>new CpuEngine()</c> rather than taking
+/// <c>AiDotNetEngine.Current</c>. Where a GPU is present the current engine evaluates a
+/// <c>Tensor&lt;double&gt;</c> in single precision on a device without native fp64, and central
+/// differences are worthless at that precision - the step size needed to beat fp32 noise is larger
+/// than the region over which the derivative is constant. On the CPU engine the same comparison has
+/// eight orders of magnitude of headroom.
+/// </para>
+/// </remarks>
+public class IstftGradientTests
+{
+    private readonly IEngine _engine = new CpuEngine();
+
+    private const int NFft = 8;
+    private const int HopLength = 4;
+    private const int NumFreqs = NFft / 2 + 1;
+    private const int NumFrames = 3;
+    private const int OutputLength = ((NumFrames - 1) * HopLength) + NFft;
+
+    /// <summary>
+    /// A deliberately asymmetric window with no zero taps.
+    /// </summary>
+    /// <remarks>
+    /// Asymmetric so that any transposed index error shows up as a wrong value rather than
+    /// cancelling, and non-zero throughout so every output sample takes the normalised branch.
+    /// </remarks>
+    private Tensor<double> Window()
+    {
+        var w = new double[NFft];
+        for (int i = 0; i < NFft; i++)
+        {
+            w[i] = 0.3 + (0.1 * i);
+        }
+
+        return new Tensor<double>(w, new[] { NFft });
+    }
+
+    private static Tensor<double> Magnitudes()
+    {
+        var m = new double[NumFreqs * NumFrames];
+        for (int i = 0; i < m.Length; i++)
+        {
+            m[i] = 0.4 + (0.17 * ((i * 7) % 5));
+        }
+
+        return new Tensor<double>(m, new[] { NumFreqs, NumFrames });
+    }
+
+    private static Tensor<double> Phases()
+    {
+        var p = new double[NumFreqs * NumFrames];
+        for (int i = 0; i < p.Length; i++)
+        {
+            p[i] = -2.0 + (0.31 * ((i * 3) % 11));
+        }
+
+        return new Tensor<double>(p, new[] { NumFreqs, NumFrames });
+    }
+
+    /// <summary>Fixed, varied loss weights, so the seed gradient is not a uniform vector.</summary>
+    private static Tensor<double> LossWeights()
+    {
+        var c = new double[OutputLength];
+        for (int i = 0; i < c.Length; i++)
+        {
+            c[i] = 0.25 + (0.11 * ((i * 5) % 7));
+        }
+
+        return new Tensor<double>(c, new[] { OutputLength });
+    }
+
+    private double Loss(Tensor<double> magnitude, Tensor<double> phase, Tensor<double> weights)
+    {
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: false);
+        double total = 0;
+        for (int i = 0; i < OutputLength; i++)
+        {
+            total += reconstructed[i] * weights[i];
+        }
+
+        return total;
+    }
+
+    private (Tensor<double> Magnitude, Tensor<double> Phase) AnalyticGradients()
+    {
+        var magnitude = Magnitudes();
+        var phase = Phases();
+        var weights = LossWeights();
+
+        using var tape = new GradientTape<double>();
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: false);
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(reconstructed, weights), null);
+        var grads = tape.ComputeGradients(loss, new[] { magnitude, phase });
+
+        Assert.True(grads.ContainsKey(magnitude), "ISTFT recorded no gradient for magnitude");
+        Assert.True(grads.ContainsKey(phase), "ISTFT recorded no gradient for phase");
+        return (grads[magnitude], grads[phase]);
+    }
+
+    [Fact]
+    public void Istft_MagnitudeGradient_MatchesFiniteDifferences()
+    {
+        var (analyticMagnitude, _) = AnalyticGradients();
+        var weights = LossWeights();
+        const double h = 1e-6;
+
+        for (int j = 0; j < NumFreqs * NumFrames; j++)
+        {
+            var plus = Magnitudes();
+            var minus = Magnitudes();
+            plus[j] += h;
+            minus[j] -= h;
+
+            var numeric = (Loss(plus, Phases(), weights) - Loss(minus, Phases(), weights)) / (2 * h);
+            Assert.Equal(numeric, analyticMagnitude[j], 1e-7);
+        }
+    }
+
+    [Fact]
+    public void Istft_PhaseGradient_MatchesFiniteDifferences()
+    {
+        var (_, analyticPhase) = AnalyticGradients();
+        var weights = LossWeights();
+        const double h = 1e-6;
+
+        for (int j = 0; j < NumFreqs * NumFrames; j++)
+        {
+            var plus = Phases();
+            var minus = Phases();
+            plus[j] += h;
+            minus[j] -= h;
+
+            var numeric = (Loss(Magnitudes(), plus, weights) - Loss(Magnitudes(), minus, weights)) / (2 * h);
+            Assert.Equal(numeric, analyticPhase[j], 1e-7);
+        }
+    }
+
+    [Fact]
+    public void Istft_GradientReachesBothInputs_NotSilentlyZero()
+    {
+        // The regression that matters. Before this change ISTFT sat in
+        // OpRegistry.NonDifferentiableOps, so a loss downstream of it produced no gradient at all
+        // and training proceeded quietly. A forward-only test would not have noticed.
+        var (analyticMagnitude, analyticPhase) = AnalyticGradients();
+
+        var magnitudeMoved = false;
+        var phaseMoved = false;
+        for (int j = 0; j < NumFreqs * NumFrames; j++)
+        {
+            if (analyticMagnitude[j] != 0.0) { magnitudeMoved = true; }
+            if (analyticPhase[j] != 0.0) { phaseMoved = true; }
+        }
+
+        Assert.True(magnitudeMoved, "every magnitude gradient is zero - the tape connection is severed");
+        Assert.True(phaseMoved, "every phase gradient is zero - the tape connection is severed");
+    }
+
+    [Fact]
+    public void Istft_ForwardIsUnchanged()
+    {
+        // Recording on the tape must not perturb the value. Overlap-add with a window-sum
+        // normalisation is exactly reconstructible for a constant-magnitude, zero-phase spectrum
+        // only in the interior, so this pins the whole vector against a direct recomputation
+        // instead of against a closed form.
+        var magnitude = Magnitudes();
+        var phase = Phases();
+        var window = Window();
+
+        var withoutTape = _engine.ISTFT(magnitude, phase, NFft, HopLength, window, center: false);
+
+        double[] expected;
+        using (var tape = new GradientTape<double>())
+        {
+            var withTape = _engine.ISTFT(magnitude, phase, NFft, HopLength, window, center: false);
+            expected = new double[OutputLength];
+            for (int i = 0; i < OutputLength; i++)
+            {
+                expected[i] = withTape[i];
+            }
+        }
+
+        for (int i = 0; i < OutputLength; i++)
+        {
+            Assert.Equal(expected[i], withoutTape[i], 1e-12);
+        }
+    }
+
+    [Fact]
+    public void Istft_GradientFlowsThroughAConsistencyRoundTrip()
+    {
+        // The shape of the objective from issue #905: synthesise, re-analyse, and define the loss
+        // on the re-analysed magnitude. This only trains if synthesis is differentiable.
+        var magnitude = Magnitudes();
+        var phase = Phases();
+
+        using var tape = new GradientTape<double>();
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: false);
+        var reanalysed = _engine.Spectrogram(reconstructed, NFft, HopLength, NFft, Window());
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(reanalysed, reanalysed), null);
+        var grads = tape.ComputeGradients(loss, new[] { magnitude, phase });
+
+        Assert.True(grads.ContainsKey(magnitude), "no gradient reached magnitude through the round trip");
+
+        var moved = false;
+        for (int j = 0; j < NumFreqs * NumFrames; j++)
+        {
+            if (grads[magnitude][j] != 0.0) { moved = true; }
+        }
+
+        Assert.True(moved, "the round-trip gradient is identically zero");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/StftPhaseGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/StftPhaseGradientTests.cs
@@ -168,29 +168,63 @@ public class StftPhaseGradientTests
         Assert.True(moved, "every waveform gradient is zero - the tape connection is severed");
     }
 
+    /// <summary>
+    /// Fixed, varied weights, so the seed gradient is not uniform.
+    /// </summary>
+    private static Tensor<double> RoundTripWeights(int length)
+    {
+        var w = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            w[i] = 0.25 + (0.11 * ((i * 5) % 7));
+        }
+
+        return new Tensor<double>(w, new[] { length });
+    }
+
     [Fact]
     public void StftPhase_AndIstft_CloseTheRoundTrip()
     {
         // Both inputs of ISTFT are now differentiable functions of the waveform, so a consistency
         // objective defined across analysis and synthesis trains end to end.
+        //
+        // The loss is built from the reconstruction ALONE. An obvious spelling of this test uses the
+        // residual (reconstructed - waveform), which is wrong here: that subtraction gives the
+        // waveform a direct edge to the loss, so its gradient stays non-zero even with the whole
+        // round trip severed. Measured with StopGradient across the chain, the residual form still
+        // reported a non-zero waveform gradient - it was passing for a reason unrelated to what it
+        // claimed. Asserting on the two intermediates as well pins each leg of the chain.
         var waveform = Waveform();
+        var weights = RoundTripWeights(SignalLength);
 
         using var tape = new GradientTape<double>();
         var magnitude = _engine.Spectrogram(waveform, NFft, HopLength, NFft, Window());
         var phase = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
         var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: true, SignalLength);
-        var residual = _engine.TensorSubtract(reconstructed, waveform);
-        var loss = _engine.ReduceSum(_engine.TensorMultiply(residual, residual), null);
-        var grads = tape.ComputeGradients(loss, new[] { waveform });
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(reconstructed, weights), null);
+        var grads = tape.ComputeGradients(loss, new[] { waveform, magnitude, phase });
 
-        Assert.True(grads.ContainsKey(waveform), "no gradient survived the analysis-synthesis round trip");
+        AssertMoved(grads, waveform, "waveform", SignalLength);
+        AssertMoved(grads, magnitude, "magnitude", magnitude.Length);
+        AssertMoved(grads, phase, "phase", phase.Length);
+    }
 
-        var moved = false;
-        for (int j = 0; j < SignalLength; j++)
+    private static void AssertMoved(
+        System.Collections.Generic.Dictionary<Tensor<double>, Tensor<double>> grads,
+        Tensor<double> tensor,
+        string name,
+        int length)
+    {
+        Assert.True(grads.ContainsKey(tensor), $"no gradient reached {name} through the round trip");
+
+        for (int j = 0; j < length; j++)
         {
-            if (grads[waveform][j] != 0.0) { moved = true; }
+            if (grads[tensor][j] != 0.0)
+            {
+                return;
+            }
         }
 
-        Assert.True(moved, "the round-trip gradient is identically zero");
+        Assert.Fail($"every {name} gradient is zero - that leg of the round trip is severed");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/StftPhaseGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/StftPhaseGradientTests.cs
@@ -1,0 +1,196 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+/// <summary>
+/// Gradient guards for <c>StftPhase</c>, the phase counterpart of <c>Spectrogram</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #905 wants a differentiable path to an angle. <c>STFT</c> emits phase through an
+/// <c>out</c> parameter and is deliberately unrecorded, so the only differentiable analysis output
+/// was magnitude, via <c>Spectrogram</c>. An objective defined on phase had nothing to attach to.
+/// </para>
+/// <para>
+/// Built on <c>new CpuEngine()</c> for the same reason as the ISTFT gradchecks: where a GPU is
+/// present the current engine evaluates a <c>Tensor&lt;double&gt;</c> in single precision on a
+/// device without native fp64, and central differences are worthless at that precision.
+/// </para>
+/// </remarks>
+public class StftPhaseGradientTests
+{
+    private readonly IEngine _engine = new CpuEngine();
+
+    private const int NFft = 16;
+    private const int HopLength = 4;
+    private const int SignalLength = 64;
+
+    private static Tensor<double> Window()
+    {
+        var w = new double[NFft];
+        for (int i = 0; i < NFft; i++)
+        {
+            w[i] = 0.5 - (0.5 * Math.Cos(2.0 * Math.PI * i / (NFft - 1)));
+        }
+
+        return new Tensor<double>(w, new[] { NFft });
+    }
+
+    /// <summary>
+    /// A deterministic waveform with no near-silent bins.
+    /// </summary>
+    /// <remarks>
+    /// The phase derivative carries a 1/|C| factor, so a bin whose magnitude approaches zero has an
+    /// unbounded true derivative and finite differences there measure nothing meaningful. Two
+    /// incommensurate tones plus an offset keep every bin comfortably excited.
+    /// </remarks>
+    private static Tensor<double> Waveform()
+    {
+        var x = new double[SignalLength];
+        for (int i = 0; i < SignalLength; i++)
+        {
+            x[i] = 0.6 + Math.Sin(0.37 * i) + (0.4 * Math.Cos(1.13 * i));
+        }
+
+        return new Tensor<double>(x, new[] { SignalLength });
+    }
+
+    private double Loss(Tensor<double> waveform)
+    {
+        var phase = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
+        double total = 0;
+        for (int i = 0; i < phase.Length; i++)
+        {
+            total += phase[i];
+        }
+
+        return total;
+    }
+
+    private Tensor<double> AnalyticGradient()
+    {
+        var waveform = Waveform();
+        using var tape = new GradientTape<double>();
+        var phase = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
+        var loss = _engine.ReduceSum(phase, null);
+        var grads = tape.ComputeGradients(loss, new[] { waveform });
+
+        Assert.True(grads.ContainsKey(waveform), "StftPhase recorded no gradient for the waveform");
+        return grads[waveform];
+    }
+
+    [Fact]
+    public void StftPhase_MatchesTheStftPhaseOutput()
+    {
+        var waveform = Waveform();
+        _engine.STFT(waveform, NFft, HopLength, Window(), center: true, out _, out var expected);
+
+        var actual = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i], actual[i], 1e-12);
+        }
+    }
+
+    [Fact]
+    public void StftPhase_ShapeMatchesSpectrogram()
+    {
+        // The two must be usable together bin for bin - that is the whole point of adding this one.
+        var waveform = Waveform();
+        var magnitude = _engine.Spectrogram(waveform, NFft, HopLength, NFft, Window());
+        var phase = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
+
+        Assert.Equal(magnitude.Shape.ToArray(), phase.Shape.ToArray());
+    }
+
+    /// <summary>
+    /// Central difference at one step size.
+    /// </summary>
+    private double CentralDifference(int j, double h)
+    {
+        var plus = Waveform();
+        var minus = Waveform();
+        plus[j] += h;
+        minus[j] -= h;
+        return (Loss(plus) - Loss(minus)) / (2 * h);
+    }
+
+    [Fact]
+    public void StftPhase_Gradient_MatchesFiniteDifferences()
+    {
+        var analytic = AnalyticGradient();
+        const double h = 1e-6;
+
+        for (int j = 0; j < SignalLength; j++)
+        {
+            // Richardson extrapolation rather than a bare central difference. A central difference
+            // is O(h^2) accurate, and wrapped phase is nonlinear enough that at h = 1e-6 that error
+            // reached 1.2e-6 in absolute terms - larger than the disagreement worth detecting.
+            // Combining two step sizes as (4 D(h/2) - D(h)) / 3 cancels the h^2 term and leaves
+            // O(h^4). Measured over all 64 samples, the worst relative disagreement falls from
+            // 1.07e-6 to 1.41e-7 - so the threshold below sits about 7x above the observed noise
+            // rather than being widened until the test happened to pass.
+            //
+            // What remains is subtraction roundoff, not a systematic error. Two things say so: the
+            // discrepancy SHRANK with the step size, which a missing term would not do, and its
+            // sign is balanced across the samples (31 positive, 33 negative) where a missing term
+            // would bias one way. A wrong derivative misses by O(1) relative, six orders above this.
+            var coarse = CentralDifference(j, h);
+            var fine = CentralDifference(j, h / 2);
+            var numeric = ((4 * fine) - coarse) / 3;
+
+            var scale = Math.Max(1.0, Math.Max(Math.Abs(numeric), Math.Abs(analytic[j])));
+            Assert.True(
+                Math.Abs(numeric - analytic[j]) / scale < 1e-6,
+                $"waveform[{j}]: analytic {analytic[j]:G10} vs numeric {numeric:G10}");
+        }
+    }
+
+    [Fact]
+    public void StftPhase_GradientReachesTheWaveform_NotSilentlyZero()
+    {
+        // The regression that matters: before this op existed the only way to reach phase was the
+        // unrecorded STFT out-parameter, which produced no gradient at all while training ran.
+        var analytic = AnalyticGradient();
+
+        var moved = false;
+        for (int j = 0; j < SignalLength; j++)
+        {
+            if (analytic[j] != 0.0) { moved = true; }
+        }
+
+        Assert.True(moved, "every waveform gradient is zero - the tape connection is severed");
+    }
+
+    [Fact]
+    public void StftPhase_AndIstft_CloseTheRoundTrip()
+    {
+        // Both inputs of ISTFT are now differentiable functions of the waveform, so a consistency
+        // objective defined across analysis and synthesis trains end to end.
+        var waveform = Waveform();
+
+        using var tape = new GradientTape<double>();
+        var magnitude = _engine.Spectrogram(waveform, NFft, HopLength, NFft, Window());
+        var phase = _engine.StftPhase(waveform, NFft, HopLength, NFft, Window());
+        var reconstructed = _engine.ISTFT(magnitude, phase, NFft, HopLength, Window(), center: true, SignalLength);
+        var residual = _engine.TensorSubtract(reconstructed, waveform);
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(residual, residual), null);
+        var grads = tape.ComputeGradients(loss, new[] { waveform });
+
+        Assert.True(grads.ContainsKey(waveform), "no gradient survived the analysis-synthesis round trip");
+
+        var moved = false;
+        for (int j = 0; j < SignalLength; j++)
+        {
+            if (grads[waveform][j] != 0.0) { moved = true; }
+        }
+
+        Assert.True(moved, "the round-trip gradient is identically zero");
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/GpuCpuAutoDifferentialTests.cs
@@ -711,6 +711,11 @@ public sealed class GpuCpuAutoDifferentialTests : IClassFixture<GpuCpuAutoDiffer
         "PitchShift(Tensor<T>,Int32,Double,Int32,Int32)",
         "ReorderToNchwc(Tensor<T>,TensorLayout)",
         "Spectrogram(Tensor<T>,Int32,Int32,Int32,Tensor<T>)",
+        // Same STFT kernel as Spectrogram, keeping the other output. Covered by the StftPhaseCos
+        // and StftPhaseSin parity cases, which compare through cos and sin rather than the angle:
+        // the output is WRAPPED phase, so two correct implementations can report +pi and -pi for one
+        // angle and differ by exactly 2*pi. The generic fuzzer would read that as a failure.
+        "StftPhase(Tensor<T>,Int32,Int32,Int32,Tensor<T>)",
         "TensorArgsort(Tensor<T>,Int32,Boolean)",
         "TensorBucketize(Tensor<T>,Tensor<T>,Boolean)",
         "TensorCross(Tensor<T>,Tensor<T>,Int32)",

--- a/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/OpParity/OpParityRegistry.cs
@@ -3257,6 +3257,24 @@ public static class OpParityRegistry
         yield return new OpCase("RFFT[16]", "fft", e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).F()), e => e.RFFT(OpInput.Rand(2400, new[] { 16 }).D()), ParityTol.Accum(1e-3), opMethod: "RFFT")
         { GraphCaptureExpectation = GraphCaptureExpectation.Required };
         yield return new OpCase("Spectrogram[1,64;n16h8w16]", "audio", e => e.Spectrogram(OpInput.Rand(2401, new[] { 1, 64 }).F(), 16, 8, 16, null), e => e.Spectrogram(OpInput.Rand(2401, new[] { 1, 64 }).D(), 16, 8, 16, null), ParityTol.Accum(1e-3), opMethod: "Spectrogram");
+        // StftPhase runs the same StftMagPhase kernel as Spectrogram and keeps the other output, so
+        // without a case of its own the GPU override would be entirely unexercised - it is
+        // float-only and needs a backend, which the double-precision gradient tests never provide.
+        //
+        // Compared through cos and sin rather than directly. The output is WRAPPED phase, so two
+        // correct implementations may report +pi and -pi for the same angle and differ by exactly
+        // 2*pi: comparing raw values, CPU gave 3.1415927 and GPU -3.1415923 at bin 72, a 2157060020
+        // ULP "disagreement" that is really no disagreement at all. cos and sin are continuous
+        // across the cut, and the pair pins the angle uniquely mod 2*pi where either alone would
+        // leave a reflection unconstrained.
+        //
+        // Seed 7 rather than the 2401 used elsewhere in this file. Under 2401 one bin landed with
+        // its phase on the cut, where CPU and GPU drifted 6e-6 radians apart - invisible in cos,
+        // which is at a turning point near +/-pi, but passed through one for one by sin, which is
+        // at maximum slope there. Choosing an input that keeps the bins off the cut is a fixture
+        // fix; widening the tolerance to accommodate it would not have been.
+        yield return new OpCase("StftPhaseCos[1,64;n16h8w16]", "audio", e => e.TensorCos(e.StftPhase(OpInput.Rand(7, new[] { 1, 64 }).F(), 16, 8, 16, null)), e => e.TensorCos(e.StftPhase(OpInput.Rand(7, new[] { 1, 64 }).D(), 16, 8, 16, null)), ParityTol.Accum(1e-3), opMethod: "StftPhase");
+        yield return new OpCase("StftPhaseSin[1,64;n16h8w16]", "audio", e => e.TensorSin(e.StftPhase(OpInput.Rand(7, new[] { 1, 64 }).F(), 16, 8, 16, null)), e => e.TensorSin(e.StftPhase(OpInput.Rand(7, new[] { 1, 64 }).D(), 16, 8, 16, null)), ParityTol.Accum(1e-3), opMethod: "StftPhase");
 
         var lg = OpInput.Rand(2410, new[] { 4, 8 }, -3.0, 3.0);
         var gg = OpInput.Rand(2411, new[] { 4, 8 });


### PR DESCRIPTION
## What

Closes the remaining half of issue #905: **item 2**, the STFT round trip.

- `ISTFT` is now differentiable, with `IstftBackward` as the genuine transpose of overlap-add
  synthesis.
- New `StftPhase` op, the phase counterpart of `Spectrogram`, on both the CPU and GPU.
- A pre-existing transform defect fixed along the way (see below).

Together with `Spectrogram`, both inputs of `ISTFT` are now differentiable functions of the waveform,
so an STFT-consistency objective `|| S - STFT(ISTFT(S)) ||` trains end to end.

## Why

The issue reports that `STFT` returns through `out` parameters and so cannot appear in a
differentiable graph, while `ISTFT` "returns its result and composes fine". **That second half is not
true** - both were in `OpRegistry.NonDifferentiableOps`. The real division is that `STFT`/`ISTFT` are
deliberately unrecorded primitives and `Spectrogram`/`MelSpectrogram` are the recorded entry points
built on them. So the actual gaps were narrower and different from the report:

1. Synthesis had no gradient at all. A consistency objective is defined *across* the round trip, so
   half of it was untrainable while the loop still ran and reported a number.
2. No differentiable path returned **phase**. `Spectrogram` is magnitude-only by construction.

## How

**`IstftBackward`** transposes each forward stage in reverse: the window-sum normalisation (under
the same `1e-8` guard the forward uses, or the two disagree exactly where the forward declined to
divide), the windowed scatter-add inverted to a gather, the unnormalised inverse DFT whose transpose
is a forward one, the Hermitian mirror folded back onto bins `1..numFreqs-2`, and the polar map
`dL/dm = gRe cos p + gIm sin p`, `dL/dp = m (gIm cos p - gRe sin p)`.

**`StftPhase`** mirrors `Spectrogram` exactly. Magnitude and phase share every step of their adjoint
except the per-bin seed, so `MagnitudeStftAdjoint` becomes a thin forwarder onto one implementation
selected by an `StftAdjointTarget`. The phase seed is the magnitude seed rotated a quarter turn and
scaled by `1/|C|` - which is also the only reason the phase target needs a floor, since at zero
magnitude the angle is undefined rather than merely steep.

**Both engines record.** A GPU path computing the right values and recording nothing would make
trainability depend on which engine happened to be current, which is the same defect one level down.
The GPU `StftPhase` reuses the `StftMagPhase` kernel `Spectrogram` already runs.

**`GriffinLim` and `TimeStretch`** call `ISTFT` internally and stay non-differentiable, so their
internals are wrapped in `NoGradScope` - otherwise a tape-active `GriffinLim` would unroll 60
iterations onto the tape. On the GPU engine that scope also covers its momentum arithmetic, which was
*already* recording `TensorSubtract`/`TensorAdd` nodes while the CPU engine recorded none. The two
engines now agree.

## A pre-existing defect this surfaced

`DifferentiableOpsGradCheckSweep` failed on ISTFT, and the cause was not the adjoint.

**`FFTCore` zero-pads a non-power-of-two length to the next power of two**, which computes a
different transform - its bins sit at `k/nPadded` rather than `k/n`. This was already known and
documented on `UnnormalizedTransformForAdjoint`, but only the **adjoint** had been moved onto the
exact transform. At those lengths `STFT` and `ISTFT` were therefore disagreeing with their own
transposes, silently. Both now use it; identical call for power-of-two lengths, which is every
realistic one. The helper loses its `ForAdjoint` suffix since it is no longer adjoint-only.

## Verification

**4207 passed, 0 failed** across the autodiff, op-parity, completeness, FFT and audio suites.

Gradients are checked by central differences under **Richardson extrapolation**, on an explicit
`new CpuEngine()` so the check runs in true double rather than the fp32 a GPU engine uses for
`Tensor<double>` on a device without native fp64.

Two measurements say the residual is roundoff rather than a systematic error: extrapolation drops the
worst relative disagreement over 64 samples from **1.07e-6 to 1.41e-7**, and its sign is balanced
**31 positive / 33 negative**. A missing term would neither shrink with step size nor balance in sign.

## What adversarial review of the first commit changed

- **Every ISTFT gradcheck used `center: false`** - mine and the sweep's synthesized argument alike -
  leaving the centred path, with its negative write offsets and out-of-range trimming, unchecked.
  Both finite-difference tests are now theories over both settings.
- **The `NoGradScope` keeping `GriffinLim` off the tape had no test.** A scope that silently stopped
  working would surface nowhere, because the forward value is identical either way.
  `GriffinLim_StaysOffTheTape` covers it.
- **`StftPhase`'s GPU override had no coverage at all.** It is float-only and needs a backend, which
  the double-precision gradient tests never provide, and OpParity is a hand-maintained registry
  rather than reflective. Added parity cases - which then failed, exactly as intended.

## On the parity cases

They compare `cos` and `sin` of the phase, not the phase itself. Two correct implementations may
report `+pi` and `-pi` for the same angle and differ by exactly `2*pi`: comparing raw values, CPU gave
`3.1415927` and GPU `-3.1415923` at one bin, a 2157060020-ULP "disagreement" that is no disagreement.
`cos` and `sin` are continuous across the cut and the pair pins the angle uniquely.

**No tolerance was widened for this.** The tape-gradient bar is hardcoded at `1e-4` for all ops and is
untouched. The seed keeps every bin off the cut, so both cases run at the default tolerances - a
fixture fix rather than a relaxed bound.

Refs #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added differentiable STFT phase output for CPU and GPU engines.
  - Added gradient support for inverse STFT, including magnitude and phase inputs.
  - Enabled phase-based audio analysis and reconstruction workflows.

- **Bug Fixes**
  - Improved STFT and inverse STFT accuracy for odd and non-power-of-two transform lengths.
  - Prevented Griffin-Lim processing from recording unsupported gradients.
  - Improved handling of near-zero-magnitude phase bins to avoid unstable gradients.
  - Improved consistency between CPU and GPU phase-processing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->