### PR TITLE
feat(autotune): persist quarantine and restore validated deployments

### DIFF
--- a/docs/EVOLUTIONARY_AUTOTUNING.md
+++ b/docs/EVOLUTIONARY_AUTOTUNING.md
@@ -48,6 +48,11 @@ Evolution runs only in an explicit offline, startup, or caller-admitted idle wor
 pre-resolved `KernelTuningDeployment<TConfiguration>`; its hit path is one volatile reference read and a typed
 assignment, with no filesystem access, parsing, reflection, hashing, or search.
 
+An opt-in `QuarantinedKernelTuningStore<TConfiguration>` adds persistent admission checks off the dispatch path.
+`QuarantineAsync` deactivates an exact observed failing snapshot, retains structured regression evidence, and can
+restore a caller-retained validated prior snapshot. See [quarantine and rollback](evolution-runtime-fallback.md)
+for failure handling, producer coordination and the remaining automatic-monitoring limitations.
+
 ## Integrated domains
 
 - `GemmAutoTuner.CreateEvolutionTuner` searches actual typed `GemmConfig` code-generation and launch fields. The

--- a/docs/evolution-runtime-fallback.md
+++ b/docs/evolution-runtime-fallback.md
@@ -1,6 +1,78 @@
-# Deactivating an observed tuning deployment
+# Quarantine, rollback and in-memory deactivation
 
-Roadmap slice: US-25. Validated promotion already exists; this adds a runtime escape hatch.
+Roadmap slice: US-25. Validated promotion already exists. These APIs add an explicit runtime response to
+caller-observed regression; they do not implement an automatic monitor.
+
+## Persistent quarantine and optional rollback
+
+Pass `QuarantinedKernelTuningStore<TConfiguration>` through the tuner's existing `store` parameter, wrapping
+your existing store if needed. Use the same canonical, absolute, private journal directory for every cooperating
+producer. Capture both the exact active snapshot used by the operation and any prior validated snapshot you
+intend to retain for rollback. The default remains opt-out; existing constructors and package pins are unchanged.
+
+```csharp
+var store = new QuarantinedKernelTuningStore<MyConfiguration>(absolutePrivateJournalDirectory, existingStore);
+// Supply store: store when constructing EvolutionKernelAutotuner<MyConfiguration>.
+// A monitor observes a regression against the exact snapshot used by the operation:
+var evidence = new KernelTuningRegressionEvidence(
+    KernelTuningRegressionReason.Latency,
+    policyVersion: "paired-p95-ms-v1",
+    rawEvidenceSha256: retainedRawMeasurementsSha256,
+    observedValue: observedP95Milliseconds,
+    maximumAllowedValue: allowedP95Milliseconds,
+    observedAt: observationTime);
+var result = await tuner.QuarantineAsync(observedSnapshot, evidence, priorValidatedSnapshot, cancellationToken);
+// WasApplied: the exact snapshot was removed and blocked in this process.
+// WasPersisted / ReceiptPath: this call retained a complete write-once regression receipt.
+// RollbackDeployment / WasRollbackPersisted: distinguish activation from winner-store persistence.
+```
+
+This is a usage fragment: the application supplies immutable `MyConfiguration`, its codec, the configured tuner,
+actual monitoring measurements, their raw artifact, and the optional retained prior snapshot. No runtime measurement
+or raw artifact is manufactured by the quarantine API. The policy version defines the statistic and its units;
+both observed value and limit use those units, and the observed larger-is-worse statistic must exceed its limit.
+
+Given a regression for the exact active snapshot, when `QuarantineAsync` runs, then it deactivates that snapshot,
+blocks its canonical configuration, and attempts a durable receipt before publishing any rollback.
+
+Given a later snapshot is active, when stale evidence arrives, then `WasApplied` is false and the later snapshot
+is preserved, including a newer validation of the same genome.
+
+Given a retained prior snapshot matches the tuning identity, canonical codec hash and current deployment
+validator, when it is not quarantined, then it may be restored and separately persisted. When quarantine was
+applied but no eligible prior was published, the handle remains empty for built-in fallback. Stale unapplied
+requests leave the current deployment untouched. This is explicit rollback to caller-retained evidence, not an automatic
+search through deployment history or a new measurement of the prior configuration.
+
+Given a winner was loaded before quarantine, when final publication is attempted afterward, then publication
+rechecks admission under the same process-local journal gate and rejects it. Load-only filtering is insufficient.
+
+Given a complete receipt is retained, when another tuner loads that journal, then the same configuration is
+inadmissible even if selected by a new run. The key includes the exact tuning envelope, codec id/version and
+canonical configuration hash; the source run-state hash is retained as evidence, not used to bypass quarantine.
+Changed device, protocol or codec identity is a separate applicability envelope requiring caller policy.
+
+Given a corrupt, empty or unknown-version record exists, when admission checks its key, then it is denied without
+parsing the record. Missing or unreadable journal state also denies admission. Valid receipts contain bounded
+strict-UTF8 configuration payloads, identifiers and structured regression evidence; they do not embed raw evidence
+or credentials. The caller must protect journal and evidence-artifact permissions.
+
+Given a receipt write fails, when quarantine finishes, then the configuration remains blocked across wrappers
+sharing that journal in this process, but `WasPersisted` is false and restart safety is not established. Receipt
+writes use create-new temporary files, a disk flush and a non-overwriting move. Existing receipts are retained;
+incomplete or conflicting `.pending` files are left recoverable. A preexisting receipt is not falsely reported
+as this invocation's successful write. No automatic deletion, unblock or release API exists in this slice.
+
+Given cancellation arrives before mutation, when quarantine checks it, then it changes nothing. After mutation
+starts, persistence and rollback finish without cancellation so cancellation cannot interrupt the safety response.
+
+Publication and quarantine are serialized within this process, not across processes. Already active handles
+elsewhere are not automatically revoked; an explicit `TryHydrate` rechecks and deactivates an inadmissible current
+snapshot. Concurrent cross-process publication, filesystem aliases, journal tampering, in-flight operations,
+automatic drift detection, bounded revalidation, and program/AutoML deployment registries remain outside this
+slice. Serving `TryGet` still performs only a volatile snapshot read: no file I/O, hashes, locks or monitor calls.
+
+## In-memory deactivation only
 
 ```csharp
 var observed = deployment.Current;
@@ -18,5 +90,28 @@ false and cannot remove the newer deployment, even if both snapshots name the sa
 
 This does not cancel already running kernels, mutate cache files, persist a quarantine, automatically detect
 drift, or forbid later hydration/tuning from republishing. A persistent operational quarantine needs a separate
-policy controlling those producers and the cache. Never reread Current after the failing operation and use that
+policy controlling those producers and the cache, such as the opt-in decorator above. Never reread Current after the failing operation and use that
 new snapshot as the deactivation target: capture the one actually used.
+
+## Verification scope
+
+The tests use deterministic fake kernel configurations and measurements: they verify deployment and persistence
+contracts, not GPU performance or automatic detection quality. They exercise the real tuner, cache and filesystem,
+including publication barriers, stale observations, corrupt tombstones, write failures, independent journal-state
+reload, immutable evidence, invalid rollback and unchanged legacy behavior.
+
+Cross-runtime verification also exposed an existing winner-cache write failure on .NET Framework: appending a
+temporary suffix turned a usable 224-character destination into a failing 263-character path. Both cache and
+quarantine now use short unique sibling temporary filenames, retaining same-directory rename semantics. The
+regression test uses the original test paths, not shortened fixture paths or a suppressed failure.
+
+Run the committed tests through the main test project:
+
+```text
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f net10.0 -p:GeneratePackageOnBuild=false --filter FullyQualifiedName~Helpers.Autotune
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f net471 -p:GeneratePackageOnBuild=false --filter FullyQualifiedName~Helpers.Autotune
+```
+
+The net471 test command requires a compatible .NET Framework runtime (local Windows verification). The library
+also builds for net8.0; the main test project does not target net8.0. No package publication, native kernel change,
+paid model call or automatic production rollout is part of this change.

--- a/docs/evolution-runtime-fallback.md
+++ b/docs/evolution-runtime-fallback.md
@@ -23,7 +23,7 @@ var evidence = new KernelTuningRegressionEvidence(
     observedAt: observationTime);
 var result = await tuner.QuarantineAsync(observedSnapshot, evidence, priorValidatedSnapshot, cancellationToken);
 // WasApplied: the exact snapshot was removed and blocked in this process.
-// WasPersisted / ReceiptPath: this call retained a complete write-once regression receipt.
+// WasPersisted / ReceiptPath: all supported durability barriers succeeded for this receipt.
 // RollbackDeployment / WasRollbackPersisted: distinguish activation from winner-store persistence.
 ```
 
@@ -63,6 +63,18 @@ writes use create-new temporary files, a disk flush and a non-overwriting move. 
 incomplete or conflicting `.pending` files are left recoverable. A preexisting receipt is not falsely reported
 as this invocation's successful write. No automatic deletion, unblock or release API exists in this slice.
 
