### PR TITLE
ci: stop an unrelated apt mirror from failing the pocl shards

### DIFF
--- a/.github/workflows/gpu-parity-pocl.yml
+++ b/.github/workflows/gpu-parity-pocl.yml
@@ -84,8 +84,25 @@ jobs:
 
     - name: Install POCL (CPU OpenCL device) + ICD loader
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ocl-icd-opencl-dev pocl-opencl-icd clinfo
+        # Drop the third-party apt sources the runner image ships with, before updating.
+        #
+        # None of them provide the packages below - those come from the Ubuntu archives - but
+        # `apt-get update` exits 100 if ANY configured source fails, and this step runs under
+        # `bash -e`, so one unrelated mirror hiccup kills the shard before a single test runs.
+        # That happened on run 34491921445: dl.google.com/linux/chrome-stable served a
+        # Packages.gz whose size disagreed with its own Release file ("Mirror sync in progress"),
+        # and tape-grad-6 went red on PR #1017 with nothing in its log but an apt error.
+        #
+        # The parity step below is deliberately `continue-on-error` because POCL is not reliable
+        # enough on hosted runners to gate on. Setup failing the job anyway contradicts that: it
+        # reports a problem with the change under test when the problem is a Google mirror.
+        #
+        # Removed by name rather than globbing `*.list`, so a runner image that keeps the Ubuntu
+        # archive in a `.list` file is not left with no sources at all. `rm -f` is a no-op when
+        # they are absent.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list                    /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y -o Acquire::Retries=3 ocl-icd-opencl-dev pocl-opencl-icd clinfo
         echo "=== clinfo: OpenCL platforms/devices ==="
         clinfo || echo "::warning::clinfo failed — POCL may not be registered."
 


### PR DESCRIPTION
## What

Makes the POCL install step in `gpu-parity-pocl.yml` tolerant of the third-party apt repositories the
GitHub runner image ships with.

## Why

`apt-get update` exits 100 if **any** configured source fails, and the step runs under `bash -e`. One
hiccup in a repository this job does not use therefore kills the shard before a single test runs.

That is what took `tape-grad-6` red on #1017 (run 34491921445):

```
Err:27 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  File has unexpected size (1411 != 1409). Mirror sync in progress?
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

Google's Chrome repository served a `Packages.gz` whose size disagreed with its own `Release` file.
Nothing to do with OpenCL, the tests, or the change under review - and the job log contained no test
output at all, because the tests never executed.

## Why fix rather than just re-run

The parity step immediately below carries `continue-on-error: true`, with the comment "POCL is not
yet reliable as a hard gate on hosted runners." The job is explicitly informational.

Setup steps failing it anyway contradicts that. A red X on a PR says something is wrong with the
change; here it said a Google mirror was mid-sync. I chased that failure through an empty log before
finding the apt error, which is the cost this is meant to remove.

## How

- Remove `google-chrome.list` and `microsoft-prod.list` before updating. Neither provides
  `ocl-icd-opencl-dev`, `pocl-opencl-icd` or `clinfo` - those come from the Ubuntu archives.
- Add `Acquire::Retries=3` to both `update` and `install` for ordinary network flake.

Removal is **by name rather than globbing `*.list`**, deliberately: a runner image that keeps the
Ubuntu archive in a `.list` file rather than deb822 `ubuntu.sources` would otherwise be left with no
sources at all, turning a rare flake into a guaranteed failure. `rm -f` is a no-op when they are
absent.

A genuine inability to install POCL still fails the step, which is the signal worth keeping.

## Scope

`gpu-parity-pocl.yml` is the only workflow in the repository that runs `apt-get`, so this is the only
place the pattern appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of POCL setup by removing conflicting third-party package sources and retrying package metadata updates and installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->