+Durable success currently requires Linux on x86, x64, ARM32 or ARM64: after the flushed file is renamed, the containing directory and its
+ancestors are synchronized, including the newly created journal path. A file flush alone does not persist its
+directory entry, as specified by the [Linux `fsync` contract](https://man7.org/linux/man-pages/man2/fsync.2.html).
+Any failed or unavailable barrier leaves `WasPersisted` false; an already visible tombstone is not removed.
+Storage must honor the operating system's flush requests.
+
+Windows, macOS and other platforms currently retain only a best-effort receipt and report `WasPersisted=false`.
+In particular, [Windows `MoveFileExW`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw)
+documents `MOVEFILE_WRITE_THROUGH` flushing for copy/delete moves; this implementation does not infer a
+same-volume no-overwrite rename guarantee from the flag name. A normal process restart can still see the
+best-effort tombstone, but callers must not treat it as power-loss-safe quarantine.
+
 Given cancellation arrives before mutation, when quarantine checks it, then it changes nothing. After mutation
 starts, persistence and rollback finish without cancellation so cancellation cannot interrupt the safety response.
 
@@ -99,6 +111,8 @@ The tests use deterministic fake kernel configurations and measurements: they ve
 contracts, not GPU performance or automatic detection quality. They exercise the real tuner, cache and filesystem,
 including publication barriers, stale observations, corrupt tombstones, write failures, independent journal-state
 reload, immutable evidence, invalid rollback and unchanged legacy behavior.
+Typed, per-store fault injection additionally verifies ordering and failed directory/ancestor barriers. Those
+tests do not simulate a power cut: native filesystem tests and the documented OS barriers define that contract.
 
 Cross-runtime verification also exposed an existing winner-cache write failure on .NET Framework: appending a
 temporary suffix turned a usable 224-character destination into a failing 263-character path. Both cache and

--- a/docs/evolution-runtime-fallback.md
+++ b/docs/evolution-runtime-fallback.md
@@ -1,0 +1,22 @@
+# Deactivating an observed tuning deployment
+
+Roadmap slice: US-25. Validated promotion already exists; this adds a runtime escape hatch.
+
+```csharp
+var observed = deployment.Current;
+// Dispatch/validate against this exact snapshot. On a detected regression:
+if (observed is not null)
+    deployment.TryDeactivate(observed);
+// Future TryGet calls return false if removal won; dispatch uses its built-in fallback.
+```
+
+Given a runtime check fails for a captured snapshot, when `TryDeactivate` sees that snapshot still active,
+then it atomically removes it so subsequent dispatch can fall back.
+
+Given a newer snapshot was published, when an older operation reports failure, then its deactivation returns
+false and cannot remove the newer deployment, even if both snapshots name the same genome.
+
+This does not cancel already running kernels, mutate cache files, persist a quarantine, automatically detect
+drift, or forbid later hydration/tuning from republishing. A persistent operational quarantine needs a separate
+policy controlling those producers and the cache. Never reread Current after the failing operation and use that
+new snapshot as the deactivation target: capture the one actually used.

--- a/docs/evolution-runtime-fallback.md
+++ b/docs/evolution-runtime-fallback.md
@@ -114,6 +114,34 @@ reload, immutable evidence, invalid rollback and unchanged legacy behavior.
 Typed, per-store fault injection additionally verifies ordering and failed directory/ancestor barriers. Those
 tests do not simulate a power cut: native filesystem tests and the documented OS barriers define that contract.
 
+### Review verification (2026-09-11)
+
+On the original source, nine Windows cases incorrectly claimed durable receipt
+persistence (9 failed, 55 passed in the controlled contract run). After the
+directory-barrier fix, the full `Helpers.Autotune` selection passes **202 tests
+with no skips** on Windows/net10, Windows/net471 and Linux/net10. The main reviewer
+independently reviewed the native boundary and repeated all three selections,
+including actual Linux `open`/`fsync` calls in an SDK container. This is syscall,
+status and ordering evidence, not a physical power-cut experiment.
+
+```powershell
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f net10.0 --filter FullyQualifiedName~Helpers.Autotune --logger trx
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f net471 --filter FullyQualifiedName~Helpers.Autotune --logger trx
+```
+
+The typed-cache round-trip now asserts the exact loaded `KernelChoice.Variant`.
+All closed invalid-input fixture modes in the touched quarantine tests use enums.
+Defensive null cases invoke the real runtime guards through reflection, without
+null-forgiving operators or weakening the public nullable contracts. An initial
+test-only reflection lookup missed internal `CanDeploy`; the preserved
+`pr1024-root-typed-guards.trx` records that failure, and all final selections use
+the corrected lookup. No runtime guard was removed to make that test pass.
+
+Final independent reports: `pr1024-root-typed-guards-final.trx`,
+`pr1024-root-typed-net471-final.trx`, and the Linux TRX/log under
+`artifacts/pr1024-linux-root`. Linux source/cache mounts were read-only and its
+build outputs temporary; it did not overwrite the Windows build artifacts.
+
 Cross-runtime verification also exposed an existing winner-cache write failure on .NET Framework: appending a
 temporary suffix turned a usable 224-character destination into a failing 263-character path. Both cache and
 quarantine now use short unique sibling temporary filenames, retaining same-directory rename semantics. The

--- a/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/AutotuneCache.cs
@@ -256,7 +256,9 @@ public static class AutotuneCache
         // paths share a filesystem (they do, same directory), so concurrent
         // readers see either the old file or the new file — never a half-written
         // one.
-        string tmpPath = finalPath + ".tmp-" + Environment.CurrentManagedThreadId + "-" + Guid.NewGuid().ToString("N");
+        // Do not append to the already-long canonical winner filename: on .NET Framework a valid
+        // final path can otherwise become an unusable temporary path. Keep the unique temp on the same volume.
+        string tmpPath = Path.Combine(directory, ".autotune-" + Guid.NewGuid().ToString("N") + ".tmp");
         try
         {
             File.WriteAllText(tmpPath, json);

--- a/src/AiDotNet.Tensors/Helpers/Autotune/EvolutionKernelAutotuner.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/EvolutionKernelAutotuner.cs
@@ -120,10 +120,16 @@ public sealed class EvolutionKernelAutotuner<TConfiguration>
     public bool TryHydrate()
     {
         KernelTuningDeploymentSnapshot<TConfiguration>? current = _deployment.Current;
-        if (current is not null) return CanDeploy(current.Configuration);
+        if (current is not null)
+        {
+            bool admitted = CanDeploy(current.Configuration);
+            if (!admitted && _store is QuarantinedKernelTuningStore<TConfiguration>)
+                _deployment.TryDeactivate(current);
+            return admitted;
+        }
         if (!TryLoadValidSnapshot(out KernelTuningDeploymentSnapshot<TConfiguration>? snapshot) ||
             snapshot is null) return false;
-        if (_deployment.TryPublishIfEmpty(snapshot)) return true;
+        if (TryPublish(snapshot, onlyIfEmpty: true)) return true;
 
         current = _deployment.Current;
         return current is not null && CanDeploy(current.Configuration);
@@ -173,12 +179,52 @@ public sealed class EvolutionKernelAutotuner<TConfiguration>
     {
         try
         {
-            return _deploymentValidator(configuration);
+            return _deploymentValidator(configuration) &&
+                (_store is not QuarantinedKernelTuningStore<TConfiguration> quarantine ||
+                 quarantine.CanDeploy(_identity, configuration, _codec));
         }
         catch
         {
             return false;
         }
+    }
+
+    private bool TryPublish(KernelTuningDeploymentSnapshot<TConfiguration> snapshot, bool onlyIfEmpty = false)
+    {
+        if (_store is QuarantinedKernelTuningStore<TConfiguration> quarantine)
+            return quarantine.TryPublish(_deployment, snapshot, _codec, onlyIfEmpty);
+        if (onlyIfEmpty) return _deployment.TryPublishIfEmpty(snapshot);
+        _deployment.Publish(snapshot);
+        return true;
+    }
+
+    /// <summary>Persistently quarantines an exact observed deployment and optionally restores a validated prior snapshot.</summary>
+    /// <remarks>
+    /// Requires an explicitly configured <see cref="QuarantinedKernelTuningStore{TConfiguration}"/>.
+    /// The caller supplies genuine regression evidence and retains the raw artifact named by its digest.
+    /// Stale observations cannot remove newer deployments. Invalid or quarantined rollback candidates leave the
+    /// handle empty for built-in fallback. Cancellation is honored before mutation; once deactivated, receipt
+    /// persistence and rollback finish without cancellation. Check the result before claiming restart safety.
+    /// This does not cancel in-flight dispatch, detect drift automatically or validate the raw evidence itself.
+    /// </remarks>
+    public async Task<KernelTuningQuarantineResult<TConfiguration>> QuarantineAsync(
+        KernelTuningDeploymentSnapshot<TConfiguration> expected,
+        KernelTuningRegressionEvidence evidence,
+        KernelTuningDeploymentSnapshot<TConfiguration>? priorValidatedSnapshot = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (expected is null) throw new ArgumentNullException(nameof(expected));
+        if (evidence is null) throw new ArgumentNullException(nameof(evidence));
+        if (!string.Equals(expected.Identity.StableKey, _identity.StableKey, StringComparison.Ordinal))
+            throw new ArgumentException("The observed snapshot has a different tuning identity.", nameof(expected));
+        if (_store is not QuarantinedKernelTuningStore<TConfiguration> quarantine)
+            throw new InvalidOperationException("Persistent quarantine requires QuarantinedKernelTuningStore.");
+        using IDisposable deviceLease = await KernelTuningCoordinator.EnterAsync(
+            _identity.Device, cancellationToken).ConfigureAwait(false);
+        if (priorValidatedSnapshot is not null &&
+            (!string.Equals(priorValidatedSnapshot.Identity.StableKey, _identity.StableKey, StringComparison.Ordinal) ||
+             !CanDeploy(priorValidatedSnapshot.Configuration))) priorValidatedSnapshot = null;
+        return quarantine.Quarantine(_deployment, expected, _codec, evidence, priorValidatedSnapshot, cancellationToken);
     }
 
     /// <summary>Runs tuning during an explicit offline or startup workflow.</summary>
@@ -287,13 +333,15 @@ public sealed class EvolutionKernelAutotuner<TConfiguration>
                     run, incumbent, proposed, existing, false, false);
             }
 
-            _deployment.Publish(incumbent);
+            if (!TryPublish(incumbent))
+                throw new InvalidOperationException("The replay incumbent was denied by the deployment policy.");
             bool incumbentPersisted = TryPersist(incumbent);
             return new EvolutionKernelTuningResult<TConfiguration>(
                 run, incumbent, proposed, incumbent, false, incumbentPersisted);
         }
 
-        _deployment.Publish(proposed);
+        if (!TryPublish(proposed))
+            throw new InvalidOperationException("The proposed winner was denied by the deployment policy.");
         bool persisted = TryPersist(proposed);
         return new EvolutionKernelTuningResult<TConfiguration>(
             run, incumbent, proposed, proposed, true, persisted);

--- a/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningDeployment.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningDeployment.cs
@@ -98,7 +98,9 @@ public sealed class KernelTuningDeployment<TConfiguration>
     /// already using the snapshot is not interrupted. A stale rejection cannot remove a newer deployment, including
     /// a newly validated snapshot of the same genome. This is an in-memory action, not a persistent quarantine:
     /// hydration or a later tuning run may publish again. Stop those producers and invalidate their cache separately
-    /// when a configuration must remain disabled across runs. No I/O or model call occurs here.
+    /// when a configuration must remain disabled across runs, or opt into
+    /// <see cref="QuarantinedKernelTuningStore{TConfiguration}"/> and use the tuner's QuarantineAsync workflow.
+    /// No I/O or model call occurs here.
     /// </remarks>
     public bool TryDeactivate(KernelTuningDeploymentSnapshot<TConfiguration> expected)
     {

--- a/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningDeployment.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningDeployment.cs
@@ -90,6 +90,22 @@ public sealed class KernelTuningDeployment<TConfiguration>
         return true;
     }
 
+    /// <summary>Deactivates exactly the snapshot that failed a caller's runtime validation.</summary>
+    /// <param name="expected">The snapshot observed by the failing operation, not a later read of <see cref="Current"/>.</param>
+    /// <returns>True only when that exact snapshot was still active and has been removed.</returns>
+    /// <remarks>
+    /// Subsequent <see cref="TryGet"/> calls return false so dispatch can use its built-in safe fallback. An operation
+    /// already using the snapshot is not interrupted. A stale rejection cannot remove a newer deployment, including
+    /// a newly validated snapshot of the same genome. This is an in-memory action, not a persistent quarantine:
+    /// hydration or a later tuning run may publish again. Stop those producers and invalidate their cache separately
+    /// when a configuration must remain disabled across runs. No I/O or model call occurs here.
+    /// </remarks>
+    public bool TryDeactivate(KernelTuningDeploymentSnapshot<TConfiguration> expected)
+    {
+        ValidateIdentity(expected);
+        return ReferenceEquals(Interlocked.CompareExchange(ref _current, null, expected), expected);
+    }
+
     internal void Publish(KernelTuningDeploymentSnapshot<TConfiguration> snapshot)
     {
         ValidateIdentity(snapshot);

--- a/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningQuarantine.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningQuarantine.cs
@@ -74,7 +74,7 @@ public sealed class KernelTuningQuarantineResult<TConfiguration> where TConfigur
     public bool WasApplied { get; }
     /// <summary>Gets whether this invocation durably retained a complete regression receipt.</summary>
     public bool WasPersisted { get; }
-    /// <summary>Gets the write-once receipt path, or null when no complete receipt was persisted.</summary>
+    /// <summary>Gets the durably retained receipt path, or null, including for best-effort-only writes.</summary>
     public string? ReceiptPath { get; }
     /// <summary>Gets the supplied prior snapshot published by this operation, or null if none was published.</summary>
     public KernelTuningDeploymentSnapshot<TConfiguration>? RollbackDeployment { get; }
@@ -92,6 +92,8 @@ public sealed class KernelTuningQuarantineResult<TConfiguration> where TConfigur
 /// admission, but already active handles and simultaneous cross-process publication are not revoked atomically.
 /// Filesystem aliases, hostile journal tampering and automatic drift detection are outside this contract.
 /// Failed writes retain a process-local block; they do not establish restart safety. Dispatch reads remain I/O-free.
+/// Durable publication currently requires Linux x86/x64/ARM32/ARM64 file/directory synchronization. Other platforms retain a
+/// best-effort tombstone but report persistence failure. Storage must honor the operating system's barriers.
 /// </remarks>
 public sealed class QuarantinedKernelTuningStore<TConfiguration> : IKernelTuningStore<TConfiguration>
     where TConfiguration : notnull
@@ -99,10 +101,18 @@ public sealed class QuarantinedKernelTuningStore<TConfiguration> : IKernelTuning
     private readonly string _directory;
     private readonly QuarantineJournalState _state;
     private readonly IKernelTuningStore<TConfiguration> _inner;
+    private readonly IQuarantineCommitOperations _commitOperations;
 
     /// <summary>Creates the explicit journal directory; initialization failures are reported to the caller.</summary>
     public QuarantinedKernelTuningStore(string journalDirectory, IKernelTuningStore<TConfiguration>? inner = null)
+        : this(journalDirectory, inner, QuarantineReceiptCommit.Native)
     {
+    }
+
+    internal QuarantinedKernelTuningStore(string journalDirectory, IKernelTuningStore<TConfiguration>? inner,
+        IQuarantineCommitOperations commitOperations)
+    {
+        _commitOperations = commitOperations ?? throw new ArgumentNullException(nameof(commitOperations));
         if (string.IsNullOrWhiteSpace(journalDirectory) || !Path.IsPathRooted(journalDirectory) ||
             (Path.DirectorySeparatorChar == '\\' && !journalDirectory.StartsWith("\\\\", StringComparison.Ordinal) &&
              (journalDirectory.Length < 3 || journalDirectory[1] != ':' ||
@@ -197,8 +207,15 @@ public sealed class QuarantinedKernelTuningStore<TConfiguration> : IKernelTuning
         }
         byte[] receipt = JsonSerializer.SerializeToUtf8Bytes(new
         {
-            Schema = "tensor-kernel-quarantine-v1", entry.Key, entry.Identity, entry.CodecId,
-            entry.CodecVersion, entry.GenomeId, entry.PayloadBase64, expected.RunStateHash, Evidence = evidence
+            Schema = "tensor-kernel-quarantine-v1",
+            entry.Key,
+            entry.Identity,
+            entry.CodecId,
+            entry.CodecVersion,
+            entry.GenomeId,
+            entry.PayloadBase64,
+            expected.RunStateHash,
+            Evidence = evidence
         });
         bool persisted;
         KernelTuningDeploymentSnapshot<TConfiguration>? rollback = null;
@@ -247,19 +264,20 @@ public sealed class QuarantinedKernelTuningStore<TConfiguration> : IKernelTuning
 
     private string RecordPath(string key) => Path.Combine(_directory, key + ".quarantine.json");
 
-    private static bool TryWriteReceipt(string path, byte[] receipt)
+    private bool TryWriteReceipt(string path, byte[] receipt)
     {
         // Conservative status: a preexisting or corrupt receipt is still blocking, but is not this write's success.
         try
         {
-            string pending = Path.Combine(Path.GetDirectoryName(path)!, ".quarantine-" + Guid.NewGuid().ToString("N") + ".pending");
+            string? directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(directory)) return false;
+            string pending = Path.Combine(directory, ".quarantine-" + Guid.NewGuid().ToString("N") + ".pending");
             using (var stream = new FileStream(pending, FileMode.CreateNew, FileAccess.Write, FileShare.None))
             {
                 stream.Write(receipt, 0, receipt.Length);
                 stream.Flush(true);
             }
-            File.Move(pending, path);
-            return true;
+            return QuarantineReceiptCommit.TryCommit(pending, path, _commitOperations);
         }
         catch { return false; }
     }

--- a/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningQuarantine.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/KernelTuningQuarantine.cs
@@ -1,0 +1,335 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Evolution;
+
+namespace AiDotNet.Tensors.Helpers.Autotune;
+
+/// <summary>The runtime regression reported by the caller's monitoring policy.</summary>
+public enum KernelTuningRegressionReason
+{
+    /// <summary>A measured latency statistic exceeded its limit.</summary>
+    Latency = 0,
+    /// <summary>A measured correctness error exceeded its tolerance.</summary>
+    Correctness = 1,
+    /// <summary>A measured resource statistic exceeded its limit.</summary>
+    ResourceUsage = 2
+}
+
+/// <summary>Bounded caller-supplied regression evidence; this object does not run a monitor.</summary>
+public sealed class KernelTuningRegressionEvidence
+{
+    /// <summary>Creates evidence for a finite, nonnegative, larger-is-worse statistic exceeding its limit.</summary>
+    public KernelTuningRegressionEvidence(
+        KernelTuningRegressionReason reason, string policyVersion, string rawEvidenceSha256,
+        double observedValue, double maximumAllowedValue, DateTimeOffset observedAt)
+    {
+        if (!Enum.IsDefined(typeof(KernelTuningRegressionReason), reason))
+            throw new ArgumentOutOfRangeException(nameof(reason));
+        QuarantineEncoding.ValidateLabel(policyVersion, nameof(policyVersion));
+        if (rawEvidenceSha256 is null || rawEvidenceSha256.Length != 64 ||
+            rawEvidenceSha256.Any(c => !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))))
+            throw new ArgumentException("Evidence must have a lowercase SHA256 digest.", nameof(rawEvidenceSha256));
+        if (!KernelTuningMeasurement.IsFinite(maximumAllowedValue) || maximumAllowedValue < 0)
+            throw new ArgumentOutOfRangeException(nameof(maximumAllowedValue));
+        if (!KernelTuningMeasurement.IsFinite(observedValue) || observedValue <= maximumAllowedValue)
+            throw new ArgumentOutOfRangeException(nameof(observedValue));
+        if (observedAt == default) throw new ArgumentOutOfRangeException(nameof(observedAt));
+        Reason = reason;
+        PolicyVersion = policyVersion;
+        RawEvidenceSha256 = rawEvidenceSha256;
+        ObservedValue = observedValue;
+        MaximumAllowedValue = maximumAllowedValue;
+        ObservedAt = observedAt.ToUniversalTime();
+    }
+
+    /// <summary>Gets the category of regression.</summary>
+    public KernelTuningRegressionReason Reason { get; }
+    /// <summary>Gets the caller's versioned measurement and decision policy.</summary>
+    public string PolicyVersion { get; }
+    /// <summary>Gets the digest of the separately retained raw evidence artifact.</summary>
+    public string RawEvidenceSha256 { get; }
+    /// <summary>Gets the observed larger-is-worse statistic in the policy's units.</summary>
+    public double ObservedValue { get; }
+    /// <summary>Gets the maximum permitted statistic in the same units.</summary>
+    public double MaximumAllowedValue { get; }
+    /// <summary>Gets the UTC time of observation.</summary>
+    public DateTimeOffset ObservedAt { get; }
+}
+
+/// <summary>Separates in-memory safety from successful persistence and optional rollback.</summary>
+public sealed class KernelTuningQuarantineResult<TConfiguration> where TConfiguration : notnull
+{
+    internal KernelTuningQuarantineResult(bool applied, bool persisted, string? receiptPath,
+        KernelTuningDeploymentSnapshot<TConfiguration>? rollback, bool rollbackPersisted)
+    {
+        WasApplied = applied;
+        WasPersisted = persisted;
+        ReceiptPath = receiptPath;
+        RollbackDeployment = rollback;
+        WasRollbackPersisted = rollbackPersisted;
+    }
+
+    /// <summary>Gets whether the exact observed snapshot was deactivated and blocked in this process.</summary>
+    public bool WasApplied { get; }
+    /// <summary>Gets whether this invocation durably retained a complete regression receipt.</summary>
+    public bool WasPersisted { get; }
+    /// <summary>Gets the write-once receipt path, or null when no complete receipt was persisted.</summary>
+    public string? ReceiptPath { get; }
+    /// <summary>Gets the supplied prior snapshot published by this operation, or null if none was published.</summary>
+    public KernelTuningDeploymentSnapshot<TConfiguration>? RollbackDeployment { get; }
+    /// <summary>Gets whether the published rollback was saved by the underlying winner store.</summary>
+    public bool WasRollbackPersisted { get; }
+}
+
+/// <summary>Opt-in persistent quarantine decorator for an existing typed winner store.</summary>
+/// <remarks>
+/// Use one canonical private journal directory and this decorator for every producer sharing a deployment.
+/// A record's presence blocks its configuration, including corrupt or unknown records. Records are never
+/// deleted automatically. Configuration identity includes the tuning envelope and codec id/version, but not
+/// the selecting run hash: another run cannot silently retry the same quarantined configuration.
+/// Publication and quarantine are serialized within this process. Other processes check durable records on
+/// admission, but already active handles and simultaneous cross-process publication are not revoked atomically.
+/// Filesystem aliases, hostile journal tampering and automatic drift detection are outside this contract.
+/// Failed writes retain a process-local block; they do not establish restart safety. Dispatch reads remain I/O-free.
+/// </remarks>
+public sealed class QuarantinedKernelTuningStore<TConfiguration> : IKernelTuningStore<TConfiguration>
+    where TConfiguration : notnull
+{
+    private readonly string _directory;
+    private readonly QuarantineJournalState _state;
+    private readonly IKernelTuningStore<TConfiguration> _inner;
+
+    /// <summary>Creates the explicit journal directory; initialization failures are reported to the caller.</summary>
+    public QuarantinedKernelTuningStore(string journalDirectory, IKernelTuningStore<TConfiguration>? inner = null)
+    {
+        if (string.IsNullOrWhiteSpace(journalDirectory) || !Path.IsPathRooted(journalDirectory) ||
+            (Path.DirectorySeparatorChar == '\\' && !journalDirectory.StartsWith("\\\\", StringComparison.Ordinal) &&
+             (journalDirectory.Length < 3 || journalDirectory[1] != ':' ||
+              (journalDirectory[2] != '\\' && journalDirectory[2] != '/'))))
+            throw new ArgumentException("An absolute private journal directory is required.", nameof(journalDirectory));
+        _directory = Path.GetFullPath(journalDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.IsNullOrEmpty(_directory) || string.Equals(_directory, Path.GetPathRoot(_directory)?.TrimEnd(
+                Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("The filesystem root cannot be a quarantine journal.", nameof(journalDirectory));
+        Directory.CreateDirectory(_directory);
+        _state = QuarantineJournalState.For(_directory);
+        _inner = inner ?? new AutotuneCacheKernelTuningStore<TConfiguration>();
+    }
+
+    /// <inheritdoc />
+    public bool TryLoad(KernelTuningIdentity identity, IEvolutionGenomeCodec<TConfiguration> codec,
+        out KernelTuningDeploymentSnapshot<TConfiguration>? snapshot)
+    {
+        snapshot = null;
+        try
+        {
+            if (!_inner.TryLoad(identity, codec, out var loaded) || loaded is null ||
+                !string.Equals(identity.StableKey, loaded.Identity.StableKey, StringComparison.Ordinal)) return false;
+            Entry entry = Describe(loaded, codec);
+            lock (_state.Gate)
+            {
+                if (!IsAdmitted(entry.Key)) return false;
+                snapshot = loaded;
+                return true;
+            }
+        }
+        catch { return false; }
+    }
+
+    /// <inheritdoc />
+    public bool TryStore(KernelTuningDeploymentSnapshot<TConfiguration> snapshot,
+        IEvolutionGenomeCodec<TConfiguration> codec)
+    {
+        try
+        {
+            Entry entry = Describe(snapshot, codec);
+            lock (_state.Gate) { if (!IsAdmitted(entry.Key)) return false; }
+            // User stores run outside the journal lock. A racing stale write remains inadmissible on load.
+            if (!_inner.TryStore(snapshot, codec)) return false;
+            lock (_state.Gate) { return IsAdmitted(entry.Key); }
+        }
+        catch { return false; }
+    }
+
+    internal bool CanDeploy(KernelTuningIdentity identity, TConfiguration configuration,
+        IEvolutionGenomeCodec<TConfiguration> codec)
+    {
+        try
+        {
+            Entry entry = Describe(identity, configuration, codec);
+            lock (_state.Gate) { return IsAdmitted(entry.Key); }
+        }
+        catch { return false; }
+    }
+
+    internal bool TryPublish(KernelTuningDeployment<TConfiguration> deployment,
+        KernelTuningDeploymentSnapshot<TConfiguration> snapshot, IEvolutionGenomeCodec<TConfiguration> codec,
+        bool onlyIfEmpty)
+    {
+        try
+        {
+            // Caller codec execution must precede the lock; it may reenter the tuner.
+            Entry entry = Describe(snapshot, codec);
+            lock (_state.Gate)
+            {
+                if (!IsAdmitted(entry.Key)) return false;
+                if (onlyIfEmpty) return deployment.TryPublishIfEmpty(snapshot);
+                deployment.Publish(snapshot);
+                return true;
+            }
+        }
+        catch { return false; }
+    }
+
+    internal KernelTuningQuarantineResult<TConfiguration> Quarantine(
+        KernelTuningDeployment<TConfiguration> deployment, KernelTuningDeploymentSnapshot<TConfiguration> expected,
+        IEvolutionGenomeCodec<TConfiguration> codec, KernelTuningRegressionEvidence evidence,
+        KernelTuningDeploymentSnapshot<TConfiguration>? prior, CancellationToken cancellationToken)
+    {
+        Entry entry = Describe(expected, codec);
+        QuarantineEncoding.ValidateLabel(expected.RunStateHash, nameof(expected));
+        Entry? rollbackEntry = null;
+        if (prior is not null)
+        {
+            try { rollbackEntry = Describe(prior, codec); }
+            catch { prior = null; }
+        }
+        byte[] receipt = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            Schema = "tensor-kernel-quarantine-v1", entry.Key, entry.Identity, entry.CodecId,
+            entry.CodecVersion, entry.GenomeId, entry.PayloadBase64, expected.RunStateHash, Evidence = evidence
+        });
+        bool persisted;
+        KernelTuningDeploymentSnapshot<TConfiguration>? rollback = null;
+        string path = RecordPath(entry.Key);
+        lock (_state.Gate)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // CAS also protects callers that independently invoke in-memory TryDeactivate.
+            if (!deployment.TryDeactivate(expected))
+                return new KernelTuningQuarantineResult<TConfiguration>(false, false, null, null, false);
+            _state.Blocked.Add(entry.Key);
+            persisted = TryWriteReceipt(path, receipt);
+            if (prior is not null && rollbackEntry is not null &&
+                string.Equals(prior.Identity.StableKey, expected.Identity.StableKey, StringComparison.Ordinal) &&
+                IsAdmitted(rollbackEntry.Key) && deployment.TryPublishIfEmpty(prior)) rollback = prior;
+        }
+        bool rollbackPersisted = rollback is not null && TryStore(rollback, codec);
+        return new KernelTuningQuarantineResult<TConfiguration>(true, persisted, persisted ? path : null,
+            rollback, rollbackPersisted);
+    }
+
+    private bool IsAdmitted(string key)
+    {
+        if (_state.Blocked.Contains(key)) return false;
+        try
+        {
+            // Exists() hides permission errors. Only a missing record in a readable directory allows admission.
+            if ((File.GetAttributes(_directory) & FileAttributes.Directory) == 0) return false;
+            using var record = new FileStream(RecordPath(key), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return false; // Any existing record, even empty/corrupt/future-schema, is a tombstone.
+        }
+        catch (FileNotFoundException) { return DirectoryIsReadable(); }
+        catch { return false; }
+    }
+
+    private bool DirectoryIsReadable()
+    {
+        try
+        {
+            using var entries = Directory.EnumerateFileSystemEntries(_directory).GetEnumerator();
+            _ = entries.MoveNext();
+            return true;
+        }
+        catch { return false; }
+    }
+
+    private string RecordPath(string key) => Path.Combine(_directory, key + ".quarantine.json");
+
+    private static bool TryWriteReceipt(string path, byte[] receipt)
+    {
+        // Conservative status: a preexisting or corrupt receipt is still blocking, but is not this write's success.
+        try
+        {
+            string pending = Path.Combine(Path.GetDirectoryName(path)!, ".quarantine-" + Guid.NewGuid().ToString("N") + ".pending");
+            using (var stream = new FileStream(pending, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(receipt, 0, receipt.Length);
+                stream.Flush(true);
+            }
+            File.Move(pending, path);
+            return true;
+        }
+        catch { return false; }
+    }
+
+    private static Entry Describe(KernelTuningDeploymentSnapshot<TConfiguration> snapshot,
+        IEvolutionGenomeCodec<TConfiguration> codec)
+    {
+        if (snapshot is null) throw new ArgumentNullException(nameof(snapshot));
+        Entry entry = Describe(snapshot.Identity, snapshot.Configuration, codec);
+        if (!string.Equals(entry.GenomeId, snapshot.GenomeId, StringComparison.Ordinal))
+            throw new ArgumentException("The snapshot does not match its canonical configuration.", nameof(snapshot));
+        return entry;
+    }
+
+    private static Entry Describe(KernelTuningIdentity identity, TConfiguration configuration,
+        IEvolutionGenomeCodec<TConfiguration> codec)
+    {
+        if (identity is null) throw new ArgumentNullException(nameof(identity));
+        if (codec is null) throw new ArgumentNullException(nameof(codec));
+        string id = codec.Id;
+        string version = codec.VersionHash;
+        QuarantineEncoding.ValidateLabel(id, nameof(codec));
+        QuarantineEncoding.ValidateLabel(version, nameof(codec));
+        string payload = codec.Serialize(configuration);
+        if (payload is null || payload.Length > 65536)
+            throw new ArgumentException("Quarantine payloads must not exceed 64K UTF16 code units.", nameof(configuration));
+        byte[] bytes = QuarantineEncoding.StrictUtf8.GetBytes(payload);
+        if (bytes.Length > 65536)
+            throw new ArgumentException("Quarantine payloads must not exceed 64 KiB UTF8.", nameof(configuration));
+        if (!string.Equals(id, codec.Id, StringComparison.Ordinal) ||
+            !string.Equals(version, codec.VersionHash, StringComparison.Ordinal))
+            throw new InvalidOperationException("The codec identity changed during serialization.");
+        string genomeId = EvolutionHash.Compute(payload);
+        string key = EvolutionHash.Combine(new[] { "tensor-kernel-quarantine-v1", identity.StableKey, id, version, genomeId });
+        return new Entry(key, identity.StableKey, id, version, genomeId, Convert.ToBase64String(bytes));
+    }
+
+    private sealed class Entry
+    {
+        internal Entry(string key, string identity, string codecId, string codecVersion, string genomeId, string payloadBase64)
+        {
+            Key = key; Identity = identity; CodecId = codecId; CodecVersion = codecVersion;
+            GenomeId = genomeId; PayloadBase64 = payloadBase64;
+        }
+        public string Key { get; }
+        public string Identity { get; }
+        public string CodecId { get; }
+        public string CodecVersion { get; }
+        public string GenomeId { get; }
+        public string PayloadBase64 { get; }
+    }
+}
+
+internal sealed class QuarantineJournalState
+{
+    private static readonly ConcurrentDictionary<string, QuarantineJournalState> Journals = new(
+        Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+    internal object Gate { get; } = new();
+    internal HashSet<string> Blocked { get; } = new(StringComparer.Ordinal);
+    internal static QuarantineJournalState For(string directory) => Journals.GetOrAdd(directory, _ => new());
+}
+
+internal static class QuarantineEncoding
+{
+    internal static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    internal static void ValidateLabel(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > 256 || value.Any(char.IsControl))
+            throw new ArgumentException("A nonempty printable label of at most 256 characters is required.", parameterName);
+        try { _ = StrictUtf8.GetByteCount(value); }
+        catch (EncoderFallbackException error) { throw new ArgumentException("Labels must be valid Unicode.", parameterName, error); }
+    }
+}

--- a/src/AiDotNet.Tensors/Helpers/Autotune/QuarantineReceiptCommit.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/QuarantineReceiptCommit.cs
@@ -1,0 +1,117 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace AiDotNet.Tensors.Helpers.Autotune;
+
+internal enum QuarantineCommitMode
+{
+    Unsupported,
+    LinuxDirectorySync
+}
+
+[Flags]
+internal enum LinuxDirectoryOpenFlags
+{
+    ReadOnly = 0,
+    ArmDirectory = 1 << 14,
+    GenericDirectory = 1 << 16,
+    CloseOnExec = 1 << 19
+}
+
+/// <summary>The native boundary, injectable per store for deterministic I/O failure tests.</summary>
+internal interface IQuarantineCommitOperations
+{
+    QuarantineCommitMode Mode { get; }
+    bool MoveNewFile(string source, string destination);
+    bool FlushDirectory(string directory);
+}
+
+/// <summary>Publishes an already flushed file without replacing an existing tombstone.</summary>
+internal static class QuarantineReceiptCommit
+{
+    internal static IQuarantineCommitOperations Native { get; } = new NativeCommitOperations();
+
+    internal static bool TryGetDirectoryFlags(Architecture architecture, out LinuxDirectoryOpenFlags flags)
+    {
+        // Linux ARM32 overrides O_DIRECTORY; x86/x64/ARM64 use the generic UAPI.
+        // Unknown ABIs are unsupported rather than guessing syscall flag values.
+        switch (architecture)
+        {
+            case Architecture.Arm:
+                flags = LinuxDirectoryOpenFlags.ArmDirectory | LinuxDirectoryOpenFlags.CloseOnExec;
+                return true;
+            case Architecture.X86:
+            case Architecture.X64:
+            case Architecture.Arm64:
+                flags = LinuxDirectoryOpenFlags.GenericDirectory | LinuxDirectoryOpenFlags.CloseOnExec;
+                return true;
+            default:
+                flags = LinuxDirectoryOpenFlags.ReadOnly;
+                return false;
+        }
+    }
+
+    internal static bool TryCommit(string pending, string destination, IQuarantineCommitOperations operations)
+    {
+        QuarantineCommitMode mode = operations.Mode;
+        if (mode != QuarantineCommitMode.Unsupported && mode != QuarantineCommitMode.LinuxDirectorySync)
+            return false;
+
+        string? directory = Path.GetDirectoryName(destination);
+        if (string.IsNullOrEmpty(directory) || !Path.IsPathRooted(directory) ||
+            !string.Equals(directory, Path.GetDirectoryName(pending), StringComparison.Ordinal)) return false;
+
+        if (!operations.MoveNewFile(pending, destination)) return false;
+        // Retain the best-effort tombstone even without a verified directory barrier;
+        // it protects ordinary restarts, but cannot promise power-loss safety.
+        if (mode == QuarantineCommitMode.Unsupported) return false;
+
+        // fsync(file) does not persist the directory entry created by rename.
+        // Include ancestors: the journal directory itself may have just been created.
+        // A failed barrier leaves the visible tombstone intact but cannot claim durability.
+        while (!string.IsNullOrEmpty(directory))
+        {
+            if (!operations.FlushDirectory(directory)) return false;
+            directory = Path.GetDirectoryName(directory);
+        }
+        return true;
+    }
+
+    private sealed class NativeCommitOperations : IQuarantineCommitOperations
+    {
+        public QuarantineCommitMode Mode => RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            && TryGetDirectoryFlags(RuntimeInformation.ProcessArchitecture, out _)
+            ? QuarantineCommitMode.LinuxDirectorySync : QuarantineCommitMode.Unsupported;
+
+        public bool MoveNewFile(string source, string destination)
+        {
+            File.Move(source, destination);
+            return true;
+        }
+
+        public bool FlushDirectory(string directory)
+        {
+            if (Mode != QuarantineCommitMode.LinuxDirectorySync) return false;
+            if (!TryGetDirectoryFlags(RuntimeInformation.ProcessArchitecture, out LinuxDirectoryOpenFlags flags)) return false;
+            int descriptor = OpenDirectory(directory, flags);
+            if (descriptor < 0) return false;
+            using var handle = new DirectoryHandle(descriptor);
+            return Synchronize(descriptor) == 0;
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int OpenDirectory([MarshalAs(UnmanagedType.LPUTF8Str)] string path, LinuxDirectoryOpenFlags flags);
+
+    [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+    private static extern int Synchronize(int descriptor);
+
+    [DllImport("libc", EntryPoint = "close")]
+    private static extern int CloseDirectory(int descriptor);
+
+    private sealed class DirectoryHandle : SafeHandleMinusOneIsInvalid
+    {
+        internal DirectoryHandle(int descriptor) : base(true) => SetHandle(new IntPtr(descriptor));
+        protected override bool ReleaseHandle() => CloseDirectory(handle.ToInt32()) == 0;
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/EvolutionKernelAutotunerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/EvolutionKernelAutotunerTests.cs
@@ -7,7 +7,7 @@ namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
 
 /// <summary>GPU-free contract tests for correctness-first typed evolutionary tuning.</summary>
 [Collection("AutotuneCacheTests")]
-public sealed class EvolutionKernelAutotunerTests : IDisposable
+public sealed partial class EvolutionKernelAutotunerTests : IDisposable
 {
     private const string CacheEnvironmentVariable = "AIDOTNET_AUTOTUNE_CACHE_PATH";
     private readonly string? _originalCachePath;

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/EvolutionKernelAutotunerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/EvolutionKernelAutotunerTests.cs
@@ -511,6 +511,49 @@ public sealed class EvolutionKernelAutotunerTests : IDisposable
         if (Directory.Exists(_temporaryCachePath)) Directory.Delete(_temporaryCachePath, recursive: true);
     }
 
+    [Fact]
+    public async Task DeactivateRemovesOnlyTheObservedSnapshotAndAllowsSafeFallback()
+    {
+        var registry = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>();
+        EvolutionKernelAutotuner<FakeKernelConfiguration> tuner = CreateTuner(registry, new MemoryStore(), MeasurePassed);
+        EvolutionKernelTuningResult<FakeKernelConfiguration> result = await tuner.TuneAsync(Seeds());
+        Assert.True(tuner.Deployment.TryDeactivate(result.ActiveDeployment));
+        Assert.False(tuner.Deployment.TryGet(out _));
+        Assert.Null(tuner.Deployment.Current);
+        Assert.False(tuner.Deployment.TryDeactivate(result.ActiveDeployment));
+    }
+
+    [Fact]
+    public async Task StaleDeactivationCannotRemoveANewerValidationOfTheSameGenome()
+    {
+        var registry = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>();
+        EvolutionKernelAutotuner<FakeKernelConfiguration> first = CreateTuner(registry, new MemoryStore(), MeasurePassed);
+        EvolutionKernelTuningResult<FakeKernelConfiguration> oldRun = await first.TuneAsync(Seeds());
+        KernelTuningDeploymentSnapshot<FakeKernelConfiguration> original = oldRun.ActiveDeployment;
+        var revalidated = new KernelTuningDeploymentSnapshot<FakeKernelConfiguration>(original.Identity,
+            original.Configuration, original.GenomeId, original.Measurement, original.RunStateHash,
+            original.PromotionEvidence, original.EvidenceRole);
+        first.Deployment.Publish(revalidated);
+        Assert.Equal(original.GenomeId, revalidated.GenomeId);
+        Assert.NotSame(original, revalidated);
+        Assert.False(first.Deployment.TryDeactivate(oldRun.ActiveDeployment));
+        Assert.Same(revalidated, first.Deployment.Current);
+    }
+
+    [Fact]
+    public async Task DeactivationRejectsNullAndAnotherDeploymentIdentity()
+    {
+        EvolutionKernelAutotuner<FakeKernelConfiguration> tuner = CreateTuner(
+            new KernelTuningDeploymentRegistry<FakeKernelConfiguration>(), new MemoryStore(), MeasurePassed);
+        EvolutionKernelTuningResult<FakeKernelConfiguration> result = await tuner.TuneAsync(Seeds());
+        Assert.Throws<ArgumentNullException>(() => tuner.Deployment.TryDeactivate(null!));
+        var other = new KernelTuningIdentity(new KernelId("test", "another-kernel"), Identity().Shape,
+            Identity().Device, Identity().Backend, Identity().SearchSpaceVersion, Identity().BenchmarkProtocolVersion);
+        var otherHandle = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(other);
+        Assert.Throws<InvalidOperationException>(() => otherHandle.TryDeactivate(result.ActiveDeployment));
+        Assert.Same(result.ActiveDeployment, tuner.Deployment.Current);
+    }
+
     private static EvolutionKernelAutotuner<FakeKernelConfiguration> CreateTuner(
         KernelTuningDeploymentRegistry<FakeKernelConfiguration> registry,
         IKernelTuningStore<FakeKernelConfiguration> store,

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Runtime.InteropServices;
 using AiDotNet.Evolution;
 using AiDotNet.Tensors.Helpers.Autotune;
 using Xunit;
@@ -10,12 +11,24 @@ public sealed partial class EvolutionKernelAutotunerTests
 {
     private string Journal(string suffix = "journal") => Path.Combine(_temporaryCachePath, suffix);
 
+    private static void AssertNativePersistence(KernelTuningQuarantineResult<FakeKernelConfiguration> result)
+    {
+        // Only Linux currently has a verified no-overwrite rename + directory barrier.
+        // Do not infer the expected guarantee from the implementation's selected backend.
+        bool supportsDurability = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+            RuntimeInformation.ProcessArchitecture is Architecture.X86 or Architecture.X64 or Architecture.Arm or Architecture.Arm64;
+        Assert.Equal(supportsDurability, result.WasPersisted);
+        if (supportsDurability) Assert.IsType<string>(result.ReceiptPath);
+        else Assert.Null(result.ReceiptPath);
+    }
+
     [Fact]
     public void TypedCachePath_StoreRoundTripsWithoutSuppressingWriteErrors()
     {
         var kernel = new KernelId(Identity().Kernel.Category, "typed-evolution-" + Identity().StableKey);
         AutotuneCache.Store(kernel, Identity().Shape, new KernelChoice { Variant = "typed-path-probe" });
-        Assert.NotNull(AutotuneCache.Lookup(kernel, Identity().Shape));
+        KernelChoice loaded = Assert.IsType<KernelChoice>(AutotuneCache.Lookup(kernel, Identity().Shape));
+        Assert.Equal("typed-path-probe", loaded.Variant);
     }
 
     private static KernelTuningRegressionEvidence Regression() => new(
@@ -32,7 +45,7 @@ public sealed partial class EvolutionKernelAutotunerTests
         var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
 
         Assert.True(result.WasApplied);
-        Assert.True(result.WasPersisted);
+        AssertNativePersistence(result);
         Assert.False(result.WasRollbackPersisted);
         Assert.Null(result.RollbackDeployment);
         Assert.Null(tuner.Deployment.Current);
@@ -42,19 +55,20 @@ public sealed partial class EvolutionKernelAutotunerTests
             run.ActiveDeployment.Configuration, run.ActiveDeployment.GenomeId, run.ActiveDeployment.Measurement,
             "another-run-state", run.ActiveDeployment.PromotionEvidence, run.ActiveDeployment.EvidenceRole);
         Assert.False(store.TryPublish(tuner.Deployment, anotherRun, new FakeKernelCodec(), false));
-        using var receipt = JsonDocument.Parse(File.ReadAllBytes(result.ReceiptPath!));
+        string receiptPath = Assert.Single(Directory.GetFiles(Journal(), "*.quarantine.json"));
+        using var receipt = JsonDocument.Parse(File.ReadAllBytes(receiptPath));
         var root = receipt.RootElement;
         Assert.Equal("tensor-kernel-quarantine-v1", root.GetProperty("Schema").GetString());
         Assert.Equal(run.ActiveDeployment.Identity.StableKey, root.GetProperty("Identity").GetString());
         Assert.Equal(run.ActiveDeployment.RunStateHash, root.GetProperty("RunStateHash").GetString());
         Assert.Equal(new FakeKernelCodec().Serialize(run.ActiveDeployment.Configuration),
-            Encoding.UTF8.GetString(Convert.FromBase64String(root.GetProperty("PayloadBase64").GetString()!)));
+            Encoding.UTF8.GetString(Convert.FromBase64String(Assert.IsType<string>(root.GetProperty("PayloadBase64").GetString()))));
         Assert.Equal(Regression().RawEvidenceSha256, root.GetProperty("Evidence").GetProperty("RawEvidenceSha256").GetString());
         Assert.Equal(TimeSpan.Zero, root.GetProperty("Evidence").GetProperty("ObservedAt").GetDateTimeOffset().Offset);
 
         // A different journal root has no process-local block: only the retained file can deny this load.
         Directory.CreateDirectory(Journal("fresh-process-state"));
-        File.Copy(result.ReceiptPath!, Path.Combine(Journal("fresh-process-state"), Path.GetFileName(result.ReceiptPath!)));
+        File.Copy(receiptPath, Path.Combine(Journal("fresh-process-state"), Path.GetFileName(receiptPath)));
         var fresh = CreateTuner(new(), new QuarantinedKernelTuningStore<FakeKernelConfiguration>(
             Journal("fresh-process-state"), inner), MeasurePassed);
         Assert.False(fresh.TryHydrate());
@@ -71,19 +85,20 @@ public sealed partial class EvolutionKernelAutotunerTests
         var run = await tuner.TuneAsync(Seeds());
         var prior = Snapshot(Identity(), Seeds()[1], 0);
         var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression(), prior);
-        Assert.True(result.WasPersisted);
+        AssertNativePersistence(result);
         Assert.True(result.WasRollbackPersisted);
         Assert.Same(prior, result.RollbackDeployment);
         Assert.Same(prior, tuner.Deployment.Current);
         Assert.True(CreateTuner(new(), store, MeasurePassed).TryHydrate());
 
-        byte[] original = File.ReadAllBytes(result.ReceiptPath!);
+        string receiptPath = Assert.Single(Directory.GetFiles(Journal(), "*.quarantine.json"));
+        byte[] original = File.ReadAllBytes(receiptPath);
         var stale = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
         Assert.False(stale.WasApplied);
         Assert.False(stale.WasPersisted);
         Assert.Null(stale.ReceiptPath);
         Assert.Same(prior, tuner.Deployment.Current);
-        Assert.Equal(original, File.ReadAllBytes(result.ReceiptPath!));
+        Assert.Equal(original, File.ReadAllBytes(receiptPath));
     }
 
     [Fact]
@@ -140,7 +155,7 @@ public sealed partial class EvolutionKernelAutotunerTests
         try
         {
             Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
-            Assert.True((await tuner.QuarantineAsync(run.ActiveDeployment, Regression())).WasPersisted);
+            AssertNativePersistence(await tuner.QuarantineAsync(run.ActiveDeployment, Regression()));
         }
         finally { release.Set(); }
         Assert.False(await publication);
@@ -168,7 +183,7 @@ public sealed partial class EvolutionKernelAutotunerTests
             prior.RunStateHash, prior.PromotionEvidence, prior.EvidenceRole);
         if (invalidity == "validator") rejectPrior = true;
         var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression(), prior);
-        Assert.True(result.WasPersisted);
+        AssertNativePersistence(result);
         Assert.Null(result.RollbackDeployment);
         Assert.False(result.WasRollbackPersisted);
         Assert.False(tuner.Deployment.TryGet(out _));
@@ -279,7 +294,7 @@ public sealed partial class EvolutionKernelAutotunerTests
         try
         {
             Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
-            Assert.True((await tuner.QuarantineAsync(run.ActiveDeployment, Regression())).WasPersisted);
+            AssertNativePersistence(await tuner.QuarantineAsync(run.ActiveDeployment, Regression()));
         }
         finally { release.Set(); }
         Assert.False(await hydration);
@@ -310,7 +325,7 @@ public sealed partial class EvolutionKernelAutotunerTests
         var prior = Snapshot(Identity(), Seeds()[1], 0);
         var result = await tuner.QuarantineAsync(active, Regression(), prior);
         Assert.True(result.WasApplied);
-        Assert.True(result.WasPersisted);
+        AssertNativePersistence(result);
         Assert.False(result.WasRollbackPersisted);
         Assert.Same(prior, tuner.Deployment.Current);
     }

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
@@ -1,0 +1,415 @@
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Evolution;
+using AiDotNet.Tensors.Helpers.Autotune;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
+
+public sealed partial class EvolutionKernelAutotunerTests
+{
+    private string Journal(string suffix = "journal") => Path.Combine(_temporaryCachePath, suffix);
+
+    [Fact]
+    public void TypedCachePath_StoreRoundTripsWithoutSuppressingWriteErrors()
+    {
+        var kernel = new KernelId(Identity().Kernel.Category, "typed-evolution-" + Identity().StableKey);
+        AutotuneCache.Store(kernel, Identity().Shape, new KernelChoice { Variant = "typed-path-probe" });
+        Assert.NotNull(AutotuneCache.Lookup(kernel, Identity().Shape));
+    }
+
+    private static KernelTuningRegressionEvidence Regression() => new(
+        KernelTuningRegressionReason.Latency, "p95-ms-v1", new string('a', 64), 12, 10,
+        new DateTimeOffset(2026, 9, 10, 12, 0, 0, TimeSpan.FromHours(-4)));
+
+    [Fact]
+    public async Task Quarantine_PersistsExactEvidence_AndBlocksFreshJournalHydration()
+    {
+        var inner = new MemoryStore();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+
+        Assert.True(result.WasApplied);
+        Assert.True(result.WasPersisted);
+        Assert.False(result.WasRollbackPersisted);
+        Assert.Null(result.RollbackDeployment);
+        Assert.Null(tuner.Deployment.Current);
+        Assert.False(tuner.TryHydrate());
+        Assert.False(store.TryStore(run.ActiveDeployment, new FakeKernelCodec()));
+        var anotherRun = new KernelTuningDeploymentSnapshot<FakeKernelConfiguration>(Identity(),
+            run.ActiveDeployment.Configuration, run.ActiveDeployment.GenomeId, run.ActiveDeployment.Measurement,
+            "another-run-state", run.ActiveDeployment.PromotionEvidence, run.ActiveDeployment.EvidenceRole);
+        Assert.False(store.TryPublish(tuner.Deployment, anotherRun, new FakeKernelCodec(), false));
+        using var receipt = JsonDocument.Parse(File.ReadAllBytes(result.ReceiptPath!));
+        var root = receipt.RootElement;
+        Assert.Equal("tensor-kernel-quarantine-v1", root.GetProperty("Schema").GetString());
+        Assert.Equal(run.ActiveDeployment.Identity.StableKey, root.GetProperty("Identity").GetString());
+        Assert.Equal(run.ActiveDeployment.RunStateHash, root.GetProperty("RunStateHash").GetString());
+        Assert.Equal(new FakeKernelCodec().Serialize(run.ActiveDeployment.Configuration),
+            Encoding.UTF8.GetString(Convert.FromBase64String(root.GetProperty("PayloadBase64").GetString()!)));
+        Assert.Equal(Regression().RawEvidenceSha256, root.GetProperty("Evidence").GetProperty("RawEvidenceSha256").GetString());
+        Assert.Equal(TimeSpan.Zero, root.GetProperty("Evidence").GetProperty("ObservedAt").GetDateTimeOffset().Offset);
+
+        // A different journal root has no process-local block: only the retained file can deny this load.
+        Directory.CreateDirectory(Journal("fresh-process-state"));
+        File.Copy(result.ReceiptPath!, Path.Combine(Journal("fresh-process-state"), Path.GetFileName(result.ReceiptPath!)));
+        var fresh = CreateTuner(new(), new QuarantinedKernelTuningStore<FakeKernelConfiguration>(
+            Journal("fresh-process-state"), inner), MeasurePassed);
+        Assert.False(fresh.TryHydrate());
+        Assert.Null(fresh.Deployment.Current);
+        var retuned = await tuner.TuneAsync(Seeds());
+        Assert.NotEqual(run.ActiveDeployment.GenomeId, retuned.ActiveDeployment.GenomeId);
+    }
+
+    [Fact]
+    public async Task Quarantine_RestoresEligiblePrior_AndStaleObservationCannotRemoveIt()
+    {
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        var prior = Snapshot(Identity(), Seeds()[1], 0);
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression(), prior);
+        Assert.True(result.WasPersisted);
+        Assert.True(result.WasRollbackPersisted);
+        Assert.Same(prior, result.RollbackDeployment);
+        Assert.Same(prior, tuner.Deployment.Current);
+        Assert.True(CreateTuner(new(), store, MeasurePassed).TryHydrate());
+
+        byte[] original = File.ReadAllBytes(result.ReceiptPath!);
+        var stale = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+        Assert.False(stale.WasApplied);
+        Assert.False(stale.WasPersisted);
+        Assert.Null(stale.ReceiptPath);
+        Assert.Same(prior, tuner.Deployment.Current);
+        Assert.Equal(original, File.ReadAllBytes(result.ReceiptPath!));
+    }
+
+    [Fact]
+    public async Task Quarantine_WriteFailureBlocksAcrossWrappers_ButDoesNotClaimDurability()
+    {
+        var inner = new MemoryStore();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        Directory.Move(Journal(), Journal("moved"));
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+        Assert.True(result.WasApplied);
+        Assert.False(result.WasPersisted);
+        Assert.Null(result.ReceiptPath);
+        Assert.Null(tuner.Deployment.Current);
+        var recreated = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        Assert.False(CreateTuner(new(), recreated, MeasurePassed).TryHydrate());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{invalid-json")]
+    [InlineData("{\"Schema\":\"future-format\"}")]
+    public void Quarantine_AnyExistingRecordDeniesWithoutParsing(string contents)
+    {
+        var snapshot = Snapshot(Identity(), Seeds()[2], 0);
+        var codec = new FakeKernelCodec();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(snapshot));
+        string key = EvolutionHash.Combine(new[] { "tensor-kernel-quarantine-v1", Identity().StableKey,
+            codec.Id, codec.VersionHash, snapshot.GenomeId });
+        File.WriteAllText(Path.Combine(Journal(), key + ".quarantine.json"), contents);
+        Assert.False(store.TryLoad(Identity(), codec, out _));
+        Assert.False(store.TryPublish(new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(Identity()),
+            snapshot, codec, false));
+    }
+
+    [Fact]
+    public async Task Quarantine_AdmissionAtPublicationRejectsPreviouslyLoadedWinner()
+    {
+        var inner = new MemoryStore();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        Assert.True(store.TryLoad(Identity(), new FakeKernelCodec(), out var loaded));
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var otherHandle = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(Identity());
+        var codec = new CallbackQuarantineCodec(() =>
+        {
+            entered.Set();
+            if (!release.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException();
+        });
+        Task<bool> publication = Task.Run(() => store.TryPublish(otherHandle, loaded!, codec, true));
+        try
+        {
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
+            Assert.True((await tuner.QuarantineAsync(run.ActiveDeployment, Regression())).WasPersisted);
+        }
+        finally { release.Set(); }
+        Assert.False(await publication);
+        Assert.Null(otherHandle.Current);
+    }
+
+    [Theory]
+    [InlineData("same")]
+    [InlineData("identity")]
+    [InlineData("hash")]
+    [InlineData("validator")]
+    public async Task Quarantine_InvalidRollbackLeavesBuiltInFallback(string invalidity)
+    {
+        var registry = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
+        bool rejectPrior = false;
+        var tuner = new EvolutionKernelAutotuner<FakeKernelConfiguration>(Identity(), new FakeKernelCodec(),
+            new FakeKernelVariation(), MeasurePassed, Finalist(), EngineOptions(), deploymentRegistry: registry,
+            store: store, deploymentValidator: c => !rejectPrior || c.Variant != FakeKernelVariant.Fast);
+        var run = await tuner.TuneAsync(Seeds());
+        var prior = Snapshot(Identity(), Seeds()[1], 0);
+        if (invalidity == "same") prior = Snapshot(Identity(), run.ActiveDeployment.Configuration, 10);
+        if (invalidity == "identity") prior = Snapshot(DifferentIdentity(), Seeds()[1], 0);
+        if (invalidity == "hash") prior = new(prior.Identity, prior.Configuration, "wrong-hash", prior.Measurement,
+            prior.RunStateHash, prior.PromotionEvidence, prior.EvidenceRole);
+        if (invalidity == "validator") rejectPrior = true;
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression(), prior);
+        Assert.True(result.WasPersisted);
+        Assert.Null(result.RollbackDeployment);
+        Assert.False(result.WasRollbackPersisted);
+        Assert.False(tuner.Deployment.TryGet(out _));
+    }
+
+    [Fact]
+    public async Task Quarantine_CancellationAndInvalidExpectedDoNotMutate()
+    {
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        using var canceled = new CancellationTokenSource();
+        canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tuner.QuarantineAsync(
+            run.ActiveDeployment, Regression(), cancellationToken: canceled.Token));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => tuner.QuarantineAsync(null!, Regression()));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => tuner.QuarantineAsync(run.ActiveDeployment, null!));
+        await Assert.ThrowsAsync<ArgumentException>(() => tuner.QuarantineAsync(Snapshot(DifferentIdentity(), Seeds()[2], 0), Regression()));
+        var invalid = new KernelTuningDeploymentSnapshot<FakeKernelConfiguration>(Identity(), Seeds()[2], "bad-hash",
+            run.ActiveDeployment.Measurement, "run", run.ActiveDeployment.PromotionEvidence, run.ActiveDeployment.EvidenceRole);
+        await Assert.ThrowsAsync<ArgumentException>(() => tuner.QuarantineAsync(invalid, Regression()));
+        Assert.Same(run.ActiveDeployment, tuner.Deployment.Current);
+        Assert.Empty(Directory.GetFiles(Journal()));
+    }
+
+    [Fact]
+    public async Task Quarantine_IsExplicit_AndHotReadsNeverConsultJournal()
+    {
+        var legacy = CreateTuner(new(), new MemoryStore(), MeasurePassed);
+        var run = await legacy.TuneAsync(Seeds());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => legacy.QuarantineAsync(run.ActiveDeployment, Regression()));
+        Assert.True(legacy.Deployment.TryDeactivate(run.ActiveDeployment));
+        Assert.True(legacy.TryHydrate()); // Existing in-memory deactivation semantics remain unchanged.
+
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var deployed = (await tuner.TuneAsync(Seeds())).ActiveDeployment;
+        Directory.Move(Journal(), Journal("offline"));
+        Assert.True(tuner.Deployment.TryGet(out var configuration));
+        Assert.Equal(deployed.Configuration, configuration);
+        Assert.False(store.TryLoad(Identity(), new FakeKernelCodec(), out _));
+    }
+
+    [Theory]
+    [InlineData("relative/path")]
+    [InlineData("")]
+    public void Quarantine_JournalRequiresAbsolutePrivateDirectory(string path) =>
+        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>(path));
+
+    [Theory]
+    [InlineData("policy")]
+    [InlineData("digest")]
+    [InlineData("reason")]
+    [InlineData("observed")]
+    [InlineData("limit")]
+    [InlineData("time")]
+    public void Quarantine_RegressionEvidenceRejectsInvalidFields(string field)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new KernelTuningRegressionEvidence(
+            field == "reason" ? (KernelTuningRegressionReason)99 : KernelTuningRegressionReason.Latency,
+            field == "policy" ? "bad\uD800" : "policy-v1", field == "digest" ? "bad" : new string('a', 64),
+            field == "observed" ? double.NaN : 2, field == "limit" ? -1 : 1,
+            field == "time" ? default : DateTimeOffset.UtcNow));
+    }
+
+    [Theory]
+    [InlineData("oversize")]
+    [InlineData("unicode")]
+    [InlineData("empty-id")]
+    [InlineData("version-change")]
+    [InlineData("exception")]
+    public void Quarantine_RejectsUnboundedOrUnstableCodecs(string failure)
+    {
+        var snapshot = Snapshot(Identity(), Seeds()[2], 0);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(snapshot));
+        var codec = new CallbackQuarantineCodec(() => { if (failure == "exception") throw new IOException(); })
+        {
+            Payload = failure == "oversize" ? new string('x', 65537) : failure == "unicode" ? "\uD800" : null,
+            EmptyId = failure == "empty-id",
+            ChangeVersion = failure == "version-change"
+        };
+        Assert.False(store.TryLoad(Identity(), codec, out _));
+        Assert.False(store.CanDeploy(Identity(), snapshot.Configuration, codec));
+    }
+
+    private static KernelTuningIdentity DifferentIdentity() => new(Identity().Kernel, Identity().Shape,
+        Identity().Device, Identity().Backend, new KernelSearchSpaceVersion(999), Identity().BenchmarkProtocolVersion);
+
+    [Fact]
+    public async Task Quarantine_HydrationPublicationCannotRacePastReceipt()
+    {
+        var inner = new MemoryStore();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        int serializations = 0;
+        var codec = new CallbackQuarantineCodec(() =>
+        {
+            if (++serializations != 4) return; // TryLoad, CanDeploy, canonical hash, final publication.
+            entered.Set();
+            if (!release.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException();
+        });
+        var loading = new EvolutionKernelAutotuner<FakeKernelConfiguration>(Identity(), codec,
+            new FakeKernelVariation(), MeasurePassed, Finalist(), EngineOptions(), store: store);
+        Task<bool> hydration = Task.Run(loading.TryHydrate);
+        try
+        {
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
+            Assert.True((await tuner.QuarantineAsync(run.ActiveDeployment, Regression())).WasPersisted);
+        }
+        finally { release.Set(); }
+        Assert.False(await hydration);
+        Assert.Null(loading.Deployment.Current);
+    }
+
+    [Fact]
+    public async Task Quarantine_ExplicitHydrationRechecksOtherActiveHandle()
+    {
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+        var other = CreateTuner(new(), store, MeasurePassed);
+        Assert.True(other.TryHydrate());
+        await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+        Assert.True(other.Deployment.TryGet(out _)); // No implicit dispatch-time filesystem check.
+        Assert.False(other.TryHydrate());
+        Assert.Null(other.Deployment.Current);
+    }
+
+    [Fact]
+    public async Task Quarantine_RollbackStoreFailureDoesNotUndoSafeInMemoryRollback()
+    {
+        var active = Snapshot(Identity(), Seeds()[2], 0);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FailWriteQuarantineStore(active));
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        Assert.True(tuner.TryHydrate());
+        var prior = Snapshot(Identity(), Seeds()[1], 0);
+        var result = await tuner.QuarantineAsync(active, Regression(), prior);
+        Assert.True(result.WasApplied);
+        Assert.True(result.WasPersisted);
+        Assert.False(result.WasRollbackPersisted);
+        Assert.Same(prior, tuner.Deployment.Current);
+    }
+
+    [Fact]
+    public async Task Quarantine_ExistingReceiptIsNotOverwrittenOrClaimedAsNewPersistence()
+    {
+        var active = Snapshot(Identity(), Seeds()[2], 0);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(active));
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        Assert.True(tuner.TryHydrate());
+        var codec = new FakeKernelCodec();
+        string key = EvolutionHash.Combine(new[] { "tensor-kernel-quarantine-v1", Identity().StableKey,
+            codec.Id, codec.VersionHash, active.GenomeId });
+        string path = Path.Combine(Journal(), key + ".quarantine.json");
+        File.WriteAllText(path, "first receipt");
+        var result = await tuner.QuarantineAsync(active, Regression());
+        Assert.True(result.WasApplied);
+        Assert.False(result.WasPersisted);
+        Assert.Equal("first receipt", File.ReadAllText(path));
+        Assert.Single(Directory.GetFiles(Journal(), "*.pending"));
+        Assert.Null(tuner.Deployment.Current);
+    }
+
+    [Theory]
+    [InlineData("throw")]
+    [InlineData("identity")]
+    public void Quarantine_StoreFailureOrWrongIdentityCannotHydrate(string failure)
+    {
+        IKernelTuningStore<FakeKernelConfiguration> inner = failure == "throw" ? new ThrowingStore() :
+            new FixedLoadStore(Snapshot(DifferentIdentity(), Seeds()[2], 0));
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner);
+        Assert.False(store.TryLoad(Identity(), new FakeKernelCodec(), out _));
+    }
+
+    [Theory]
+    [InlineData("spaces")]
+    [InlineData("long")]
+    [InlineData("control")]
+    [InlineData("equal")]
+    [InlineData("infinite")]
+    [InlineData("limit-nan")]
+    [InlineData("uppercase-digest")]
+    public void Quarantine_EvidenceRejectsAdditionalBoundaryValues(string field)
+    {
+        string policy = field == "spaces" ? " " : field == "long" ? new string('x', 257) :
+            field == "control" ? "bad\nlabel" : "v1";
+        Assert.ThrowsAny<ArgumentException>(() => new KernelTuningRegressionEvidence(
+            KernelTuningRegressionReason.Latency, policy, new string(field == "uppercase-digest" ? 'A' : 'a', 64),
+            field == "equal" ? 1 : field == "infinite" ? double.PositiveInfinity : 2,
+            field == "limit-nan" ? double.NaN : 1, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Quarantine_RejectsRootAndDriveRelativePaths()
+    {
+        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Path.GetPathRoot(Journal())!));
+        if (Path.DirectorySeparatorChar != '\\') return;
+        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>("C:relative"));
+        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>("\\relative"));
+    }
+
+    [Fact]
+    public void Quarantine_PayloadByteLimitAndNullArgumentsFailClosed()
+    {
+        var snapshot = Snapshot(Identity(), Seeds()[2], 0);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(snapshot));
+        var codec = new CallbackQuarantineCodec(() => { }) { Payload = new string('\u20ac', 30000) };
+        Assert.False(store.TryLoad(Identity(), codec, out _));
+        Assert.False(store.TryLoad(null!, new FakeKernelCodec(), out _));
+        Assert.False(store.TryStore(null!, new FakeKernelCodec()));
+        Assert.False(store.TryStore(snapshot, null!));
+        Assert.False(store.CanDeploy(null!, snapshot.Configuration, new FakeKernelCodec()));
+        Assert.False(store.TryPublish(new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(Identity()),
+            snapshot, codec, true));
+    }
+
+    private sealed class FailWriteQuarantineStore : IKernelTuningStore<FakeKernelConfiguration>
+    {
+        private readonly KernelTuningDeploymentSnapshot<FakeKernelConfiguration> _snapshot;
+        internal FailWriteQuarantineStore(KernelTuningDeploymentSnapshot<FakeKernelConfiguration> snapshot) => _snapshot = snapshot;
+        public bool TryLoad(KernelTuningIdentity identity, IEvolutionGenomeCodec<FakeKernelConfiguration> codec,
+            out KernelTuningDeploymentSnapshot<FakeKernelConfiguration>? snapshot)
+        { snapshot = _snapshot; return true; }
+        public bool TryStore(KernelTuningDeploymentSnapshot<FakeKernelConfiguration> snapshot,
+            IEvolutionGenomeCodec<FakeKernelConfiguration> codec) => false;
+    }
+
+    private sealed class CallbackQuarantineCodec : IEvolutionGenomeCodec<FakeKernelConfiguration>
+    {
+        private readonly Action _callback;
+        private int _versionReads;
+        internal CallbackQuarantineCodec(Action callback) => _callback = callback;
+        internal string? Payload { get; set; }
+        internal bool EmptyId { get; set; }
+        internal bool ChangeVersion { get; set; }
+        public string Id => EmptyId ? "" : new FakeKernelCodec().Id;
+        public string VersionHash => ChangeVersion ? (++_versionReads).ToString() : new FakeKernelCodec().VersionHash;
+        public string Serialize(FakeKernelConfiguration configuration) { _callback(); return Payload ?? new FakeKernelCodec().Serialize(configuration); }
+        public FakeKernelConfiguration Deserialize(string payload) => new FakeKernelCodec().Deserialize(payload);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/KernelTuningQuarantineTests.cs
@@ -9,6 +9,11 @@ namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
 
 public sealed partial class EvolutionKernelAutotunerTests
 {
+    public enum RollbackFault { SameGenome, Identity, GenomeHash, Validator }
+    public enum EvidenceField { Policy, Digest, Reason, Observed, Limit, Time }
+    public enum CodecFault { Oversize, Unicode, EmptyId, VersionChange, Exception }
+    public enum EvidenceBoundary { Spaces, TooLong, Control, Equal, Infinite, LimitNaN, UppercaseDigest }
+
     private string Journal(string suffix = "journal") => Path.Combine(_temporaryCachePath, suffix);
 
     private static void AssertNativePersistence(KernelTuningQuarantineResult<FakeKernelConfiguration> result)
@@ -143,6 +148,7 @@ public sealed partial class EvolutionKernelAutotunerTests
         var tuner = CreateTuner(new(), store, MeasurePassed);
         var run = await tuner.TuneAsync(Seeds());
         Assert.True(store.TryLoad(Identity(), new FakeKernelCodec(), out var loaded));
+        var loadedSnapshot = Assert.IsType<KernelTuningDeploymentSnapshot<FakeKernelConfiguration>>(loaded);
         using var entered = new ManualResetEventSlim();
         using var release = new ManualResetEventSlim();
         var otherHandle = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(Identity());
@@ -151,7 +157,7 @@ public sealed partial class EvolutionKernelAutotunerTests
             entered.Set();
             if (!release.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException();
         });
-        Task<bool> publication = Task.Run(() => store.TryPublish(otherHandle, loaded!, codec, true));
+        Task<bool> publication = Task.Run(() => store.TryPublish(otherHandle, loadedSnapshot, codec, true));
         try
         {
             Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
@@ -163,11 +169,11 @@ public sealed partial class EvolutionKernelAutotunerTests
     }
 
     [Theory]
-    [InlineData("same")]
-    [InlineData("identity")]
-    [InlineData("hash")]
-    [InlineData("validator")]
-    public async Task Quarantine_InvalidRollbackLeavesBuiltInFallback(string invalidity)
+    [InlineData(RollbackFault.SameGenome)]
+    [InlineData(RollbackFault.Identity)]
+    [InlineData(RollbackFault.GenomeHash)]
+    [InlineData(RollbackFault.Validator)]
+    public async Task Quarantine_InvalidRollbackLeavesBuiltInFallback(RollbackFault invalidity)
     {
         var registry = new KernelTuningDeploymentRegistry<FakeKernelConfiguration>();
         var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal());
@@ -177,11 +183,11 @@ public sealed partial class EvolutionKernelAutotunerTests
             store: store, deploymentValidator: c => !rejectPrior || c.Variant != FakeKernelVariant.Fast);
         var run = await tuner.TuneAsync(Seeds());
         var prior = Snapshot(Identity(), Seeds()[1], 0);
-        if (invalidity == "same") prior = Snapshot(Identity(), run.ActiveDeployment.Configuration, 10);
-        if (invalidity == "identity") prior = Snapshot(DifferentIdentity(), Seeds()[1], 0);
-        if (invalidity == "hash") prior = new(prior.Identity, prior.Configuration, "wrong-hash", prior.Measurement,
+        if (invalidity == RollbackFault.SameGenome) prior = Snapshot(Identity(), run.ActiveDeployment.Configuration, 10);
+        if (invalidity == RollbackFault.Identity) prior = Snapshot(DifferentIdentity(), Seeds()[1], 0);
+        if (invalidity == RollbackFault.GenomeHash) prior = new(prior.Identity, prior.Configuration, "wrong-hash", prior.Measurement,
             prior.RunStateHash, prior.PromotionEvidence, prior.EvidenceRole);
-        if (invalidity == "validator") rejectPrior = true;
+        if (invalidity == RollbackFault.Validator) rejectPrior = true;
         var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression(), prior);
         AssertNativePersistence(result);
         Assert.Null(result.RollbackDeployment);
@@ -199,8 +205,10 @@ public sealed partial class EvolutionKernelAutotunerTests
         canceled.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tuner.QuarantineAsync(
             run.ActiveDeployment, Regression(), cancellationToken: canceled.Token));
-        await Assert.ThrowsAsync<ArgumentNullException>(() => tuner.QuarantineAsync(null!, Regression()));
-        await Assert.ThrowsAsync<ArgumentNullException>(() => tuner.QuarantineAsync(run.ActiveDeployment, null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => InvokeDefensiveNullCase<Task>(
+            tuner, nameof(tuner.QuarantineAsync), null, Regression(), null, CancellationToken.None));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => InvokeDefensiveNullCase<Task>(
+            tuner, nameof(tuner.QuarantineAsync), run.ActiveDeployment, null, null, CancellationToken.None));
         await Assert.ThrowsAsync<ArgumentException>(() => tuner.QuarantineAsync(Snapshot(DifferentIdentity(), Seeds()[2], 0), Regression()));
         var invalid = new KernelTuningDeploymentSnapshot<FakeKernelConfiguration>(Identity(), Seeds()[2], "bad-hash",
             run.ActiveDeployment.Measurement, "run", run.ActiveDeployment.PromotionEvidence, run.ActiveDeployment.EvidenceRole);
@@ -234,36 +242,36 @@ public sealed partial class EvolutionKernelAutotunerTests
         Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>(path));
 
     [Theory]
-    [InlineData("policy")]
-    [InlineData("digest")]
-    [InlineData("reason")]
-    [InlineData("observed")]
-    [InlineData("limit")]
-    [InlineData("time")]
-    public void Quarantine_RegressionEvidenceRejectsInvalidFields(string field)
+    [InlineData(EvidenceField.Policy)]
+    [InlineData(EvidenceField.Digest)]
+    [InlineData(EvidenceField.Reason)]
+    [InlineData(EvidenceField.Observed)]
+    [InlineData(EvidenceField.Limit)]
+    [InlineData(EvidenceField.Time)]
+    public void Quarantine_RegressionEvidenceRejectsInvalidFields(EvidenceField field)
     {
         Assert.ThrowsAny<ArgumentException>(() => new KernelTuningRegressionEvidence(
-            field == "reason" ? (KernelTuningRegressionReason)99 : KernelTuningRegressionReason.Latency,
-            field == "policy" ? "bad\uD800" : "policy-v1", field == "digest" ? "bad" : new string('a', 64),
-            field == "observed" ? double.NaN : 2, field == "limit" ? -1 : 1,
-            field == "time" ? default : DateTimeOffset.UtcNow));
+            field == EvidenceField.Reason ? (KernelTuningRegressionReason)99 : KernelTuningRegressionReason.Latency,
+            field == EvidenceField.Policy ? "bad\uD800" : "policy-v1", field == EvidenceField.Digest ? "bad" : new string('a', 64),
+            field == EvidenceField.Observed ? double.NaN : 2, field == EvidenceField.Limit ? -1 : 1,
+            field == EvidenceField.Time ? default : DateTimeOffset.UtcNow));
     }
 
     [Theory]
-    [InlineData("oversize")]
-    [InlineData("unicode")]
-    [InlineData("empty-id")]
-    [InlineData("version-change")]
-    [InlineData("exception")]
-    public void Quarantine_RejectsUnboundedOrUnstableCodecs(string failure)
+    [InlineData(CodecFault.Oversize)]
+    [InlineData(CodecFault.Unicode)]
+    [InlineData(CodecFault.EmptyId)]
+    [InlineData(CodecFault.VersionChange)]
+    [InlineData(CodecFault.Exception)]
+    public void Quarantine_RejectsUnboundedOrUnstableCodecs(CodecFault failure)
     {
         var snapshot = Snapshot(Identity(), Seeds()[2], 0);
         var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(snapshot));
-        var codec = new CallbackQuarantineCodec(() => { if (failure == "exception") throw new IOException(); })
+        var codec = new CallbackQuarantineCodec(() => { if (failure == CodecFault.Exception) throw new IOException(); })
         {
-            Payload = failure == "oversize" ? new string('x', 65537) : failure == "unicode" ? "\uD800" : null,
-            EmptyId = failure == "empty-id",
-            ChangeVersion = failure == "version-change"
+            Payload = failure == CodecFault.Oversize ? new string('x', 65537) : failure == CodecFault.Unicode ? "\uD800" : null,
+            EmptyId = failure == CodecFault.EmptyId,
+            ChangeVersion = failure == CodecFault.VersionChange
         };
         Assert.False(store.TryLoad(Identity(), codec, out _));
         Assert.False(store.CanDeploy(Identity(), snapshot.Configuration, codec));
@@ -362,27 +370,28 @@ public sealed partial class EvolutionKernelAutotunerTests
     }
 
     [Theory]
-    [InlineData("spaces")]
-    [InlineData("long")]
-    [InlineData("control")]
-    [InlineData("equal")]
-    [InlineData("infinite")]
-    [InlineData("limit-nan")]
-    [InlineData("uppercase-digest")]
-    public void Quarantine_EvidenceRejectsAdditionalBoundaryValues(string field)
+    [InlineData(EvidenceBoundary.Spaces)]
+    [InlineData(EvidenceBoundary.TooLong)]
+    [InlineData(EvidenceBoundary.Control)]
+    [InlineData(EvidenceBoundary.Equal)]
+    [InlineData(EvidenceBoundary.Infinite)]
+    [InlineData(EvidenceBoundary.LimitNaN)]
+    [InlineData(EvidenceBoundary.UppercaseDigest)]
+    public void Quarantine_EvidenceRejectsAdditionalBoundaryValues(EvidenceBoundary field)
     {
-        string policy = field == "spaces" ? " " : field == "long" ? new string('x', 257) :
-            field == "control" ? "bad\nlabel" : "v1";
+        string policy = field == EvidenceBoundary.Spaces ? " " : field == EvidenceBoundary.TooLong ? new string('x', 257) :
+            field == EvidenceBoundary.Control ? "bad\nlabel" : "v1";
         Assert.ThrowsAny<ArgumentException>(() => new KernelTuningRegressionEvidence(
-            KernelTuningRegressionReason.Latency, policy, new string(field == "uppercase-digest" ? 'A' : 'a', 64),
-            field == "equal" ? 1 : field == "infinite" ? double.PositiveInfinity : 2,
-            field == "limit-nan" ? double.NaN : 1, DateTimeOffset.UtcNow));
+            KernelTuningRegressionReason.Latency, policy, new string(field == EvidenceBoundary.UppercaseDigest ? 'A' : 'a', 64),
+            field == EvidenceBoundary.Equal ? 1 : field == EvidenceBoundary.Infinite ? double.PositiveInfinity : 2,
+            field == EvidenceBoundary.LimitNaN ? double.NaN : 1, DateTimeOffset.UtcNow));
     }
 
     [Fact]
     public void Quarantine_RejectsRootAndDriveRelativePaths()
     {
-        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Path.GetPathRoot(Journal())!));
+        string root = Assert.IsType<string>(Path.GetPathRoot(Journal()));
+        Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>(root));
         if (Path.DirectorySeparatorChar != '\\') return;
         Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>("C:relative"));
         Assert.Throws<ArgumentException>(() => new QuarantinedKernelTuningStore<FakeKernelConfiguration>("\\relative"));
@@ -395,12 +404,22 @@ public sealed partial class EvolutionKernelAutotunerTests
         var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new FixedLoadStore(snapshot));
         var codec = new CallbackQuarantineCodec(() => { }) { Payload = new string('\u20ac', 30000) };
         Assert.False(store.TryLoad(Identity(), codec, out _));
-        Assert.False(store.TryLoad(null!, new FakeKernelCodec(), out _));
-        Assert.False(store.TryStore(null!, new FakeKernelCodec()));
-        Assert.False(store.TryStore(snapshot, null!));
-        Assert.False(store.CanDeploy(null!, snapshot.Configuration, new FakeKernelCodec()));
+        Assert.False(InvokeDefensiveNullCase<bool>(store, nameof(store.TryLoad), null, new FakeKernelCodec(), null));
+        Assert.False(InvokeDefensiveNullCase<bool>(store, nameof(store.TryStore), null, new FakeKernelCodec()));
+        Assert.False(InvokeDefensiveNullCase<bool>(store, nameof(store.TryStore), snapshot, null));
+        Assert.False(InvokeDefensiveNullCase<bool>(store, nameof(store.CanDeploy), null, snapshot.Configuration, new FakeKernelCodec()));
         Assert.False(store.TryPublish(new KernelTuningDeploymentRegistry<FakeKernelConfiguration>().GetOrCreate(Identity()),
             snapshot, codec, true));
+    }
+
+    private static TResult InvokeDefensiveNullCase<TResult>(object instance, string methodName, params object?[] arguments)
+    {
+        // Test runtime guards without claiming null satisfies the public non-null
+        // contract. Production signatures and nullable warnings remain unchanged.
+        var method = instance.GetType().GetMethod(methodName, System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"The defensive-null probe lost {methodName}.");
+        return Assert.IsAssignableFrom<TResult>(method.Invoke(instance, arguments));
     }
 
     private sealed class FailWriteQuarantineStore : IKernelTuningStore<FakeKernelConfiguration>

--- a/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/QuarantineReceiptDurabilityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Helpers/Autotune/QuarantineReceiptDurabilityTests.cs
@@ -1,0 +1,149 @@
+using AiDotNet.Tensors.Helpers.Autotune;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Helpers.Autotune;
+
+public sealed partial class EvolutionKernelAutotunerTests
+{
+    public enum ReceiptFailure { None, MoveDenied, DirectoryDenied, AncestorDenied, MissingNativeEntry }
+
+    [Theory]
+    [InlineData(Architecture.X86, 0x90000)]
+    [InlineData(Architecture.X64, 0x90000)]
+    [InlineData(Architecture.Arm64, 0x90000)]
+    [InlineData(Architecture.Arm, 0x84000)]
+    public void Quarantine_DirectoryFlagsMatchTheLinuxArchitecture(Architecture architecture, int expected)
+    {
+        Assert.True(QuarantineReceiptCommit.TryGetDirectoryFlags(architecture, out LinuxDirectoryOpenFlags flags));
+        Assert.Equal(expected, (int)flags);
+    }
+
+    [Fact]
+    public void Quarantine_UnknownArchitectureCannotGuessDirectoryFlags()
+        => Assert.False(QuarantineReceiptCommit.TryGetDirectoryFlags((Architecture)int.MaxValue, out _));
+
+    [Theory]
+    [InlineData(ReceiptFailure.MoveDenied)]
+    [InlineData(ReceiptFailure.DirectoryDenied)]
+    [InlineData(ReceiptFailure.AncestorDenied)]
+    [InlineData(ReceiptFailure.MissingNativeEntry)]
+    public async Task Quarantine_FailedCommitBarrierCannotClaimDurability(ReceiptFailure failure)
+    {
+        var operations = new RecordedCommitOperations(QuarantineCommitMode.LinuxDirectorySync, failure);
+        var inner = new MemoryStore();
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), inner, operations);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+
+        Assert.True(result.WasApplied);
+        Assert.False(result.WasPersisted);
+        Assert.Null(result.ReceiptPath);
+        Assert.Null(tuner.Deployment.Current);
+        Assert.False(tuner.TryHydrate());
+        Assert.True(operations.MoveAttempted);
+        Assert.Contains("tensor-kernel-quarantine-v1", operations.ReceiptBeforeMove, StringComparison.Ordinal);
+        if (failure == ReceiptFailure.MoveDenied)
+        {
+            Assert.Empty(operations.DirectoryBarriers);
+            Assert.Empty(Directory.GetFiles(Journal(), "*.quarantine.json"));
+            Assert.Single(Directory.GetFiles(Journal(), "*.pending"));
+        }
+        else
+        {
+            // A post-rename barrier failure must not remove the visible tombstone.
+            string receipt = Assert.Single(Directory.GetFiles(Journal(), "*.quarantine.json"));
+            Assert.Empty(Directory.GetFiles(Journal(), "*.pending"));
+            Assert.Equal(failure == ReceiptFailure.AncestorDenied ? 2 : 1, operations.DirectoryBarriers.Count);
+            Directory.CreateDirectory(Journal("other-process"));
+            File.Copy(receipt, Path.Combine(Journal("other-process"), Path.GetFileName(receipt)));
+            var fresh = CreateTuner(new(), new QuarantinedKernelTuningStore<FakeKernelConfiguration>(
+                Journal("other-process"), inner), MeasurePassed);
+            Assert.False(fresh.TryHydrate());
+        }
+    }
+
+    [Fact]
+    public async Task Quarantine_UnsupportedDurabilityRetainsOnlyBestEffortReceipt()
+    {
+        var operations = new RecordedCommitOperations(QuarantineCommitMode.Unsupported, ReceiptFailure.None);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new MemoryStore(), operations);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+
+        Assert.True(result.WasApplied);
+        Assert.False(result.WasPersisted);
+        Assert.Null(result.ReceiptPath);
+        Assert.True(operations.MoveAttempted);
+        Assert.Single(Directory.GetFiles(Journal(), "*.quarantine.json"));
+        Assert.Empty(Directory.GetFiles(Journal(), "*.pending"));
+        Assert.Empty(operations.DirectoryBarriers);
+        Assert.False(tuner.TryHydrate());
+    }
+
+    [Fact]
+    public async Task Quarantine_RequiresEveryDirectoryBarrierAfterPublication()
+    {
+        var operations = new RecordedCommitOperations(QuarantineCommitMode.LinuxDirectorySync, ReceiptFailure.None);
+        var store = new QuarantinedKernelTuningStore<FakeKernelConfiguration>(Journal(), new MemoryStore(), operations);
+        var tuner = CreateTuner(new(), store, MeasurePassed);
+        var run = await tuner.TuneAsync(Seeds());
+
+        var result = await tuner.QuarantineAsync(run.ActiveDeployment, Regression());
+
+        Assert.True(result.WasApplied);
+        Assert.True(result.WasPersisted);
+        Assert.Equal(Assert.Single(Directory.GetFiles(Journal(), "*.quarantine.json")), result.ReceiptPath);
+        var expectedDirectories = new List<string>();
+        for (string? directory = Journal(); !string.IsNullOrEmpty(directory); directory = Path.GetDirectoryName(directory))
+            expectedDirectories.Add(directory);
+        Assert.Equal(expectedDirectories, operations.DirectoryBarriers);
+        Assert.Empty(Directory.GetFiles(Journal(), "*.pending"));
+    }
+
+    private sealed class RecordedCommitOperations : IQuarantineCommitOperations
+    {
+        private readonly ReceiptFailure _failure;
+        private string? _destination;
+
+        internal RecordedCommitOperations(QuarantineCommitMode mode, ReceiptFailure failure)
+        {
+            Mode = mode;
+            _failure = failure;
+        }
+
+        public QuarantineCommitMode Mode { get; }
+        internal bool MoveAttempted { get; private set; }
+        internal string ReceiptBeforeMove { get; private set; } = string.Empty;
+        internal List<string> DirectoryBarriers { get; } = new();
+
+        public bool MoveNewFile(string source, string destination)
+        {
+            MoveAttempted = true;
+            // The writer must have closed its exclusive file before attempting publication.
+            ReceiptBeforeMove = File.ReadAllText(source);
+            if (_failure == ReceiptFailure.MoveDenied) return false;
+            File.Move(source, destination);
+            _destination = destination;
+            return true;
+        }
+
+        public bool FlushDirectory(string directory)
+        {
+            Assert.NotNull(_destination);
+            Assert.True(File.Exists(_destination), "Directory barriers must follow publication.");
+            DirectoryBarriers.Add(directory);
+            return _failure switch
+            {
+                ReceiptFailure.DirectoryDenied => false,
+                ReceiptFailure.AncestorDenied => DirectoryBarriers.Count < 2,
+                ReceiptFailure.MissingNativeEntry => throw new EntryPointNotFoundException("The directory barrier is unavailable."),
+                _ => true
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Review readiness — September 11, 2026

**Ready for review of the completed quarantine and validated-rollback slice at `665cb3c8149d9811e9ee5d802caac676be39fa14`.** Current build, GPU-parity and coverage checks pass; approval remains required. The earlier cancelled title check has a successful replacement. Broader US-25 drift/retuning/registry work remains open in [Evolution issue #43](https://github.com/ooples/AiDotNet.Evolution/issues/43) and [dependent story PR #1030](https://github.com/ooples/AiDotNet.Tensors/pull/1030). This is not a full-story completion, merge or deployment authorization.

## Current implementation — 665cb3c8

Companion to ooples/AiDotNet.Evolution#15 and ooples/AiDotNet#2148. US-25 remains partial; this PR now adds persistent quarantine and explicit validated rollback in addition to in-memory deactivation.

- Opt-in QuarantinedKernelTuningStore<TConfiguration> uses the existing store parameter; no constructor/package compatibility change.
- QuarantineAsync removes only the exact observed snapshot, retains bounded caller-supplied regression evidence, and can restore an eligible retained prior snapshot.
- Quarantine checks cover final publication as well as cache loading; the process-local journal gate closes the stale-load/publication race. TryGet stays lock-free and I/O-free.
- Identity includes the canonical configuration, tuning envelope and codec version, not the selecting run. Corrupt/unknown receipts deny admission. Failed writes retain a process-local block and do not claim restart safety.
- Short sibling temporary filenames also fix the reproduced net471 winner-cache write failure (224-character final path, failing 263-character temporary path).

### Given / When / Then

- Given a currently observed failing snapshot, when quarantine runs, then it is deactivated and its configuration is blocked with separately reported persistence outcomes.
- Given a stale observation, when quarantine runs, then a newer deployment is not removed.
- Given a winner loaded before quarantine, when publication resumes afterward, then the final admission gate rejects it.
- Given an eligible prior validated snapshot, when rollback is requested, then it is restored and independently persisted; invalid/quarantined prior snapshots leave built-in fallback after applied quarantine.
- Given a failed write or corrupt record, when safety is evaluated, then fail-closed behavior is retained without claiming successful receipt persistence.

### Local verification

- Normal Release library build: net10.0, net8.0 and net471, zero warnings/errors.
- Main-project Helpers.Autotune tests: 191 passed separately on net10.0 and net471, zero failed/skipped. Test projects retain existing warnings; diagnostic analyzers were disabled for those test rebuilds.
- net8.0 focused linked-source harness: 64 passed (main test project does not target net8.0).
- Quarantine executable lines: 174/175. Changed tuner lines: 28/30; changed cache write line covered. Broader selected-file coverage: 615/733 lines, 291/359 branches, not 99% assembly coverage.
- Final DLL production/test-copy hashes checked; whitespace verification and git diff --check passed.
- Raw local evidence: TestResults/quarantine-analyzed-net10, TestResults/quarantine-net471-final, TestResults/quarantine-net8-final. Earlier failing evidence retained in TestResults/quarantine-net471 and TestResults/quarantine-path-probe.

### Remaining scope and review

No automatic drift monitor, bounded revalidation/retuning, program/AutoML registry, cross-process active-handle revocation, GPU performance claim, hostile-journal attestation, package publication or automatic production rollout. All producers must use the opt-in policy. No paid/model call was needed. Hosted checks now pass and the PR is ready for review of this bounded slice; independent approval remains outstanding. See docs/evolution-runtime-fallback.md.

## Historical first slice (77d16869)

Companion to ooples/AiDotNet.Evolution#15 and ooples/AiDotNet#2148 (US-25 slice). Add KernelTuningDeployment.TryDeactivate(expected) using compare-and-swap: runtime failure evidence can remove only the exact deployment observed by that operation. Subsequent dispatch can use the existing built-in fallback; stale evidence cannot erase a newer validation of the same genome.

## Given / When / Then

- Given a failing observed snapshot, when it is still active, then deactivation removes it atomically and TryGet returns false.
- Given a newer deployment, when stale evidence arrives, then deactivation returns false and preserves the newer snapshot.
- Given another identity or null, when deactivation is requested, then it is rejected without changing the active deployment.

## Validation

22 targeted EvolutionKernelAutotunerTests passed again on net10.0 at 77d16869 after fast-forwarding to the GitHub merge from main, including the three new deactivation tests. git diff --check passed. Earlier hosted runs were cancelled; current-head hosted validation remains unfinished and this PR remains a draft.

## Scope

Builds on existing validated promotion; no kernel math or hot-path generation changed. This is explicitly in-memory deactivation, not persistent quarantine, drift detection, cache invalidation or cancellation of in-flight kernels. Later tuning/hydration may publish again. docs/evolution-runtime-fallback.md explains usage and limitations. Full US-25 is not claimed complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistent quarantine for failed kernel-tuning deployments, including structured regression evidence and journal receipts.
  * Added safe rollback to a previously validated deployment when available.
  * Added in-memory deactivation for removing a specific active deployment.
  * Added admission checks that prevent quarantined configurations from being loaded or published.
* **Bug Fixes**
  * Improved temporary-file handling for autotuning cache updates, including compatibility with path-length limitations.
* **Documentation**
  * Documented quarantine, rollback, fallback behavior, and monitoring limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
