### PR TITLE
fix: preserve streaming transactions and GPU cache coherence

### DIFF
--- a/docs/development/streaming-tape-transaction-validation.md
+++ b/docs/development/streaming-tape-transaction-validation.md
@@ -21,12 +21,13 @@ result, or a throughput benchmark. Other target frameworks were built, not run.
 | Historical autodiff/COW/streaming family, before upstream merge | 1,078 passed, 29 skipped, 2 failed; 1,109 total | 1,089 passed, same 29 skipped, 0 failed; 1,118 total |
 | Expanded post-merge autodiff/COW/streaming/precision/GEMM family | Broader selection, not the same test count | 1,508 passed, 30 skipped, 0 failed; 1,538 total |
 | Five physical journal/cache invalidation repros | 0 passed, 5 failed | Same five passed, included in the GPU set below |
-| AMD/OpenCL GPU/COW/journal/lifetime/precision set | Earlier comparison set: 200 passed | 208 passed, 0 skipped, 0 failed, both before and after upstream merge |
+| AMD/OpenCL GPU/COW/journal/lifetime/precision set | Initial comparison: 200 passed, 0 skipped, 0 failed | Expanded set before merge: 208 passed; same set after merge: 208 passed; both 0 skipped, 0 failed |
 | Library build: net10.0, net8.0, net471 | Not a before/after benchmark | Passed, 0 warnings, 0 errors |
 | Test-project build: net10.0, net471 | Not a before/after benchmark | Passed, 195 warnings, 0 errors after upstream merge |
 
-The initial CPU-family increase is eight array-access contract cases plus one
-causal attention regression. The GPU-set increase is the same eight array-access
+The initial CPU-family total increases by nine: eight array-access contract cases
+plus one causal attention regression. The passed count increases by eleven because
+the two existing MaxPool1D/attention failures also become passes. The GPU-set increase is the same eight array-access
 cases. The expanded post-merge selection additionally passed all 18 inverse-trig,
 14 ISTFT, 5 STFT-phase, 4 exact-type-precision, and 5 cross-thread GEMM cases.
 The broad name filter also selected 371 GPU/CPU autodifferential cases and three
@@ -184,3 +185,255 @@ build, verified again after both runs. All 3,922 added C# lines relative to
 `origin/main` were checked for null-forgiving operators: none found.
 `git diff --check origin/main -- src tests` was clean. Local `.token-optimizer`
 hook-generated files are unrelated and must be excluded from the companion PR.
+
+## Stable-package release gate (not yet satisfied)
+
+An additional, actual stable-version pack check on 2026-09-11 failed:
+
+```powershell
+dotnet pack src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release `
+    --no-build --no-restore -o artifacts/pr1029-package-validation `
+    --nologo -v minimal -p:Version=0.130.4
+```
+
+The result was `NU5104` for each of the three target frameworks: a stable Tensors
+package depends on `AiDotNet.Evolution [0.1.0-preview.1, )`. A normal local build
+does not expose this because the project's default version is itself prerelease.
+The all-framework rebuild immediately before this check still had zero warnings
+and zero errors. The package failure is not counted as successful validation.
+
+The Evolution reference is already present in the merged `main` baseline; it is
+not introduced by the storage fixes. Nevertheless, it blocks publishing those
+fixes as a stable Tensors update. At this check the official NuGet feed contained
+only the prerelease Evolution package. Stable Evolution publication followed by
+a normal stable package reference is required; suppressing `NU5104` would not
+prove that release path. `0.130.4` above is only the local candidate version used
+to exercise the gate, not a published version or a reserved release number.
+
+AiDotNet also needs its existing Evolution package-ownership migration (#2092)
+before consuming this dependency graph normally. Its local source-reference
+alias is a diagnostic aid, not a solution for downstream package consumers.
+
+
+## PR #1029 review-fix validation (2026-09-11)
+
+This section validates the review-fix working tree based on
+`230dbb53ac0ee650753ed3bd5d65e2b8f298deb2`; the earlier sections describe
+historical snapshots. No package reference or warning suppression was changed.
+The stable-package release gate above remains unsatisfied.
+
+| Check | Actual result |
+| --- | --- |
+| Controlled original-source repro, `pr1029-review-autodiff-before.trx` | 1 passed, 3 failed: strided MaxPool1D gradient; compiled and optimized FP32 policy propagation |
+| Focused CPU review cases, `pr1029-review-cpu-final.trx` | 100 passed, 27 explicit GPU skips, 0 failed |
+| Final broad autodiff/COW/streaming/precision family, `pr1029-review-autodiff-final.trx` | 1,166 passed, 429 explicit skips, 0 failed; 1,595 total |
+| Final strict AMD/OpenCL set, `pr1029-review-opencl-final.trx` | 226 passed, 0 skipped, 0 failed |
+| Library build, net10.0/net8.0/net471 | 0 warnings, 0 errors |
+| Test build, net10.0/net471 | 191 warnings, 0 errors |
+
+The broad CPU command explicitly disables GPU backends. Its 429 skips include
+the 371 GPU autodifferential cases selected by the broad `Autodiff` name filter,
+plus other GPU-only and pre-existing skipped diagnostics. It is not the same
+hardware configuration as the historical 1,508-passed run; the lower passed count
+does not represent failed tests. The final broad CPU run took 79 seconds, and the
+strict AMD run took 10 seconds. These overlapping suites must not be summed.
+
+The strict selection retains all 208 historical cases and adds 18: eight OpenCL
+context-ownership cases, three persistent-cache ownership cases, three journal
+boundary/fault cases, three operation-kind fallback cases, and one repeated
+explicit-invalidation case. Of the 226 total, **50 require hardware**: 21 physical
+cache, five journal, one accumulation, nine native-FP16, six half-GEMM, and eight
+OpenCL context cases. Forty-two exercise numerical/device data paths; eight
+exercise argument/context rejection. Mock-buffer and CPU tests are not counted
+as physical kernels.
+
+Concrete proof from this review pass:
+
+- The original strided MaxPool1D case threw on `AsSpan()`; it now produces
+  `[0,1,0,3,0,2,0,4]` while preserving the noncontiguous input gradient.
+- Both original compiled-policy failures observed FP16 fan-out addition despite
+  a configured FP32 policy. Six current tape/compiled/optimized cases prove
+  configured FP32 and inherited policy, unchanged FP16 backward kernels,
+  numerical gradient `1.0005`, and restoration of a conflicting outer policy.
+- AMD accumulation still reports
+  `expected=1.0005; inherited=1.0009766 (error=0.00047656250000005507); FP32=1.0005 (error=3.623962396837044E-08)`.
+- Repeated raw-array mutation without an epoch increment followed by explicit
+  invalidation produces real GPU values `[20,4,6,8]` then `[22,4,6,8]`.
+  Separate tracking-backend cases verify exactly one disposal per allocation
+  after successful, failed, and eight concurrent invalidations.
+- Six actual OpenCL cases reject foreign-context float/byte wrappers in each
+  operand position; two same-context control cases execute GEMM successfully.
+- Injected journal write failure preserves committed records when range cleanup
+  succeeds; injected cleanup failure invalidates every record and poisons all
+  subsequent operations. Oversized deferred payload rejection does not
+  materialize the backing array.
+
+Two intermediate failures in the newly added physical invalidation test were
+test-contract mistakes, not hidden successes: OpenCL returns disposed allocations
+to its pool without zeroing their native handle, and eager reads may clear a
+tensor-local shortcut while retaining its persistent cache entry. The final test
+tracks published borrowed allocations and device values; exact disposal remains
+covered by the tracking backend. The failed intermediate reports
+`pr1029-review-opencl-after.trx` and `pr1029-review-opencl-complete.trx` are
+preserved. A new OpenCL fixture also initially failed the net471 test build until
+it adopted the existing fixture's `NET6_0_OR_GREATER` guard.
+
+### Review checklist
+
+These are source/test responses awaiting independent review, not claims that
+GitHub threads have already been resolved.
+
+| Review comment ID | Response and coverage |
+| --- | --- |
+| 3985388622 | Distinguish initial 200-case GPU baseline from expanded 208-case pre/post-merge runs. |
+| 3985388625 | Explain nine new CPU cases plus two existing failures becoming passes. |
+| 3985388633 | Materialize only noncontiguous MaxPool1D gradients before read-only span access; controlled red/green regression. |
+| 3985388665 | Carry accumulation policy into compiled and optimized backward execution; six policy/scope cases. |
+| 3985388673 | Persistent-weight comments now describe storage `GpuCacheVersion`. |
+| 3985388681 | Reject foreign OpenCL contexts before precision dispatch; six rejection and two same-context cases. |
+| 3985388689 | Remove the unused private untracked-memory overload and require an epoch at every persistent-cache insertion; preserve existing tracked-cache fast paths. |
+| 3985388698 | Serialize all persistent replacement publishers under the existing lock and retire the displaced allocation; failure/concurrency ownership and real GPU mutation cases. |
+| 3985388704 | Preserve typed operation kind in every CPU precision fallback; three planner cases. |
+| 3985388711 | Reject unsupported byte length before deferred materialization; allocation-free boundary case. |
+| 3985388713 | Typed internal file-operation fault seam proves recoverable append failure versus poisoned cleanup; diagnostic wording now names append cleanup. |
+| 3985388721 | Continue bulk allocator cleanup after individual failures and remove registrations exactly once; reset and dead-owner-prune cases. |
+| 3985388726 | Accumulation tests dynamically skip missing hardware/support unless hardware is explicitly required. |
+| 3985388731 | Pin the default FP32 accumulation policy. |
+| 3985388738 | CPU engine observations test the actual tape option-to-fan-out path and backward kernel precision, not only scope helpers. |
+| 3985388746 | Bound readiness/start/completion waits and signal readiness even when worker setup fails. |
+| 3985388752 | State `ReleaseAfterBackward` explicitly in the saved-state release regression. |
+| 3985388759 | All five hardware-dependent journal cases report explicit skips without hardware. |
+| 3985388764 | Physical cache cases report explicit skips without hardware; the strict AMD run executes all 21. |
+
+The untracked-cache review concern was addressed without accepting version-blind
+cache hits: repository-wide call-site inspection found that only an unused private
+`ReadOnlyMemory<T>` overload could publish an untracked entry. Removing that
+overload and the sentinel makes the epoch mandatory at compile time instead of
+weakening stale-value detection. Cache ownership changes affect replacement and
+invalidation, not the unchanged lock-free read path.
+
+### Reproduction commands for this review snapshot
+
+From the repository root, after ordinary restore:
+
+```powershell
+dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release --no-restore --nologo -v quiet
+dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release --no-restore --nologo -v quiet
+```
+
+CPU selection (the controlled before run used only
+`FullyQualifiedName~BackwardReviewRegressionTests` before applying the fixes):
+
+```powershell
+$names = @(
+    'Autodiff'
+    'GemmDeterminismAcrossThreadsTests'
+    'ExactTypePrecisionTests'
+    'AdamMomentKernelsParityTests'
+    'StreamingTensorPoolTests'
+    'TensorArrayAccessContractTests'
+    'TensorCowCloneTests'
+    'TensorCowInferenceReadPathTests'
+    'WeightLifetimeIntegrationTests'
+    'WeightStreamingTransparentAccessTests'
+    'StreamingTensorJournalTests'
+    'GpuPrecisionPolicyTests'
+    'PersistentCacheOwnershipTests'
+)
+$filter = ($names | ForEach-Object { 'FullyQualifiedName~' + $_ }) -join '|'
+$report = 'pr1029-review-autodiff-final.trx'
+if (Test-Path -LiteralPath ('tests/AiDotNet.Tensors.Tests/TestResults/' + $report)) {
+    throw 'Proof report already exists; choose a new name.'
+}
+$env:AIDOTNET_FORCE_CPU = '1'
+$env:AIDOTNET_DIRECTGPU_BACKENDS = 'none'
+Remove-Item Env:AIDOTNET_REQUIRE_GPU_TESTS -ErrorAction SilentlyContinue
+dotnet vstest tests/AiDotNet.Tensors.Tests/bin/Release/net10.0/AiDotNet.Tensors.Tests.dll ("/TestCaseFilter:" + $filter) ("/Logger:trx;LogFileName=" + $report) /ResultsDirectory:tests/AiDotNet.Tensors.Tests/TestResults '/Logger:console;Verbosity=quiet'
+```
+
+Strict AMD selection, in a separate process:
+
+```powershell
+$names = @(
+    'GradientAccumulationPhysicalGpuTests'
+    'CompiledTrainingCowIsolationTests'
+    'ActivationCacheEvictionLifetimeTests'
+    'InvalidateActivationCacheEntryLifetimeTests'
+    'OpenClFp16NativeOpTests'
+    'OpenClHalfPrecisionGemmTests'
+    'GpuPrecisionExecutionTests'
+    'GpuPrecisionPolicyTests'
+    'StreamingTensorJournalTests'
+    'TensorArrayAccessContractTests'
+    'TensorCowCloneTests'
+    'TensorCowInferenceReadPathTests'
+    'TensorGpuCachePhysicalTests'
+    'TensorGpuCacheVersionTests'
+    'OpenClPrecisionBufferOwnershipTests'
+    'PersistentCacheOwnershipTests'
+)
+$filter = ($names | ForEach-Object { 'FullyQualifiedName~' + $_ }) -join '|'
+$report = 'pr1029-review-opencl-final.trx'
+if (Test-Path -LiteralPath ('tests/AiDotNet.Tensors.Tests/TestResults/' + $report)) {
+    throw 'Proof report already exists; choose a new name.'
+}
+$env:AIDOTNET_DIRECTGPU_BACKENDS = 'opencl'
+$env:AIDOTNET_REQUIRE_GPU_TESTS = '1'
+Remove-Item Env:AIDOTNET_FORCE_CPU -ErrorAction SilentlyContinue
+dotnet vstest tests/AiDotNet.Tensors.Tests/bin/Release/net10.0/AiDotNet.Tensors.Tests.dll ("/TestCaseFilter:" + $filter) ("/Logger:trx;LogFileName=" + $report) /ResultsDirectory:tests/AiDotNet.Tensors.Tests/TestResults '/Logger:console;Verbosity=quiet'
+```
+
+### Final review artifacts
+
+The final broad CPU and strict GPU runs used the same unchanged binaries.
+Reports remain local artifacts under `tests/AiDotNet.Tensors.Tests/TestResults/`.
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Controlled before TRX | `B79D7696BAEDEE9962F444D289BF7E9169959E96F0964FB5E61325798B6C0D59` |
+| Final broad CPU TRX | `9CC95BD2FC4D3EDAD6732D6222682782804FFE961E06ABA5F508BF090EB27A7D` |
+| Final strict GPU TRX | `0CA833E03B725653C6DA2A1D97DEDD27BD7A08E228E2EE0F2933BFDAC7F0479C` |
+| Library net10.0, including copied test dependency | `8585288EFB410BD932B06138945CD0588BAA8F6749E8625872087EA5129080A2` |
+| Library net8.0 | `E11FBF4AB63EFB170D6BA1D8B2D5AC06436835DAB7E0920C256BA00B0D970F15` |
+| Library net471 | `5CD93510BD559A81DAFF15FBDD6882E98BB953845AAACA03E0F73C6610053930` |
+| Final net10.0 test binary | `849031DB58DE2C62B7CA7892F09F40CF702BC3E7A6D1F1195E9D8DB35DF3D426` |
+
+Added tracked C# lines and all three new C# files were scanned for null-forgiving
+operators: none found. `git diff --check` is clean. No CUDA/Metal runtime or
+throughput claim is made by these checks. The unrelated `.token-optimizer`
+hook files remain excluded from review-fix source changes.
+
+### Independent cleanup follow-up and final source identity
+
+Independent review found two additional secondary-failure paths: a user-supplied
+trace listener could interrupt bulk reclamation after an allocator failure, and
+replacement-buffer disposal could throw before a failed invalidation evicted its
+stale cache metadata. The focused failure-first run
+`pr1029-root-double-fault-before.trx` reproduced **3 failures and 3 passing
+controls**. Diagnostics are now best effort, and stale-entry cleanup is in a
+`finally` block, even when replacement disposal also fails. No lock was added to
+ordinary cache reads.
+
+Final independently executed results:
+
+- `pr1029-root-double-fault-after.trx`: 17 passed, no failures/skips.
+- `pr1029-root-broad-after.trx`: 1,170 passed, 429 explicit GPU skips, no failures.
+- `pr1029-root-strict-opencl-after.trx`: 228 passed, no failures/skips. The two
+  additions to the earlier 226 are mocked double-failure ownership controls;
+  the number of hardware-required cases remains 50, not 228 physical kernels.
+- `pr1029-root-cleanup-net471-after.trx`: 17 passed, no failures/skips.
+- Rebuilt the library on all three targets: zero warnings/errors. Rebuilt both
+  test targets: 191 existing warnings, zero errors. A temporary trace-listener
+  annotation mismatch was removed; the final test binary is byte-identical to
+  the one used by the first three final reports above.
+
+Use the preceding reproduction commands with the new report names; the CPU and
+GPU selection sets are unchanged. The final net10 library SHA-256 is
+`5A62A0BF737909AEFC81F038293AA668CA6C355DC38029BF37C20DF580D6E624`;
+the final net10 test binary is
+`3EA8B926BA28CF7D16A48C82C43A55433F31B8E17FC81D7AD174491A07F308E9`.
+The earlier hashes describe their explicitly named earlier snapshots.
+
+The stable-package `NU5104` prerequisite described above still applies. Passing
+local runtime checks does not claim that an unavailable stable Evolution package
+has been published, that stable packing succeeds, or that this PR is merge-ready.

--- a/docs/development/streaming-tape-transaction-validation.md
+++ b/docs/development/streaming-tape-transaction-validation.md
@@ -1,0 +1,186 @@
+# Streaming tape transaction validation
+
+## Validated snapshot and scope
+
+Final local validation on 2026-09-10, at merge commit
+`2b48d9c6f50736cdc6ff75b46a3ce844c2f66358` on
+`fix/streaming-tape-transaction`: fix commit `63fdc84e6` plus upstream
+`5d22aa7f4`. All declared library/test target frameworks were rebuilt after the
+merge. Binary hashes below identify that final build. The expanded post-merge
+run selects every current `Autodiff` test class, not only the historical fixture
+set used for the initial controlled comparison.
+
+The machine has a Radeon RX 5500 XT, driver `32.0.21037.1004`. Physical GPU checks
+used OpenCL. This is not CUDA/Metal runtime validation, an AiDotNet model-shard
+result, or a throughput benchmark. Other target frameworks were built, not run.
+
+## Results
+
+| Check | Before | After |
+| --- | --- | --- |
+| Historical autodiff/COW/streaming family, before upstream merge | 1,078 passed, 29 skipped, 2 failed; 1,109 total | 1,089 passed, same 29 skipped, 0 failed; 1,118 total |
+| Expanded post-merge autodiff/COW/streaming/precision/GEMM family | Broader selection, not the same test count | 1,508 passed, 30 skipped, 0 failed; 1,538 total |
+| Five physical journal/cache invalidation repros | 0 passed, 5 failed | Same five passed, included in the GPU set below |
+| AMD/OpenCL GPU/COW/journal/lifetime/precision set | Earlier comparison set: 200 passed | 208 passed, 0 skipped, 0 failed, both before and after upstream merge |
+| Library build: net10.0, net8.0, net471 | Not a before/after benchmark | Passed, 0 warnings, 0 errors |
+| Test-project build: net10.0, net471 | Not a before/after benchmark | Passed, 195 warnings, 0 errors after upstream merge |
+
+The initial CPU-family increase is eight array-access contract cases plus one
+causal attention regression. The GPU-set increase is the same eight array-access
+cases. The expanded post-merge selection additionally passed all 18 inverse-trig,
+14 ISTFT, 5 STFT-phase, 4 exact-type-precision, and 5 cross-thread GEMM cases.
+The broad name filter also selected 371 GPU/CPU autodifferential cases and three
+other matching cases. The one added skip is the existing
+`Issue471CpuMatmulCrashRepro.Gpu_autodiff_training_stress` diagnostic; all 29
+original skips remain unchanged. The expanded run used the CPU configuration;
+its broader differential coverage is not counted as strict physical GPU proof.
+The suites overlap; their totals must not be summed as unique test coverage.
+Final run durations were approximately 1 minute 41 seconds for the expanded
+family and 11 seconds for the strict AMD/OpenCL set.
+
+The 208-test set is **not 208 physical kernel tests**. It includes these 41
+explicitly hardware-required cases:
+
+| Fixture | Hardware-required cases | Numerical/device-data-path cases |
+| --- | ---: | ---: |
+| `TensorGpuCachePhysicalTests` | 20 | 20 |
+| Physical cases in `StreamingTensorJournalTests` | 5 | 5 |
+| `GradientAccumulationPhysicalGpuTests` | 1 | 1 |
+| `OpenClFp16NativeOpTests` | 9 | 8 |
+| `OpenClHalfPrecisionGemmTests` | 6 | 5 |
+| Total | 41 | 39 |
+
+The other two cases validate argument guards with an initialized physical
+backend. The 26 cache/journal/accumulation cases enable
+`ThrowOnGpuKernelFallback`; the 13 OpenCL numerical cases call the physical
+backend directly. Five additional nonempty DirectGpu COW cases ran with an
+available GPU, but do not all forbid CPU fallback, so they are not counted as
+strict numerical-kernel proof. The remaining coverage includes CPU contracts,
+mock-buffer lifetimes, precision policy, and empty-input guards.
+
+## Concrete before/after evidence
+
+- Physical cache restore previously returned `[2, 4, 6, 8]` instead of
+  `[20, 40, 60, 80]`. All five original physical cache repros now pass. Twenty
+  additional physical cache cases cover late-created views, in-place mutation
+  order, inference, independent raw-array/Vector wrappers, COW detachment, and
+  retention of the same persistent allocation during repeated in-place work.
+- Causal attention previously produced `dQ[1049] = 0.0015641242` instead of
+  `0.041369293` for `(B=1,H=2,S=64,Dh=16)`, exceeding the unchanged `1e-3` tolerance.
+  It also failed in isolation. The same test now passes; all 12 attention cases
+  pass, including the new masked-first-query gradient/input-nonmutation canary.
+- MaxPool1D previously produced gradient `0` instead of numerical `0.999451` at
+  index 1. The original numerical-gradient test now passes.
+- The actual AMD accumulation output was
+  `expected=1.0005; inherited=1.0009766 (error=0.00047656250000005507); FP32=1.0005 (error=3.623962396837044E-08)`.
+  This compares inherited half accumulation and explicit FP32 accumulation on
+  the same physical backend, not simulated policy selection.
+
+The attention/pooling writes now acquire writable spans and notify mutation.
+The original full-contiguous-view backing-array contract is retained rather
+than globally banning views. Eight array-access tests cover zero-copy reads,
+COW write isolation, full-view write-through, offset/noncontiguous snapshots,
+deferred materialization, and lazy evaluation. These establish allocation and
+ownership contracts, not a measured end-to-end speedup.
+
+## Commands used
+
+Run from the repository root in PowerShell, with dependencies already restored.
+These build all declared target frameworks:
+
+```powershell
+dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false --nologo -v quiet -clp:ErrorsOnly
+dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release --no-restore -p:GeneratePackageOnBuild=false --nologo -v quiet -clp:ErrorsOnly
+```
+
+These are the final post-merge commands, with the TRX-derived fixture lists
+expanded into literals so they also work without the historical local artifacts.
+The resulting filter strings were verified identical to those executed. The CPU
+command deliberately uses broad `FullyQualifiedName~Autodiff` instead of the old
+autodiff class list. No Tensors build ran concurrently with these tests.
+
+CPU family:
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$report = 'pr2088-postmerge-after-autodiff-20260910.trx'
+if (Test-Path -LiteralPath ('tests/AiDotNet.Tensors.Tests/TestResults/' + $report)) {
+    throw 'Refusing to overwrite an existing proof report.'
+}
+$classes = @(
+    'AiDotNet.Tensors.Tests.Engines.GemmDeterminismAcrossThreadsTests'
+    'AiDotNet.Tensors.Tests.Engines.Gpu.ExactTypePrecisionTests'
+    'AiDotNet.Tensors.Tests.Engines.Simd.AdamMomentKernelsParityTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.StreamingTensorPoolTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorArrayAccessContractTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorCowCloneTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorCowInferenceReadPathTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.WeightLifetimeIntegrationTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.WeightStreamingTransparentAccessTests'
+)
+$filter = (@('FullyQualifiedName~Autodiff') + @($classes | Sort-Object -Unique | ForEach-Object { 'FullyQualifiedName~' + $_ })) -join '|'
+$env:AIDOTNET_FORCE_CPU = '1'
+Remove-Item Env:AIDOTNET_REQUIRE_GPU_TESTS -ErrorAction SilentlyContinue
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -f net10.0 -c Release --no-build --no-restore --filter $filter --logger ('trx;LogFileName=' + $report) --logger 'console;verbosity=minimal' --nologo
+```
+
+Strict AMD/OpenCL set, in a separate PowerShell process:
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$report = 'pr2088-postmerge-after-gpu-cow-20260910.trx'
+if (Test-Path -LiteralPath ('tests/AiDotNet.Tensors.Tests/TestResults/' + $report)) {
+    throw 'Refusing to overwrite an existing proof report.'
+}
+$classes = @(
+    'AiDotNet.Tensors.Tests.Engines.Autodiff.GradientAccumulationPhysicalGpuTests'
+    'AiDotNet.Tensors.Tests.Engines.Compilation.CompiledTrainingCowIsolationTests'
+    'AiDotNet.Tensors.Tests.Engines.DirectGpu.ActivationCacheEvictionLifetimeTests'
+    'AiDotNet.Tensors.Tests.Engines.DirectGpu.InvalidateActivationCacheEntryLifetimeTests'
+    'AiDotNet.Tensors.Tests.Engines.DirectGpu.OpenClFp16NativeOpTests'
+    'AiDotNet.Tensors.Tests.Engines.DirectGpu.OpenClHalfPrecisionGemmTests'
+    'AiDotNet.Tensors.Tests.Engines.Gpu.GpuPrecisionExecutionTests'
+    'AiDotNet.Tensors.Tests.Engines.Gpu.GpuPrecisionPolicyTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.StreamingTensorJournalTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorArrayAccessContractTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorCowCloneTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorCowInferenceReadPathTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorGpuCachePhysicalTests'
+    'AiDotNet.Tensors.Tests.LinearAlgebra.TensorGpuCacheVersionTests'
+)
+$filter = (@($classes | Sort-Object -Unique | ForEach-Object { 'FullyQualifiedName~' + $_ }) -join '|')
+$env:AIDOTNET_DIRECTGPU_BACKENDS = 'opencl'
+$env:AIDOTNET_REQUIRE_GPU_TESTS = '1'
+Remove-Item Env:AIDOTNET_FORCE_CPU -ErrorAction SilentlyContinue
+dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -f net10.0 -c Release --no-build --no-restore --filter $filter --logger ('trx;LogFileName=' + $report) --logger 'console;verbosity=minimal' --nologo
+```
+
+## Preserved artifacts and SHA-256
+
+TRXs are local test artifacts under
+`tests/AiDotNet.Tensors.Tests/TestResults/`; they are not checked-in files or
+published CI evidence. Preserve the original files rather than rerunning with
+the same names. The isolated attention repro is also retained as
+`pr2088-attention-isolation.trx`.
+
+| TRX | SHA-256 |
+| --- | --- |
+| `pr2088-gpu-cache-before.trx` | `2CAEB7BD748FFA7AC83CECBBE35F9AC951C5173D3224C90AB66426C79EA1BAC2` |
+| `pr2088-autodiff-family.trx` | `FDD5FF756304FC76B2042A20C76EE2D8F835AEB69A7E8DD0DFA11307D3B189D6` |
+| `pr2088-final-after-autodiff-20260910.trx` | `BB3BC8C8C7C9724D8647699FF46ECAE8E42A623475C8498C3B5276A89B5B6FB9` |
+| `pr2088-final-after-gpu-cow-20260910.trx` | `E9C317146E937B45FF188427AF65630D5CB8A234B6C208E82F81C8751B55F3C5` |
+| `pr2088-postmerge-after-autodiff-20260910.trx` | `58B9BD8A51A7C2E54A2649C502035C1537B8C8C73642426C92DAD393378FE417` |
+| `pr2088-postmerge-after-gpu-cow-20260910.trx` | `DCFC1182F378378BA51316FC06CFFB9BB2F3BDEDE956E1D258A9AB0C84CF7B2E` |
+
+| Release binary | SHA-256 |
+| --- | --- |
+| Library `net10.0/AiDotNet.Tensors.dll` | `D81257F6E1ADDD2939ED463329EF46FA1ABD0C6C6DA1B76D377A73321823E7A6` |
+| Library `net8.0/AiDotNet.Tensors.dll` | `57A9E24D3305769309927962617C6600EB1D3CF32028ACEDB4EB2A26FD48A537` |
+| Library `net471/AiDotNet.Tensors.dll` | `C8F3DAF1DF7CF0404360FA8D7FF1ECFE0479F1C8391CE709E111D54A90136BB4` |
+| Test `net10.0/AiDotNet.Tensors.Tests.dll` | `3E6FC73F501606CEDC2D02E32C63D018D7CC378AE4570C6CA89E345C4FA39D5C` |
+
+The copied `net10.0` library in the test output has the same hash as the library
+build, verified again after both runs. All 3,922 added C# lines relative to
+`origin/main` were checked for null-forgiving operators: none found.
+`git diff --check origin/main -- src tests` was clean. Local `.token-optimizer`
+hook-generated files are unrelated and must be excluded from the companion PR.

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2984,14 +2984,15 @@ internal static class BackwardFunctions<T>
         var numOps = MathHelper.GetNumericOperations<T>();
         int[] argmax = (int[])savedState[0];
         var inputGrad = TensorPool<T>.RentZeroed(inputs[0]._shape);
-        var gradData = gradOutput.GetDataArray();
-        var resultData = inputGrad.GetDataArray();
+        ReadOnlySpan<T> gradData = gradOutput.AsSpan();
+        Span<T> resultData = inputGrad.AsWritableSpan();
         for (int i = 0; i < argmax.Length; i++)
         {
             int idx = argmax[i];
             if (idx >= 0 && idx < resultData.Length)
                 resultData[idx] = numOps.Add(resultData[idx], gradData[i]);
         }
+        inputGrad.IncrementVersion();
         DifferentiableOps.AccumulateGrad(grads, inputs[0], inputGrad, engine);
     }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -3066,6 +3066,7 @@ internal static class BackwardFunctions<T>
         var numOps = MathHelper.GetNumericOperations<T>();
         int[] argmax = (int[])savedState[0];
         var inputGrad = TensorPool<T>.RentZeroed(inputs[0]._shape);
+        if (!gradOutput.IsContiguous) gradOutput = gradOutput.Contiguous();
         ReadOnlySpan<T> gradData = gradOutput.AsSpan();
         Span<T> resultData = inputGrad.AsWritableSpan();
         for (int i = 0; i < argmax.Length; i++)

--- a/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/CompiledBackwardGraph.cs
@@ -55,6 +55,7 @@ public sealed class CompiledBackwardGraph<T>
     private readonly int _entryCount;
 
     private readonly IEngine _engine;
+    private readonly GradientAccumulationPrecision _accumulationPrecision;
 
     /// <summary>
     /// Optional reference to the owning tape's RetainGrad set. When non-null,
@@ -75,7 +76,8 @@ public sealed class CompiledBackwardGraph<T>
         Tensor<T> loss,
         Tensor<T>[]? sources,
         IEngine engine,
-        HashSet<Tensor<T>>? retainGrad = null)
+        HashSet<Tensor<T>>? retainGrad = null,
+        GradientAccumulationPrecision accumulationPrecision = GradientAccumulationPrecision.Float32)
     {
         // Arena reference is shared with the owning tape. Safe because:
         // 1. CompiledBackwardGraph is created inside ComputeGradients which holds the tape
@@ -86,6 +88,7 @@ public sealed class CompiledBackwardGraph<T>
         _loss = loss;
         _sources = sources;
         _engine = engine;
+        _accumulationPrecision = accumulationPrecision;
         _retainGrad = retainGrad;
 
         // Dead node elimination: find which entries are reachable from loss
@@ -132,6 +135,7 @@ public sealed class CompiledBackwardGraph<T>
     /// </summary>
     internal Dictionary<Tensor<T>, Tensor<T>> Execute(Tensor<T>? currentLoss)
     {
+        using var accumulationScope = new GradientAccumulationPrecisionScope(_accumulationPrecision);
         var loss = currentLoss ?? _loss;
         if (loss is null)
             throw new InvalidOperationException(
@@ -148,7 +152,7 @@ public sealed class CompiledBackwardGraph<T>
         if (Optimization.TensorCodecOptions.Current.EnableAlgebraicBackward)
         {
             var optimized = OptimizedBackwardPlan<T>.TryCreate(
-                _entries, _reachableEntryIndices, loss, _sources, _engine, _retainGrad);
+                _entries, _reachableEntryIndices, loss, _sources, _engine, _retainGrad, _accumulationPrecision);
             if (optimized is not null)
                 return optimized.Execute();
         }
@@ -458,8 +462,8 @@ internal static class BackwardInputBuffers<T>
     /// </summary>
     internal static void Clear()
     {
-        if (_buf1 is not null) _buf1[0] = null!;
-        if (_buf2 is not null) { _buf2[0] = null!; _buf2[1] = null!; }
-        if (_buf3 is not null) { _buf3[0] = null!; _buf3[1] = null!; _buf3[2] = null!; }
+        if (_buf1 is not null) Array.Clear(_buf1, 0, _buf1.Length);
+        if (_buf2 is not null) Array.Clear(_buf2, 0, _buf2.Length);
+        if (_buf3 is not null) Array.Clear(_buf3, 0, _buf3.Length);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/DifferentiableOps.cs
@@ -627,6 +627,11 @@ internal static class DifferentiableOps
         // fast path engages ONLY here (the dedicated, non-aliased gradient leaf) and never hijacks forward
         // in-place ops on aliased activations (that hijack threw CUDA-700). No-op for non-DirectGpu engines.
         using var _gradAccumScope = (engine as AiDotNet.Tensors.Engines.DirectGpuTensorEngine)?.EnterGradAccumulation();
+        // FP32 accumulation is narrower than FP32 backward: only the addition which combines
+        // fan-out contributions overrides autocast. The backward kernels that produced each
+        // contribution retain their configured FP16/BF16/FP8 precision.
+        using var _accumulationPrecisionScope =
+            GradientAccumulationPrecisionScope.EnterFloat32AutocastForAddition();
 
         // Higher-order AD: in-place add records a "TensorAddInPlace"
         // entry whose saved input is a *clone* of the existing gradient,

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -432,7 +432,9 @@ public static class FusedAttention<T>
         int[] shape = scores._shape;
         int b = shape[0], h = shape[1], sq = shape[2], sk = shape[3];
         if (!scores.IsContiguous) scores = scores.Contiguous();
-        var data = scores.GetDataArray();
+        // Scores are normally a reshape view. Array access returns a snapshot for views;
+        // the causal mask must write through the tensor's COW-aware storage instead.
+        var data = scores.AsWritableSpan();
         T negInf = numOps.FromDouble(double.NegativeInfinity);
         for (int i = 0; i < b; i++)
         {
@@ -448,6 +450,7 @@ public static class FusedAttention<T>
                 }
             }
         }
+        scores.IncrementVersion();
         return scores;
     }
 
@@ -638,7 +641,7 @@ public static class FusedAttention<T>
             int bk = Math.Min(tileBk, Sk - j0);
             var kt = SliceAxis1(numOps, kf, BH, Sk, headDim, j0, bk);                       // [BH, bk, Dh]
             var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
-            var s = sTile.GetDataArray();
+            var s = sTile.AsSpan();
             for (int row = 0; row < BH * Sq; row++)
             {
                 int b0 = row * bk;
@@ -669,8 +672,8 @@ public static class FusedAttention<T>
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
             var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
             var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
-            var s = sTile.GetDataArray();
-            var dp = dpTile.GetDataArray();
+            var s = sTile.AsSpan();
+            var dp = dpTile.AsSpan();
             for (int row = 0; row < BH * Sq; row++)
             {
                 int b0 = row * bk;
@@ -696,8 +699,8 @@ public static class FusedAttention<T>
             var vt = SliceAxis1(numOps, vf, BH, Sk, Dv, j0, bk);                            // [BH, bk, Dv]
             var sTile = ScoresTileWithBias(engine, qf, kt, scaleT, attentionBias, B, H, Sq, bk, j0); // [BH, Sq, bk]
             var dpTile = engine.TensorBatchMatMul(dof, vt.TransposeLast2D());               // [BH, Sq, bk]
-            var s = sTile.GetDataArray();
-            var dp = dpTile.GetDataArray();
+            var s = sTile.AsSpan();
+            var dp = dpTile.AsSpan();
 
             // Masked (j >= jMax) entries stay zero-init, so they contribute nothing to the
             // dV / dK / dQ GEMMs below — exactly the causal mask.
@@ -720,15 +723,15 @@ public static class FusedAttention<T>
 
             // dV_j = Σ_i P_ij · dO_i  -> [BH, bk, Dv]; keys are disjoint per tile, so write.
             var dVtile = engine.TensorBatchMatMul(pTile.TransposeLast2D(), dof);            // [BH, bk, Dv]
-            CopyTileIntoAxis1(dVfull, dVtile.GetDataArray(), BH, Sk, Dv, j0, bk);
+            CopyTileIntoAxis1(dVfull, dVtile.AsSpan(), BH, Sk, Dv, j0, bk);
             // dK_j = scale · Σ_i dS_ij · q_i -> [BH, bk, Dh]
             var dKtile = engine.TensorMultiplyScalar(
                 engine.TensorBatchMatMul(dsTile.TransposeLast2D(), qf), scaleT);            // [BH, bk, Dh]
-            CopyTileIntoAxis1(dKfull, dKtile.GetDataArray(), BH, Sk, headDim, j0, bk);
+            CopyTileIntoAxis1(dKfull, dKtile.AsSpan(), BH, Sk, headDim, j0, bk);
             // dQ_i += scale · Σ_j dS_ij · k_j -> [BH, Sq, Dh] (accumulate across tiles)
             var dQtile = engine.TensorMultiplyScalar(
                 engine.TensorBatchMatMul(dsTile, kt), scaleT);                              // [BH, Sq, Dh]
-            var dq = dQtile.GetDataArray();
+            var dq = dQtile.AsSpan();
             for (int idx = 0; idx < dQacc.Length; idx++)
                 dQacc[idx] = numOps.Add(dQacc[idx], dq[idx]);
         }
@@ -766,19 +769,20 @@ public static class FusedAttention<T>
     /// tensor into a fresh contiguous [BH, bk, D] tile.</summary>
     private static Tensor<T> SliceAxis1(INumericOperations<T> numOps, Tensor<T> src, int BH, int S, int D, int j0, int bk)
     {
-        var srcData = src.IsContiguous ? src.GetDataArray() : src.Contiguous().GetDataArray();
+        if (!src.IsContiguous) src = src.Contiguous();
+        var srcData = src.AsSpan();
         var dst = new T[BH * bk * D];
         for (int b = 0; b < BH; b++)
-            Array.Copy(srcData, (b * S + j0) * D, dst, b * bk * D, bk * D);
+            srcData.Slice((b * S + j0) * D, bk * D).CopyTo(dst.AsSpan(b * bk * D, bk * D));
         return new Tensor<T>(dst, new[] { BH, bk, D });
     }
 
     /// <summary>Writes a [BH, bk, D] tile into the [:, j0:j0+bk, :] slice of a flat [BH, S, D]
     /// destination buffer (keys are disjoint across tiles, so a copy is correct).</summary>
-    private static void CopyTileIntoAxis1(T[] dst, T[] tile, int BH, int S, int D, int j0, int bk)
+    private static void CopyTileIntoAxis1(T[] dst, ReadOnlySpan<T> tile, int BH, int S, int D, int j0, int bk)
     {
         for (int b = 0; b < BH; b++)
-            Array.Copy(tile, b * bk * D, dst, (b * S + j0) * D, bk * D);
+            tile.Slice(b * bk * D, bk * D).CopyTo(dst.AsSpan((b * S + j0) * D, bk * D));
     }
 
     /// <summary>
@@ -792,8 +796,8 @@ public static class FusedAttention<T>
         if (!P.IsContiguous) P = P.Contiguous();
         var shape = P._shape;
         int b = shape[0], h = shape[1], sq = shape[2], sk = shape[3];
-        var pData = P.GetDataArray();
-        var dpData = dP.GetDataArray();
+        var pData = P.AsSpan();
+        var dpData = dP.AsSpan();
         var dsData = new T[pData.Length];
         for (int i = 0; i < b; i++)
         {

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientAccumulationPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientAccumulationPrecision.cs
@@ -1,0 +1,52 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Threading;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.Autodiff;
+
+/// <summary>Precision policy for fan-out gradient additions during backward.</summary>
+public enum GradientAccumulationPrecision
+{
+    /// <summary>Use the active backward autocast precision for gradient additions.</summary>
+    InheritBackwardPrecision = 0,
+
+    /// <summary>Perform gradient additions in FP32 while leaving all other backward kernels autocast.</summary>
+    Float32 = 1,
+}
+
+internal sealed class GradientAccumulationPrecisionScope : IDisposable
+{
+    private static readonly AsyncLocal<GradientAccumulationPrecisionScope?> CurrentScope = new();
+    private readonly GradientAccumulationPrecisionScope? _previous;
+    private bool _disposed;
+
+    internal GradientAccumulationPrecisionScope(GradientAccumulationPrecision precision)
+    {
+        Precision = precision;
+        _previous = CurrentScope.Value;
+        CurrentScope.Value = this;
+    }
+
+    internal GradientAccumulationPrecision Precision { get; }
+
+    internal static IDisposable? EnterFloat32AutocastForAddition()
+    {
+        if (CurrentScope.Value?.Precision != GradientAccumulationPrecision.Float32
+            || !AutocastScope.IsEnabled
+            || AutocastScope.ActivePrecision == PrecisionMode.Float32)
+        {
+            return null;
+        }
+
+        return new AutocastScope(PrecisionMode.Float32, AutocastScope.Current?.Policy);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        CurrentScope.Value = _previous;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -57,6 +57,8 @@ public sealed class GradientTape<T> : IDisposable
     private readonly GradientTape<T>? _parent;
     private readonly TapeEntryArena<T> _entries;
     private readonly GradientTapeOptions _options;
+    private readonly bool _releaseStreamingActivations;
+    private bool _lifecycleCounterRegistered;
     private IEngine _engine;
     private bool _engineExplicitlyBound;
 
@@ -239,21 +241,24 @@ public sealed class GradientTape<T> : IDisposable
     [ThreadStatic]
     private static Tensor<T>? _cachedScalarSeed;
 
-    // Release each node's activation references during the streaming backward as the
-    // reverse walk consumes them — the standard autograd memory model (matches
-    // PyTorch's default retain_graph=False, which frees saved tensors as each node's
-    // backward completes). In reverse-topological order an output's consumers have
-    // all already run by the time its own backward runs, so releasing it there can
-    // never drop a tensor a later step needs; parameters/sources are guarded by
-    // lastUse. This is UNCONDITIONAL in production (no opt-out) — ComputeGradientsStreaming
-    // is already a one-shot, gradient-freeing backward, so retaining activations would
-    // only ever leak. The settable property is a TEST SEAM so the on-vs-off bit-identity
-    // regression test can still assert releasing never changes a gradient.
-    internal static bool ReleaseStreamingActivations { get; set; } = true;
-
     public GradientTape(GradientTapeOptions? options = null)
     {
         _options = options ?? GradientTapeOptions.Default;
+        _releaseStreamingActivations = _options.StreamingGraphRetention switch
+        {
+            StreamingGraphRetentionMode.ReleaseAfterBackward => true,
+            StreamingGraphRetentionMode.RetainUntilTapeDisposal => false,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(options),
+                _options.StreamingGraphRetention,
+                "Unknown streaming graph retention mode."),
+        };
+        if (!_options.Persistent && !_releaseStreamingActivations)
+        {
+            throw new ArgumentException(
+                "Retaining a streaming graph requires a persistent gradient tape.",
+                nameof(options));
+        }
         // Reuse cached arena if available, otherwise create new one
         _entries = _cachedArena ?? new TapeEntryArena<T>();
         _cachedArena = null; // Take ownership — will return on Dispose
@@ -322,6 +327,7 @@ public sealed class GradientTape<T> : IDisposable
         }
 
         SetCurrentTape(this);
+        _lifecycleCounterRegistered = true;
         System.Threading.Interlocked.Increment(ref DifferentiableOps._anyTapeActive);
         // Per-thread counter — used to suppress AutoTracer for THIS thread's
         // tape lifecycle without affecting unrelated inference threads. The
@@ -350,9 +356,9 @@ public sealed class GradientTape<T> : IDisposable
             throw new InvalidOperationException(
                 "This persistent GradientTape's activations were released by a prior " +
                 "ComputeGradientsStreaming call, so its recorded graph can no longer be " +
-                "reused. Record a fresh tape for the next step, or set " +
-                "GradientTape<T>.ReleaseStreamingActivations = false to keep activations " +
-                "resident when you need to record onto or differentiate the same tape again.");
+                "reused. Record a fresh tape for the next step, or construct the tape with " +
+                "StreamingGraphRetentionMode.RetainUntilTapeDisposal when the algorithm " +
+                "requires deterministic replay.");
         }
     }
 
@@ -508,8 +514,9 @@ public sealed class GradientTape<T> : IDisposable
     /// </remarks>
     /// <param name="loss">The scalar loss tensor to differentiate. Must be
     /// tape-connected (non-null <c>GradFn</c>).</param>
-    /// <param name="sources">Parameter tensors whose gradients to stream. Each is
-    /// emitted exactly once, when complete.</param>
+    /// <param name="sources">Leaf parameter tensors whose gradients to stream. Each is emitted
+    /// exactly once, when complete. Intermediate graph outputs are rejected because releasing their
+    /// gradient before their own producer runs would sever propagation to earlier ancestors.</param>
     /// <param name="onSourceGradient">Invoked as <c>(source, gradient)</c> the
     /// moment <paramref name="loss"/>'s gradient w.r.t. that source is final.</param>
     public void ComputeGradientsStreaming(
@@ -517,6 +524,27 @@ public sealed class GradientTape<T> : IDisposable
         IReadOnlyList<Tensor<T>> sources,
         Action<Tensor<T>, Tensor<T>> onSourceGradient)
     {
+        if (onSourceGradient is null) throw new ArgumentNullException(nameof(onSourceGradient));
+        ComputeGradientsStreamingTyped(loss, sources, (source, gradient) =>
+            onSourceGradient(source, MaterializeStreamingGradient(gradient)));
+    }
+
+    /// <summary>
+    /// Memory-bounded streaming backward that preserves indexed sparse embedding gradients instead
+    /// of forcing them through a full vocabulary-sized dense tensor.
+    /// </summary>
+    /// <param name="loss">The scalar tape-connected loss.</param>
+    /// <param name="sources">Leaf source tensors whose completed gradients should be emitted.</param>
+    /// <param name="onSourceGradient">
+    /// Synchronous consumer for a typed dense, sparse, or composite gradient payload.
+    /// </param>
+    public void ComputeGradientsStreamingTyped(
+        Tensor<T> loss,
+        IReadOnlyList<Tensor<T>> sources,
+        Action<Tensor<T>, StreamingSourceGradient<T>> onSourceGradient)
+    {
+        using var accumulationPrecisionScope = new GradientAccumulationPrecisionScope(
+            _options.GradientAccumulationPrecision);
         if (_disposed) throw new ObjectDisposedException(nameof(GradientTape<T>));
         ThrowIfStreamingReleased();
         ResolveEngineFromData();
@@ -524,9 +552,19 @@ public sealed class GradientTape<T> : IDisposable
         if (onSourceGradient is null) throw new ArgumentNullException(nameof(onSourceGradient));
         if (_entries.Count == 0)
             throw new InvalidOperationException("Cannot compute gradients: the tape has no recorded operations.");
-        if (loss.GradFn is null)
-            throw new InvalidOperationException(
-                "Streaming backward requires a tape-connected loss (loss.GradFn is null).");
+        GradNode<T> lossGradFn = loss.GradFn ?? throw new InvalidOperationException(
+            "Streaming backward requires a tape-connected loss (loss.GradFn is null).");
+        for (int sourceIndex = 0; sourceIndex < sources.Count; sourceIndex++)
+        {
+            Tensor<T>? source = sources[sourceIndex];
+            if (source is not null && source.GradFn is not null)
+            {
+                throw new ArgumentException(
+                    "Streaming backward sources must be leaf tensors. Use ComputeGradients when " +
+                    "requesting an intermediate graph output and one of its ancestors.",
+                    nameof(sources));
+            }
+        }
 
         int recordedEntryCount = _entries.Count;
 
@@ -537,19 +575,23 @@ public sealed class GradientTape<T> : IDisposable
         // tape entries (parity with the non-streaming graph path, which also
         // suspends — see ComputeGradients line ~306).
         var savedCurrent = _current;
+        Dictionary<Tensor<T>, Tensor<T>>? streamingGrads = null;
+        var indexedTensors = new List<Tensor<T>>();
+        BackwardStep<T>[] steps = Array.Empty<BackwardStep<T>>();
+        GradNode<T>[] nodes = Array.Empty<GradNode<T>>();
         SetCurrentTape(null);
         try
         {
             // Forward topological order; reverse is the backward execution order.
             var visited = new HashSet<GradNode<T>>();
             var topoOrder = new List<GradNode<T>>();
-            TopologicalSort(loss.GradFn!, visited, topoOrder);
+            TopologicalSort(lossGradFn, visited, topoOrder);
             int stepCount = topoOrder.Count;
 
-            var steps = new BackwardStep<T>[stepCount];
+            steps = new BackwardStep<T>[stepCount];
             // #1624: parallel node handles so each step's backward can release its
             // activation references the moment they are consumed (see below).
-            var nodes = new GradNode<T>[stepCount];
+            nodes = new GradNode<T>[stepCount];
             for (int i = 0; i < stepCount; i++)
             {
                 var node = topoOrder[stepCount - 1 - i]; // reverse for backward
@@ -574,7 +616,7 @@ public sealed class GradientTape<T> : IDisposable
             // arena slot for each activation as the reverse walk consumes it. The streaming backward walks
             // the GradFn graph (not _entries), so clearing arena slots never affects the backward itself.
             Dictionary<Tensor<T>, int>? entrySlotOfOutput = null;
-            if (ReleaseStreamingActivations)
+            if (_releaseStreamingActivations)
             {
                 int entryCount = _entries.Count;
                 entrySlotOfOutput = new Dictionary<Tensor<T>, int>(
@@ -615,8 +657,33 @@ public sealed class GradientTape<T> : IDisposable
                 list.Add(kv.Key);
             }
 
-            var grads = new Dictionary<Tensor<T>, Tensor<T>>(
+            // Use the same indexed dense + sparse accumulator contract as the ordinary backward.
+            // Without this wiring, embedding backwards assume there is no sparse consumer and
+            // allocate a full [vocabulary, dimension] dense gradient before the callback can run.
+            int gradIndexCount = 0;
+            for (int e = 0; e < _entries.Count; e++)
+            {
+                ref var entry = ref _entries[e];
+                AssignStreamingGradientIndex(entry.Output, indexedTensors, ref gradIndexCount);
+                AssignStreamingGradientIndex(entry.Input0, indexedTensors, ref gradIndexCount);
+                if (entry.InputCount >= 2)
+                    AssignStreamingGradientIndex(entry.Input1, indexedTensors, ref gradIndexCount);
+                if (entry.InputCount >= 3)
+                    AssignStreamingGradientIndex(entry.Input2, indexedTensors, ref gradIndexCount);
+                if (entry.InputsOverflow is not null)
+                {
+                    foreach (Tensor<T> input in entry.InputsOverflow)
+                        AssignStreamingGradientIndex(input, indexedTensors, ref gradIndexCount);
+                }
+            }
+            var indexedGrads = new object?[gradIndexCount];
+            var indexedSparseGrads = new object?[gradIndexCount];
+            DifferentiableOps.SetIndexedGrads(indexedGrads);
+            DifferentiableOps.SetIndexedSparseGrads(indexedSparseGrads);
+
+            streamingGrads = new Dictionary<Tensor<T>, Tensor<T>>(
                 stepCount + 1, ReferenceEqualityComparer<Tensor<T>>.Instance);
+            var grads = streamingGrads;
 
             // Seed gradient (dL/dL = 1), same construction as ComputeGradients:
             // use the loss's ACTUAL shape (which may be [] for a 0-dim scalar or
@@ -697,11 +764,31 @@ public sealed class GradientTape<T> : IDisposable
                     for (int k = 0; k < ready.Count; k++)
                     {
                         var src = ready[k];
-                        if (grads.TryGetValue(src, out var g))
+                        grads.TryGetValue(src, out Tensor<T>? denseGradient);
+                        IReadOnlyList<SparseEmbeddingGradient<T>>? sparseGradient =
+                            DifferentiableOps.GetSparseEmbeddingGradsFor(src);
+                        if (denseGradient is not null || sparseGradient is { Count: > 0 })
                         {
-                            onSourceGradient(src, g);
-                            grads.Remove(src);   // drop the dict reference …
-                            src.Grad = null;     // … and the per-tensor mirror → reclaimable
+                            try
+                            {
+                                onSourceGradient(
+                                    src,
+                                    StreamingSourceGradient<T>.Create(denseGradient, sparseGradient));
+                            }
+                            finally
+                            {
+                                // A journal, validation, or optimizer callback may throw. The
+                                // gradient is unpublished and must never remain rooted on the
+                                // trainable source after that failure.
+                                grads.Remove(src);
+                                src.Grad = null;
+                                int gradientIndex = src._gradIndex;
+                                if (gradientIndex >= 0 && gradientIndex < indexedGrads.Length)
+                                {
+                                    indexedGrads[gradientIndex] = null;
+                                    indexedSparseGrads[gradientIndex] = null;
+                                }
+                            }
                         }
                     }
                 }
@@ -722,7 +809,7 @@ public sealed class GradientTape<T> : IDisposable
                 // all already run by the time its producer's backward runs, and the
                 // node Output is never a source (sources are leaves, emitted + released
                 // above), so this never drops a tensor a later step or the optimizer needs.
-                if (ReleaseStreamingActivations)
+                if (_releaseStreamingActivations)
                 {
                     var n = nodes[i];
                     if (n is not null)
@@ -780,17 +867,54 @@ public sealed class GradientTape<T> : IDisposable
         finally
         {
             SetCurrentTape(savedCurrent);
+            // Clear every source, including ones whose callback was still pending when an earlier
+            // callback failed. Preserve the original exception by keeping cleanup non-throwing.
+            foreach (Tensor<T> source in sources)
+            {
+                if (source is null) continue;
+                streamingGrads?.Remove(source);
+                source.Grad = null;
+            }
+            DifferentiableOps.ClearIndexedGrads();
+            DifferentiableOps.ClearIndexedSparseGrads();
+            foreach (Tensor<T> indexedTensor in indexedTensors)
+                indexedTensor._gradIndex = -1;
             // Release every entry recorded before streaming began, including dead
             // entries that were absent from the GradFn traversal. Entries already
             // released while dropping activations are guarded by their ownership bit.
-            ReleaseSavedStatePins(recordedEntryCount);
-            if (!_options.Persistent)
+            // A retained persistent graph must keep the entry-owned saved-state pins as well as
+            // its node references. Releasing those pins here lets the arena recycle RMSNorm,
+            // LayerNorm, attention, and dropout state before the next replay, corrupting a graph
+            // that the typed retention mode promises remains valid. Reset/Dispose owns their
+            // eventual release. Destructive streaming and non-persistent tapes still release now.
+            if (_releaseStreamingActivations)
+            {
+                ReleaseSavedStatePins(recordedEntryCount);
+                // The destructive mode owns the complete graph cleanup even when a backward or
+                // callback fails before the reverse walk reaches every node. Leaving unprocessed
+                // nodes populated makes the permanently-consumed tape retain the activation graph.
+                for (int nodeIndex = 0; nodeIndex < nodes.Length; nodeIndex++)
+                {
+                    GradNode<T>? node = nodes[nodeIndex];
+                    if (node is null) continue;
+                    node.Output = null;
+                    node.SavedState = null;
+                    node.Backward = null;
+                    node.Input0 = null;
+                    node.Input1 = null;
+                    node.Input2 = null;
+                    node.InputsOverflow = null;
+                }
+                Array.Clear(steps, 0, steps.Length);
+                _entries.Reset();
+            }
+            else if (!_options.Persistent)
             {
                 // Non-persistent tapes drop the whole arena here, so they're safe to
                 // re-record from scratch — no consumed-guard needed.
                 _entries.Reset();
             }
-            else if (ReleaseStreamingActivations)
+            if (_options.Persistent && _releaseStreamingActivations)
             {
                 // Persistent tape whose arena/graph we just destructively released:
                 // arm the consumed-guard so any later Record/ComputeGradients fails
@@ -798,6 +922,42 @@ public sealed class GradientTape<T> : IDisposable
                 _streamingActivationsReleased = true;
             }
         }
+    }
+
+    private static void AssignStreamingGradientIndex(
+        Tensor<T>? tensor,
+        List<Tensor<T>> indexedTensors,
+        ref int nextIndex)
+    {
+        if (tensor is null || tensor._gradIndex >= 0) return;
+        tensor._gradIndex = nextIndex++;
+        indexedTensors.Add(tensor);
+    }
+
+    private Tensor<T> MaterializeStreamingGradient(StreamingSourceGradient<T> gradient)
+    {
+        Tensor<T>? dense = gradient.HasDense ? gradient.Dense : null;
+        if (gradient.HasSparseEmbedding)
+        {
+            IReadOnlyList<SparseEmbeddingGradient<T>> sparse = gradient.SparseEmbedding;
+            for (int i = 0; i < sparse.Count; i++)
+            {
+                Tensor<T> contribution = sparse[i].ToDense(_engine);
+                if (dense is null)
+                {
+                    dense = contribution;
+                }
+                else
+                {
+                    using var accumulationScope =
+                        GradientAccumulationPrecisionScope.EnterFloat32AutocastForAddition();
+                    dense = _engine.TensorAdd(dense, contribution);
+                }
+            }
+        }
+
+        return dense ?? throw new InvalidOperationException(
+            "The streaming gradient did not contain a materializable contribution.");
     }
 
     public Dictionary<Tensor<T>, Tensor<T>> ComputeGradients(
@@ -822,6 +982,8 @@ public sealed class GradientTape<T> : IDisposable
         bool createGraph,
         IReadOnlyList<KeyValuePair<Tensor<T>, Tensor<T>>>? seedOverride)
     {
+        using var accumulationPrecisionScope = new GradientAccumulationPrecisionScope(
+            _options.GradientAccumulationPrecision);
         if (_disposed)
         {
             throw new ObjectDisposedException(nameof(GradientTape<T>));
@@ -2431,7 +2593,11 @@ public sealed class GradientTape<T> : IDisposable
     /// </summary>
     ~GradientTape()
     {
-        if (!_disposed)
+        // A constructor can reject invalid typed options before this instance registers in the
+        // process-wide counter. Finalizable objects whose constructor throws are still finalized;
+        // decrementing for an instance that never incremented corrupts the gate for unrelated
+        // live tapes and makes their operations silently skip recording.
+        if (!_disposed && _lifecycleCounterRegistered)
             System.Threading.Interlocked.Decrement(ref DifferentiableOps._anyTapeActive);
     }
 
@@ -2447,7 +2613,11 @@ public sealed class GradientTape<T> : IDisposable
         // This is critical for nested tapes: an inner tape disposing must not
         // clear replay suppression that an outer tape still needs.
         Compilation.AutoTrainingCompiler.ReplayMode = _savedReplayMode;
-        System.Threading.Interlocked.Decrement(ref DifferentiableOps._anyTapeActive);
+        if (_lifecycleCounterRegistered)
+        {
+            System.Threading.Interlocked.Decrement(ref DifferentiableOps._anyTapeActive);
+            _lifecycleCounterRegistered = false;
+        }
         DifferentiableOps._threadTapeDepth--;
         SetCurrentTape(_parent);
         // AiDotNet#1340: explicitly clear the cached delegate chain's

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTape.cs
@@ -2531,7 +2531,8 @@ public sealed class GradientTape<T> : IDisposable
         // A caller that compiles directly never goes through ComputeGradients, so without this the
         // compiled graph captures the constructor default instead of the data-derived engine.
         ResolveEngineFromData();
-        return new CompiledBackwardGraph<T>(_entries, loss, sources, _engine, _retainGrad);
+        return new CompiledBackwardGraph<T>(
+            _entries, loss, sources, _engine, _retainGrad, _options.GradientAccumulationPrecision);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/GradientTapeOptions.cs
@@ -1,6 +1,24 @@
 namespace AiDotNet.Tensors.Engines.Autodiff;
 
 /// <summary>
+/// Controls the lifetime of the recorded graph after a streaming backward pass.
+/// </summary>
+public enum StreamingGraphRetentionMode
+{
+    /// <summary>
+    /// Release activations as soon as their backward step has consumed them. This is the
+    /// memory-bounded default and makes the recorded graph unavailable for another backward.
+    /// </summary>
+    ReleaseAfterBackward = 0,
+
+    /// <summary>
+    /// Keep the recorded graph until the tape is disposed so the same deterministic graph can
+    /// be replayed. Use this for algorithms that must inspect gradients before committing updates.
+    /// </summary>
+    RetainUntilTapeDisposal = 1,
+}
+
+/// <summary>
 /// Configuration options for <see cref="GradientTape{T}"/>.
 /// Properties use init-only setters to prevent mutation of the shared <see cref="Default"/> instance.
 /// </summary>
@@ -55,6 +73,21 @@ public sealed class GradientTapeOptions
     /// When false, in-place operations are not recorded (gradients will not flow through them).
     /// </summary>
     public bool RecordInPlace { get; init; } = true;
+
+    /// <summary>
+    /// Controls whether <see cref="GradientTape{T}.ComputeGradientsStreaming"/> releases the
+    /// recorded graph after each backward or retains it for replay until tape disposal.
+    /// Defaults to <see cref="StreamingGraphRetentionMode.ReleaseAfterBackward"/>.
+    /// </summary>
+    public StreamingGraphRetentionMode StreamingGraphRetention { get; init; }
+        = StreamingGraphRetentionMode.ReleaseAfterBackward;
+
+    /// <summary>
+    /// Precision used only for fan-out gradient additions. Backward kernels continue to use the
+    /// active autocast precision. Defaults to FP32 accumulation for numerical stability.
+    /// </summary>
+    public GradientAccumulationPrecision GradientAccumulationPrecision { get; init; }
+        = GradientAccumulationPrecision.Float32;
 
     /// <summary>
     /// Whether to enable tensor hooks (RegisterHook, RetainGrad).

--- a/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/OptimizedBackwardPlan.cs
@@ -23,6 +23,7 @@ internal sealed class OptimizedBackwardPlan<T>
     private readonly Tensor<T> _loss;
     private readonly Tensor<T>[]? _sources;
     private readonly IEngine _engine;
+    private readonly GradientAccumulationPrecision _accumulationPrecision;
     private readonly BackwardStorageReleasePlan<T> _storageReleasePlan;
 
     /// <summary>
@@ -46,7 +47,8 @@ internal sealed class OptimizedBackwardPlan<T>
         Tensor<T>[]? sources,
         IEngine engine,
         BackwardAnalysis analysis,
-        HashSet<Tensor<T>>? retainGrad = null)
+        HashSet<Tensor<T>>? retainGrad = null,
+        GradientAccumulationPrecision accumulationPrecision = GradientAccumulationPrecision.Float32)
     {
         _entries = entries;
         _entryCount = entries.Count;
@@ -54,6 +56,7 @@ internal sealed class OptimizedBackwardPlan<T>
         _loss = loss;
         _sources = sources;
         _engine = engine;
+        _accumulationPrecision = accumulationPrecision;
         _retainGrad = retainGrad;
         _storageReleasePlan = BackwardStorageReleasePlan<T>.Create(entries, reachableIndices);
         _ = analysis; // Retained for future backward optimization passes
@@ -65,6 +68,7 @@ internal sealed class OptimizedBackwardPlan<T>
     /// </summary>
     internal Dictionary<Tensor<T>, Tensor<T>> Execute()
     {
+        using var accumulationScope = new GradientAccumulationPrecisionScope(_accumulationPrecision);
         var numOps = MathHelper.GetNumericOperations<T>();
         var cse = new BackwardCSEPass<T>(_engine);
 
@@ -364,13 +368,15 @@ internal sealed class OptimizedBackwardPlan<T>
         Tensor<T> loss,
         Tensor<T>[]? sources,
         IEngine engine,
-        HashSet<Tensor<T>>? retainGrad = null)
+        HashSet<Tensor<T>>? retainGrad = null,
+        GradientAccumulationPrecision accumulationPrecision = GradientAccumulationPrecision.Float32)
     {
         var analysis = SymbolicBackwardGraphBuilder.Analyze(entries, reachableIndices);
 
         if (!analysis.CanBenefit)
             return null;
 
-        return new OptimizedBackwardPlan<T>(entries, reachableIndices, loss, sources, engine, analysis, retainGrad);
+        return new OptimizedBackwardPlan<T>(
+            entries, reachableIndices, loss, sources, engine, analysis, retainGrad, accumulationPrecision);
     }
 }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/ParameterBuffer.cs
@@ -544,16 +544,17 @@ public sealed class ParameterBuffer<T>
             {
                 contiguous = param.IsContiguous ? param : param.Contiguous();
             }
-            var srcData = contiguous.DataVector;
-            var src = srcData.AsSpan().Slice(contiguous._storageOffset, contiguous.Length);
             int expectedSize = 1;
             foreach (int d in _shapes[i]) expectedSize *= d;
-            if (src.Length != expectedSize)
+            if (contiguous.Length != expectedSize)
                 throw new ArgumentException(
-                    $"Parameter {i} length ({src.Length}) does not match expected shape size. " +
+                    $"Parameter {i} length ({contiguous.Length}) does not match expected shape size. " +
                     "Ensure parameter tensors match the shapes provided at buffer construction.");
-            var denseDst = bufferSpan.Slice(_offsets[i], contiguous.Length);
-            src.CopyTo(denseDst);
+            var denseDst = bufferSpan.Slice(_offsets[i], expectedSize);
+            // Tensor.CopyTo owns logical-offset and streaming-materialization semantics. Reading
+            // DataVector and then applying _storageOffset again breaks when a streaming provider
+            // returns a vector already scoped to the logical tensor.
+            contiguous.CopyTo(denseDst);
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Autodiff/SparseEmbeddingGradient.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/SparseEmbeddingGradient.cs
@@ -22,9 +22,10 @@ namespace AiDotNet.Tensors.Engines.Autodiff;
 /// indices they belong to. The dense [vocabSize, embeddingDim] tensor is
 /// recoverable on demand via <see cref="ToDense(IEngine)"/>, but optimizers and
 /// downstream consumers that understand the sparse representation can skip that
-/// materialization and instead apply scatter-style updates directly to the
-/// accessed rows, cutting both the per-step allocation and the per-step memory
-/// traffic from <c>O(vocabSize * embeddingDim)</c> to <c>O(numIndices * embeddingDim)</c>.
+/// materialization. Gradient storage then scales as <c>O(numIndices * embeddingDim)</c>.
+/// Optimizer traffic also scales with the accessed rows only when its update contract permits
+/// untouched moments and weights to remain unchanged. Dense-equivalent Adam/AMSGrad updates may
+/// still traverse the full table, even when a compact gradient avoids its dense allocation.
 /// </para>
 /// <para>
 /// Duplicate indices are NOT pre-aggregated here. Both the dense

--- a/src/AiDotNet.Tensors/Engines/Autodiff/StreamingSourceGradient.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/StreamingSourceGradient.cs
@@ -1,0 +1,84 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tensors.Engines.Autodiff;
+
+/// <summary>The storage representation produced for one completed source gradient.</summary>
+public enum StreamingSourceGradientKind
+{
+    /// <summary>A conventional dense tensor.</summary>
+    Dense = 0,
+
+    /// <summary>One or more indexed embedding-table contributions.</summary>
+    SparseEmbedding = 1,
+
+    /// <summary>Both dense and indexed contributions target the same source.</summary>
+    DenseAndSparseEmbedding = 2,
+}
+
+/// <summary>
+/// Typed, ephemeral gradient payload emitted by streaming backward.
+/// </summary>
+/// <remarks>
+/// The payload and every tensor it references belong to the active backward pass. Consumers must
+/// synchronously copy, journal, or apply them before returning from the callback.
+/// </remarks>
+public readonly struct StreamingSourceGradient<T>
+{
+    private readonly Tensor<T>? _dense;
+    private readonly IReadOnlyList<SparseEmbeddingGradient<T>>? _sparseEmbedding;
+
+    private StreamingSourceGradient(
+        StreamingSourceGradientKind kind,
+        Tensor<T>? dense,
+        IReadOnlyList<SparseEmbeddingGradient<T>>? sparseEmbedding)
+    {
+        Kind = kind;
+        _dense = dense;
+        _sparseEmbedding = sparseEmbedding;
+    }
+
+    /// <summary>The payload representation.</summary>
+    public StreamingSourceGradientKind Kind { get; }
+
+    /// <summary>Whether this payload contains a dense contribution.</summary>
+    public bool HasDense => Kind is StreamingSourceGradientKind.Dense
+        or StreamingSourceGradientKind.DenseAndSparseEmbedding;
+
+    /// <summary>Whether this payload contains indexed embedding contributions.</summary>
+    public bool HasSparseEmbedding => Kind is StreamingSourceGradientKind.SparseEmbedding
+        or StreamingSourceGradientKind.DenseAndSparseEmbedding;
+
+    /// <summary>The dense contribution.</summary>
+    public Tensor<T> Dense => HasDense && _dense is Tensor<T> dense
+        ? dense
+        : throw new InvalidOperationException("This streaming gradient has no dense contribution.");
+
+    /// <summary>The indexed embedding contributions.</summary>
+    public IReadOnlyList<SparseEmbeddingGradient<T>> SparseEmbedding =>
+        HasSparseEmbedding && _sparseEmbedding is IReadOnlyList<SparseEmbeddingGradient<T>> sparse
+            ? sparse
+            : throw new InvalidOperationException(
+                "This streaming gradient has no sparse embedding contribution.");
+
+    /// <summary>Creates a validated payload from one or both supported representations.</summary>
+    public static StreamingSourceGradient<T> Create(
+        Tensor<T>? dense,
+        IReadOnlyList<SparseEmbeddingGradient<T>>? sparseEmbedding)
+    {
+        bool hasDense = dense is not null;
+        bool hasSparse = sparseEmbedding is { Count: > 0 };
+        if (!hasDense && !hasSparse)
+            throw new ArgumentException("A streaming gradient must contain at least one contribution.");
+
+        StreamingSourceGradientKind kind = hasDense
+            ? hasSparse
+                ? StreamingSourceGradientKind.DenseAndSparseEmbedding
+                : StreamingSourceGradientKind.Dense
+            : StreamingSourceGradientKind.SparseEmbedding;
+        return new StreamingSourceGradient<T>(kind, dense, sparseEmbedding);
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledInferencePlan.cs
@@ -967,7 +967,7 @@ internal sealed class CompiledInferencePlan<T> : ICompiledPlan<T>
                     $"Captured-graph input {i} resident buffer (size {buf.Size}) is smaller than its host data " +
                     $"({data.Length}); cannot refresh in place.");
             cb.UploadBufferInPlace((float[])(object)data, buf);
-            inT._gpuBufferVersion = inT.Version;
+            inT._gpuBufferVersion = inT.GpuCacheVersion;
         }
     }
 

--- a/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
+++ b/src/AiDotNet.Tensors/Engines/Compilation/CompiledTrainingPlan.cs
@@ -846,7 +846,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
             bool streamCapturing =
                 backend is Engines.DirectGpu.CUDA.CudaBackend cuda && cuda.IsStreamCapturing();
             if (resident is not null &&
-                (streamCapturing || gradient._gpuBufferVersion == gradient.Version))
+                (streamCapturing || gradient._gpuBufferVersion == gradient.GpuCacheVersion))
             {
                 gpuGradients[p] = resident;
                 continue;
@@ -1730,7 +1730,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
         var data = inT.GetDataArray();                 // host backing (T==float on the graph path)
         if (buf.Size < data.Length) return;
         cb.UploadBufferInPlace((float[])(object)data, buf);
-        inT._gpuBufferVersion = inT.Version;
+        inT._gpuBufferVersion = inT.GpuCacheVersion;
     }
 
     private void RunGpuStepBodyForCapture(Engines.DirectGpu.CUDA.CudaBackend cb)
@@ -3414,7 +3414,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // mirroring the per-tensor GPU path so eval/forward see the fresh resident weights.
                     for (int p = 0; p < paramCount; p++)
                     {
-                        _parameters[p]._gpuBufferVersion = _parameters[p].Version;
+                        _parameters[p]._gpuBufferVersion = _parameters[p].GpuCacheVersion;
                         if (_engine is Engines.DirectGpuTensorEngine rebindEngine && gpuParam[p] is { } gpBind && gpuBackends[p] is { } beBind)
                             rebindEngine.BindResidentBuffer(_parameters[p], gpBind, beBind);
                     }
@@ -3589,7 +3589,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // ~weight-size GPU leak that OOMs the eval at d256/L4+. A later CPU SetParameters legitimately
                     // re-bumps Version (without this device write) → mismatch returns → correct re-upload. Harmless
                     // to capture (the gate's ResidentStepActive branch already covers it).
-                    _parameters[p]._gpuBufferVersion = _parameters[p].Version;
+                    _parameters[p]._gpuBufferVersion = _parameters[p].GpuCacheVersion;
 
                     // RE-ARM the device→host deferred download so the NEXT host-side read of this parameter
                     // re-downloads the freshly-updated weights. The eager forward reads its weight operand via
@@ -4259,7 +4259,7 @@ internal sealed class CompiledTrainingPlan<T> : ICompiledTrainingPlan<T>
                     // backing (which the on-device update never touched). Without this the grouped
                     // (per-layer-LR) GPU path — the path the Transformer's Noam/warmup schedule
                     // takes — trains against frozen weights: loss flat, weights drift, accuracy = chance.
-                    _parameters[p]._gpuBufferVersion = _parameters[p].Version;
+                    _parameters[p]._gpuBufferVersion = _parameters[p].GpuCacheVersion;
                     continue;
                 }
 

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Fp16NativeOps.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.Fp16NativeOps.cs
@@ -42,10 +42,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!EnsureFp16NativeOpKernels() || !_kernelCache.TryGetValue(Fp16NativeOpKernels.AddKernelName, out var k))
                 throw new NotSupportedException("FP16-native op kernels are not available on this OpenCL device.");
 
+            IntPtr aHandle = GetPrecisionBufferHandle(a, (long)n * sizeof(ushort));
+            IntPtr bHandle = GetPrecisionBufferHandle(b, (long)n * sizeof(ushort));
+            IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)n * sizeof(ushort));
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)a).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)b).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            k.SetArg(arg++, aHandle);
+            k.SetArg(arg++, bHandle);
+            k.SetArg(arg++, outputHandle);
             k.SetArg(arg++, n);
             k.Execute1D(n, Math.Min(256, n));
         }
@@ -60,9 +63,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!EnsureFp16NativeOpKernels() || !_kernelCache.TryGetValue(Fp16NativeOpKernels.SoftmaxKernelName, out var k))
                 throw new NotSupportedException("FP16-native op kernels are not available on this OpenCL device.");
 
+            IntPtr inputHandle = GetPrecisionBufferHandle(input, (long)rows * cols * sizeof(ushort));
+            IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)rows * cols * sizeof(ushort));
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            k.SetArg(arg++, inputHandle);
+            k.SetArg(arg++, outputHandle);
             k.SetArg(arg++, rows);
             k.SetArg(arg++, cols);
             int local = Fp16NativeOpKernels.RowReduceLocalSize;
@@ -91,13 +96,19 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             var varBuf = varFp32 ?? (tmpVar = AllocateBuffer(rows));
             try
             {
+                IntPtr inputHandle = GetPrecisionBufferHandle(input, (long)rows * cols * sizeof(ushort));
+                IntPtr gammaHandle = GetPrecisionBufferHandle(gamma, (long)cols * sizeof(ushort));
+                IntPtr betaHandle = GetPrecisionBufferHandle(beta, (long)cols * sizeof(ushort));
+                IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)rows * cols * sizeof(ushort));
+                IntPtr meanHandle = GetPrecisionBufferHandle(meanBuf, (long)rows * sizeof(float));
+                IntPtr varHandle = GetPrecisionBufferHandle(varBuf, (long)rows * sizeof(float));
                 uint arg = 0;
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)gamma).Buffer.Handle);
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)beta).Buffer.Handle);
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)meanBuf).Buffer.Handle);
-                k.SetArg(arg++, ((DirectOpenClGpuBuffer)varBuf).Buffer.Handle);
+                k.SetArg(arg++, inputHandle);
+                k.SetArg(arg++, gammaHandle);
+                k.SetArg(arg++, betaHandle);
+                k.SetArg(arg++, outputHandle);
+                k.SetArg(arg++, meanHandle);
+                k.SetArg(arg++, varHandle);
                 k.SetArg(arg++, rows);
                 k.SetArg(arg++, cols);
                 k.SetArg(arg++, eps);
@@ -120,9 +131,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
             if (!EnsureFp16NativeOpKernels() || !_kernelCache.TryGetValue(kernelName, out var k))
                 throw new NotSupportedException("FP16-native op kernels are not available on this OpenCL device.");
 
+            IntPtr inputHandle = GetPrecisionBufferHandle(input, (long)n * sizeof(ushort));
+            IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)n * sizeof(ushort));
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            k.SetArg(arg++, inputHandle);
+            k.SetArg(arg++, outputHandle);
             k.SetArg(arg++, n);
             k.Execute1D(n, Math.Min(256, n));
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.HalfPrecision.cs
@@ -41,13 +41,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         public void Hgemm(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp16,
             int m, int n, int k)
             => DispatchHalfGemm(HalfPrecisionGemmKernels.Fp16In16fOutKernelName,
-                aFp16, bFp16, cFp16, m, n, k);
+                aFp16, bFp16, cFp16, m, n, k, GpuScalarType.Float16);
 
         /// <inheritdoc/>
         public void GemmFp16In32fOut(IGpuBuffer aFp16, IGpuBuffer bFp16, IGpuBuffer cFp32,
             int m, int n, int k)
             => DispatchHalfGemm(HalfPrecisionGemmKernels.Fp16In32fOutKernelName,
-                aFp16, bFp16, cFp32, m, n, k);
+                aFp16, bFp16, cFp32, m, n, k, GpuScalarType.Float32);
 
         /// <inheritdoc/>
         /// <remarks>
@@ -122,7 +122,7 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         }
 
         private void DispatchHalfGemm(string kernelName, IGpuBuffer a, IGpuBuffer b, IGpuBuffer c,
-            int m, int n, int k)
+            int m, int n, int k, GpuScalarType outputType)
         {
             if (a is null) throw new ArgumentNullException(nameof(a));
             if (b is null) throw new ArgumentNullException(nameof(b));
@@ -139,10 +139,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             const int ts = HalfPrecisionGemmKernels.TileSize;
 
+            IntPtr aHandle = GetPrecisionBufferHandle(a, (long)m * k * sizeof(ushort));
+            IntPtr bHandle = GetPrecisionBufferHandle(b, (long)k * n * sizeof(ushort));
+            IntPtr cHandle = GetPrecisionBufferHandle(c, (long)m * n * (outputType == GpuScalarType.Float16 ? sizeof(ushort) : sizeof(float)));
             uint arg = 0;
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)a).Buffer.Handle);
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)b).Buffer.Handle);
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)c).Buffer.Handle);
+            kernel.SetArg(arg++, aHandle);
+            kernel.SetArg(arg++, bHandle);
+            kernel.SetArg(arg++, cHandle);
             kernel.SetArg(arg++, m);
             kernel.SetArg(arg++, n);
             kernel.SetArg(arg++, k);
@@ -170,10 +173,13 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
 
             const int ts = HalfPrecisionGemmKernels.TileSize;
 
+            IntPtr aHandle = GetPrecisionBufferHandle(a, (long)mo * kc * sizeof(ushort));
+            IntPtr bHandle = GetPrecisionBufferHandle(b, (long)kc * no * sizeof(ushort));
+            IntPtr cHandle = GetPrecisionBufferHandle(c, (long)mo * no * (gradOutHalf ? sizeof(ushort) : sizeof(float)));
             uint arg = 0;
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)a).Buffer.Handle);
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)b).Buffer.Handle);
-            kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)c).Buffer.Handle);
+            kernel.SetArg(arg++, aHandle);
+            kernel.SetArg(arg++, bHandle);
+            kernel.SetArg(arg++, cHandle);
             kernel.SetArg(arg++, mo);
             kernel.SetArg(arg++, no);
             kernel.SetArg(arg++, kc);
@@ -225,9 +231,11 @@ namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL
         if (elems > int.MaxValue)
             throw new NotSupportedException($"FP16 im2col work size {elems} exceeds the 1-D dispatch limit.");
 
+        IntPtr inputHandle = GetPrecisionBufferHandle(input, checked((long)batch * channels * height * width * sizeof(float)));
+        IntPtr outputHandle = GetPrecisionBufferHandle(outputHalf, elems * sizeof(ushort));
         uint arg = 0;
-        kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-        kernel.SetArg(arg++, ((DirectOpenClGpuBuffer)outputHalf).Buffer.Handle);
+        kernel.SetArg(arg++, inputHandle);
+        kernel.SetArg(arg++, outputHandle);
         kernel.SetArg(arg++, batch);
         kernel.SetArg(arg++, channels);
         kernel.SetArg(arg++, height);

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.PrecisionBuffers.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.PrecisionBuffers.cs
@@ -7,17 +7,20 @@ public sealed partial class OpenClBackend
 {
     // Precision describes kernel storage, not the CLR wrapper used to allocate its cl_mem.
     // Both the legacy float-sized allocation and an exact byte-sized allocation are valid.
-    private static IntPtr GetPrecisionBufferHandle(IGpuBuffer buffer, long requiredBytes)
+    private IntPtr GetPrecisionBufferHandle(IGpuBuffer buffer, long requiredBytes)
     {
         if (buffer is null) throw new ArgumentNullException(nameof(buffer));
         if (requiredBytes < 0 || buffer.SizeInBytes < requiredBytes)
             throw new ArgumentException($"Precision kernel requires {requiredBytes} bytes, but the buffer has {buffer.SizeInBytes}.", nameof(buffer));
-        IntPtr handle = buffer switch
+        IDirectOpenClMemoryObject memory = buffer switch
         {
-            DirectOpenClGpuBuffer floats => floats.Buffer.Handle,
-            DirectOpenClGpuByteBuffer bytes => bytes.Buffer.Handle,
+            DirectOpenClGpuBuffer floats => floats.Buffer,
+            DirectOpenClGpuByteBuffer bytes => bytes.Buffer,
             _ => throw new ArgumentException("The buffer must be owned by the OpenCL backend.", nameof(buffer)),
         };
+        if (_context is null || memory.OwningContext.Context != _context.Context)
+            throw new ArgumentException("The buffer must belong to this OpenCL backend's context.", nameof(buffer));
+        IntPtr handle = memory.NativeHandle;
         if (handle == IntPtr.Zero) throw new ObjectDisposedException(nameof(buffer));
         return handle;
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.PrecisionBuffers.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.PrecisionBuffers.cs
@@ -1,0 +1,24 @@
+using System;
+using AiDotNet.Tensors.Engines.Gpu;
+
+namespace AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+
+public sealed partial class OpenClBackend
+{
+    // Precision describes kernel storage, not the CLR wrapper used to allocate its cl_mem.
+    // Both the legacy float-sized allocation and an exact byte-sized allocation are valid.
+    private static IntPtr GetPrecisionBufferHandle(IGpuBuffer buffer, long requiredBytes)
+    {
+        if (buffer is null) throw new ArgumentNullException(nameof(buffer));
+        if (requiredBytes < 0 || buffer.SizeInBytes < requiredBytes)
+            throw new ArgumentException($"Precision kernel requires {requiredBytes} bytes, but the buffer has {buffer.SizeInBytes}.", nameof(buffer));
+        IntPtr handle = buffer switch
+        {
+            DirectOpenClGpuBuffer floats => floats.Buffer.Handle,
+            DirectOpenClGpuByteBuffer bytes => bytes.Buffer.Handle,
+            _ => throw new ArgumentException("The buffer must be owned by the OpenCL backend.", nameof(buffer)),
+        };
+        if (handle == IntPtr.Zero) throw new ObjectDisposedException(nameof(buffer));
+        return handle;
+    }
+}

--- a/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpu/OpenCL/OpenClBackend.cs
@@ -12079,6 +12079,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
+            if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
+            if (size == 0) return;
+            IntPtr inputHandle = GetPrecisionBufferHandle(input, (long)size * sizeof(float));
+            IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)size * sizeof(ushort));
 
             // Prefer the cl_khr_fp16 (hardware-extension) convert kernel when present; otherwise fall back to
             // the NATIVE convert kernel, which uses only the CORE vstore_half built-in (no cl_khr_fp16). The
@@ -12096,8 +12100,8 @@ KERNEL VARIANTS (A/B testing):
                     "nor the native vstore_half convert kernel could be used).");
 
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            k.SetArg(arg++, inputHandle);
+            k.SetArg(arg++, outputHandle);
             k.SetArg(arg++, size);
             k.Execute1D(size, Math.Min(256, size));
         }
@@ -12106,6 +12110,10 @@ KERNEL VARIANTS (A/B testing):
         {
             if (_context == null)
                 throw new InvalidOperationException("OpenCL context not available");
+            if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
+            if (size == 0) return;
+            IntPtr inputHandle = GetPrecisionBufferHandle(input, (long)size * sizeof(ushort));
+            IntPtr outputHandle = GetPrecisionBufferHandle(output, (long)size * sizeof(float));
 
             DirectOpenClKernel? k = null;
             if (_supportsFp16 && _mixedPrecisionKernelsAvailable)
@@ -12118,8 +12126,8 @@ KERNEL VARIANTS (A/B testing):
                     "kernel nor the native vload_half convert kernel could be used).");
 
             uint arg = 0;
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)input).Buffer.Handle);
-            k.SetArg(arg++, ((DirectOpenClGpuBuffer)output).Buffer.Handle);
+            k.SetArg(arg++, inputHandle);
+            k.SetArg(arg++, outputHandle);
             k.SetArg(arg++, size);
             k.Execute1D(size, Math.Min(256, size));
         }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -122,6 +122,12 @@ internal sealed class ActivationCacheEntry : IDisposable
     // (half the bytes). A consumer/backward read re-inflates it to FP32 via TryUpcastActivationFp32.
     public bool IsFp16 { get; }
     public int ElementCount { get; }
+    private int _hostVersion;
+    public int HostVersion
+    {
+        get => Volatile.Read(ref _hostVersion);
+        set => Volatile.Write(ref _hostVersion, value);
+    }
 
     // 5-arg overload preserved for reflection-based callers (test helpers like
     // EvictActivationsCreatedAfterLifetimeTests.GetActivationCacheEntryCtor
@@ -131,12 +137,18 @@ internal sealed class ActivationCacheEntry : IDisposable
     // moment the FP16 storage params are added to the canonical ctor.
     public ActivationCacheEntry(IGpuBuffer buffer, int[] shape, long timestamp, IDirectGpuBackend backend,
         long managedBytes)
-        : this(buffer, shape, timestamp, backend, managedBytes, isFp16: false, elementCount: 0)
+        : this(buffer, shape, timestamp, backend, managedBytes, isFp16: false, elementCount: 0, hostVersion: 0)
     {
     }
 
     public ActivationCacheEntry(IGpuBuffer buffer, int[] shape, long timestamp, IDirectGpuBackend backend,
         long managedBytes, bool isFp16, int elementCount)
+        : this(buffer, shape, timestamp, backend, managedBytes, isFp16, elementCount, hostVersion: 0)
+    {
+    }
+
+    public ActivationCacheEntry(IGpuBuffer buffer, int[] shape, long timestamp, IDirectGpuBackend backend,
+        long managedBytes, bool isFp16, int elementCount, int hostVersion)
     {
         Buffer = buffer;
         Shape = shape;
@@ -146,6 +158,7 @@ internal sealed class ActivationCacheEntry : IDisposable
         ThreadId = System.Environment.CurrentManagedThreadId;
         IsFp16 = isFp16;
         ElementCount = elementCount;
+        HostVersion = hostVersion;
     }
 
     public void Dispose()
@@ -530,7 +543,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var data = t.GetDataArray();
         if (buf.Size < data.Length) return;
         cb.UploadBufferInPlace((float[])(object)data, buf);
-        t._gpuBufferVersion = t.Version;
+        t._gpuBufferVersion = t.GpuCacheVersion;
     }
 
     /// <summary>Binds <paramref name="t"/> to a STABLE resident GPU buffer (uploading its current host data),
@@ -547,7 +560,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             && existing.Handle != System.IntPtr.Zero && existing.Size >= data.Length)
         {
             cb.UploadBufferInPlace((float[])(object)data, existing);
-            t._gpuBufferVersion = t.Version;
+            t._gpuBufferVersion = t.GpuCacheVersion;
             return;
         }
         // Release the previous allocation before overwriting it. The reuse branch above already returned for a
@@ -558,7 +571,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var buf = cb.AllocateBuffer((float[])(object)data); // sync upload — OK in the non-capturing pre-pass
         t._gpuBuffer = buf;
         t._gpuBackend = cb;
-        t._gpuBufferVersion = t.Version;
+        t._gpuBufferVersion = t.GpuCacheVersion;
     }
 
     /// <summary>Downloads <paramref name="t"/>'s resident GPU buffer (which a replayed graph just wrote) into a
@@ -678,7 +691,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// registers a downconvert (FP16→FP32) host materializer so CPU reads stay correct.</summary>
     internal void BindResidentBufferFp16<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend, int elementCount)
     {
-        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
+        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.GpuCacheVersion;
         var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return;
         _fp16ResidentArrays[arr] = elementCount;
@@ -710,6 +723,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null || !_fp16ResidentArrays.TryGetValue(arr, out count)) return null;
         if (t._gpuBuffer is null || t._gpuBuffer.Handle == System.IntPtr.Zero) return null;
+        if (!ResidentStepActive && t._gpuBufferVersion != t.GpuCacheVersion)
+        {
+            _fp16ResidentArrays.TryRemove(arr, out _);
+            count = 0;
+            return null;
+        }
         return t._gpuBuffer;
     }
 
@@ -761,7 +780,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             else { using var bbuf = GetResidentOrPersistentInputBuffer(cb, b); bHalf = Fp32InputToFp16Stable(cb, bbuf.Buffer, len, aArr); }
             cb.Fp16Add(aHalf, bHalf, aHalf, len);
             ResidentSyncCheck("AddInPlace");
-            a._gpuBufferVersion = a.Version; // a stays FP16-resident + tagged
+            a._gpuBufferVersion = a.GpuCacheVersion; // a stays FP16-resident + tagged
             return true;
         }
         catch (Exception ex) { AliasDiag($"Fp16AddInPlace FELLBACK: {ex.GetType().Name}: {ex.Message}"); return false; }
@@ -789,7 +808,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             else { using var bbuf = GetResidentOrPersistentInputBuffer(cb, b); biasHalf = Fp32InputToFp16Stable(cb, bbuf.Buffer, b.Length, aArr); }
             cb.Fp16BroadcastAddChannel(aHalf, biasHalf, n, c, hw);
             ResidentSyncCheck("BroadcastAddInPlace");
-            a._gpuBufferVersion = a.Version;
+            a._gpuBufferVersion = a.GpuCacheVersion;
             return true;
         }
         catch (Exception ex) { AliasDiag($"Fp16BroadcastAddInPlace FELLBACK: {ex.GetType().Name}: {ex.Message}"); return false; }
@@ -1469,6 +1488,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (!tensor.IsContiguous || tensor._storageOffset != 0)
             tensor = (Tensor<T>)tensor.Contiguous();
 
+        int hostVersion = tensor.GpuCacheVersion;
+
         // Fast path: tensor already has a GPU buffer from a previous GPU operation
         // AND nothing has mutated the tensor's CPU data since that upload (Version
         // bumps on IncrementVersion). If Version mismatched, the cached buffer
@@ -1481,7 +1502,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // mismatch (the path below) would orphan a deferred materializer registered by BindResidentBuffer →
             // a later host read fires it on a recycled buffer = #226 "buffer released before materialization".
             if (tensor._gpuBuffer.Handle != IntPtr.Zero
-                && (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))))
+                && (ResidentStepActive || (tensor._gpuBufferVersion == hostVersion && IsCachedGpuBufferLive(tensor, backend))))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);
 
             // Stale snapshot — also clear any matching activation-cache entry so
@@ -1509,38 +1530,50 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is not null)
         {
-            // Check caches using the raw array reference (no download triggered)
-            var cached = TryGetCachedBuffer(backingArray);
-            if (cached != null)
-                return new OwnedBuffer(cached, ownsBuffer: false);
+            // Persistent tensors use the same host-version gate as the dedicated weight path.
+            // A raw array-key lookup is insufficient because journal restore and host mutation
+            // retain the array identity while advancing the storage's GPU-cache epoch.
+            if (_persistentBufferCache.TryGetValue(backingArray, out var persistentEntry))
+                return GetOrCacheWeightBuffer(backend, backingArray, persistentEntry.Role, hostVersion);
 
+            bool staleActivation = false;
             lock (_activationCacheLock)
             {
-                if (_activationCache.TryGetValue(backingArray, out var activationEntry) &&
-                    ReferenceEquals(activationEntry.Backend, backend))
+                if (_activationCache.TryGetValue(backingArray, out var activationEntry))
                 {
-                    return new OwnedBuffer(activationEntry.Buffer, ownsBuffer: false);
+                    if (ReferenceEquals(activationEntry.Backend, backend)
+                        && activationEntry.HostVersion == hostVersion)
+                        return new OwnedBuffer(activationEntry.Buffer, ownsBuffer: false);
+                    staleActivation = true;
                 }
             }
+            if (staleActivation)
+                InvalidateActivationCacheEntry(backingArray);
         }
         else
         {
             // GPU-resident tensor with no backing array — check activation cache by vector key
             var vector = tensor.DataVector;
+            bool staleActivation = false;
             lock (_activationCacheLock)
             {
-                if (_activationCache.TryGetValue(vector, out var activationEntry) &&
-                    ReferenceEquals(activationEntry.Backend, backend))
+                if (_activationCache.TryGetValue(vector, out var activationEntry))
                 {
-                    return new OwnedBuffer(activationEntry.Buffer, ownsBuffer: false);
+                    if (ReferenceEquals(activationEntry.Backend, backend)
+                        && activationEntry.HostVersion == hostVersion)
+                        return new OwnedBuffer(activationEntry.Buffer, ownsBuffer: false);
+                    staleActivation = true;
                 }
             }
+            if (staleActivation)
+                InvalidateActivationCacheEntry(vector);
         }
 
         // Not in any cache — materialize the CPU value for upload through the read-only
         // tensor accessor. GetDataArray() is a writable escape and therefore detaches a
         // copy-on-write clone even though an upload only reads the operand.
-        return GetOrAllocateBuffer(backend, tensor.GetReadOnlyDataArray());
+        float[] floatData = DirectGpuEngine.ToFloatArray(tensor.GetReadOnlyDataArray());
+        return new OwnedBuffer(backend.AllocateBuffer(floatData), ownsBuffer: true);
     }
 
     /// <summary>
@@ -1781,6 +1814,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// </summary>
     private OwnedBuffer UploadTensor<T>(IDirectGpuBackend backend, Tensor<T> tensor)
     {
+        int hostVersion = tensor.GpuCacheVersion;
         // Fast path: tensor has a GPU buffer from a previous GPU operation, and
         // the tensor's CPU-side Version hasn't advanced since the upload. Stale-
         // version case is handled by GetOrAllocateBuffer(Tensor<T>) above —
@@ -1789,12 +1823,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (tensor._gpuBuffer is not null && ReferenceEquals(tensor._gpuBackend, backend))
         {
             if (tensor._gpuBuffer.Handle != IntPtr.Zero
-                && (ResidentStepActive || (tensor._gpuBufferVersion == tensor.Version && IsCachedGpuBufferLive(tensor, backend))))
+                && (ResidentStepActive || (tensor._gpuBufferVersion == hostVersion && IsCachedGpuBufferLive(tensor, backend))))
                 return new OwnedBuffer(tensor._gpuBuffer, ownsBuffer: false);   // compiled step: buffers pinned, don't orphan aliases
 
             var staleArray = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (staleArray is not null)
                 InvalidateActivationCacheEntry(staleArray);
+            InvalidateActivationCacheEntry(tensor.DataVector);
             tensor._gpuBuffer = null;
             tensor._gpuBackend = null;
             tensor._gpuBufferVersion = -1;
@@ -1804,19 +1839,25 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
         if (backingArray is not null)
         {
-            var cached = TryGetCachedBuffer(backingArray);
-            if (cached != null) return new OwnedBuffer(cached, ownsBuffer: false);
+            if (_persistentBufferCache.TryGetValue(backingArray, out var persistentEntry))
+                return GetOrCacheWeightBuffer(backend, backingArray, persistentEntry.Role, hostVersion);
 
             bool upcastNeeded2 = false;
+            bool staleActivation = false;
             lock (_activationCacheLock)
             {
-                if (_activationCache.TryGetValue(backingArray, out var entry) &&
-                    ReferenceEquals(entry.Backend, backend))
+                if (_activationCache.TryGetValue(backingArray, out var entry))
                 {
-                    if (entry.IsFp16) upcastNeeded2 = true;  // #558: re-inflate before returning
-                    else return new OwnedBuffer(entry.Buffer, ownsBuffer: false);
+                    if (!ReferenceEquals(entry.Backend, backend) || entry.HostVersion != hostVersion)
+                        staleActivation = true;
+                    else if (entry.IsFp16)
+                        upcastNeeded2 = true;  // #558: re-inflate before returning
+                    else
+                        return new OwnedBuffer(entry.Buffer, ownsBuffer: false);
                 }
             }
+            if (staleActivation)
+                InvalidateActivationCacheEntry(backingArray);
             if (upcastNeeded2)
             {
                 if (s_fp16FwdStore && TryTransientUpcastFp16(backingArray, backend, out var transient))
@@ -1825,7 +1866,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 lock (_activationCacheLock)
                 {
                     if (_activationCache.TryGetValue(backingArray, out var e2) &&
-                        ReferenceEquals(e2.Backend, backend) && !e2.IsFp16)
+                        ReferenceEquals(e2.Backend, backend) && !e2.IsFp16 && e2.HostVersion == hostVersion)
                         return new OwnedBuffer(e2.Buffer, ownsBuffer: false);
                 }
             }
@@ -1853,15 +1894,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Also set the tensor's _gpuBuffer so future operations find it directly.
             tensor._gpuBuffer = owned.Buffer;
             tensor._gpuBackend = backend;
-            tensor._gpuBufferVersion = tensor.Version;
+            tensor._gpuBufferVersion = tensor.GpuCacheVersion;
             var backingArray = tensor.GetBackingArrayForCacheLookupUnsafe();
             if (backingArray is not null)
             {
-                CacheActivation(backingArray, owned.Buffer, tensor.Shape.ToArray(), backend);
+                CacheActivation(backingArray, owned.Buffer, tensor.Shape.ToArray(), backend, hostVersion: tensor.GpuCacheVersion);
             }
             else
             {
-                CacheActivation(tensor.DataVector, owned.Buffer, tensor.Shape.ToArray(), backend);
+                CacheActivation(tensor.DataVector, owned.Buffer, tensor.Shape.ToArray(), backend, hostVersion: tensor.GpuCacheVersion);
             }
         }
         return owned.Buffer;
@@ -1936,11 +1977,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// The result data array serves as the cache key.
     /// Thread-safe: uses lock to coordinate with cache lookups.
     /// </summary>
-    private void CacheActivation<T>(T[] resultData, IGpuBuffer buffer, int[] shape, IDirectGpuBackend backend)
-        => CacheActivation((object)resultData, buffer, shape, backend);
+    private void CacheActivation<T>(T[] resultData, IGpuBuffer buffer, int[] shape, IDirectGpuBackend backend,
+        int hostVersion = 0)
+        => CacheActivation((object)resultData, buffer, shape, backend, hostVersion: hostVersion);
 
     private void CacheActivation(object cacheKey, IGpuBuffer buffer, int[] shape, IDirectGpuBackend backend,
-        bool isFp16 = false, int elementCount = 0)
+        bool isFp16 = false, int elementCount = 0, int hostVersion = 0)
     {
         // Approximate managed-heap footprint of the key array this entry pins
         // (product(shape) * 4 bytes; activation backing arrays are float[]). Bounds
@@ -1994,8 +2036,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
             var timestamp = System.Threading.Interlocked.Increment(ref _activationCacheTimestamp);
             var entry = isFp16
-                ? new ActivationCacheEntry(buffer, shape, timestamp, backend, managedBytes: managedBytes, isFp16: true, elementCount: elementCount)
-                : new ActivationCacheEntry(buffer, shape, timestamp, backend, managedBytes);
+                ? new ActivationCacheEntry(buffer, shape, timestamp, backend, managedBytes: managedBytes, isFp16: true, elementCount: elementCount, hostVersion: hostVersion)
+                : new ActivationCacheEntry(buffer, shape, timestamp, backend, managedBytes, isFp16: false, elementCount: 0, hostVersion: hostVersion);
             bool added = false;
             try
             {
@@ -2092,7 +2134,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // is unchanged by the FP16 swap, so the managed-heap retention it pins is too.
             // Dropping it would make RemoveActivationCacheEntry decrement 0 against the
             // insert-time add and drift _currentActivationManagedBytes upward.
-            _activationCache[key] = new ActivationCacheEntry(fp16, e.Shape, e.Timestamp, e.Backend, managedBytes: e.ManagedBytes, isFp16: true, elementCount: elementCount);
+            _activationCache[key] = new ActivationCacheEntry(fp16, e.Shape, e.Timestamp, e.Backend, managedBytes: e.ManagedBytes, isFp16: true, elementCount: elementCount, hostVersion: e.HostVersion);
             System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, fp16.SizeInBytes - e.Buffer.SizeInBytes);
             old = e;
         }
@@ -2147,7 +2189,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             }
             catch { return false; }
             // Same ManagedBytes carry-through as the FP16 compress swap above.
-            _activationCache[key] = new ActivationCacheEntry(fp32, e.Shape, e.Timestamp, e.Backend, managedBytes: e.ManagedBytes, isFp16: false, elementCount: e.ElementCount);
+            _activationCache[key] = new ActivationCacheEntry(fp32, e.Shape, e.Timestamp, e.Backend, managedBytes: e.ManagedBytes, isFp16: false, elementCount: e.ElementCount, hostVersion: e.HostVersion);
             System.Threading.Interlocked.Add(ref _currentActivationCacheBytes, fp32.SizeInBytes - e.Buffer.SizeInBytes);
             old = e;
         }
@@ -2211,7 +2253,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         return true;
     }
 
-    private bool TryReplacePersistentBuffer<T>(T[] data, IGpuBuffer buffer)
+    private bool TryReplacePersistentBuffer<T>(T[] data, IGpuBuffer buffer, int hostVersion)
     {
         lock (_persistentBufferLock)
         {
@@ -2224,11 +2266,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 Version = nextVersion
             };
 
-            if (_persistentBufferCache.TryRemove(data, out var removed))
-                removed.Dispose();
+            if (_persistentBufferCache.TryRemove(data, out var removed)
+                && !ReferenceEquals(removed.Buffer, buffer))
+                _retiredWeightBuffers.Add(removed.Buffer);
 
             _persistentBufferCache[data] = replacement;
             _tensorVersions[data] = nextVersion;
+            _persistentWeightHostVersion[data] = hostVersion;
             return true;
         }
     }
@@ -2552,7 +2596,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // fallback, losing the 1.8× whole-step capture). So in the resident step trust the device buffer
             // unconditionally; the #649 stale-weight gate still guards the eager/eval inference path.
             bool versionTracked = weights._gpuBuffer != null;
-            if (ResidentStepActive || !versionTracked || weights._gpuBufferVersion == weights.Version)
+            if (ResidentStepActive || !versionTracked || weights._gpuBufferVersion == weights.GpuCacheVersion)
                 return new OwnedBuffer(resident, ownsBuffer: false);
         }
         return GetOrCacheWeightBufferVersionAware(backend, weights, role);
@@ -2585,7 +2629,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // reused -- until a genuine write privatises the storage, which is exactly when a
         // re-upload is correct. This is the read/write split GetDataArray's own remarks call
         // "Stage 2"; weights are an input operand the GPU only reads.
-        => GetOrCacheWeightBuffer(backend, weights.GetReadOnlyDataArray(), role, weights.Version);
+        => GetOrCacheWeightBuffer(backend, weights.GetReadOnlyDataArray(), role, weights.GpuCacheVersion);
 
     /// <summary>
     /// Gets a GPU buffer for weight/bias tensor, auto-caching if not already persistent.
@@ -2896,7 +2940,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var dst = (Half[])arr;
             for (int i = 0; i < cn; i++) dst[i] = (Half)fdata[i];
         });
-        CacheActivation(oKey, oBuf, o.Shape._dims, backend, isFp16: true, elementCount: n);
+        CacheActivation(oKey, oBuf, o.Shape._dims, backend, isFp16: true, elementCount: n,
+            hostVersion: o.GpuCacheVersion);
         return true;
     }
 
@@ -2908,18 +2953,23 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (param is null || typeof(T) != typeof(float) || !TryGetBackend(out var backend)) return;
         var arr = param.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not float[] farr) return;
-        lock (_persistentBufferLock)
+
+        int hostVersion = param.GpuCacheVersion;
+        PersistentTensorRole role = _persistentBufferCache.TryGetValue(arr, out var current)
+            ? current.Role
+            : PersistentTensorRole.Weights;
+        var resident = GetOrCacheWeightBuffer(backend, farr, role, hostVersion);
+        if (resident.OwnsBuffer)
         {
-            if (_persistentBufferCache.TryGetValue(arr, out var existing))
-            {
-                param._gpuBuffer = existing.Buffer; param._gpuBackend = backend; param._gpuBufferVersion = param.Version;
-                return;
-            }
-            var buf = backend.AllocateBuffer(farr);
-            _persistentBufferCache[arr] = new GpuBufferCacheEntry(buf, PersistentTensorRole.Weights);
-            _tensorVersions.TryAdd(arr, 0);
-            param._gpuBuffer = buf; param._gpuBackend = backend; param._gpuBufferVersion = param.Version;
+            // A concurrent remove can make the shared helper return an uncached owner.
+            // Do not bind that ephemeral allocation as a supposedly persistent parameter.
+            resident.Dispose();
+            return;
         }
+
+        param._gpuBuffer = resident.Buffer;
+        param._gpuBackend = backend;
+        param._gpuBufferVersion = hostVersion;
     }
 
     /// <summary>Resident FP16 training (#633): forward down-cast of FP32 input <paramref name="x"/> (an optimizer-
@@ -2943,7 +2993,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // host cast (MixedPrecisionCast.CastToFp16) over the fresh host array — identical to the pre-resident
             // behavior. Without this gate the stale resident buffer masks host param mutations (the forward output
             // stops tracking weight changes), which broke the standalone/host-optimizer mixed-precision paths.
-            if (x._gpuBuffer is not null && ReferenceEquals(x._gpuBackend, backend) && x._gpuBufferVersion == x.Version)
+            if (x._gpuBuffer is not null && ReferenceEquals(x._gpuBackend, backend) && x._gpuBufferVersion == x.GpuCacheVersion)
             {
                 var persistent = xarr is not null ? TryGetCachedBuffer(xarr) : null;
                 if ((persistent is not null && ReferenceEquals(persistent, x._gpuBuffer))
@@ -2990,7 +3040,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (!reused)
             {
                 InvalidateActivationCacheEntry(o.DataVector);
-                CacheActivation(oArr, halfBuf, o._shape, backend, isFp16: true, elementCount: n);
+                CacheActivation(oArr, halfBuf, o._shape, backend, isFp16: true, elementCount: n,
+                    hostVersion: o.GpuCacheVersion);
             }
             o._gpuBuffer = null; o._gpuBackend = null; o._gpuBufferVersion = -1;
             return true;
@@ -3277,7 +3328,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             var cArr = src.GetBackingArrayForCacheLookupUnsafe();
             if (cArr is not null && src.IsContiguous && !Helpers.DeferredArrayMaterializer.IsPending(cArr))
             {
-                try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights, src.Version).Buffer; }
+                try { srcBuf = GetOrCacheWeightBuffer(backend, src.GetDataArray(), PersistentTensorRole.Weights, src.GpuCacheVersion).Buffer; }
                 catch { srcBuf = null; }
             }
         }
@@ -3285,7 +3336,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             bool capturing = backend is Engines.DirectGpu.CUDA.CudaBackend cbk && cbk.IsStreamCapturing();
             bool hasBuf = src._gpuBuffer is not null;
-            bool verMatch = hasBuf && src._gpuBufferVersion == src.Version;
+            bool verMatch = hasBuf && src._gpuBufferVersion == src.GpuCacheVersion;
             var srcArr2 = src.GetBackingArrayForCacheLookupUnsafe();
             string realProducer = (srcArr2 is not null && s_producerOf.TryGetValue(srcArr2, out var rp)) ? rp : "<untagged/host>";
             AliasDiag($"skip: src not resident PRODUCER={realProducer} consumer={s_currentForwardOp} shape=[{string.Join(",", src._shape)}] hasBuf={hasBuf} capturing={capturing}");
@@ -3302,7 +3353,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // truth; if src's buffer is later evicted, the consumer cleanly falls back to a re-upload.
         dest._gpuBuffer = srcBuf;
         dest._gpuBackend = backend;
-        dest._gpuBufferVersion = dest.Version;
+        dest._gpuBufferVersion = dest.GpuCacheVersion;
 
         // Host reads of dest (the loss scalar, a debug checksum, a host op) download from the borrowed buffer.
         var capturedBuf = srcBuf;
@@ -3331,8 +3382,11 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// <paramref name="elementCount"/>.
     /// </param>
     /// <param name="elementCount">Number of elements that will be written.</param>
-    private void DownloadGpuBufferInto<T>(IDirectGpuBackend backend, OwnedBuffer outputBuffer, T[] destination, int elementCount)
+    private void DownloadGpuBufferInto<T>(IDirectGpuBackend backend, OwnedBuffer outputBuffer,
+        Tensor<T> destinationTensor, T[] destination, int elementCount)
     {
+        destinationTensor.IncrementVersion();
+        int hostVersion = destinationTensor.GpuCacheVersion;
         Helpers.DeferredArrayMaterializer.Remove(destination);
         RemoveActivationCacheEntry(destination);
 
@@ -3357,8 +3411,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             Array.Copy(converted, (T[])arr, Math.Min(converted.Length, ((T[])arr).Length));
         });
 
-        if (!TryReplacePersistentBuffer(destination, outputBuffer.Buffer))
-            CacheActivation(destination, outputBuffer.Buffer, new[] { elementCount }, backend);
+        if (!TryReplacePersistentBuffer(destination, outputBuffer.Buffer, hostVersion))
+            CacheActivation(destination, outputBuffer.Buffer, new[] { elementCount }, backend,
+                hostVersion: hostVersion);
+        outputBuffer.RelinquishOwnership();
     }
 
     /// <summary>
@@ -3391,7 +3447,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // the freshly-allocated GPU buffer as stale and re-uploads from an
         // empty CPU backing array, zeroing out downstream ops that reference
         // the deferred result (e.g. StopGradient → TensorMultiply chain).
-        tensor._gpuBufferVersion = tensor.Version;
+        tensor._gpuBufferVersion = tensor.GpuCacheVersion;
 
         // Register materializer keyed by the vector — when GetDataArray() is called,
         // it allocates the backing array and then TryMaterialize(vector) downloads from GPU.
@@ -3455,7 +3511,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
 
         // Cache the GPU buffer so GetOrAllocateBuffer finds it
         // Use the vector as cache key since there's no backing array yet
-        CacheActivation(vector, outputBuffer, shape, backend);
+        CacheActivation(vector, outputBuffer, shape, backend, hostVersion: tensor.GpuCacheVersion);
 
         return tensor;
     }
@@ -4345,7 +4401,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (ScratchPoolingActive)
             return RentActionScratch(backend, length);
         var buf = backend.AllocateBuffer(length);
-        if (arr is not null) CacheActivation(arr, buf, t._shape, backend);
+        if (arr is not null) CacheActivation(arr, buf, t._shape, backend, hostVersion: t.GpuCacheVersion);
         return buf;
     }
 
@@ -4353,7 +4409,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // a deferred materializer keeps host reads correct. Used by the compiled-step resident op paths.
     internal void BindResidentBuffer<T>(Tensor<T> t, IGpuBuffer buf, IDirectGpuBackend backend)
     {
-        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = t.Version;
+        int hostVersion = t.GpuCacheVersion;
+        t._gpuBuffer = buf; t._gpuBackend = backend; t._gpuBufferVersion = hostVersion;
         var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is null) return;
 
@@ -4369,7 +4426,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // dictionary re-key: it preserves the buffer, timestamp, byte accounting, and GPU residency,
         // and adds no device synchronization or host transfer to the hot path.
         var displacedEntry = RekeyActivationCacheForResidentBinding(
-            t, arr, buf, backend, out var previousVectorKey);
+            t, arr, buf, backend, hostVersion, out var previousVectorKey);
 
         // Bind is an authoritative overwrite of this tensor's resident value. Supersede either
         // historical key rather than relying on Register's intentional first-write-wins behavior;
@@ -4411,6 +4468,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         object arrayKey,
         IGpuBuffer buffer,
         IDirectGpuBackend backend,
+        int hostVersion,
         out object? previousVectorKey)
     {
         previousVectorKey = null;
@@ -4420,7 +4478,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (_activationCache.TryGetValue(arrayKey, out var arrayEntry)
             && ReferenceEquals(arrayEntry.Buffer, buffer)
             && ReferenceEquals(arrayEntry.Backend, backend))
+        {
+            arrayEntry.HostVersion = hostVersion;
             return null;
+        }
 
         // Only a tensor that acquired its host array after a zero-allocation GPU result can need
         // migration. Resolve the old identity after the common path has returned.
@@ -4431,7 +4492,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             if (_activationCache.TryGetValue(arrayKey, out arrayEntry)
                 && ReferenceEquals(arrayEntry.Buffer, buffer)
                 && ReferenceEquals(arrayEntry.Backend, backend))
+            {
+                arrayEntry.HostVersion = hostVersion;
                 return null;
+            }
 
             if (!_activationCache.TryGetValue(vectorKey, out var vectorEntry)
                 || !ReferenceEquals(vectorEntry.Buffer, buffer)
@@ -4455,6 +4519,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     _activationCache.TryAdd(arrayKey, displaced);
                 return null;
             }
+
+            owner.HostVersion = hostVersion;
 
             if (!_activationCache.TryAdd(arrayKey, owner))
             {
@@ -4557,21 +4623,30 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// propagate residency through metadata-only views (Reshape) during the resident step.</summary>
     private IGpuBuffer? ResolveResidentBufferNoUpload<T>(IDirectGpuBackend backend, Tensor<T> t, int need)
     {
+        bool residentStep = ResidentStepActive;
+        int hostVersion = residentStep ? 0 : t.GpuCacheVersion;
+        // During capture the device is authoritative. Eager consumers must instead reject
+        // snapshots superseded by a host write, including writes through another storage view.
         if (t._gpuBuffer is not null && ReferenceEquals(t._gpuBackend, backend)
-            && t._gpuBuffer.Handle != System.IntPtr.Zero && t._gpuBuffer.Size >= need)
+            && t._gpuBuffer.Handle != System.IntPtr.Zero && t._gpuBuffer.Size >= need
+            && (residentStep || (t._gpuBufferVersion == hostVersion && IsCachedGpuBufferLive(t, backend))))
             return t._gpuBuffer;
         var resident = t.TryGetGpuBuffer();
-        if (resident is not null && resident.Handle != System.IntPtr.Zero && resident.Size >= need)
+        if (resident is not null && resident.Handle != System.IntPtr.Zero && resident.Size >= need
+            && (residentStep || t._gpuBuffer is null))
             return resident;
         var arr = t.GetBackingArrayForCacheLookupUnsafe();
         if (arr is not null)
         {
             var cached = TryGetCachedBuffer(arr);
-            if (cached is not null && cached.Handle != System.IntPtr.Zero && cached.Size >= need)
+            if (cached is not null && cached.Handle != System.IntPtr.Zero && cached.Size >= need
+                && (residentStep || (_persistentWeightHostVersion.TryGetValue(arr, out var stamped)
+                    && stamped == hostVersion)))
                 return cached;
             lock (_activationCacheLock)
                 if (_activationCache.TryGetValue(arr, out var e) && ReferenceEquals(e.Backend, backend) && !e.IsFp16
-                    && e.Buffer.Handle != System.IntPtr.Zero && e.Buffer.Size >= need)
+                    && e.Buffer.Handle != System.IntPtr.Zero && e.Buffer.Size >= need
+                    && (residentStep || e.HostVersion == hostVersion))
                     return e.Buffer;
         }
         return null;
@@ -4891,7 +4966,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 + $"outBufElems={outBuf.Size} tableElems={tableBuf.Size} idxBufElems={_cachedEmbIndexBuffer.Size} impliedV={tableBuf.Size/embeddingDim}");
             backend.Embedding(_cachedEmbIndexBuffer, tableBuf, outBuf, numIndices, embeddingDim);
             ResidentSyncCheck("Embedding");
-            output._gpuBuffer = outBuf; output._gpuBackend = backend; output._gpuBufferVersion = output.Version;
+            output._gpuBuffer = outBuf; output._gpuBackend = backend; output._gpuBufferVersion = output.GpuCacheVersion;
             var oArr = output.GetBackingArrayForCacheLookupUnsafe();
             if (oArr is not null && s_currentForwardOp is not null) if (s_producerDiagEnabled && s_producerOf.Count < ProducerDiagCap) s_producerOf[oArr] = s_currentForwardOp;
             return true;
@@ -5128,7 +5203,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     op(backend, bufferA.Buffer, bufferB.Buffer, output.Buffer, left.Length);
                 }
 
-                DownloadGpuBufferInto(backend, output, destinationArray, left.Length);
+                DownloadGpuBufferInto(backend, output, destination, destinationArray, left.Length);
                 Gpu.GpuPrecisionDiagnostics.Publish(precisionPlan);
                 return true;
             }
@@ -5184,7 +5259,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             try
             {
                 op(backend, bufferA.Buffer, output.Buffer, ToFloatScalar(scalar), input.Length);
-                DownloadGpuBufferInto(backend, output, destinationArray, input.Length);
+                DownloadGpuBufferInto(backend, output, destination, destinationArray, input.Length);
                 return true;
             }
             catch
@@ -6486,6 +6561,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 // _gpuBufferVersion to the new Version and registers the host-read materializer).
                 a.IncrementVersion();
                 BindResidentBuffer(a, aResident, backend);
+                if (!ResidentStepActive) StampInPlaceGpuBuffer(a, backend, aResident);
                 return true;
             }
             catch (Exception rex)
@@ -6516,12 +6592,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return false;
 
         var aData = a.GetDataArray();
-        var bData = b.GetDataArray();
+        var bData = b.GetReadOnlyDataArray();
         if (aData.Length != bData.Length)
             return false;
 
-        using var bufferA = GetOrAllocateBuffer(backend, aData);
-        using var bufferB = GetOrAllocateBuffer(backend, bData);
+        using var bufferA = GetOrAllocateBuffer(backend, a);
+        using var bufferB = GetOrAllocateBuffer(backend, b);
 
         // A cached buffer (persistent/activation cache, keyed by the array
         // reference) can be SMALLER than the logical array when a pooled
@@ -6550,7 +6626,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // the next GPU op shouldn't trigger a CPU→GPU re-upload via
         // GetOrAllocateBuffer's staleness check.
         a.IncrementVersion();
-        a._gpuBufferVersion = a.Version;
+        StampInPlaceGpuBuffer(a, backend, bufferA.Buffer);
         return true;
     }
 
@@ -6577,7 +6653,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return TryRunUnaryInPlaceResident(tensor, op);
 
         var data = tensor.GetDataArray();
-        using var buffer = GetOrAllocateBuffer(backend, data);
+        using var buffer = GetOrAllocateBuffer(backend, tensor);
 
         // See TryRunBinaryInPlace: a stale cached buffer can be smaller than the
         // logical array when a pooled backing array is reused at a larger shape.
@@ -6595,8 +6671,34 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // Version + sync _gpuBufferVersion so subsequent GPU ops reuse
         // the freshly-written buffer instead of re-uploading.
         tensor.IncrementVersion();
-        tensor._gpuBufferVersion = tensor.Version;
+        StampInPlaceGpuBuffer(tensor, backend, buffer.Buffer);
         return true;
+    }
+
+    /// <summary>
+    /// Marks the exact buffer written by an eager in-place kernel as current. Updating its existing
+    /// cache owner avoids a needless re-upload on the next operation without certifying an unrelated
+    /// tensor field or cache entry. This path performs no allocation, upload, or synchronization.
+    /// </summary>
+    private void StampInPlaceGpuBuffer<T>(Tensor<T> tensor, IDirectGpuBackend backend, IGpuBuffer buffer)
+    {
+        int hostVersion = tensor.GpuCacheVersion;
+        if (ReferenceEquals(tensor._gpuBuffer, buffer) && ReferenceEquals(tensor._gpuBackend, backend))
+            tensor._gpuBufferVersion = hostVersion;
+
+        object cacheKey = (object?)tensor.GetBackingArrayForCacheLookupUnsafe() ?? tensor.DataVector;
+        lock (_persistentBufferLock)
+        {
+            if (_persistentBufferCache.TryGetValue(cacheKey, out var persistent)
+                && ReferenceEquals(persistent.Buffer, buffer))
+                _persistentWeightHostVersion[cacheKey] = hostVersion;
+        }
+        lock (_activationCacheLock)
+        {
+            if (_activationCache.TryGetValue(cacheKey, out var activation)
+                && ReferenceEquals(activation.Buffer, buffer) && ReferenceEquals(activation.Backend, backend))
+                activation.HostVersion = hostVersion;
+        }
     }
 
     /// <summary>
@@ -6655,12 +6757,14 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // On a cache HIT the entry already maps this same (now in-place-modified) buffer, and
         // re-caching would TryAdd-fail and Dispose the live buffer (ActivationCacheEntry.Dispose
         // frees Buffer), so DO NOT re-cache a hit.
-        if (owned.OwnsBuffer)
-            CacheActivation(cacheKey, buf, tensor.Shape._dims, backend);
         tensor.IncrementVersion();
+        if (owned.OwnsBuffer)
+            CacheActivation(cacheKey, buf, tensor.Shape._dims, backend,
+                hostVersion: tensor.GpuCacheVersion);
         // Pin the buffer to the tensor + (re)register the deferred materializer so the final CPU
         // read downloads the kernel's output after Execute() instead of the stale pre-op data.
         BindResidentBuffer(tensor, buf, backend);
+        if (!ResidentStepActive) StampInPlaceGpuBuffer(tensor, backend, buf);
         return true;
     }
 
@@ -7191,7 +7295,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 $"Got: {role}. Use UploadToGpu for other tensor types.", nameof(role))
         };
         // Persistent-weight read: pass the host Version so an in-place weight load re-uploads (shared gate).
-        var ownedBuffer = GetOrCacheWeightBuffer(backend, tensor.GetDataArray(), persistentRole, tensor.Version);
+        var ownedBuffer = GetOrCacheWeightBuffer(backend, tensor.GetDataArray(), persistentRole, tensor.GpuCacheVersion);
 
         // Propagate ownership: if cache owns buffer, GpuTensor shouldn't dispose;
         // if we own buffer (race condition fallback), GpuTensor should take ownership
@@ -12411,7 +12515,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             _tensorVersions[key] = newEntry.Version;
             // Re-stamp with the host Version this fresh buffer matches, so the version-aware weight reader
             // does not needlessly re-upload it again on the next read.
-            _persistentWeightHostVersion[key] = tensor.Version;
+            _persistentWeightHostVersion[key] = tensor.GpuCacheVersion;
         }
         catch
         {
@@ -15769,7 +15873,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // on-device for CUDA-graph capture. Without it, the first consumer re-uploads and the chain collapses.
         output._gpuBuffer = outBuf;
         output._gpuBackend = backend;
-        output._gpuBufferVersion = output.Version;
+        output._gpuBufferVersion = output.GpuCacheVersion;
         return true;
     }
 
@@ -18623,10 +18727,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         // deliberately omits this gate for capture-time metadata views, so using it here could
         // execute eager arithmetic against a stale pre-mutation buffer.
         if (a._gpuBuffer is null || !ReferenceEquals(a._gpuBackend, backend)
-            || a._gpuBufferVersion != a.Version || !IsCachedGpuBufferLive(a, backend)
+            || a._gpuBufferVersion != a.GpuCacheVersion || !IsCachedGpuBufferLive(a, backend)
             || a._gpuBuffer.Handle == System.IntPtr.Zero || a._gpuBuffer.Size < a.Length
             || b._gpuBuffer is null || !ReferenceEquals(b._gpuBackend, backend)
-            || b._gpuBufferVersion != b.Version || !IsCachedGpuBufferLive(b, backend)
+            || b._gpuBufferVersion != b.GpuCacheVersion || !IsCachedGpuBufferLive(b, backend)
             || b._gpuBuffer.Handle == System.IntPtr.Zero || b._gpuBuffer.Size < b.Length)
             return null;
         var residentA = a._gpuBuffer;
@@ -20503,14 +20607,16 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                     else
                     {
                         outBuf = backend.AllocateBuffer(output.Length);
-                        if (arr is not null) CacheActivation(arr, outBuf, output._shape, backend);
+                        if (arr is not null)
+                            CacheActivation(arr, outBuf, output._shape, backend,
+                                hostVersion: output.GpuCacheVersion);
                     }
                 }
                 backend.Permute(bufIn.Buffer, outBuf, tensor.Shape._dims, axes);
                 ResidentSyncCheck("Permute");
                 output._gpuBuffer = outBuf;
                 output._gpuBackend = backend;
-                output._gpuBufferVersion = output.Version;
+                output._gpuBufferVersion = output.GpuCacheVersion;
                 if (arr is not null)
                 {
                     var capBuf = outBuf; var capBackend = backend;
@@ -20529,7 +20635,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 var bufOut = AllocateOutputBuffer(backend, tensor.Length);
                 backend.Permute(bufIn.Buffer, bufOut.Buffer, tensor.Shape._dims, axes);
                 var dst = output.GetDataArray();
-                DownloadGpuBufferInto(backend, bufOut, dst, output.Length);
+                DownloadGpuBufferInto(backend, bufOut, output, dst, output.Length);
             }
         }
         catch (Exception)
@@ -21684,7 +21790,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             ops.FromFloatSpan(new ReadOnlySpan<float>(result), tensor.AsWritableSpan());
             // Version-counter contract — same rationale as TryRunUnaryInPlace.
             tensor.IncrementVersion();
-            tensor._gpuBufferVersion = tensor.Version;
+            tensor._gpuBufferVersion = tensor.GpuCacheVersion;
             return;
         }
         catch { }
@@ -23216,7 +23322,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                         ? (ulong)(uint)seed.Value
                         : (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed);
                     b.GenerateRandomUniform(go.Buffer, destination.Length, ToFloatScalar(min), ToFloatScalar(max), gpuSeed);
-                    DownloadGpuBufferInto(b, go, destinationArray, destination.Length);
+                    DownloadGpuBufferInto(b, go, destination, destinationArray, destination.Length);
                     return;
                 }
                 catch
@@ -23270,7 +23376,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                         ToFloatScalar(mean),
                         ToFloatScalar(stddev),
                         (ulong)System.Threading.Interlocked.Increment(ref _gpuRngSeed));
-                    DownloadGpuBufferInto(b, go, destinationArray, destination.Length);
+                    DownloadGpuBufferInto(b, go, destination, destinationArray, destination.Length);
                     return;
                 }
                 catch
@@ -25659,7 +25765,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         var tensor = Tensor<Complex<T>>.CreateGpuResident(shape, deviceType);
         tensor._gpuBuffer = outputBuffer;
         tensor._gpuBackend = backend;
-        tensor._gpuBufferVersion = tensor.Version;
+        tensor._gpuBufferVersion = tensor.GpuCacheVersion;
         tensor._gpuBufferIsSplitComplex = true;
 
         var vector = tensor.DataVector;
@@ -25685,7 +25791,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         tensor._gpuMaterializerCallback = materialize;
         tensor._gpuMaterializerKey = vector;
         Helpers.DeferredArrayMaterializer.Register(vector, materialize);
-        CacheActivation(vector, outputBuffer, shape, backend);
+        CacheActivation(vector, outputBuffer, shape, backend, hostVersion: tensor.GpuCacheVersion);
         return tensor;
     }
 
@@ -25728,7 +25834,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             && tensor._gpuBuffer.Handle != IntPtr.Zero
             && ReferenceEquals(tensor._gpuBackend, backend)
             && (ResidentStepActive
-                || (tensor._gpuBufferVersion == tensor.Version
+                || (tensor._gpuBufferVersion == tensor.GpuCacheVersion
                     && IsCachedGpuBufferLive(tensor, backend))))
         {
             IGpuBuffer? real = null;

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -272,13 +272,13 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     // Version tracking for invalidation
     private readonly ConcurrentDictionary<object, int> _tensorVersions = new();
 
-    // Host-tensor Version stamped onto each PERSISTENT weight/bias buffer at the moment it was uploaded.
+    // Shared-storage GpuCacheVersion stamped onto each PERSISTENT weight/bias buffer when uploaded.
     // The persistent cache is keyed by the host backing array, but a weight is commonly registered at
     // construction (with random INIT values) and then loaded IN PLACE by SetParameters — which bumps the
-    // tensor Version but shares the same backing array, so the cache key does not change. Without a version
+    // storage GpuCacheVersion but shares the same backing array, so the cache key does not change. Without a version
     // gate the reader would keep serving the stale random buffer (a real GGUF decoder loaded under the GPU
     // engine produced pure garbage this way). GetWeightBufferPreferResident compares the tensor's current
-    // Version to this stamp and re-uploads on a mismatch, mirroring the resident _gpuBuffer version gate so
+    // GpuCacheVersion to this stamp and re-uploads on a mismatch, mirroring the resident _gpuBuffer version gate so
     // an explicit InvalidatePersistentTensor is no longer required for correctness.
     private readonly ConcurrentDictionary<object, int> _persistentWeightHostVersion = new();
 
@@ -2266,9 +2266,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 Version = nextVersion
             };
 
-            if (_persistentBufferCache.TryRemove(data, out var removed)
-                && !ReferenceEquals(removed.Buffer, buffer))
-                _retiredWeightBuffers.Add(removed.Buffer);
+            // All persistent-cache publishers hold this lock. Retire exactly the
+            // observed entry instead of removing and then overwriting a second slot.
+            if (!ReferenceEquals(existing.Buffer, buffer))
+                _retiredWeightBuffers.Add(existing.Buffer);
 
             _persistentBufferCache[data] = replacement;
             _tensorVersions[data] = nextVersion;
@@ -2608,19 +2609,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// as a persistent buffer at construction (random init), then <c>SetParameters</c> loads the real
     /// weights into the same backing array — bumping Version via the indexer/SetFlat/CopyFromArray paths —
     /// but the cache key (the array) is unchanged, so a version-blind lookup would return the stale
-    /// construction-time buffer. This compares the current Version to the stamp recorded at upload and
+    /// construction-time buffer. This compares the current GpuCacheVersion to the stamp recorded at upload and
     /// re-uploads on a mismatch, so correctness no longer depends on the layer also calling
     /// <see cref="InvalidatePersistentTensor{T}"/>. Raw-span writes (AsWritableSpan) that bypass the
     /// version bump still require an explicit invalidate, per the documented Tensor mutation contract.
     /// </summary>
-    /// <summary>Sentinel for <see cref="GetOrCacheWeightBuffer{T}(IDirectGpuBackend,T[],PersistentTensorRole,int)"/>:
-    /// skip the host-Version staleness gate (legacy version-blind behavior for non-weight callers).</summary>
-    private const int NoHostVersionGate = -1;
-
     private OwnedBuffer GetOrCacheWeightBufferVersionAware<T>(IDirectGpuBackend backend, Tensor<T> weights, PersistentTensorRole role)
         // Thin wrapper: the version gate itself lives in the shared persistent-cache lookup below, so EVERY
-        // persistent-weight read path that passes the host Tensor.Version gets the same in-place-load
-        // protection — not just this one (CodeRabbit #821). We hold the Version at read time.
+        // persistent-weight read path that passes the shared Tensor.GpuCacheVersion gets the same in-place-load
+        // protection — not just this one (CodeRabbit #821). We hold the storage epoch at read time.
         // READ-ONLY accessor: GetDataArray is write-intent and calls EnsureOwnedForWrite, so using
         // it to key this cache PRIVATISED every copy-on-write clone as a side effect of looking up
         // its buffer. A cloned model therefore got fresh arrays, missed the cache, and uploaded a
@@ -2637,15 +2634,15 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     /// so subsequent calls reuse the same GPU buffer without re-uploading.
     /// Thread-safe: uses lock to coordinate with cache invalidation.
     /// <para>
-    /// SHARED version gate: when <paramref name="hostVersion"/> is not <see cref="NoHostVersionGate"/>, a
-    /// cached buffer is served only if it was uploaded at that same host <see cref="Tensor{T}.Version"/>. An
-    /// in-place weight load (indexer / SetFlat / CopyFromArray) bumps Version WITHOUT changing the backing
+    /// SHARED version gate: every caller supplies <paramref name="hostVersion"/>. A
+    /// tracked buffer is served only if uploaded at that same storage <see cref="Tensor{T}.GpuCacheVersion"/>. An
+    /// in-place weight load (indexer / SetFlat / CopyFromArray) bumps GpuCacheVersion WITHOUT changing the backing
     /// array (the cache key), so a version-blind hit would keep serving the stale construction-time buffer
     /// (a real GGUF-decoder-under-GPU garbage bug). Callers reading persistent WEIGHTS pass the tensor's
-    /// Version; version-blind callers (activations/inputs, which are not in-place-loaded) pass the sentinel.
+    /// GpuCacheVersion. Persistent buffers are never published without a storage epoch.
     /// </para>
     /// </summary>
-    private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, T[] data, PersistentTensorRole role, int hostVersion = NoHostVersionGate)
+    private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, T[] data, PersistentTensorRole role, int hostVersion)
     {
         // A synchronize is illegal inside CUDA graph capture (it aborts the capture, CUDA-900). This path is
         // reachable during capture via TryAliasResidentOutput on a nonresident source under ResidentStepActive,
@@ -2667,8 +2664,8 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Persistent-cache lookup WITH the shared version gate.
             if (_persistentBufferCache.TryGetValue(data, out var existing))
             {
-                bool valid = hostVersion == NoHostVersionGate
-                    || (_persistentWeightHostVersion.TryGetValue(data, out int stamped) && stamped == hostVersion);
+                bool valid = _persistentWeightHostVersion.TryGetValue(data, out int stamped)
+                    && stamped == hostVersion;
                 if (valid)
                     return new OwnedBuffer(existing.Buffer, ownsBuffer: false);
 
@@ -2683,12 +2680,10 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             // Not cached (or just invalidated) - upload and cache for future use.
             float[] floatData = DirectGpuEngine.ToFloatArray(data);
             IGpuBuffer gpuBuffer = backend.AllocateBuffer(floatData);
-            if (hostVersion != NoHostVersionGate && !capturing)
+            if (!capturing)
                 backend.Synchronize();
 
-            // Insert via TryAdd, not a direct set: RegisterPersistentTensor adds lock-free (it does not take
-            // _persistentBufferLock), so a concurrent register could have populated this key while we uploaded.
-            // If so, dispose our buffer and alias the existing one rather than overwrite-and-leak it.
+            // Keep insertion ownership explicit, including any reentrant registration during upload.
             var entry = new GpuBufferCacheEntry(gpuBuffer, role);
             if (!_persistentBufferCache.TryAdd(data, entry))
             {
@@ -2702,30 +2697,9 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
                 return new OwnedBuffer(gpuBuffer, ownsBuffer: true);
             }
             _tensorVersions.TryAdd(data, 0);
-            if (hostVersion != NoHostVersionGate)
-                _persistentWeightHostVersion[data] = hostVersion;
+            _persistentWeightHostVersion[data] = hostVersion;
             return new OwnedBuffer(gpuBuffer, ownsBuffer: false);
         }
-    }
-
-    /// <summary>
-    /// Gets a GPU buffer for weight/bias Memory&lt;T&gt; data, auto-caching if not already persistent.
-    /// Uses MemoryMarshal.TryGetArray to extract underlying array for cache lookup and efficient upload.
-    /// </summary>
-    private OwnedBuffer GetOrCacheWeightBuffer<T>(IDirectGpuBackend backend, ReadOnlyMemory<T> memory, PersistentTensorRole role)
-    {
-        // Try to get the underlying array for cache-friendly behavior
-        if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment) &&
-            segment.Offset == 0 && segment.Count == segment.Array!.Length)
-        {
-            // Memory is backed by a full array - use the array-based overload for caching
-            return GetOrCacheWeightBuffer(backend, segment.Array, role);
-        }
-
-        // Memory is a slice or not array-backed - upload without caching
-        // (We can't cache slices reliably since the key would be the slice, not the source)
-        float[] floatData = DirectGpuEngine.ToFloatArray(memory.ToArray());
-        return new OwnedBuffer(backend.AllocateBuffer(floatData), ownsBuffer: true);
     }
 
     /// <summary>
@@ -12486,43 +12460,36 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (key is null)
             return;
 
-        if (!_persistentBufferCache.TryGetValue(key, out var entry))
-            return;
-
-        // The UPLOAD SOURCE is a different question from the cache key. The identity accessor never
-        // fires a pending deferred GPU->CPU download (DeferredArrayMaterializer), so a tensor whose
-        // latest value still lives on the device would re-upload its STALE host bytes. The read-only
-        // data accessor materialises that download without privatising a COW clone, and for the simple
-        // CPU layout the cache can hit on it hands back the very array used as the key. Resolve it
-        // BEFORE disposing the old buffer, so a failed materialisation leaves the cache entry intact.
-        T[] hostData = tensor.GetReadOnlyDataArray();
-
-        try
+        lock (_persistentBufferLock)
         {
-            // Dispose old buffer
-            entry.Buffer.Dispose();
+            if (!_persistentBufferCache.ContainsKey(key)) return;
 
-            // Upload new data
-            float[] floatData = DirectGpuEngine.ToFloatArray(hostData);
-            IGpuBuffer newBuffer = backend.AllocateBuffer(floatData);
-            backend.Synchronize();
-
-            // Update cache entry with new buffer
-            var newEntry = new GpuBufferCacheEntry(newBuffer, entry.Role);
-            newEntry.Version = entry.Version + 1;
-
-            _persistentBufferCache[key] = newEntry;
-            _tensorVersions[key] = newEntry.Version;
-            // Re-stamp with the host Version this fresh buffer matches, so the version-aware weight reader
-            // does not needlessly re-upload it again on the next read.
-            _persistentWeightHostVersion[key] = tensor.GpuCacheVersion;
-        }
-        catch
-        {
-            // On failure, remove from cache - operations will fall back to CPU
-            _persistentBufferCache.TryRemove(key, out _);
-            _tensorVersions.TryRemove(key, out _);
-            _persistentWeightHostVersion.TryRemove(key, out _);
+            // Materialize deferred input while the old buffer is still live. Cache
+            // maintenance must never detach a COW alias just to read its value.
+            T[] hostData = tensor.GetReadOnlyDataArray();
+            IGpuBuffer? replacement = null;
+            try
+            {
+                replacement = backend.AllocateBuffer(DirectGpuEngine.ToFloatArray(hostData));
+                backend.Synchronize();
+                if (!TryReplacePersistentBuffer(key, replacement, tensor.GpuCacheVersion))
+                    throw new InvalidOperationException("The persistent cache entry disappeared during replacement.");
+                replacement = null; // Ownership transferred to the persistent cache.
+            }
+            catch
+            {
+                try { replacement?.Dispose(); }
+                finally
+                {
+                    // An explicit invalidation may follow a raw-span write with no epoch
+                    // increment. Even if replacement disposal also fails, the old
+                    // snapshot must not remain eligible for cache hits.
+                    if (_persistentBufferCache.TryRemove(key, out var failedEntry))
+                        _retiredWeightBuffers.Add(failedEntry.Buffer);
+                    _tensorVersions.TryRemove(key, out _);
+                    _persistentWeightHostVersion.TryRemove(key, out _);
+                }
+            }
         }
     }
 
@@ -20207,7 +20174,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
                     backend, "TensorMatMul.NDx2D", ndPlan.RequestedPreference,
-                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}", ndPlan.OperationKind));
                 return base.TensorMatMul(a, b);
             }
         }
@@ -20264,7 +20231,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             {
                 Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
                     backend, "TensorMatMul.NDxND", batchPlan.RequestedPreference,
-                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                    $"GPU route failed with {ex.GetType().Name}: {ex.Message}", batchPlan.OperationKind));
                 return base.TensorMatMul(a, b);
             }
         }
@@ -20355,7 +20322,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
                 backend, "TensorMatMul.Rank2", rank2Plan.RequestedPreference,
-                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}", rank2Plan.OperationKind));
             return base.TensorMatMul(a, b);
         }
     }
@@ -20403,7 +20370,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
                 backend, "TensorMatMulTransposed", plan.RequestedPreference,
-                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}", plan.OperationKind));
             return base.TensorMatMulTransposed(a, b);
         }
     }
@@ -20516,7 +20483,7 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         {
             Gpu.GpuPrecisionDiagnostics.Publish(Gpu.GpuPrecisionPlanner.CpuFallback<T>(
                 backend, "BatchMatMul", plan.RequestedPreference,
-                $"GPU route failed with {ex.GetType().Name}: {ex.Message}"));
+                $"GPU route failed with {ex.GetType().Name}: {ex.Message}", plan.OperationKind));
             if (ThrowOnGpuKernelFallback) throw;
             return base.BatchMatMul(a, b);
         }

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuOptimizer.cs
@@ -43,7 +43,7 @@ public static class GpuOptimizer
     {
         if (tensor is null) return;
         tensor.MarkModified(CreateWriteSyncPoint(backend));
-        tensor._gpuBufferVersion = tensor.Version;
+        tensor._gpuBufferVersion = tensor.GpuCacheVersion;
     }
 
     private static void MarkGpuUpdated(IDirectGpuBackend backend, Tensor<float>? first, Tensor<float>? second)

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
@@ -400,8 +400,9 @@ public static class GpuPrecisionPlanner
         IDirectGpuBackend backend,
         string operationName,
         GpuComputePreference requested,
-        string reason)
-        => CpuPlan(backend, operationName, typeof(T), requested, reason);
+        string reason,
+        GpuPrecisionOperation operation)
+        => CpuPlan(backend, operationName, typeof(T), requested, reason, operation);
 
     private static GpuComputePlan FromCapability(
         IDirectGpuBackend backend,

--- a/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
+++ b/src/AiDotNet.Tensors/Engines/Gpu/GpuPrecisionPolicy.cs
@@ -255,11 +255,13 @@ public sealed class GpuComputePlan
         GpuScalarType outputStorage,
         GpuPrecisionImplementation? implementation,
         bool reducesStorageBytes,
-        string? fallbackReason)
+        string? fallbackReason,
+        GpuPrecisionOperation operationKind = GpuPrecisionOperation.General)
     {
         Route = route;
         Backend = backend;
         Operation = operation;
+        OperationKind = operationKind;
         PublicType = publicType;
         RequestedPreference = requestedPreference;
         ComputeFormat = computeFormat;
@@ -278,6 +280,8 @@ public sealed class GpuComputePlan
     public string Backend { get; }
     /// <summary>Gets the operation name.</summary>
     public string Operation { get; }
+    /// <summary>Gets the typed operation family, without parsing a diagnostic name.</summary>
+    public GpuPrecisionOperation OperationKind { get; }
     /// <summary>Gets the caller-visible tensor element type.</summary>
     public Type PublicType { get; }
     /// <summary>Gets the requested compute preference.</summary>
@@ -344,10 +348,10 @@ public static class GpuPrecisionPlanner
         {
             var exact = FindPreserving(capabilities, sourceType);
             if (exact is not null)
-                return FromCapability(backend, operationName, typeof(T), requested, exact, null);
+                return FromCapability(backend, operationName, typeof(T), requested, exact, null, operation);
 
             return CpuPlan(backend, operationName, typeof(T), requested,
-                $"{backend.BackendName} has no {sourceType} {operation} route required by PreserveInputType.");
+                $"{backend.BackendName} has no {sourceType} {operation} route required by PreserveInputType.", operation);
         }
 
         var desired = requested == GpuComputePreference.Auto
@@ -359,7 +363,7 @@ public static class GpuPrecisionPlanner
             string? conversionReason = requested == GpuComputePreference.Auto && sourceType != desired
                 ? $"SpeedFirst Auto converts public {sourceType} through {desired}."
                 : null;
-            return FromCapability(backend, operationName, typeof(T), requested, selected, conversionReason);
+            return FromCapability(backend, operationName, typeof(T), requested, selected, conversionReason, operation);
         }
 
         if (policy.FallbackBehavior == GpuPrecisionFallbackBehavior.Throw)
@@ -372,12 +376,12 @@ public static class GpuPrecisionPlanner
             if (selected is not null)
             {
                 return FromCapability(backend, operationName, typeof(T), requested, selected,
-                    $"Requested {desired} is unavailable for {operation}; using {selected.ComputeFormat}.");
+                    $"Requested {desired} is unavailable for {operation}; using {selected.ComputeFormat}.", operation);
             }
         }
 
         return CpuPlan(backend, operationName, typeof(T), requested,
-            $"{backend.BackendName} exposes no eligible GPU precision for {operation}.");
+            $"{backend.BackendName} exposes no eligible GPU precision for {operation}.", operation);
     }
 
     internal static IReadOnlyList<GpuPrecisionCapability> GetCapabilities(
@@ -405,7 +409,8 @@ public static class GpuPrecisionPlanner
         Type publicType,
         GpuComputePreference requested,
         GpuPrecisionCapability capability,
-        string? fallbackReason)
+        string? fallbackReason,
+        GpuPrecisionOperation operation)
         => new(
             GpuExecutionRoute.Gpu,
             backend.BackendName,
@@ -419,14 +424,15 @@ public static class GpuPrecisionPlanner
             capability.OutputStorage,
             capability.Implementation,
             capability.ReducesStorageBytes,
-            fallbackReason);
+            fallbackReason, operation);
 
     private static GpuComputePlan CpuPlan(
         IDirectGpuBackend backend,
         string operationName,
         Type publicType,
         GpuComputePreference requested,
-        string reason)
+        string reason,
+        GpuPrecisionOperation operation = GpuPrecisionOperation.General)
         => new(
             GpuExecutionRoute.Cpu,
             backend.BackendName,
@@ -440,7 +446,7 @@ public static class GpuPrecisionPlanner
             ScalarTypeFor(publicType),
             null,
             false,
-            reason);
+            reason, operation);
 
     private static GpuPrecisionCapability? Find(
         IReadOnlyList<GpuPrecisionCapability> capabilities,

--- a/src/AiDotNet.Tensors/Engines/Simd/AdamMomentKernels.cs
+++ b/src/AiDotNet.Tensors/Engines/Simd/AdamMomentKernels.cs
@@ -200,6 +200,69 @@ internal static class AdamMomentKernels
         }
     }
 
+    /// <summary>
+    /// FP32 Adam over a sorted unique sparse gradient. Only indexed coordinates are touched, matching
+    /// the native CUDA/HIP/OpenCL/Metal/Vulkan/WebGPU sparse-optimizer contract.
+    /// </summary>
+    internal static void AdamStepSparse(
+        Span<float> param, ReadOnlySpan<int> indices, ReadOnlySpan<float> values,
+        Span<float> m, Span<float> v,
+        float beta1, float beta2, float oneMinusBeta1, float oneMinusBeta2,
+        float bc1, float bc2, float lr, float eps)
+    {
+        AdamStepSparse(
+            param, indices, values, m, v, Span<float>.Empty,
+            beta1, beta2, oneMinusBeta1, oneMinusBeta2,
+            bc1, bc2, lr, eps, useAmsgrad: false);
+    }
+
+    /// <summary>
+    /// FP32 Adam/AMSGrad over a sorted unique sparse gradient. AMSGrad stores the raw running
+    /// second-moment maximum and applies bias correction in the denominator, matching every GPU
+    /// sparse backend.
+    /// </summary>
+    internal static void AdamStepSparse(
+        Span<float> param, ReadOnlySpan<int> indices, ReadOnlySpan<float> values,
+        Span<float> m, Span<float> v, Span<float> vMax,
+        float beta1, float beta2, float oneMinusBeta1, float oneMinusBeta2,
+        float bc1, float bc2, float lr, float eps, bool useAmsgrad)
+    {
+        ValidateSparseArguments(param.Length, indices, values.Length, m.Length, v.Length, vMax.Length, useAmsgrad);
+        for (int sparsePosition = 0; sparsePosition < indices.Length; sparsePosition++)
+        {
+            int i = indices[sparsePosition];
+            float g = values[sparsePosition];
+            float mNew;
+            float vNew;
+            if (FastMath)
+            {
+                mNew = FmaTail(oneMinusBeta1, g, beta1 * m[i]);
+                vNew = FmaTail(oneMinusBeta2 * g, g, beta2 * v[i]);
+            }
+            else
+            {
+                mNew = beta1 * m[i] + oneMinusBeta1 * g;
+                vNew = beta2 * v[i] + oneMinusBeta2 * g * g;
+            }
+            m[i] = mNew;
+            v[i] = vNew;
+            float mHat = mNew / bc1;
+            float vHatEff;
+            if (useAmsgrad)
+            {
+                float previous = vMax[i];
+                float maximum = vNew > previous ? vNew : previous;
+                vMax[i] = maximum;
+                vHatEff = maximum / bc2;
+            }
+            else
+            {
+                vHatEff = vNew / bc2;
+            }
+            param[i] -= lr * mHat / (SqrtF(vHatEff) + eps);
+        }
+    }
+
     /// <summary>fp64 Adam/AMSGrad step, in place over <paramref name="param"/>/<paramref name="m"/>/<paramref name="v"/> (and <paramref name="vMax"/> when <paramref name="useAmsgrad"/>).</summary>
     internal static unsafe void AdamStep(
         Span<double> param, ReadOnlySpan<double> grad, Span<double> m, Span<double> v, Span<double> vMax,
@@ -293,6 +356,89 @@ internal static class AdamMomentKernels
                 }
                 pParam[i] -= lr * mHat / (Math.Sqrt(vHatEff) + eps);
             }
+        }
+    }
+
+    /// <summary>FP64 counterpart to the sparse FP32 Adam kernel.</summary>
+    internal static void AdamStepSparse(
+        Span<double> param, ReadOnlySpan<int> indices, ReadOnlySpan<double> values,
+        Span<double> m, Span<double> v,
+        double beta1, double beta2, double oneMinusBeta1, double oneMinusBeta2,
+        double bc1, double bc2, double lr, double eps)
+    {
+        AdamStepSparse(
+            param, indices, values, m, v, Span<double>.Empty,
+            beta1, beta2, oneMinusBeta1, oneMinusBeta2,
+            bc1, bc2, lr, eps, useAmsgrad: false);
+    }
+
+    /// <summary>FP64 counterpart to the sparse FP32 Adam/AMSGrad kernel.</summary>
+    internal static void AdamStepSparse(
+        Span<double> param, ReadOnlySpan<int> indices, ReadOnlySpan<double> values,
+        Span<double> m, Span<double> v, Span<double> vMax,
+        double beta1, double beta2, double oneMinusBeta1, double oneMinusBeta2,
+        double bc1, double bc2, double lr, double eps, bool useAmsgrad)
+    {
+        ValidateSparseArguments(param.Length, indices, values.Length, m.Length, v.Length, vMax.Length, useAmsgrad);
+        for (int sparsePosition = 0; sparsePosition < indices.Length; sparsePosition++)
+        {
+            int i = indices[sparsePosition];
+            double g = values[sparsePosition];
+            double mNew;
+            double vNew;
+            if (FastMath)
+            {
+                mNew = FmaTail(oneMinusBeta1, g, beta1 * m[i]);
+                vNew = FmaTail(oneMinusBeta2 * g, g, beta2 * v[i]);
+            }
+            else
+            {
+                mNew = beta1 * m[i] + oneMinusBeta1 * g;
+                vNew = beta2 * v[i] + oneMinusBeta2 * g * g;
+            }
+            m[i] = mNew;
+            v[i] = vNew;
+            double mHat = mNew / bc1;
+            double vHatEff;
+            if (useAmsgrad)
+            {
+                double previous = vMax[i];
+                double maximum = vNew > previous ? vNew : previous;
+                vMax[i] = maximum;
+                vHatEff = maximum / bc2;
+            }
+            else
+            {
+                vHatEff = vNew / bc2;
+            }
+            param[i] -= lr * mHat / (Math.Sqrt(vHatEff) + eps);
+        }
+    }
+
+    private static void ValidateSparseArguments(
+        int parameterLength,
+        ReadOnlySpan<int> indices,
+        int valueCount,
+        int firstMomentLength,
+        int secondMomentLength,
+        int maximumMomentLength,
+        bool useAmsgrad)
+    {
+        if (indices.Length != valueCount)
+            throw new ArgumentException("Sparse Adam indices and values must have the same length.");
+        if (firstMomentLength != parameterLength || secondMomentLength != parameterLength)
+            throw new ArgumentException("Sparse Adam moments must match the parameter length.");
+        if (useAmsgrad && maximumMomentLength != parameterLength)
+            throw new ArgumentException("Sparse AMSGrad maximum moments must match the parameter length.");
+        int previous = -1;
+        for (int i = 0; i < indices.Length; i++)
+        {
+            int index = indices[i];
+            if (index <= previous || index < 0 || index >= parameterLength)
+                throw new ArgumentException(
+                    "Sparse Adam indices must be sorted, unique, and inside the parameter extent.",
+                    nameof(indices));
+            previous = index;
         }
     }
 }

--- a/src/AiDotNet.Tensors/Helpers/DeferredArrayMaterializer.cs
+++ b/src/AiDotNet.Tensors/Helpers/DeferredArrayMaterializer.cs
@@ -34,6 +34,8 @@ internal static class DeferredArrayMaterializer
     /// </summary>
     private static int _pendingCount;
 
+    internal static bool HasPendingMaterializations => Volatile.Read(ref _pendingCount) != 0;
+
     // Diagnostics: total deferred GPU→CPU downloads actually performed (each fired callback = one DtoH copy of a
     // resident tensor to host). A test resets this around a training step and asserts it stays ~0 to prove the
     // forward/backward kept every activation/gradient GPU-resident (no per-op host round-trip). Always-on counter

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorJournal.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorJournal.cs
@@ -87,6 +87,12 @@ internal enum StreamingTensorJournalLifecycle
     Disposed,
 }
 
+internal enum StreamingTensorJournalFileOperation
+{
+    Write,
+    ReleaseRange,
+}
+
 /// <summary>A lossless tensor journal with hard-bounded resident tensor payload.</summary>
 /// <remarks>
 /// The configured budget covers the reusable typed replay tensor and resident record payload.
@@ -118,6 +124,8 @@ public sealed class StreamingTensorJournal<T> : IDisposable
     private readonly string _backingFilePath;
     private readonly HashSet<StreamingTensorJournalRecord<T>> _liveRecords = new();
     private readonly List<FreeFileRange> _freeFileRanges = new();
+    // Per-instance, internal fault seam; production journals do not allocate a callback.
+    private readonly Action<StreamingTensorJournalFileOperation>? _beforeFileOperation;
 #if NETFRAMEWORK
     // FileStream on .NET Framework has no Span-based API. One reusable bounded adapter avoids the
     // previous byte-at-a-time virtual calls without allocating per record.
@@ -184,6 +192,15 @@ public sealed class StreamingTensorJournal<T> : IDisposable
         _backingFilePath = Path.Combine(_backingDirectory, "journal.bin");
     }
 
+    internal StreamingTensorJournal(
+        long maxResidentBytes,
+        string? backingStorePath,
+        Action<StreamingTensorJournalFileOperation> beforeFileOperation)
+        : this(maxResidentBytes, backingStorePath)
+    {
+        _beforeFileOperation = beforeFileOperation ?? throw new ArgumentNullException(nameof(beforeFileOperation));
+    }
+
     /// <summary>Number of live journal records.</summary>
     public int Count
     {
@@ -248,6 +265,9 @@ public sealed class StreamingTensorJournal<T> : IDisposable
                 throw new NotSupportedException(
                     "Streaming tensor journals require a contiguous tensor. Call Contiguous() explicitly first.");
 
+            if (tensor.Length > int.MaxValue / _elementSize)
+                throw new NotSupportedException(
+                    "A journal record cannot exceed Int32.MaxValue bytes. Chunk the tensor before appending.");
             ReadOnlySpan<byte> sourceBytes = GetReadOnlyBytes(tensor);
             // One tensor owns at most one storage extent. Segmenting by the resident budget made
             // metadata grow as O(tensorBytes / budget), which was unbounded and catastrophic for a
@@ -550,6 +570,7 @@ public sealed class StreamingTensorJournal<T> : IDisposable
 
     private void WriteFileRange(long fileOffset, ReadOnlySpan<byte> source)
     {
+        _beforeFileOperation?.Invoke(StreamingTensorJournalFileOperation.Write);
         FileStream stream = BackingFile();
         stream.Seek(fileOffset, SeekOrigin.Begin);
 #if NETFRAMEWORK
@@ -610,6 +631,7 @@ public sealed class StreamingTensorJournal<T> : IDisposable
     private void ReleaseFileRange(long offset, long length)
     {
         if (offset < 0 || length <= 0) return;
+        _beforeFileOperation?.Invoke(StreamingTensorJournalFileOperation.ReleaseRange);
         int insertion = 0;
         while (insertion < _freeFileRanges.Count && _freeFileRanges[insertion].Offset < offset)
             insertion++;
@@ -684,7 +706,7 @@ public sealed class StreamingTensorJournal<T> : IDisposable
             throw new ObjectDisposedException(nameof(StreamingTensorJournal<T>));
         if (_lifecycle == StreamingTensorJournalLifecycle.Poisoned)
             throw new InvalidOperationException(
-                "The streaming tensor journal is unavailable after a backing-store failure.");
+                "The streaming tensor journal is unavailable after an append cleanup failure.");
     }
 
     private void PoisonAndReleaseAllRecords()

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorJournal.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorJournal.cs
@@ -1,0 +1,768 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace AiDotNet.Tensors.LinearAlgebra;
+
+/// <summary>Opaque, element-type-safe handle for one losslessly journaled tensor.</summary>
+public sealed class StreamingTensorJournalRecord<T>
+{
+    private readonly int[] _shape;
+    private readonly IReadOnlyList<int> _publicShape;
+
+    internal StreamingTensorJournalRecord(long ownerId, JournalSegment[] segments, int[] shape, int elementCount)
+    {
+        OwnerId = ownerId;
+        Segments = segments;
+        _shape = shape;
+        _publicShape = Array.AsReadOnly(_shape);
+        ElementCount = elementCount;
+    }
+
+    internal long OwnerId { get; }
+    internal JournalSegment[] Segments { get; }
+    internal int[] ShapeInternal => _shape;
+
+    /// <summary>Shape captured when the tensor was appended.</summary>
+    public IReadOnlyList<int> Shape => _publicShape;
+
+    /// <summary>Number of tensor elements in this record.</summary>
+    public int ElementCount { get; }
+}
+
+/// <summary>Bounded tensor-payload and backing-store telemetry for a tensor journal.</summary>
+public sealed class StreamingTensorJournalReport
+{
+    /// <summary>
+    /// Configured hard cap for resident tensor payload plus the reusable typed replay tensor.
+    /// Runtime object metadata and framework-owned file buffers are intentionally excluded.
+    /// </summary>
+    public long MaxResidentBytes { get; init; }
+
+    /// <summary>Current resident tensor payload plus reusable typed replay-tensor bytes.</summary>
+    public long ResidentBytes { get; init; }
+
+    /// <summary>Maximum resident tensor-payload and typed replay-tensor bytes observed.</summary>
+    public long ResidentBytesPeak { get; init; }
+
+    /// <summary>Current allocated length of the reusable backing file.</summary>
+    public long BackingStoreBytes { get; init; }
+
+    /// <summary>Number of live tensor records.</summary>
+    public int LiveRecordCount { get; init; }
+
+    /// <summary>Total bytes written to the backing store.</summary>
+    public long DiskWriteBytes { get; init; }
+
+    /// <summary>Total bytes read from the backing store.</summary>
+    public long DiskReadBytes { get; init; }
+}
+
+/// <summary>
+/// Consumes one ephemeral, typed replay chunk. Only the first <paramref name="elementCount"/>
+/// values are part of the record. The callback is synchronous: all CPU and device work that reads
+/// the buffer must finish before it returns. The buffer is owned and reused by the journal and must
+/// not be retained after the callback returns.
+/// </summary>
+public delegate void StreamingTensorJournalChunkConsumer<T>(
+    int elementOffset,
+    Tensor<T> buffer,
+    int elementCount);
+
+internal sealed class JournalSegment
+{
+    public byte[]? ResidentData { get; set; }
+    public long FileOffset { get; set; } = -1;
+    public int ByteCount { get; set; }
+}
+
+internal enum StreamingTensorJournalLifecycle
+{
+    Active,
+    Poisoned,
+    Disposed,
+}
+
+/// <summary>A lossless tensor journal with hard-bounded resident tensor payload.</summary>
+/// <remarks>
+/// The configured budget covers the reusable typed replay tensor and resident record payload.
+/// It intentionally excludes fixed runtime overhead such as object metadata, collection capacity,
+/// and framework-owned file buffers; record metadata grows with the number of live records.
+/// Excess tensor payload is written to a private reusable backing file.
+/// Records are replayed from the exact native bytes that were appended. Removed file ranges are
+/// reused and trailing free ranges truncate the file, so repeated append/remove cycles do not
+/// grow disk usage without bound. All operations are serialized per journal.
+///
+/// <para>Float, double, and signed 64-bit integer tensors are supported. Inputs and restore destinations must be contiguous;
+/// contiguous offset views are supported, while non-contiguous and sparse layouts are rejected
+/// explicitly instead of allocating a hidden full-tensor copy.</para>
+/// </remarks>
+public sealed class StreamingTensorJournal<T> : IDisposable
+{
+    private const int DefaultIoBufferBytes = 1024 * 1024;
+    private const string BackingDirectoryPrefix = "aidotnet-tensor-journal-";
+    private static long _nextOwnerId;
+
+    private readonly object _gate = new();
+    private readonly long _ownerId = Interlocked.Increment(ref _nextOwnerId);
+    private readonly long _maxResidentBytes;
+    private readonly long _payloadResidentBudget;
+    private Tensor<T>? _replayBuffer;
+    private readonly int _elementSize;
+    private readonly int _replayBufferBytes;
+    private readonly string _backingDirectory;
+    private readonly string _backingFilePath;
+    private readonly HashSet<StreamingTensorJournalRecord<T>> _liveRecords = new();
+    private readonly List<FreeFileRange> _freeFileRanges = new();
+#if NETFRAMEWORK
+    // FileStream on .NET Framework has no Span-based API. One reusable bounded adapter avoids the
+    // previous byte-at-a-time virtual calls without allocating per record.
+    private readonly byte[] _frameworkIoBuffer;
+#endif
+
+    private FileStream? _backingFile;
+    private long _residentPayloadBytes;
+    private long _residentBytesPeak;
+    private long _backingLength;
+    private long _diskWriteBytes;
+    private long _diskReadBytes;
+    private int _replayInProgress;
+    private StreamingTensorJournalLifecycle _lifecycle = StreamingTensorJournalLifecycle.Active;
+
+    ~StreamingTensorJournal()
+    {
+        Dispose();
+    }
+
+    /// <summary>
+    /// Creates a journal whose resident tensor payload and typed replay tensor are hard-bounded.
+    /// </summary>
+    public StreamingTensorJournal(long maxResidentBytes, string? backingStorePath = null)
+    {
+        if (maxResidentBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxResidentBytes),
+                "The journal resident-byte budget must be positive.");
+        if (typeof(T) != typeof(float) && typeof(T) != typeof(double) && typeof(T) != typeof(long))
+            throw new NotSupportedException(
+                $"Streaming tensor journals support float, double, and Int64, not {typeof(T).Name}.");
+
+        _elementSize = typeof(T) == typeof(float) ? sizeof(float) : sizeof(long);
+        if (maxResidentBytes < _elementSize)
+            throw new ArgumentOutOfRangeException(nameof(maxResidentBytes),
+                $"The journal budget must hold at least one {typeof(T).Name} value ({_elementSize} bytes).");
+
+        _maxResidentBytes = maxResidentBytes;
+        // Reserve at most half the budget for replay so ordinary small records can still remain
+        // resident. A one-element budget necessarily dedicates that element to replay and spills
+        // records, which is the only way to preserve the hard journal-owned payload bound.
+        long replayBudget = maxResidentBytes >= 2L * _elementSize
+            ? maxResidentBytes / 2
+            : maxResidentBytes;
+        _replayBufferBytes = checked((int)Math.Min(DefaultIoBufferBytes, replayBudget));
+        _replayBufferBytes -= _replayBufferBytes % _elementSize;
+        if (_replayBufferBytes == 0) _replayBufferBytes = _elementSize;
+        _replayBuffer = new Tensor<T>(new[] { _replayBufferBytes / _elementSize });
+        _payloadResidentBudget = maxResidentBytes - _replayBufferBytes;
+        _residentBytesPeak = _replayBufferBytes;
+#if NETFRAMEWORK
+        // Span-based FileStream APIs are unavailable on net471. Keep one fixed-size adapter buffer
+        // independent of the tensor payload budget: tying it to a valid four-byte budget degraded a
+        // multi-megabyte spill into one managed FileStream call per float.
+        _frameworkIoBuffer = new byte[DefaultIoBufferBytes];
+#endif
+
+        string root = string.IsNullOrWhiteSpace(backingStorePath)
+            ? Path.GetTempPath()
+            : Path.GetFullPath(backingStorePath);
+        Directory.CreateDirectory(root);
+        _backingDirectory = Path.Combine(root, BackingDirectoryPrefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_backingDirectory);
+        _backingFilePath = Path.Combine(_backingDirectory, "journal.bin");
+    }
+
+    /// <summary>Number of live journal records.</summary>
+    public int Count
+    {
+        get
+        {
+            ThrowIfReplayInProgress();
+            lock (_gate)
+            {
+                ThrowIfReplayInProgress();
+                ThrowIfDisposed();
+                return _liveRecords.Count;
+            }
+        }
+    }
+
+    /// <summary>Current resident tensor payload plus reusable typed replay-tensor bytes.</summary>
+    public long ResidentBytes
+    {
+        get
+        {
+            ThrowIfReplayInProgress();
+            lock (_gate)
+            {
+                ThrowIfReplayInProgress();
+                ThrowIfDisposed();
+                return CurrentResidentBytes;
+            }
+        }
+    }
+
+    /// <summary>Returns resident-memory and backing-store telemetry.</summary>
+    public StreamingTensorJournalReport GetReport()
+    {
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            ThrowIfDisposed();
+            return new StreamingTensorJournalReport
+            {
+                MaxResidentBytes = _maxResidentBytes,
+                ResidentBytes = CurrentResidentBytes,
+                ResidentBytesPeak = _residentBytesPeak,
+                BackingStoreBytes = _backingLength,
+                LiveRecordCount = _liveRecords.Count,
+                DiskWriteBytes = _diskWriteBytes,
+                DiskReadBytes = _diskReadBytes,
+            };
+        }
+    }
+
+    /// <summary>Appends one contiguous tensor losslessly and returns an opaque typed handle.</summary>
+    public StreamingTensorJournalRecord<T> Append(Tensor<T> tensor)
+    {
+        if (tensor is null) throw new ArgumentNullException(nameof(tensor));
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            ThrowIfDisposed();
+            if (!tensor.IsContiguous)
+                throw new NotSupportedException(
+                    "Streaming tensor journals require a contiguous tensor. Call Contiguous() explicitly first.");
+
+            ReadOnlySpan<byte> sourceBytes = GetReadOnlyBytes(tensor);
+            // One tensor owns at most one storage extent. Segmenting by the resident budget made
+            // metadata grow as O(tensorBytes / budget), which was unbounded and catastrophic for a
+            // four-byte budget. Chunking belongs to replay, where one reusable bounded buffer is
+            // sufficient; storage itself is one resident payload or one contiguous file range.
+            int segmentCount = sourceBytes.Length == 0 ? 0 : 1;
+            var segments = new JournalSegment[segmentCount];
+            int completedSegments = 0;
+            try
+            {
+                if (segmentCount != 0)
+                {
+                    var segment = new JournalSegment { ByteCount = sourceBytes.Length };
+                    segments[0] = segment;
+
+                    if (_residentPayloadBytes + sourceBytes.Length <= _payloadResidentBudget)
+                    {
+                        byte[] resident = new byte[sourceBytes.Length];
+                        sourceBytes.CopyTo(resident);
+                        segment.ResidentData = resident;
+                        _residentPayloadBytes += sourceBytes.Length;
+                        UpdateResidentPeak();
+                    }
+                    else
+                    {
+                        long fileOffset = AllocateFileRange(sourceBytes.Length);
+                        try
+                        {
+                            WriteFileRange(fileOffset, sourceBytes);
+                            segment.FileOffset = fileOffset;
+                        }
+                        catch
+                        {
+                            try
+                            {
+                                ReleaseFileRange(fileOffset, sourceBytes.Length);
+                            }
+                            catch
+                            {
+                                PoisonAndReleaseAllRecords();
+                            }
+                            throw;
+                        }
+                    }
+                    completedSegments = 1;
+                }
+
+                var record = new StreamingTensorJournalRecord<T>(
+                    _ownerId,
+                    segments,
+                    (int[])tensor._shape.Clone(),
+                    tensor.Length);
+                _liveRecords.Add(record);
+                return record;
+            }
+            catch
+            {
+                try
+                {
+                    for (int i = 0; i < completedSegments; i++) ReleaseSegment(segments[i]);
+                }
+                catch
+                {
+                    PoisonAndReleaseAllRecords();
+                }
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replays a record through one reusable resident buffer without materializing the complete
+    /// tensor. The callback is synchronous: all work consuming a chunk, including queued device
+    /// work, must complete before the callback returns. Reentrant or concurrent journal operations
+    /// are rejected until replay completes, and the supplied buffer must not be retained.
+    /// </summary>
+    public void Replay(
+        StreamingTensorJournalRecord<T> record,
+        StreamingTensorJournalChunkConsumer<T> consume)
+    {
+        if (consume is null) throw new ArgumentNullException(nameof(consume));
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            Validate(record);
+            if (Interlocked.CompareExchange(ref _replayInProgress, 1, 0) != 0)
+                throw new InvalidOperationException("A tensor-journal replay is already in progress.");
+        }
+
+        try
+        {
+            Tensor<T> replayBuffer = _replayBuffer
+                ?? throw new InvalidOperationException("The replay buffer is unavailable.");
+            int capacity = replayBuffer.Length;
+            int elementOffset = 0;
+            while (elementOffset < record.ElementCount)
+            {
+                int elementCount = Math.Min(capacity, record.ElementCount - elementOffset);
+                int byteCount = checked(elementCount * _elementSize);
+                ReadRecordRangeInto(
+                    record,
+                    checked(elementOffset * _elementSize),
+                    GetWritableBytes(replayBuffer).Slice(0, byteCount));
+                replayBuffer.IncrementVersion();
+                consume(elementOffset, replayBuffer, elementCount);
+                elementOffset += elementCount;
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _replayInProgress, 0);
+        }
+    }
+
+    /// <summary>
+    /// Materializes a fresh tensor containing the exact journaled values. This convenience API
+    /// allocates memory proportional to the complete record and is not a bounded replay operation.
+    /// </summary>
+    public Tensor<T> Read(StreamingTensorJournalRecord<T> record)
+    {
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            Validate(record);
+            var tensor = new Tensor<T>((int[])record.ShapeInternal.Clone());
+            ReadRecordInto(record, tensor);
+            tensor.IncrementVersion();
+            return tensor;
+        }
+    }
+
+    /// <summary>
+    /// Atomically restores the journaled value into an existing same-shaped contiguous tensor.
+    /// The destination is not mutated unless the complete record has first been read successfully.
+    /// Atomic destination replacement requires a complete O(record-size) staging tensor; callers
+    /// that need bounded consumption should use <see cref="Replay"/> instead.
+    /// </summary>
+    public void Restore(StreamingTensorJournalRecord<T> record, Tensor<T> destination)
+    {
+        if (destination is null) throw new ArgumentNullException(nameof(destination));
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            Validate(record);
+            ValidateDestination(record, destination);
+            var staging = new Tensor<T>((int[])record.ShapeInternal.Clone());
+            ReadRecordInto(record, staging);
+            staging.ReadOnlyData.Span.CopyTo(destination.Data.Span);
+            destination.IncrementVersion();
+        }
+    }
+
+    /// <summary>Removes a record and immediately makes its resident and disk ranges reusable.</summary>
+    public void Remove(StreamingTensorJournalRecord<T> record)
+    {
+        ThrowIfReplayInProgress();
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            Validate(record);
+            for (int i = 0; i < record.Segments.Length; i++) ReleaseSegment(record.Segments[i]);
+            _liveRecords.Remove(record);
+        }
+    }
+
+    private static ReadOnlySpan<byte> GetReadOnlyBytes(Tensor<T> tensor)
+    {
+        if (typeof(T) == typeof(float))
+        {
+            var typed = (Tensor<float>)(object)tensor;
+            return MemoryMarshal.AsBytes(typed.ReadOnlyData.Span);
+        }
+
+        if (typeof(T) == typeof(double))
+        {
+            var doubleTensor = (Tensor<double>)(object)tensor;
+            return MemoryMarshal.AsBytes(doubleTensor.ReadOnlyData.Span);
+        }
+
+        var longTensor = (Tensor<long>)(object)tensor;
+        return MemoryMarshal.AsBytes(longTensor.ReadOnlyData.Span);
+    }
+
+    private void ReadRecordInto(StreamingTensorJournalRecord<T> record, Tensor<T> destination)
+    {
+        ReadRecordRangeInto(record, 0, GetWritableBytes(destination));
+    }
+
+    private void ReadRecordRangeInto(
+        StreamingTensorJournalRecord<T> record,
+        int sourceByteOffset,
+        Span<byte> destination)
+    {
+        if (destination.Length == 0) return;
+        int remainingOffset = sourceByteOffset;
+        int destinationOffset = 0;
+        for (int i = 0; i < record.Segments.Length && destinationOffset < destination.Length; i++)
+        {
+            JournalSegment segment = record.Segments[i];
+            if (remainingOffset >= segment.ByteCount)
+            {
+                remainingOffset -= segment.ByteCount;
+                continue;
+            }
+
+            int count = Math.Min(segment.ByteCount - remainingOffset, destination.Length - destinationOffset);
+            Span<byte> target = destination.Slice(destinationOffset, count);
+            if (segment.ResidentData is not null)
+            {
+                segment.ResidentData.AsSpan(remainingOffset, count).CopyTo(target);
+            }
+            else
+            {
+                ReadFileRange(segment.FileOffset + remainingOffset, target);
+            }
+            destinationOffset += count;
+            remainingOffset = 0;
+        }
+
+        if (destinationOffset != destination.Length)
+            throw new InvalidOperationException("Streaming tensor journal record ended before the requested range.");
+    }
+
+    private static Span<byte> GetWritableBytes(Tensor<T> tensor)
+    {
+        if (typeof(T) == typeof(float))
+            return MemoryMarshal.AsBytes(((Tensor<float>)(object)tensor).Data.Span);
+
+        if (typeof(T) == typeof(double))
+            return MemoryMarshal.AsBytes(((Tensor<double>)(object)tensor).Data.Span);
+
+        return MemoryMarshal.AsBytes(((Tensor<long>)(object)tensor).Data.Span);
+    }
+
+    private static void ValidateDestination(
+        StreamingTensorJournalRecord<T> record,
+        Tensor<T> destination)
+    {
+        if (!destination.IsContiguous)
+            throw new NotSupportedException(
+                "Streaming tensor journal restore requires a contiguous destination.");
+        if (destination.Length != record.ElementCount)
+            throw new ArgumentException(
+                $"Destination length {destination.Length} does not match journal record length " +
+                $"{record.ElementCount}.", nameof(destination));
+        if (destination.Rank != record.ShapeInternal.Length)
+            throw new ArgumentException("Destination rank does not match the journal record.", nameof(destination));
+        for (int i = 0; i < destination.Rank; i++)
+        {
+            if (destination._shape[i] != record.ShapeInternal[i])
+                throw new ArgumentException("Destination shape does not match the journal record.", nameof(destination));
+        }
+    }
+
+    private void Validate(StreamingTensorJournalRecord<T> record)
+    {
+        ThrowIfDisposed();
+        if (record is null) throw new ArgumentNullException(nameof(record));
+        if (record.OwnerId != _ownerId)
+            throw new ArgumentException("The record belongs to a different tensor journal.", nameof(record));
+        if (!_liveRecords.Contains(record))
+            throw new InvalidOperationException("The tensor journal record has already been removed.");
+    }
+
+    private FileStream BackingFile() => _backingFile ??= new FileStream(
+        _backingFilePath,
+        FileMode.OpenOrCreate,
+        FileAccess.ReadWrite,
+        FileShare.Read,
+        4096,
+        FileOptions.DeleteOnClose);
+
+    private long AllocateFileRange(int byteCount)
+    {
+        for (int i = 0; i < _freeFileRanges.Count; i++)
+        {
+            FreeFileRange range = _freeFileRanges[i];
+            if (range.Length < byteCount) continue;
+            long offset = range.Offset;
+            if (range.Length == byteCount)
+            {
+                _freeFileRanges.RemoveAt(i);
+            }
+            else
+            {
+                _freeFileRanges[i] = new FreeFileRange(
+                    range.Offset + byteCount,
+                    range.Length - byteCount);
+            }
+            return offset;
+        }
+
+        long appendedOffset = _backingLength;
+        _backingLength = checked(_backingLength + byteCount);
+        return appendedOffset;
+    }
+
+    private void WriteFileRange(long fileOffset, ReadOnlySpan<byte> source)
+    {
+        FileStream stream = BackingFile();
+        stream.Seek(fileOffset, SeekOrigin.Begin);
+#if NETFRAMEWORK
+        int written = 0;
+        while (written < source.Length)
+        {
+            int count = Math.Min(_frameworkIoBuffer.Length, source.Length - written);
+            source.Slice(written, count).CopyTo(_frameworkIoBuffer);
+            stream.Write(_frameworkIoBuffer, 0, count);
+            written += count;
+        }
+#else
+        stream.Write(source);
+#endif
+        _diskWriteBytes += source.Length;
+    }
+
+    private void ReadFileRange(long fileOffset, Span<byte> destination)
+    {
+        FileStream stream = BackingFile();
+        stream.Seek(fileOffset, SeekOrigin.Begin);
+        int read = 0;
+        while (read < destination.Length)
+        {
+#if NETFRAMEWORK
+            int requested = Math.Min(_frameworkIoBuffer.Length, destination.Length - read);
+            int count = stream.Read(_frameworkIoBuffer, 0, requested);
+            if (count <= 0)
+                throw new InvalidOperationException(
+                    $"Streaming tensor journal encountered a short read at offset {fileOffset + read}.");
+            _frameworkIoBuffer.AsSpan(0, count).CopyTo(destination.Slice(read, count));
+            read += count;
+#else
+            int count = stream.Read(destination.Slice(read));
+            if (count <= 0)
+                throw new InvalidOperationException(
+                    $"Streaming tensor journal encountered a short read at offset {fileOffset + read}.");
+            read += count;
+#endif
+        }
+        _diskReadBytes += destination.Length;
+    }
+
+    private void ReleaseSegment(JournalSegment segment)
+    {
+        if (segment.ResidentData is not null)
+        {
+            _residentPayloadBytes -= segment.ResidentData.Length;
+            segment.ResidentData = null;
+        }
+        else if (segment.FileOffset >= 0)
+        {
+            ReleaseFileRange(segment.FileOffset, segment.ByteCount);
+            segment.FileOffset = -1;
+        }
+    }
+
+    private void ReleaseFileRange(long offset, long length)
+    {
+        if (offset < 0 || length <= 0) return;
+        int insertion = 0;
+        while (insertion < _freeFileRanges.Count && _freeFileRanges[insertion].Offset < offset)
+            insertion++;
+        _freeFileRanges.Insert(insertion, new FreeFileRange(offset, length));
+
+        for (int i = Math.Max(0, insertion - 1); i + 1 < _freeFileRanges.Count;)
+        {
+            FreeFileRange current = _freeFileRanges[i];
+            FreeFileRange next = _freeFileRanges[i + 1];
+            if (current.Offset + current.Length < next.Offset)
+            {
+                i++;
+                continue;
+            }
+            long end = Math.Max(current.Offset + current.Length, next.Offset + next.Length);
+            _freeFileRanges[i] = new FreeFileRange(current.Offset, end - current.Offset);
+            _freeFileRanges.RemoveAt(i + 1);
+        }
+
+        long truncatedLength = _backingLength;
+        int firstTrimmedRange = _freeFileRanges.Count;
+        for (int i = _freeFileRanges.Count - 1; i >= 0; i--)
+        {
+            FreeFileRange range = _freeFileRanges[i];
+            if (range.Offset + range.Length != truncatedLength) break;
+            truncatedLength = range.Offset;
+            firstTrimmedRange = i;
+        }
+
+        if (truncatedLength == _backingLength) return;
+        if (_backingFile is not null && _backingFile.Length != truncatedLength)
+        {
+            try
+            {
+                _backingFile.SetLength(truncatedLength);
+            }
+            catch
+            {
+                // The free range remains reusable even when the operating system cannot physically
+                // truncate the file. Do not publish a shorter logical length or corrupt a live record.
+                return;
+            }
+        }
+
+        _backingLength = truncatedLength;
+        if (firstTrimmedRange < _freeFileRanges.Count)
+            _freeFileRanges.RemoveRange(
+                firstTrimmedRange,
+                _freeFileRanges.Count - firstTrimmedRange);
+    }
+
+    private long CurrentResidentBytes => checked(_replayBufferBytes + _residentPayloadBytes);
+
+    private void UpdateResidentPeak()
+    {
+        long current = CurrentResidentBytes;
+        if (current > _maxResidentBytes)
+            throw new InvalidOperationException("Streaming tensor journal exceeded its resident-byte budget.");
+        if (current > _residentBytesPeak) _residentBytesPeak = current;
+    }
+
+    private void ThrowIfReplayInProgress()
+    {
+        if (Volatile.Read(ref _replayInProgress) != 0)
+            throw new InvalidOperationException(
+                "Tensor-journal operations are not allowed while a replay callback is active.");
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_lifecycle == StreamingTensorJournalLifecycle.Disposed)
+            throw new ObjectDisposedException(nameof(StreamingTensorJournal<T>));
+        if (_lifecycle == StreamingTensorJournalLifecycle.Poisoned)
+            throw new InvalidOperationException(
+                "The streaming tensor journal is unavailable after a backing-store failure.");
+    }
+
+    private void PoisonAndReleaseAllRecords()
+    {
+        _lifecycle = StreamingTensorJournalLifecycle.Poisoned;
+        foreach (StreamingTensorJournalRecord<T> record in _liveRecords)
+        {
+            for (int i = 0; i < record.Segments.Length; i++)
+            {
+                record.Segments[i].ResidentData = null;
+                record.Segments[i].FileOffset = -1;
+            }
+        }
+        _liveRecords.Clear();
+        _freeFileRanges.Clear();
+        _residentPayloadBytes = 0;
+        _replayBuffer = null;
+        try { _backingFile?.Dispose(); } catch { }
+        _backingFile = null;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        ThrowIfReplayInProgress();
+        bool directoryRemoved;
+        lock (_gate)
+        {
+            ThrowIfReplayInProgress();
+            if (_lifecycle != StreamingTensorJournalLifecycle.Disposed)
+            {
+                foreach (StreamingTensorJournalRecord<T> record in _liveRecords)
+                {
+                    for (int i = 0; i < record.Segments.Length; i++)
+                    {
+                        record.Segments[i].ResidentData = null;
+                        record.Segments[i].FileOffset = -1;
+                    }
+                }
+                _lifecycle = StreamingTensorJournalLifecycle.Disposed;
+                _liveRecords.Clear();
+                _freeFileRanges.Clear();
+                _residentPayloadBytes = 0;
+                _replayBuffer = null;
+                try { _backingFile?.Dispose(); } catch { }
+                _backingFile = null;
+            }
+        }
+        directoryRemoved = TryRemoveBackingDirectory();
+        // If the OS temporarily refuses directory deletion, leave the finalizer registered so it
+        // can make one later best-effort retry after this instance becomes unreachable.
+        if (directoryRemoved) GC.SuppressFinalize(this);
+    }
+
+    private bool TryRemoveBackingDirectory()
+    {
+        try
+        {
+            if (Directory.Exists(_backingDirectory))
+                Directory.Delete(_backingDirectory, recursive: true);
+            return !Directory.Exists(_backingDirectory);
+        }
+        catch
+        {
+            // DeleteOnClose removes the data file even when a best-effort directory cleanup fails.
+            return false;
+        }
+    }
+
+    private readonly struct FreeFileRange
+    {
+        public FreeFileRange(long offset, long length)
+        {
+            Offset = offset;
+            Length = length;
+        }
+
+        public long Offset { get; }
+        public long Length { get; }
+    }
+}

--- a/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/StreamingTensorPool.cs
@@ -234,27 +234,59 @@ public sealed class StreamingTensorPool : IDisposable
     /// handle the caller stores on its <see cref="Tensor{T}"/> and uses for
     /// access through <see cref="MarkAccessed"/> / <see cref="Rehydrate{T}"/>.</summary>
     public long Register(byte[] data)
+        => RegisterReserved(data, 0);
+
+    // Transfer a lazy allocation's reservation atomically with registration. The tensor keeps
+    // ownership of its reservation until the registry publishes the returned handle.
+    internal long RegisterReserved(byte[] data, long reservedBytes)
     {
         if (data is null) throw new ArgumentNullException(nameof(data));
         lock (_lock)
         {
             ThrowIfDisposed();
+            if (reservedBytes < 0 || reservedBytes > _reservedBytes)
+                throw new ArgumentOutOfRangeException(nameof(reservedBytes));
+
             long id = _nextHandleId++;
             var entry = new Entry { Data = data, ResidentBytes = data.Length };
-            _entries[id] = entry;
-            var node = _lruOrder.AddFirst(id);
-            _lruIndex[id] = node;
-            // Use Interlocked for the long write so 32-bit hosts (net471
-            // x86) don't see torn reads from concurrent ResidentBytes
-            // accesses. Reads use Interlocked.Read for the same reason.
-            // Inside _lock, atomicity is already guaranteed for
-            // serialization, but the property accessor is lock-free.
-            Interlocked.Add(ref _residentBytes, data.Length);
-            long peak = Interlocked.Read(ref _residentBytesPeak);
-            long current = Interlocked.Read(ref _residentBytes);
-            if (current > peak) Interlocked.Exchange(ref _residentBytesPeak, current);
-            EvictIfOverBudget();
-            return id;
+            LinkedListNode<long>? node = null;
+            bool entryAdded = false;
+            bool residentBytesAdded = false;
+            bool reservationTransferred = false;
+            try
+            {
+                // Each bookkeeping operation can allocate. Track every successful mutation so an
+                // allocation or eviction failure cannot leave an unreachable entry or LRU node.
+                _entries.Add(id, entry);
+                entryAdded = true;
+                long current = Interlocked.Add(ref _residentBytes, data.Length);
+                residentBytesAdded = true;
+                node = _lruOrder.AddFirst(id);
+                _lruIndex.Add(id, node);
+                _reservedBytes -= reservedBytes;
+                reservationTransferred = true;
+
+                EvictIfOverBudget();
+
+                long peak = Interlocked.Read(ref _residentBytesPeak);
+                if (current > peak) Interlocked.Exchange(ref _residentBytesPeak, current);
+                return id;
+            }
+            catch
+            {
+                _prefetchPending.Remove(id);
+                _pendingOwnerDrops.Remove(id);
+                _lruIndex.Remove(id);
+                if (node is not null && node.List is not null)
+                    _lruOrder.Remove(node);
+                if (entryAdded)
+                    _entries.Remove(id);
+                if (residentBytesAdded)
+                    Interlocked.Add(ref _residentBytes, -entry.ResidentBytes);
+                if (reservationTransferred)
+                    _reservedBytes += reservedBytes;
+                throw;
+            }
         }
     }
 
@@ -587,10 +619,20 @@ public sealed class StreamingTensorPool : IDisposable
             // by live entries even when callers register/unregister at
             // high churn.
             _prefetchPending.Remove(handleId);
+            _pendingOwnerDrops.Remove(handleId);
             // The entry's slice of the contiguous backing file is left in place
             // (reclaimed when the whole file is deleted at Dispose). Weight handles
             // are register-once for a model, so per-unregister compaction would be
             // churn for no benefit; the file is bounded by total bytes paged out.
+        }
+    }
+
+    internal void UnregisterAndRestoreReservation(long handleId, long reservedBytes)
+    {
+        lock (_lock)
+        {
+            Unregister(handleId);
+            _reservedBytes += reservedBytes;
         }
     }
 

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -202,7 +202,10 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         view._gpuDeviceIndex = _gpuDeviceIndex;
         view._gpuBuffer = _gpuBuffer;
         view._gpuBackend = _gpuBackend;
-        view._gpuBufferVersion = view.Version;
+        // A metadata-only view borrows the same snapshot; it does not upload current host data.
+        // Preserve a stale source stamp so a view created after a host mutation cannot certify
+        // the old GPU buffer as current merely by adopting the storage's latest epoch.
+        view._gpuBufferVersion = _gpuBufferVersion;
         view._gpuBufferIsSplitComplex = _gpuBufferIsSplitComplex;
         view._gpuBufferContainsRawInt32 = _gpuBufferContainsRawInt32;
         view._gpuRole = _gpuRole;
@@ -3359,7 +3362,7 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         var tensor = new Tensor<T>(shape, backend.DeviceType);
         tensor._gpuBuffer = buffer;
         tensor._gpuBackend = backend;
-        tensor._gpuBufferVersion = tensor.Version;
+        tensor._gpuBufferVersion = tensor.GpuCacheVersion;
         tensor._gpuRole = role;
         tensor._gpuBufferContainsRawInt32 = bufferContainsRawInt32;
         if (ownsBuffer)
@@ -4795,14 +4798,14 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
         _gpuBackend = backend;
         // Tag the freshly-uploaded buffer with the CURRENT tensor version. The buffer was just filled from this
         // tensor's host data, so it IS in sync — but every version-gated resident-buffer consumer
-        // (GetOrAllocateBuffer / GetWeightBufferPreferResident: `_gpuBufferVersion == Version`) leaves
+        // (GetOrAllocateBuffer / GetWeightBufferPreferResident: `_gpuBufferVersion == GpuCacheVersion`) leaves
         // _gpuBufferVersion at its -1 sentinel and so immediately judges the buffer STALE, detaching it and
         // re-uploading a frozen host snapshot on the very next read. For a GPU-resident PARAMETER that is
         // catastrophic: the compiled forward then reads the frozen re-upload while the on-device fused optimizer
         // updates the (now orphaned) resident buffer in place → the model trains against frozen weights → the loss
         // goes completely flat (7.70→7.70 vs 7.70→1.31 non-resident on the same graph). This is the default GPU
         // path for the TimeSeries family (AIDOTNET_GPU_RESIDENT_PARAMS != 0), so it silently mistrained on GPU.
-        _gpuBufferVersion = Version;
+        _gpuBufferVersion = GpuCacheVersion;
         _device = backend.BackendName?.ToUpperInvariant() switch
         {
             "CUDA" or "NVIDIA" => TensorDevice.CUDA,

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorBase.cs
@@ -238,6 +238,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         var old = _storage;
         _data = fresh;
         _storage = new TensorStorage<T>(_data);
+        InvalidateGpuBindingAfterStorageReplacement();
         old.Release();
     }
 
@@ -310,6 +311,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         var old = _storage;
         _data = fresh;
         _storage = new TensorStorage<T>(_data);
+        InvalidateGpuBindingAfterStorageReplacement();
         old.Release();
     }
 
@@ -388,6 +390,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         var newStorage = new TensorStorage<T>(_data);
         newStorage.AttachMmapOwner(owner, writable); // attach BEFORE making the storage visible to anyone else
         _storage = newStorage;
+        InvalidateGpuBindingAfterStorageReplacement();
         oldStorage.Release();
     }
 
@@ -518,6 +521,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
             // changing either refcount here would steal or manufacture a tensor-owner reference.
             _storage = source._storage;
             _data = source._data;
+            InvalidateGpuBindingAfterStorageReplacement();
             return;
         }
 
@@ -530,6 +534,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         var oldStorage = _storage;
         _storage = source._storage;
         _data = source._data;
+        InvalidateGpuBindingAfterStorageReplacement();
         oldStorage.Release();
     }
 
@@ -582,7 +587,8 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
     /// <c>false</c> on shared refcount.</param>
     /// <returns><c>true</c> when the drop succeeded (refcount 1 → 0, storage
     /// replaced with empty); <c>false</c> when refcount &gt; 1 and the caller
-    /// opted for the soft path.</returns>
+    /// opted for the soft path, or when the soft path cannot allocate its empty replacement.
+    /// A failed soft drop leaves the original storage untouched for a later retry.</returns>
     internal bool TryDropStorageForStreaming(bool throwOnSharedRefcount = false)
     {
         if (!IsContiguous || _storageOffset != 0 || IsView)
@@ -600,8 +606,25 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         // TryClaimExclusive closes that window — it succeeds only when
         // refcount was exactly 1 at the moment of the claim, and after
         // success any concurrent AddRef throws ObjectDisposedException.
-        if (!_storage.TryClaimExclusive())
+        Vector<T> replacementData;
+        TensorStorage<T> replacementStorage;
+        try
         {
+            replacementData = Vector<T>.Empty();
+            replacementStorage = new TensorStorage<T>(replacementData);
+        }
+        catch (OutOfMemoryException) when (!throwOnSharedRefcount)
+        {
+            // A deferred drop is post-commit reclamation. If even the empty replacement cannot
+            // be allocated, leave the original storage and its ownership untouched and retry on
+            // the next opportunity; an already committed registration must not report failure.
+            return false;
+        }
+        var claimedStorage = _storage;
+        replacementStorage.CopyGpuCacheTrackingFrom(claimedStorage);
+        if (!claimedStorage.TryClaimExclusive())
+        {
+            replacementStorage.Release();
             if (throwOnSharedRefcount)
                 throw new InvalidOperationException(
                     $"Streaming drop requires sole storage ownership; storage refcount is {_storage.RefCount}. " +
@@ -618,12 +641,17 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         // is already 0, Release would underflow.
         // If this tensor was aliasing a zero-copy mmap slice, the mapping is no
         // longer referenced once storage is dropped — release it now.
-        DisposeStreamingMmapOwner();
         // Drop any no-upcast quantized weight too — the pool holds the canonical bytes.
         StreamingInt8 = null;
         StreamingInt4 = null;
-        _data = Vector<T>.Empty();
-        _storage = new TensorStorage<T>(_data);
+        _data = replacementData;
+        _storage = replacementStorage;
+        InvalidateGpuBindingAfterStorageReplacement();
+        // Reclamation must not turn a successful storage swap into a failed transaction.
+        try { claimedStorage.DisposeClaimedOwners(); }
+        catch (Exception error) { System.Diagnostics.Trace.TraceWarning("Streaming storage cleanup failed: {0}", error); }
+        try { DisposeStreamingMmapOwner(); }
+        catch (Exception error) { System.Diagnostics.Trace.TraceWarning("Streaming mapping cleanup failed: {0}", error); }
         return true;
     }
 
@@ -831,6 +859,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         var oldStorage = _storage;
         _data = fresh;
         _storage = new TensorStorage<T>(_data);
+        InvalidateGpuBindingAfterStorageReplacement();
         oldStorage.Release();
     }
 
@@ -1209,6 +1238,16 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
     /// </summary>
     public int Version => _version;
 
+    /// <summary>Storage-shared cache freshness, including writes made in inference mode.</summary>
+    internal int GpuCacheVersion => _storage.GpuCacheVersion;
+
+    private void InvalidateGpuBindingAfterStorageReplacement()
+    {
+        _gpuBuffer = null;
+        _gpuBackend = null;
+        _gpuBufferVersion = -1;
+    }
+
     /// <summary>
     /// Increments the version counter. Called by in-place operations to signal mutation.
     /// </summary>
@@ -1224,6 +1263,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
     /// </remarks>
     internal void IncrementVersion()
     {
+        _storage.IncrementGpuCacheVersionIfTracked();
         if (Engines.Autodiff.InferenceModeFlag.IsActive)
         {
             // Inference mode: in-place mutation is legal and the
@@ -1387,6 +1427,12 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
     /// path — element-size × Length is unsafe when T is a managed type
     /// without a stable Marshal.SizeOf.</summary>
     public long OffloadByteCount { get; internal set; }
+
+    /// <summary>
+    /// Registry-owned identity for the allocator/handle pair that created this tensor's offload
+    /// allocation. The registry, rather than the current process-wide allocator, owns the free path.
+    /// </summary>
+    internal long OffloadRegistryHandle { get; set; } = -1;
 
     /// <summary>
     /// Whether this tensor is a view into another tensor's storage.
@@ -1745,7 +1791,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         Length = expectedSize;
         if (_data.Length != expectedSize)
             throw new ArgumentException("The number of values does not match the specified shape.");
-        _storage = new TensorStorage<T>(_data);
+        _storage = new TensorStorage<T>(_data, shareExternalGpuCacheEpoch: data is T[]);
     }
 
     /// <summary>
@@ -1766,7 +1812,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         Length = expectedSize;
         if (_data.Length != expectedSize)
             throw new ArgumentException("The number of values does not match the specified shape.");
-        _storage = new TensorStorage<T>(_data);
+        _storage = new TensorStorage<T>(_data, shareExternalGpuCacheEpoch: true);
     }
 
     /// <summary>
@@ -1824,7 +1870,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         // if called on sparse tensors — use SparseTensor-specific APIs instead.
         Length = ComputeProduct(logicalShape);
         _data = values;
-        _storage = new TensorStorage<T>(_data);
+        _storage = new TensorStorage<T>(_data, shareExternalGpuCacheEpoch: true);
     }
 
     /// <summary>
@@ -1891,7 +1937,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         }
         else
         {
-            _storage = new TensorStorage<T>(_data);
+            _storage = new TensorStorage<T>(_data, shareExternalGpuCacheEpoch: true);
         }
 
         Length = totalElements;
@@ -2214,7 +2260,8 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
     }
 
     /// <summary>
-    /// Gets the underlying array. For views, returns a fresh contiguous copy.
+    /// Gets the underlying array for a full contiguous CPU layout, including a full-storage view.
+    /// Offset/strided views and GPU-resident tensors return a fresh contiguous copy.
     /// NOTE: intentionally does NOT call EnsureMaterialized on the simple-
     /// layout path. Callers that pin this array for use at plan-replay time
     /// (specialization compile) must NOT force Realize at compile time —
@@ -2241,7 +2288,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
         // specializations pinned the placeholder's zero-initialized state
         // and never saw the user's Execute-time input.
         //
-        // Lazy or GPU-resident tensors still go through ToArray() so the
+        // GPU-resident or non-full layouts still go through ToArray() so the
         // realized CPU snapshot is what the caller sees. That path
         // preserves the BERT-SQuAD × 100 fix: a lazy tensor whose
         // upstream hasn't run yet would have had its placeholder-filled
@@ -2267,21 +2314,19 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
 
     /// <summary>
     /// COW Stage 2 (issue #624): a READ-ONLY view of the live backing array that does
-    /// <b>not</b> privatize a copy-on-write clone. Identical data semantics to
-    /// <see cref="GetDataArray"/> (same live backing array for the simple CPU layout, a
-    /// realized <see cref="ToArray"/> snapshot for lazy/GPU/view layouts) minus the
-    /// <see cref="EnsureOwnedForWrite"/> privatization. The caller contract is
+    /// <b>not</b> privatize a copy-on-write clone. A full contiguous CPU view can also
+    /// return its shared backing array: reading it neither transfers ownership nor
+    /// grants a retained writable pin. Offset, strided, lazy, and GPU layouts return
+    /// a realized <see cref="ToArray"/> snapshot. The caller contract is
     /// <b>read-only</b>: engine ops use this for INPUT operands they only read (matmul
     /// operands, conv filters, norm gamma/beta, broadcast bias). Routing a genuine
     /// in-place write through this would corrupt a COW peer — those must keep using
-    /// <see cref="GetDataArray"/>/<see cref="AsWritableSpan"/>. For every non-COW tensor
-    /// (the overwhelming default) this is byte-for-byte identical to
-    /// <see cref="GetDataArray"/> at the same cost, so converting a read site is risk-free;
-    /// the benefit is that inference on a cloned model never privatizes its shared weights.
+    /// <see cref="AsWritableSpan"/> or the COW-aware <see cref="GetDataArray"/>.
+    /// Full-view reads remain zero-copy and cloned-model reads retain shared storage.
     /// </summary>
     internal T[] GetReadOnlyDataArray()
     {
-        var live = GetLiveBackingArrayOrNull();
+        var live = LazySource is null ? GetLiveBackingArrayOrNull() : null;
         if (live is not null)
         {
             // Same pending-GPU-download trigger as GetDataArray above — a read-only accessor still
@@ -2930,6 +2975,7 @@ public abstract class TensorBase<T> : IDisposable, IStreamingDroppable, ITensorS
 
                 var fresh = requester._data.Clone();
                 var privateStorage = new TensorStorage<T>(fresh);
+                privateStorage.CopyGpuCacheTrackingFrom(requester._storage);
                 for (int i = 0; i < liveMembers.Count; i++)
                 {
                     var member = liveMembers[i];

--- a/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/TensorStorage.cs
@@ -20,6 +20,67 @@ internal sealed class TensorStorage<T>
 {
     private readonly Vector<T> _data;
     private int _refCount;
+    private int _gpuCacheVersion;
+    private bool _trackGpuCacheVersion;
+    private ExternalArrayGpuCacheEpoch? _externalArrayGpuCacheEpoch;
+
+    // Independently constructed zero-copy wrappers can share one array without sharing a
+    // TensorStorage. Their GPU cache key is still that array, so they must share its epoch.
+    // Keep the weak table off ordinary shape-owned allocation and mutation paths.
+    private sealed class ExternalArrayGpuCacheEpoch
+    {
+        internal int Version;
+        internal bool IsTracked;
+    }
+
+    private static class ExternalArrayGpuCacheEpochs
+    {
+        internal static readonly ConditionalWeakTable<T[], ExternalArrayGpuCacheEpoch> Table = new();
+    }
+
+    // Shared by ordinary tensor views, separate from the per-tensor autodiff version.
+    // CPU-only tensors retain the inference fast path: no atomic counter on mutation.
+    internal int GpuCacheVersion
+    {
+        get
+        {
+            if (_externalArrayGpuCacheEpoch is { } external)
+            {
+                if (!Volatile.Read(ref external.IsTracked)) Volatile.Write(ref external.IsTracked, true);
+                return Volatile.Read(ref external.Version);
+            }
+            if (!Volatile.Read(ref _trackGpuCacheVersion)) Volatile.Write(ref _trackGpuCacheVersion, true);
+            return Volatile.Read(ref _gpuCacheVersion);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void IncrementGpuCacheVersionIfTracked()
+    {
+        if (_externalArrayGpuCacheEpoch is { } external)
+        {
+            if (Volatile.Read(ref external.IsTracked)) Interlocked.Increment(ref external.Version);
+            return;
+        }
+        if (Volatile.Read(ref _trackGpuCacheVersion)) Interlocked.Increment(ref _gpuCacheVersion);
+    }
+
+    internal void CopyGpuCacheTrackingFrom(TensorStorage<T> source)
+    {
+        // COW replacement owns a different array. Copy the snapshot, never the external
+        // epoch object, or writes to the detached clone would invalidate its former peers.
+        if (source._externalArrayGpuCacheEpoch is { } external)
+        {
+            _gpuCacheVersion = Volatile.Read(ref external.Version);
+            _trackGpuCacheVersion = Volatile.Read(ref external.IsTracked);
+        }
+        else
+        {
+            _gpuCacheVersion = Volatile.Read(ref source._gpuCacheVersion);
+            _trackGpuCacheVersion = Volatile.Read(ref source._trackGpuCacheVersion);
+        }
+        _externalArrayGpuCacheEpoch = null;
+    }
 
     // Streaming-pool zero-copy mmap alias (PR #604, CodeRabbit-Major): when
     // WeightRegistry.TryAliasZeroCopy installs an MmapTensorMemoryManager as
@@ -96,10 +157,27 @@ internal sealed class TensorStorage<T>
     /// Creates a new storage wrapping an existing Vector (zero-copy).
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when data is null.</exception>
-    internal TensorStorage(Vector<T> data)
+    internal TensorStorage(Vector<T> data, bool shareExternalGpuCacheEpoch = false)
     {
         _data = data ?? throw new ArgumentNullException(nameof(data));
         _refCount = 1;
+        if (shareExternalGpuCacheEpoch
+            && data.TryGetBackingArraySegmentForReadOnlyAccess(out var externalArray, out _)
+            && externalArray is not null)
+        {
+            _externalArrayGpuCacheEpoch = ExternalArrayGpuCacheEpochs.Table.GetValue(
+                externalArray, static _ => new ExternalArrayGpuCacheEpoch());
+        }
+        // GPU result arrays can be cached before their wrapping Tensor exists.
+        // Tag that storage while its deferred download is still registered.
+        if (Helpers.DeferredArrayMaterializer.HasPendingMaterializations)
+        {
+            _trackGpuCacheVersion = Helpers.DeferredArrayMaterializer.IsPending(data)
+                || (data.GetBackingArrayForReadOnlyAccess() is { } array
+                    && Helpers.DeferredArrayMaterializer.IsPending(array));
+            if (_trackGpuCacheVersion && _externalArrayGpuCacheEpoch is { } external)
+                Volatile.Write(ref external.IsTracked, true);
+        }
     }
 
     /// <summary>
@@ -196,14 +274,16 @@ internal sealed class TensorStorage<T>
     internal bool TryClaimExclusive()
     {
         // CAS 1 → 0. Succeeds only when no other ref exists.
-        if (Interlocked.CompareExchange(ref _refCount, 0, 1) != 1) return false;
-        // Sole-claim succeeded → no other ref exists → dispose the mmap
-        // owner too. Caller is about to abandon this storage.
+        return Interlocked.CompareExchange(ref _refCount, 0, 1) == 1;
+    }
+
+    /// <summary>Releases resources only after the caller has installed replacement storage.</summary>
+    internal void DisposeClaimedOwners()
+    {
         var owner = Interlocked.Exchange(ref _mmapOwner, null);
-        owner?.Dispose();
         var gpuOwner = Interlocked.Exchange(ref _gpuBufferOwner, null);
-        gpuOwner?.Dispose();
-        return true;
+        try { owner?.Dispose(); }
+        finally { gpuOwner?.Dispose(); }
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.Batch.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.Batch.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Engines.DirectGpu;
+
+namespace AiDotNet.Tensors.LinearAlgebra;
+
+public static partial class WeightRegistry
+{
+    /// <summary>
+    /// Configures backing storage and registers a quiescent model's weights as one transaction.
+    /// Allocation, serialization, or I/O failure leaves the prior configuration and all supplied
+    /// tensors unchanged. Duplicate references are registered once. The caller must prevent
+    /// concurrent use or mutation of the supplied model while configuring it.
+    /// </summary>
+    /// <remarks>
+    /// Streaming owners retain their data until <see cref="TryFinalizeDeferredDrop{T}"/> is called,
+    /// allowing a framework to publish its model and layer configuration before reclaiming storage.
+    /// On success this registry owns the allocator. On failure the supplied allocator remains
+    /// caller-owned. Disposal of a retired, empty backend is post-commit diagnostic cleanup.
+    /// </remarks>
+    public static void ConfigureAndRegisterBatch<T>(
+        GpuOffloadOptions options,
+        IReadOnlyList<Tensor<T>> weights,
+        IGpuOffloadAllocator? offloadAllocator = null)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (!BitConverter.IsLittleEndian)
+            throw new PlatformNotSupportedException("Weight streaming requires a little-endian host.");
+        WeightLifetime lifetime = offloadAllocator is null ? WeightLifetime.Streaming : WeightLifetime.GpuOffload;
+        List<Tensor<T>> unique = ValidateBatch(weights, lifetime, offloadAllocator, configuring: true);
+        DrainInFlightPrefetches();
+        StreamingTensorPool? candidatePool = lifetime == WeightLifetime.Streaming
+            ? new StreamingTensorPool(options)
+            : null;
+        StreamingTensorPool? retiredPool = null;
+        IGpuOffloadAllocator? retiredAllocator = null;
+        try
+        {
+            lock (_lock)
+            {
+                PruneDeadOwnersUnlocked();
+                PruneDeadOffloadOwnersUnlocked();
+                if (_streamingPool is not null && _streamingPool.RegisteredEntryCount > 0)
+                    throw new InvalidOperationException("WeightRegistry.Configure: existing streaming pool has registered entries. Unregister all weights first.");
+                if (_streamingPool is not null && _streamingPool.ReservedBytes > 0)
+                    throw new InvalidOperationException("WeightRegistry.Configure: existing streaming pool has outstanding reservations. Complete or abandon those allocations first.");
+                if (_offloadRegistrations.Count > 0)
+                    throw new InvalidOperationException("WeightRegistry.Configure: the active GPU offload allocator has live allocations. Unregister all offloaded weights first.");
+
+                List<PendingRegistration<T>> pending =
+                    StageBatchUnlocked(unique, lifetime, options, candidatePool, offloadAllocator);
+                retiredPool = _streamingPool;
+                retiredAllocator = _offloadAllocator;
+                _options = options;
+                _streamingPool = candidatePool;
+                _offloadAllocator = offloadAllocator;
+                PublishBatch(pending, lifetime);
+            }
+        }
+        catch
+        {
+            DisposeRetiredBackend(candidatePool);
+            throw;
+        }
+
+        DisposeRetiredBackend(retiredPool);
+        if (!ReferenceEquals(retiredAllocator, offloadAllocator))
+            DisposeRetiredBackend(retiredAllocator);
+    }
+
+    /// <summary>
+    /// Atomically adds newly materialized weights to the current configuration. Existing compatible
+    /// registrations are preserved. Work and rollback are proportional to the new weights, rather
+    /// than copying the entire live registry. Streaming reservations are restored on failure.
+    /// </summary>
+    public static void RegisterBatch<T>(IReadOnlyList<Tensor<T>> weights, WeightLifetime lifetime)
+    {
+        lock (_lock)
+        {
+            List<Tensor<T>> unique = ValidateBatch(weights, lifetime, _offloadAllocator, configuring: false);
+            if (unique.Count == 0) return;
+            StreamingTensorPool? pool = lifetime == WeightLifetime.Streaming ? StreamingPoolUnlocked() : null;
+            List<PendingRegistration<T>> pending = StageBatchUnlocked(unique, lifetime, _options, pool, _offloadAllocator);
+            PublishBatch(pending, lifetime);
+        }
+    }
+
+    private static List<Tensor<T>> ValidateBatch<T>(
+        IReadOnlyList<Tensor<T>> weights, WeightLifetime lifetime,
+        IGpuOffloadAllocator? allocator, bool configuring)
+    {
+        if (weights is null) throw new ArgumentNullException(nameof(weights));
+        if (lifetime is not WeightLifetime.Streaming and not WeightLifetime.GpuOffload)
+            throw new ArgumentOutOfRangeException(nameof(lifetime));
+        if (lifetime == WeightLifetime.GpuOffload && (allocator is null || !allocator.IsAvailable))
+            throw new InvalidOperationException("The requested GPU offload allocator is unavailable.");
+        var result = new List<Tensor<T>>(weights.Count);
+        var seen = new HashSet<Tensor<T>>(WeightReferenceComparer<T>.Instance);
+        for (int i = 0; i < weights.Count; i++)
+        {
+            Tensor<T> weight = weights[i] ?? throw new ArgumentException("A weight cannot be null.", nameof(weights));
+            if (!seen.Add(weight) || weight.Length == 0) continue;
+            bool registered = weight.StreamingPoolHandle >= 0 || weight.OffloadRegistryHandle >= 0
+                || weight.OffloadHostPointer != IntPtr.Zero;
+            if (registered)
+            {
+                if (!configuring && weight.Lifetime == lifetime) continue;
+                throw new InvalidOperationException("A registered weight cannot change backing configuration.");
+            }
+            if (configuring && weight.StreamingReservedBytes != 0)
+                throw new InvalidOperationException("A weight with a live streaming reservation cannot change pools.");
+            if (lifetime == WeightLifetime.Streaming && (weight.IsView || !weight.IsContiguous || weight._storageOffset != 0))
+                throw new NotSupportedException("Streaming requires owning contiguous weight tensors, not views.");
+            if (lifetime == WeightLifetime.GpuOffload) CheckedStreamingByteCount<T>(weight.Length);
+            result.Add(weight);
+        }
+        return result;
+    }
+
+    private readonly struct PendingRegistration<T>
+    {
+        internal PendingRegistration(Tensor<T> weight, long handle, byte encoding,
+            GpuOffloadHandle offload, long reservedBytes)
+        {
+            Weight = weight;
+            Handle = handle;
+            Encoding = encoding;
+            Offload = offload;
+            ReservedBytes = reservedBytes;
+        }
+        internal Tensor<T> Weight { get; }
+        internal long Handle { get; }
+        internal byte Encoding { get; }
+        internal GpuOffloadHandle Offload { get; }
+        internal long ReservedBytes { get; }
+    }
+
+    private static List<PendingRegistration<T>> StageBatchUnlocked<T>(
+        List<Tensor<T>> weights, WeightLifetime lifetime, GpuOffloadOptions options,
+        StreamingTensorPool? pool, IGpuOffloadAllocator? allocator)
+    {
+        var pending = new List<PendingRegistration<T>>(weights.Count);
+        try
+        {
+            foreach (Tensor<T> weight in weights)
+            {
+                if (lifetime == WeightLifetime.Streaming)
+                {
+                    if (pool is null) throw new InvalidOperationException("No streaming pool was staged.");
+                    var (encoding, stochastic) = ResolveStoreEncoding(weight, options);
+                    byte[] bytes;
+                    if (encoding == StreamingEncoding.Lossless) bytes = SerializeLossless(weight);
+                    else
+                    {
+                        int byteCount = encoding switch
+                        {
+                            StreamingEncoding.Bf16 => CheckedBf16ByteCount(weight.Length),
+                            StreamingEncoding.Int8 => CheckedInt8ByteCount(weight.Length, weight.Int8QuantRows),
+                            StreamingEncoding.Int4 => CheckedInt4ByteCount(weight.Length),
+                            _ => CheckedStreamingByteCount<T>(weight.Length),
+                        };
+                        bytes = new byte[byteCount];
+                        SerializeToBytes(weight, bytes, encoding, stochastic);
+                    }
+                    var owner = new WeakReference<IStreamingDroppable>(weight);
+                    long handle = pool.RegisterReserved(bytes, weight.StreamingReservedBytes);
+                    pending.Add(new PendingRegistration<T>(weight, handle, encoding, default, weight.StreamingReservedBytes));
+                    _ownerByHandle.Add(handle, owner);
+                }
+                else
+                {
+                    if (allocator is null) throw new InvalidOperationException("No GPU allocator was staged.");
+                    int byteCount = CheckedStreamingByteCount<T>(weight.Length);
+                    var bytes = new byte[byteCount];
+                    SerializeToBytes(weight, bytes);
+                    GpuOffloadHandle allocation = allocator.Allocate(byteCount, OffloadScheme.Pinned);
+                    long handle = _nextOffloadRegistrationHandle++;
+                    pending.Add(new PendingRegistration<T>(weight, handle, StreamingEncoding.Native, allocation, 0));
+                    if (allocation.HostPointer == IntPtr.Zero || allocation.Bytes < byteCount)
+                        throw new InvalidOperationException("The GPU allocator returned an invalid host allocation.");
+                    Marshal.Copy(bytes, 0, allocation.HostPointer, byteCount);
+                    _offloadRegistrations.Add(handle, new OffloadRegistration(weight, allocator, allocation));
+                }
+            }
+            return pending;
+        }
+        catch
+        {
+            foreach (PendingRegistration<T> item in pending)
+            {
+                if (lifetime == WeightLifetime.Streaming)
+                {
+                    _ownerByHandle.Remove(item.Handle);
+                    pool?.UnregisterAndRestoreReservation(item.Handle, item.ReservedBytes);
+                }
+                else
+                {
+                    _offloadRegistrations.Remove(item.Handle);
+                    try { allocator?.Free(item.Offload); }
+                    catch (Exception cleanupError) { System.Diagnostics.Trace.TraceWarning("GPU batch rollback cleanup failed: {0}", cleanupError); }
+                }
+            }
+            throw;
+        }
+    }
+
+    private static void PublishBatch<T>(List<PendingRegistration<T>> pending, WeightLifetime lifetime)
+    {
+        foreach (PendingRegistration<T> item in pending)
+        {
+            Tensor<T> weight = item.Weight;
+            weight.Lifetime = lifetime;
+            if (lifetime == WeightLifetime.Streaming)
+            {
+                weight.StreamingStoreEncoding = item.Encoding;
+                weight.StreamingReservedBytes = 0;
+                weight.StreamingDropDeferred = true;
+                weight.StreamingPoolHandle = item.Handle;
+            }
+            else
+            {
+                weight.OffloadHostPointer = item.Offload.HostPointer;
+                weight.OffloadDevicePointer = item.Offload.DevicePointer;
+                weight.OffloadOpaqueHandle = item.Offload.BackendOpaque;
+                weight.OffloadByteCount = item.Offload.Bytes;
+                weight.OffloadRegistryHandle = item.Handle;
+            }
+        }
+    }
+
+    private static void DisposeRetiredBackend(IDisposable? backend)
+    {
+        try { backend?.Dispose(); }
+        catch (Exception cleanupError) { System.Diagnostics.Trace.TraceWarning("Retired weight backend cleanup failed: {0}", cleanupError); }
+    }
+
+    private sealed class WeightReferenceComparer<T> : IEqualityComparer<Tensor<T>>
+    {
+        internal static readonly WeightReferenceComparer<T> Instance = new();
+        public bool Equals(Tensor<T>? x, Tensor<T>? y) => ReferenceEquals(x, y);
+        public int GetHashCode(Tensor<T> value) => RuntimeHelpers.GetHashCode(value);
+    }
+}

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.Batch.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.Batch.cs
@@ -101,7 +101,9 @@ public static partial class WeightRegistry
         for (int i = 0; i < weights.Count; i++)
         {
             Tensor<T> weight = weights[i] ?? throw new ArgumentException("A weight cannot be null.", nameof(weights));
-            if (!seen.Add(weight) || weight.Length == 0) continue;
+            // Empty streaming tensors still own a registered (empty) payload. Only GPU
+            // offload skips them, since a zero-byte device allocation has no backing.
+            if (!seen.Add(weight) || (weight.Length == 0 && lifetime == WeightLifetime.GpuOffload)) continue;
             bool registered = weight.StreamingPoolHandle >= 0 || weight.OffloadRegistryHandle >= 0
                 || weight.OffloadHostPointer != IntPtr.Zero;
             if (registered)

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -18,7 +18,7 @@ namespace AiDotNet.Tensors.LinearAlgebra;
 /// FSDP, the engine dispatcher) read <see cref="Tensor{T}.Lifetime"/>
 /// to pick fast paths in their kernel hot path.</para>
 /// </summary>
-public static class WeightRegistry
+public static partial class WeightRegistry
 {
     private static readonly object _lock = new();
     private static StreamingTensorPool? _streamingPool;
@@ -35,6 +35,29 @@ public static class WeightRegistry
     // UnregisterWeight doesn't leak the entry; dead targets are pruned on
     // drain. Written/read under _lock.
     private static readonly Dictionary<long, WeakReference<IStreamingDroppable>> _ownerByHandle = new();
+
+    private sealed class OffloadRegistration
+    {
+        internal OffloadRegistration(
+            IStreamingDroppable owner,
+            IGpuOffloadAllocator allocator,
+            GpuOffloadHandle handle)
+        {
+            Owner = new WeakReference<IStreamingDroppable>(owner);
+            Allocator = allocator;
+            Handle = handle;
+        }
+
+        internal WeakReference<IStreamingDroppable> Owner { get; }
+        internal IGpuOffloadAllocator Allocator { get; }
+        internal GpuOffloadHandle Handle { get; }
+    }
+
+    // Offload allocations must be freed through the allocator instance that created them. Keeping
+    // that typed ownership in the registry also lets Configure reject an allocator swap while live
+    // native handles exist. Weak owners are reclaimed opportunistically, like streaming handles.
+    private static readonly Dictionary<long, OffloadRegistration> _offloadRegistrations = new();
+    private static long _nextOffloadRegistrationHandle;
 
     // #1715: bound the set of streaming weights whose OWNER tensors hold resident _data at once.
     // Materialize hands each weight a private resident copy; the pool only accounts ITS OWN byte[]
@@ -62,60 +85,7 @@ public static class WeightRegistry
     /// well-defined on little-endian platforms (x86/x64/ARM-LE).</summary>
     public static void Configure(GpuOffloadOptions options, IGpuOffloadAllocator? offloadAllocator = null)
     {
-        if (options is null) throw new ArgumentNullException(nameof(options));
-        if (!BitConverter.IsLittleEndian)
-            throw new PlatformNotSupportedException(
-                "WeightRegistry / StreamingTensorPool requires a little-endian host. " +
-                "Big-endian platforms (legacy IBM Power, certain ARM modes) are not supported in v1.");
-        // Quiesce background prefetch workers before (possibly) disposing/swapping
-        // the pool below — same fire-and-forget-outlives-the-pool hazard Reset()
-        // guards against. Must run outside _lock (workers take _lock in their
-        // finally). See DrainInFlightPrefetches.
-        DrainInFlightPrefetches();
-        lock (_lock)
-        {
-            // #714: first reclaim entries whose owner was GC'd without UnregisterWeight. A
-            // sequentially-created-then-dropped model (test shards, long loops) leaves dead-owner
-            // entries pinned in the pool; without this sweep they would wrongly count as "live" and
-            // block the next Configure with "existing streaming pool has N registered entries" — the
-            // symptom that reddens the foundation-scale CV/diffusion model shards. Only genuinely-dead
-            // owners are reclaimed, so a real "live weights still registered" misuse still throws below.
-            PruneDeadOwnersUnlocked();
-
-            // Mid-flight guard: refuse to dispose a pool that holds live
-            // entries. Otherwise tensors registered against the old pool
-            // would silently break on Materialize.
-            if (_streamingPool is not null && _streamingPool.RegisteredEntryCount > 0)
-                throw new InvalidOperationException(
-                    $"WeightRegistry.Configure: existing streaming pool has {_streamingPool.RegisteredEntryCount} " +
-                    "registered entries. Unregister all weights first, or call Reset() to forcibly drop them.");
-            // Same for outstanding reservations from in-flight
-            // AllocateStreaming calls that haven't yet hit RegisterWeight.
-            // Swapping the pool here would orphan those reservations: the
-            // tensor still carries StreamingReservedBytes but the pool
-            // that recorded it is gone, so RegisterWeight / UnregisterWeight
-            // would later release bytes against the WRONG pool — corrupting
-            // the new pool's _reservedBytes accounting and letting later
-            // allocators overshoot the budget.
-            if (_streamingPool is not null && _streamingPool.ReservedBytes > 0)
-                throw new InvalidOperationException(
-                    $"WeightRegistry.Configure: existing streaming pool has {_streamingPool.ReservedBytes} " +
-                    "bytes of outstanding reservations from AllocateStreaming calls that haven't yet " +
-                    "called RegisterWeight (or UnregisterWeight). Complete or abandon those allocations first, " +
-                    "or call Reset() to forcibly drop them.");
-
-            // Dispose the previous allocator before swapping — otherwise its
-            // outstanding pinned/managed allocations + native context are
-            // leaked. Skip disposal when the caller passes the same instance
-            // back in (defensive: lets a caller re-Configure with new options
-            // without losing live allocations).
-            if (!ReferenceEquals(_offloadAllocator, offloadAllocator))
-                _offloadAllocator?.Dispose();
-            _options = options;
-            _offloadAllocator = offloadAllocator;
-            _streamingPool?.Dispose();
-            _streamingPool = null; // lazy-create on first Streaming registration
-        }
+        ConfigureAndRegisterBatch(options, Array.Empty<Tensor<float>>(), offloadAllocator);
     }
 
     /// <summary>The active streaming pool, lazily constructed.</summary>
@@ -178,102 +148,9 @@ public static class WeightRegistry
                 case WeightLifetime.Default:
                     return;
                 case WeightLifetime.Streaming:
-                    {
-                        // CheckedStreamingByteCount uses long arithmetic
-                        // so an oversized tensor surfaces as a clear
-                        // NotSupportedException with a chunking hint
-                        // instead of the runtime's OutOfMemoryException.
-                        // byte[] is itself bounded to ~2.15 GB, so
-                        // streaming a single tensor > 2 GB is impossible
-                        // regardless of host RAM. Helper is internal so
-                        // the overflow guard can be unit-tested directly
-                        // without faking a multi-GB tensor.
-                        // Resolve the store encoding (bf16 vs native) from the
-                        // StreamingStoreDtype policy + execution mode. bf16 halves the
-                        // registered byte[] and everything downstream (resident set,
-                        // eviction, disk) for free — the pool is byte-agnostic; only the
-                        // restore boundary widens bf16 → T (RestoreStorageFromBytes).
-                        var (encoding, stochastic) = ResolveStoreEncoding(weight);
-                        byte[] bytes;
-                        if (encoding == StreamingEncoding.Lossless)
-                        {
-                            // Lossless (byte-shuffle + LZ4) is variable-size — compress
-                            // first, then register exactly the produced bytes.
-                            bytes = SerializeLossless(weight);
-                        }
-                        else
-                        {
-                            int byteCount = encoding switch
-                            {
-                                StreamingEncoding.Bf16 => CheckedBf16ByteCount(weight.Length),
-                                StreamingEncoding.Int8 => CheckedInt8ByteCount(weight.Length, weight.Int8QuantRows),
-                                StreamingEncoding.Int4 => CheckedInt4ByteCount(weight.Length),
-                                _ => CheckedStreamingByteCount<T>(weight.Length),
-                            };
-                            bytes = new byte[byteCount];
-                            SerializeToBytes(weight, bytes, encoding, stochastic);
-                        }
-                        weight.StreamingStoreEncoding = encoding;
-                        var pool = StreamingPoolUnlocked();
-                        // If this tensor was produced by AllocateStreaming,
-                        // it carries the reservation byteCount the pool
-                        // pre-evicted on its behalf. Release the
-                        // reservation BEFORE Register so the pool's
-                        // budget check sees the same byteCount land in
-                        // _residentBytes that came out of _reservedBytes —
-                        // net-zero on the budget rather than counting
-                        // double. Tensors not produced by AllocateStreaming
-                        // have StreamingReservedBytes == 0 (no-op).
-                        long reserved = weight.StreamingReservedBytes;
-                        if (reserved > 0)
-                        {
-                            pool.ReleaseReservation(reserved);
-                            weight.StreamingReservedBytes = 0;
-                        }
-                        long handle = pool.Register(bytes);
-                        // Two-phase commit: drop storage FIRST (the operation
-                        // that can throw — non-contiguous, view, shared
-                        // refcount), then commit the handle on the tensor.
-                        // If TryDropStorageForStreaming throws after the pool
-                        // already accepted the bytes, roll the pool entry
-                        // back so we don't leak both a registered pool
-                        // entry and a tensor still in its pre-stream state
-                        // (which would lead to "handle resident but tensor
-                        // never released" + a pool entry no caller can
-                        // ever reach because StreamingPoolHandle was never
-                        // set on the tensor).
-                        //
-                        // Issue #430: lazy weights allocated via
-                        // AllocateStreaming inside OnFirstForward have their
-                        // storage captured by the very next op's autodiff
-                        // tape input list — refcount becomes 2 by the time
-                        // RegisterWeight runs. Pre-fix the strict drop threw
-                        // and broke any forward path that lazy-allocated
-                        // weights mid-Forward (PatchEmbeddingLayer in
-                        // Gemma3, DeepSeekVL, etc.). Use the non-throwing
-                        // TryDropStorageForStreaming and DEFER the drop when
-                        // refcount > 1: bind the handle anyway, mark the
-                        // tensor with StreamingDropDeferred, and let
-                        // TryFinalizeDeferredDrop retry once peer refs
-                        // release (typically end of training step).
-                        try
-                        {
-                            bool dropped = weight.TryDropStorageForStreaming(throwOnSharedRefcount: false);
-                            weight.StreamingPoolHandle = handle;
-                            weight.StreamingDropDeferred = !dropped;
-                            // Record the owner so a later pool eviction can drop
-                            // this tensor's resident _data once transparent
-                            // auto-rehydrate has paged it back in. Weak ref: a
-                            // tensor GC'd without UnregisterWeight won't leak.
-                            _ownerByHandle[handle] = new WeakReference<IStreamingDroppable>(weight);
-                        }
-                        catch
-                        {
-                            pool.Unregister(handle);
-                            throw;
-                        }
-                        return;
-                    }
+                    RegisterBatch(new[] { weight }, WeightLifetime.Streaming);
+                    TryFinalizeDeferredDrop(weight);
+                    return;
                 case WeightLifetime.GpuOffload:
                 case WeightLifetime.GpuManaged:
                 case WeightLifetime.GpuPinned:
@@ -322,6 +199,11 @@ public static class WeightRegistry
                             weight.OffloadDevicePointer = h.DevicePointer;
                             weight.OffloadOpaqueHandle = h.BackendOpaque;
                             weight.OffloadByteCount = byteCount;
+                            long registryHandle = _nextOffloadRegistrationHandle++;
+                            _offloadRegistrations.Add(
+                                registryHandle,
+                                new OffloadRegistration(weight, alloc, h));
+                            weight.OffloadRegistryHandle = registryHandle;
                         }
                         catch
                         {
@@ -586,36 +468,66 @@ public static class WeightRegistry
                 UntrackMaterializedOwner(weight.StreamingPoolHandle); // #1715
                 weight.StreamingPoolHandle = -1;
             }
-            if (weight.OffloadDevicePointer != IntPtr.Zero || weight.OffloadHostPointer != IntPtr.Zero)
+            if (weight.OffloadRegistryHandle >= 0
+                && _offloadRegistrations.TryGetValue(
+                    weight.OffloadRegistryHandle,
+                    out OffloadRegistration? registration))
             {
-                var alloc = _offloadAllocator;
-                if (alloc is not null)
-                {
-                    var scheme = weight.Lifetime == WeightLifetime.GpuManaged
-                        ? OffloadScheme.Managed : OffloadScheme.Pinned;
-                    // Reconstruct the full GpuOffloadHandle from persisted
-                    // metadata so the allocator's Free path sees the same
-                    // host / device / opaque it allocated. Host pointer is
-                    // load-bearing — Free's TryRemove keys by HostPointer.
-                    // Fall back to DevicePointer for pre-existing tensors
-                    // that don't have OffloadHostPointer set (CUDA/HIP
-                    // pinned where host==device).
-                    IntPtr host = weight.OffloadHostPointer != IntPtr.Zero
-                        ? weight.OffloadHostPointer
-                        : weight.OffloadDevicePointer;
-                    alloc.Free(new GpuOffloadHandle(
-                        host: host,
-                        device: weight.OffloadDevicePointer,
-                        bytes: weight.OffloadByteCount,
-                        scheme: scheme,
-                        opaque: weight.OffloadOpaqueHandle));
-                }
+                registration.Allocator.Free(registration.Handle);
+                _offloadRegistrations.Remove(weight.OffloadRegistryHandle);
+                weight.OffloadRegistryHandle = -1;
+                ClearOffloadMetadata(weight);
+            }
+            else if (weight.OffloadDevicePointer != IntPtr.Zero || weight.OffloadHostPointer != IntPtr.Zero)
+            {
+                // Compatibility for tensors registered by an older assembly before allocator
+                // ownership records existed. New registrations always take the branch above.
+                IGpuOffloadAllocator? allocator = _offloadAllocator;
+                if (allocator is not null)
+                    allocator.Free(CreateOffloadHandle(weight));
+                weight.OffloadRegistryHandle = -1;
+                ClearOffloadMetadata(weight);
+            }
+        }
+    }
+
+    private static GpuOffloadHandle CreateOffloadHandle<T>(Tensor<T> weight)
+    {
+        OffloadScheme scheme = weight.Lifetime == WeightLifetime.GpuManaged
+            ? OffloadScheme.Managed
+            : OffloadScheme.Pinned;
+        IntPtr host = weight.OffloadHostPointer != IntPtr.Zero
+            ? weight.OffloadHostPointer
+            : weight.OffloadDevicePointer;
+        return new GpuOffloadHandle(
+            host,
+            weight.OffloadDevicePointer,
+            weight.OffloadByteCount,
+            scheme,
+            weight.OffloadOpaqueHandle);
+    }
+
+    private static void ClearOffloadMetadata<T>(Tensor<T> weight)
+    {
                 weight.OffloadHostPointer = IntPtr.Zero;
                 weight.OffloadDevicePointer = IntPtr.Zero;
                 weight.OffloadOpaqueHandle = null;
                 weight.OffloadByteCount = 0;
-            }
+    }
+
+    private static void PruneDeadOffloadOwnersUnlocked()
+    {
+        if (_offloadRegistrations.Count == 0) return;
+
+        var deadHandles = new List<long>();
+        foreach (KeyValuePair<long, OffloadRegistration> pair in _offloadRegistrations)
+        {
+            if (pair.Value.Owner.TryGetTarget(out _)) continue;
+            pair.Value.Allocator.Free(pair.Value.Handle);
+            deadHandles.Add(pair.Key);
         }
+        for (int i = 0; i < deadHandles.Count; i++)
+            _offloadRegistrations.Remove(deadHandles[i]);
     }
 
     /// <summary>Caller must hold <see cref="_lock"/> — returns the lazy
@@ -819,10 +731,11 @@ public static class WeightRegistry
     /// and the execution-mode hint. Only float/double can be narrowed; all other types always store
     /// native. Caller holds <see cref="_lock"/>.
     /// </summary>
-    private static (byte encoding, bool stochastic) ResolveStoreEncoding<T>(Tensor<T> weight)
+    private static (byte encoding, bool stochastic) ResolveStoreEncoding<T>(Tensor<T> weight, GpuOffloadOptions? options = null)
     {
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return (StreamingEncoding.Native, false);
-        switch (_options.StreamingStoreDtype)
+        options ??= _options;
+        switch (options.StreamingStoreDtype)
         {
             case StreamingStoreDtype.FullPrecision: return (StreamingEncoding.Native, false);
             case StreamingStoreDtype.Bf16: return (StreamingEncoding.Bf16, false);
@@ -846,7 +759,7 @@ public static class WeightRegistry
                 //   • unknown (no declared mode — raw registry use) → full precision: don't guess.
                 return _streamingTrainingMode switch
                 {
-                    false => (ResolveAutoInferenceEncoding(weight), false), // inference → RAM-aware
+                    false => (ResolveAutoInferenceEncoding(weight, options), false), // inference → RAM-aware
                     true => (StreamingEncoding.Lossless, false),            // training → lossless
                     _ => (StreamingEncoding.Native, false),                 // unknown → full precision
                 };
@@ -863,10 +776,10 @@ public static class WeightRegistry
     /// precision-sensitive and a negligible share of the footprint. With no footprint hint the
     /// behaviour is unchanged (bf16).
     /// </summary>
-    private static byte ResolveAutoInferenceEncoding<T>(Tensor<T> weight)
+    private static byte ResolveAutoInferenceEncoding<T>(Tensor<T> weight, GpuOffloadOptions options)
     {
-        long footprint = _options.ExpectedStreamingFootprintBytes;
-        long cap = _options.StreamingPoolMaxResidentBytes;
+        long footprint = options.ExpectedStreamingFootprintBytes;
+        long cap = options.StreamingPoolMaxResidentBytes;
         // No footprint hint, or bf16 already fits, or a degenerate cap → keep bf16 (best fidelity,
         // unchanged default). footprint/2 is the whole-model resident cost at bf16.
         if (footprint <= 0 || cap <= 0 || footprint / 2 <= cap) return StreamingEncoding.Bf16;
@@ -2219,6 +2132,10 @@ public static class WeightRegistry
         DrainInFlightPrefetches();
         lock (_lock)
         {
+            foreach (OffloadRegistration registration in _offloadRegistrations.Values)
+                registration.Allocator.Free(registration.Handle);
+            _offloadRegistrations.Clear();
+            _nextOffloadRegistrationHandle = 0;
             _streamingPool?.Dispose();
             _streamingPool = null;
             // #1715: dispose the param-IO mmap store (deletes its backing file). Weights still aliasing

--- a/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/WeightRegistry.cs
@@ -523,8 +523,12 @@ public static partial class WeightRegistry
         foreach (KeyValuePair<long, OffloadRegistration> pair in _offloadRegistrations)
         {
             if (pair.Value.Owner.TryGetTarget(out _)) continue;
-            pair.Value.Allocator.Free(pair.Value.Handle);
             deadHandles.Add(pair.Key);
+            try { pair.Value.Allocator.Free(pair.Value.Handle); }
+            catch (Exception error)
+            {
+                TraceOffloadCleanupFailure(error);
+            }
         }
         for (int i = 0; i < deadHandles.Count; i++)
             _offloadRegistrations.Remove(deadHandles[i]);
@@ -2133,7 +2137,13 @@ public static partial class WeightRegistry
         lock (_lock)
         {
             foreach (OffloadRegistration registration in _offloadRegistrations.Values)
-                registration.Allocator.Free(registration.Handle);
+            {
+                try { registration.Allocator.Free(registration.Handle); }
+                catch (Exception error)
+                {
+                    TraceOffloadCleanupFailure(error);
+                }
+            }
             _offloadRegistrations.Clear();
             _nextOffloadRegistrationHandle = 0;
             _streamingPool?.Dispose();
@@ -2165,6 +2175,19 @@ public static partial class WeightRegistry
             // precision", so the safe-unknown state has to mean null here.
             _streamingTrainingMode = null;
             _registrationsSinceSweep = 0;
+        }
+    }
+
+    private static void TraceOffloadCleanupFailure(Exception error)
+    {
+        try
+        {
+            System.Diagnostics.Trace.TraceWarning($"Failed to release an offload allocation: {error.Message}");
+        }
+        catch (Exception)
+        {
+            // Trace listeners are user-supplied. A secondary diagnostic failure
+            // must not interrupt reclamation of the remaining allocations.
         }
     }
 

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardReviewRegressionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/BackwardReviewRegressionTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class BackwardReviewRegressionTests
+{
+    public enum ExecutionPath { Tape, Compiled, Optimized }
+
+    [Fact]
+    public void MaxPool1DBackward_AcceptsNonContiguousGradientWithoutMutatingIt()
+    {
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(new[] { 1, 2, 4 });
+        var output = new Tensor<float>(new[] { 1, 2, 2 });
+        var gradient = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 1, 2, 2 })
+            .Transpose(new[] { 0, 2, 1 });
+        Assert.False(gradient.IsContiguous);
+        float[] before = gradient.ToArray();
+        var gradients = new Dictionary<Tensor<float>, Tensor<float>>();
+
+        BackwardFunctions<float>.MaxPool1DBackward(gradient, new[] { input }, output,
+            new object[] { new[] { 1, 3, 5, 7 } }, engine, gradients);
+
+        Assert.Equal(new float[] { 0, 1, 0, 3, 0, 2, 0, 4 }, gradients[input].ToArray());
+        Assert.Equal(before, gradient.ToArray());
+        Assert.False(gradient.IsContiguous);
+    }
+
+    [Theory]
+    [InlineData(ExecutionPath.Tape)]
+    [InlineData(ExecutionPath.Compiled)]
+    [InlineData(ExecutionPath.Optimized)]
+    public void Float32Policy_ReachesFanOutAdditionButNotBackwardKernels(ExecutionPath execution)
+        => VerifyAccumulationPolicy(execution, GradientAccumulationPrecision.Float32);
+
+    [Theory]
+    [InlineData(ExecutionPath.Tape)]
+    [InlineData(ExecutionPath.Compiled)]
+    [InlineData(ExecutionPath.Optimized)]
+    public void InheritedPolicy_PreservesLowerPrecisionAndOverridesAnOuterPolicy(ExecutionPath execution)
+        => VerifyAccumulationPolicy(execution, GradientAccumulationPrecision.InheritBackwardPrecision);
+
+    private static void VerifyAccumulationPolicy(ExecutionPath execution, GradientAccumulationPrecision precision)
+    {
+        var engine = new PrecisionObservingCpuEngine();
+        IEngine previous = AiDotNetEngine.Current;
+        AiDotNetEngine.Current = engine;
+        try
+        {
+            using var autocast = new AutocastScope(PrecisionMode.Float16);
+            using var tape = new GradientTape<float>(new GradientTapeOptions
+            {
+                Persistent = true,
+                GradientAccumulationPrecision = precision,
+            });
+            var input = new Tensor<float>(new[] { 1f }, new[] { 1 });
+            var first = engine.TensorMultiplyScalar(input, 1f);
+            var second = engine.TensorMultiplyScalar(input, 0.0005f);
+            var loss = engine.ReduceSum(engine.TensorAdd(first, second), new[] { 0 }, false);
+            engine.Observe = true;
+            GradientAccumulationPrecision outerPrecision = precision == GradientAccumulationPrecision.Float32
+                ? GradientAccumulationPrecision.InheritBackwardPrecision
+                : GradientAccumulationPrecision.Float32;
+            using var outerPolicy = new GradientAccumulationPrecisionScope(outerPrecision);
+
+            Dictionary<Tensor<float>, Tensor<float>> gradients;
+            if (execution == ExecutionPath.Tape)
+                gradients = tape.ComputeGradients(loss, new[] { input }, createGraph: true);
+            else if (execution == ExecutionPath.Compiled)
+                gradients = tape.CompileBackward(loss, new[] { input }).Execute();
+            else
+            {
+                int[] indices = Enumerable.Range(0, tape.Entries.Count).Reverse().ToArray();
+                var plan = new OptimizedBackwardPlan<float>(tape.Entries, indices, loss,
+                    new[] { input }, engine, new BackwardAnalysis(), accumulationPrecision: precision);
+                gradients = plan.Execute();
+            }
+
+            Assert.InRange(Math.Abs(gradients[input][0] - 1.0005f), 0, 1e-6f);
+            Assert.NotEmpty(engine.AdditionPrecisions);
+            PrecisionMode expectedAddition = precision == GradientAccumulationPrecision.Float32
+                ? PrecisionMode.Float32 : PrecisionMode.Float16;
+            Assert.All(engine.AdditionPrecisions, observed => Assert.Equal(expectedAddition, observed));
+            Assert.NotEmpty(engine.ScalarPrecisions);
+            Assert.All(engine.ScalarPrecisions, precision => Assert.Equal(PrecisionMode.Float16, precision));
+            Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+            using var restoredOuterAddition = GradientAccumulationPrecisionScope.EnterFloat32AutocastForAddition();
+            Assert.Equal(outerPrecision == GradientAccumulationPrecision.Float32 ? PrecisionMode.Float32 : PrecisionMode.Float16,
+                AutocastScope.ActivePrecision);
+        }
+        finally { AiDotNetEngine.Current = previous; }
+    }
+
+    private sealed class PrecisionObservingCpuEngine : CpuEngine
+    {
+        internal bool Observe { get; set; }
+        internal List<PrecisionMode> AdditionPrecisions { get; } = new();
+        internal List<PrecisionMode> ScalarPrecisions { get; } = new();
+
+        public override Tensor<T> TensorAdd<T>(Tensor<T> left, Tensor<T> right)
+        {
+            if (Observe) AdditionPrecisions.Add(AutocastScope.ActivePrecision);
+            return base.TensorAdd(left, right);
+        }
+
+        public override void TensorAddInPlace<T>(Tensor<T> left, Tensor<T> right)
+        {
+            if (Observe) AdditionPrecisions.Add(AutocastScope.ActivePrecision);
+            base.TensorAddInPlace(left, right);
+        }
+
+        public override Tensor<T> TensorMultiplyScalar<T>(Tensor<T> input, T scalar)
+        {
+            if (Observe) ScalarPrecisions.Add(AutocastScope.ActivePrecision);
+            return base.TensorMultiplyScalar(input, scalar);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs
@@ -20,6 +20,46 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// </summary>
 public class FusedAttentionTiledBackwardTests
 {
+    [Fact]
+    public void Backward_CausalFirstQuery_HasNoMaskedGradientsAndDoesNotMutateInputs()
+    {
+        var engine = new CpuEngine();
+        int[] shape = { 1, 1, 3, 2 };
+        using var q = new Tensor<float>(new float[] { 0.25f, -0.5f, 1f, 0.75f, -0.25f, 1.5f }, shape);
+        using var k = new Tensor<float>(new float[] { -0.5f, 0.25f, 0.75f, 1f, 1.5f, -0.25f }, shape);
+        using var v = new Tensor<float>(new float[] { 1f, 2f, 3f, -4f, 5f, 6f }, shape);
+        using var dO = new Tensor<float>(new float[] { 1f, -2f, 0f, 0f, 0f, 0f }, shape);
+        using var qPeer = (Tensor<float>)q.CloneShared();
+        using var kPeer = (Tensor<float>)k.CloneShared();
+        using var vPeer = (Tensor<float>)v.CloneShared();
+        using var dOPeer = (Tensor<float>)dO.CloneShared();
+        float[] qBefore = q.ToArray(), kBefore = k.ToArray(), vBefore = v.ToArray(), dOBefore = dO.ToArray();
+        int qVersion = q.Version, kVersion = k.Version, vVersion = v.Version, dOVersion = dO.Version;
+
+        var (dQ, dK, dV) = FusedAttention<float>.Backward(
+            dO, q, k, v, new FlashAttentionConfig { IsCausal = true }, engine: engine);
+
+        // Only query zero contributes to the loss, and causal query zero can see only key zero.
+        // Its softmax is identically one: Q/K receive zero gradient and V receives just dO[0].
+        AssertClose(new float[6], dQ.AsSpan().ToArray(), 1e-6f, "masked dQ");
+        AssertClose(new float[6], dK.AsSpan().ToArray(), 1e-6f, "masked dK");
+        AssertClose(new float[] { 1f, -2f, 0f, 0f, 0f, 0f }, dV.AsSpan().ToArray(), 1e-6f, "masked dV");
+        Assert.Equal(qBefore, q.ToArray());
+        Assert.Equal(kBefore, k.ToArray());
+        Assert.Equal(vBefore, v.ToArray());
+        Assert.Equal(dOBefore, dO.ToArray());
+        Assert.Equal(qBefore, qPeer.ToArray());
+        Assert.Equal(kBefore, kPeer.ToArray());
+        Assert.Equal(vBefore, vPeer.ToArray());
+        Assert.Equal(dOBefore, dOPeer.ToArray());
+        Assert.Equal(qVersion, q.Version);
+        Assert.Equal(kVersion, k.Version);
+        Assert.Equal(vVersion, v.Version);
+        Assert.Equal(dOVersion, dO.Version);
+        Assert.True(q.IsCowShared && k.IsCowShared && v.IsCowShared && dO.IsCowShared,
+            "Reading attention inputs must not detach their copy-on-write storage.");
+    }
+
     [Theory]
     [InlineData(1, 2, 16, 8)]    // tiny (full-matrix path)
     [InlineData(2, 4, 64, 16)]   // medium, multi-batch/head (full-matrix path)
@@ -189,6 +229,8 @@ public class FusedAttentionTiledBackwardTests
         for (int i = 0; i < expected.Length; i++)
         {
             float d = Math.Abs(expected[i] - actual[i]);
+            if (float.IsNaN(d) || float.IsInfinity(d))
+                Assert.Fail($"{name} has a non-finite difference at index {i}: expected {expected[i]}, actual {actual[i]}.");
             // relative tolerance for larger magnitudes
             float bound = tol * (1f + Math.Abs(expected[i]));
             if (d > bound && d > maxAbs) { maxAbs = d; worst = i; }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientAccumulationPhysicalGpuTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientAccumulationPhysicalGpuTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class GradientAccumulationPhysicalGpuTests
+{
+    private readonly ITestOutputHelper _output;
+    public GradientAccumulationPhysicalGpuTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void Float32Accumulation_PreservesSmallResidualOnPhysicalGpu()
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        bool required = Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1";
+        if (!gpu.IsGpuAvailable)
+        {
+            Assert.False(required, "A physical GPU was required, but none initialized.");
+            return;
+        }
+        if (gpu.TestBackend is not IGpuFp16ElementwiseBackend { SupportsFp16NativeOps: true })
+        {
+            Assert.False(required, "Native FP16 elementwise support is required for this precision comparison.");
+            return;
+        }
+
+        var previousEngine = AiDotNetEngine.Current;
+        bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        AiDotNetEngine.Current = gpu;
+        DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+        try
+        {
+            var inherited = Accumulate(gpu, GradientAccumulationPrecision.InheritBackwardPrecision);
+            var wide = Accumulate(gpu, GradientAccumulationPrecision.Float32);
+            Assert.Equal(GpuExecutionRoute.Gpu, inherited.Plan.Route);
+            Assert.Equal(GpuScalarType.Float16, inherited.Plan.InputStorage);
+            Assert.Equal(GpuScalarType.Float16, inherited.Plan.OutputStorage);
+            Assert.Equal(GpuExecutionRoute.Gpu, wide.Plan.Route);
+            Assert.Equal(GpuScalarType.Float32, wide.Plan.InputStorage);
+            Assert.Equal(GpuScalarType.Float32, wide.Plan.AccumulatorType);
+            Assert.Equal(GpuScalarType.Float32, wide.Plan.OutputStorage);
+            const double expected = 1.0005;
+            double inheritedError = Math.Abs(inherited.Value - expected);
+            double wideError = Math.Abs(wide.Value - expected);
+            _output.WriteLine($"Backend={wide.Plan.Backend}; expected={expected:R}; inherited={inherited.Value:R} (error={inheritedError:R}); FP32={wide.Value:R} (error={wideError:R})");
+            Assert.InRange(wideError, 0, 1e-6);
+            Assert.True(wideError < inheritedError / 100,
+                "FP32 gradient accumulation must retain the small residual substantially more accurately than FP16.");
+        }
+        finally
+        {
+            DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict;
+            AiDotNetEngine.Current = previousEngine;
+        }
+    }
+
+    private static (float Value, GpuComputePlan Plan) Accumulate(
+        DirectGpuTensorEngine gpu, GradientAccumulationPrecision precision)
+    {
+        using var autocast = new AutocastScope(PrecisionMode.Float16);
+        using var tape = new GradientTape<float>(new GradientTapeOptions
+        {
+            Persistent = false,
+            GradientAccumulationPrecision = precision,
+        });
+        var x = new Tensor<float>(new[] { 1f }, new[] { 1 });
+        var main = gpu.TensorMultiplyScalar(x, 1f);
+        var residual = gpu.TensorMultiplyScalar(x, 0.0005f);
+        var sum = gpu.TensorAdd(main, residual);
+        var loss = gpu.ReduceSum(sum, new[] { 0 }, false);
+        var additions = new List<GpuComputePlan>();
+        void Capture(GpuComputePlan plan)
+        {
+            if (plan.OperationKind == GpuPrecisionOperation.Add) additions.Add(plan);
+        }
+        GpuPrecisionDiagnostics.PlanExecuted += Capture;
+        try
+        {
+            // Out-of-place accumulation is required to exercise native FP16 on all backends;
+            // the optional in-place FP16 shortcut is CUDA-specific.
+            var gradient = tape.ComputeGradients(loss, new[] { x }, createGraph: true)[x];
+            return (gradient.ToArray()[0], Assert.Single(additions));
+        }
+        finally { GpuPrecisionDiagnostics.PlanExecuted -= Capture; }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientAccumulationPhysicalGpuTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientAccumulationPhysicalGpuTests.cs
@@ -15,21 +15,16 @@ public sealed class GradientAccumulationPhysicalGpuTests
     private readonly ITestOutputHelper _output;
     public GradientAccumulationPhysicalGpuTests(ITestOutputHelper output) => _output = output;
 
-    [Fact]
+    [SkippableFact]
     public void Float32Accumulation_PreservesSmallResidualOnPhysicalGpu()
     {
         using var gpu = new DirectGpuTensorEngine();
         bool required = Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1";
-        if (!gpu.IsGpuAvailable)
-        {
-            Assert.False(required, "A physical GPU was required, but none initialized.");
-            return;
-        }
-        if (gpu.TestBackend is not IGpuFp16ElementwiseBackend { SupportsFp16NativeOps: true })
-        {
-            Assert.False(required, "Native FP16 elementwise support is required for this precision comparison.");
-            return;
-        }
+        if (required) Assert.True(gpu.IsGpuAvailable, "A physical GPU was required, but none initialized.");
+        Skip.IfNot(gpu.IsGpuAvailable, "No physical GPU backend initialized.");
+        bool nativeHalf = gpu.TestBackend is IGpuFp16ElementwiseBackend { SupportsFp16NativeOps: true };
+        if (required) Assert.True(nativeHalf, "Native FP16 elementwise support is required for this precision comparison.");
+        Skip.IfNot(nativeHalf, "Native FP16 elementwise support is unavailable.");
 
         var previousEngine = AiDotNetEngine.Current;
         bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeFinalizerTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeFinalizerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
@@ -24,6 +26,41 @@ public sealed class TapeGlobalStateSerialCollection { }
 [Collection("TapeGlobalStateSerial")]
 public class GradientTapeFinalizerTests
 {
+    [Fact]
+    public void RejectedConstruction_FinalizerDoesNotDisableUnrelatedLiveTape()
+    {
+        int baseline = DifferentiableOps._anyTapeActive;
+        var engine = new CpuEngine();
+        var source = new Tensor<float>(
+            new[] { 2 }, new Vector<float>(new[] { 2f, 3f }));
+        using var liveTape = new GradientTape<float>();
+        Assert.Equal(baseline + 1, DifferentiableOps._anyTapeActive);
+
+        CreateRejectedTapes();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.Equal(baseline + 1, DifferentiableOps._anyTapeActive);
+        var loss = engine.ReduceSum(engine.TensorMultiply(source, source), null);
+        var gradients = liveTape.ComputeGradients(loss, new[] { source });
+        Assert.Equal(new[] { 4f, 6f }, gradients[source].ToArray());
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static void CreateRejectedTapes()
+    {
+        for (int i = 0; i < 32; i++)
+        {
+            var options = new GradientTapeOptions
+            {
+                StreamingGraphRetention = (StreamingGraphRetentionMode)int.MaxValue,
+            };
+            Assert.Throws<ArgumentOutOfRangeException>(() => new GradientTape<float>(options));
+        }
+    }
+
     [Fact]
     public void UndisposedTape_DoesNotPermanentlyLeakGlobalActiveCounter()
     {

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
@@ -12,6 +12,8 @@
 // behavior.
 
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
@@ -86,5 +88,49 @@ public class GradientTapeOptionsDefaultTests
         Assert.True(options.RecordInPlace);
         Assert.Equal(0, options.MaxEntries);
         Assert.False(options.EnableHooks);
+        Assert.Equal(
+            StreamingGraphRetentionMode.ReleaseAfterBackward,
+            options.StreamingGraphRetention);
+    }
+
+    [Fact]
+    public void StreamingGraphRetention_IsExposedByTapeWithoutMutatingDefault()
+    {
+        var options = new GradientTapeOptions
+        {
+            StreamingGraphRetention = StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        };
+
+        using var tape = new GradientTape<float>(options);
+
+        Assert.Equal(
+            StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+            tape.Options.StreamingGraphRetention);
+        Assert.Equal(
+            StreamingGraphRetentionMode.ReleaseAfterBackward,
+            GradientTapeOptions.Default.StreamingGraphRetention);
+    }
+
+    [Fact]
+    public void UnknownStreamingGraphRetention_IsRejectedAtConstruction()
+    {
+        var options = new GradientTapeOptions
+        {
+            StreamingGraphRetention = (StreamingGraphRetentionMode)int.MaxValue,
+        };
+
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => new GradientTape<float>(options));
+    }
+
+    [Fact]
+    public void RetainedStreamingGraph_RequiresPersistentTape()
+    {
+        var options = new GradientTapeOptions
+        {
+            Persistent = false,
+            StreamingGraphRetention = StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        };
+
+        Assert.Throws<System.ArgumentException>(() => new GradientTape<float>(options));
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeOptionsDefaultTests.cs
@@ -91,6 +91,7 @@ public class GradientTapeOptionsDefaultTests
         Assert.Equal(
             StreamingGraphRetentionMode.ReleaseAfterBackward,
             options.StreamingGraphRetention);
+        Assert.Equal(GradientAccumulationPrecision.Float32, options.GradientAccumulationPrecision);
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
@@ -1,10 +1,16 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[CollectionDefinition("GradientTapeStreamingSerial", DisableParallelization = true)]
+public class GradientTapeStreamingSerialCollection { }
 
 /// <summary>
 /// Tests for <see cref="GradientTape{T}.ComputeGradientsStreaming"/> — the
@@ -15,15 +21,6 @@ namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
 /// emitted exactly once, and that a source used in multiple ops is only emitted
 /// after its FINAL contribution (so partial gradients are never handed out).
 /// </summary>
-[CollectionDefinition("GradientTapeStreamingSerial", DisableParallelization = true)]
-public class GradientTapeStreamingSerialCollection { }
-
-/// <remarks>
-/// Runs in a non-parallel collection: several of these tests flip the process-wide
-/// static <see cref="GradientTape{T}.ReleaseStreamingActivations"/>, so executing
-/// them in parallel with each other — or any other test that reads that flag —
-/// would race and produce intermittent failures.
-/// </remarks>
 [Collection("GradientTapeStreamingSerial")]
 public class GradientTapeStreamingTests
 {
@@ -93,51 +90,47 @@ public class GradientTapeStreamingTests
 
     /// <summary>
     /// #1624: releasing each node's activation references as the streaming
-    /// backward consumes them (ReleaseStreamingActivations, on by default) must
-    /// NOT change the gradients — it only frees memory. A/B the flag on a deeper
+    /// backward consumes them (the default policy) must NOT change the gradients —
+    /// it only frees memory. Compare both typed policies on a deeper
     /// chain (several intermediates released mid-walk) and assert the gradients
     /// are bit-identical on vs off.
     /// </summary>
     [Fact]
     public void StreamingActivationRelease_OnVsOff_BitIdentical()
     {
-        var saved = GradientTape<double>.ReleaseStreamingActivations;
-        try
-        {
-            var aData = new double[] { 2, 3, 4, 5 };
-            var bData = new double[] { 5, 6, 7, 8 };
+        var aData = new double[] { 2, 3, 4, 5 };
+        var bData = new double[] { 5, 6, 7, 8 };
 
-            System.Collections.Generic.Dictionary<string, double[]> Run(bool release)
+        System.Collections.Generic.Dictionary<string, double[]> Run(
+            StreamingGraphRetentionMode retention)
+        {
+            var a = new Tensor<double>(new[] { 4 }, new Vector<double>((double[])aData.Clone()));
+            var b = new Tensor<double>(new[] { 4 }, new Vector<double>((double[])bData.Clone()));
+            using var tape = new GradientTape<double>(new GradientTapeOptions
             {
-                GradientTape<double>.ReleaseStreamingActivations = release;
-                var a = new Tensor<double>(new[] { 4 }, new Vector<double>((double[])aData.Clone()));
-                var b = new Tensor<double>(new[] { 4 }, new Vector<double>((double[])bData.Clone()));
-                using var tape = new GradientTape<double>();
-                // Deeper chain so multiple intermediates are released mid-walk.
-                var c = _engine.TensorMultiply(a, b);
-                var d = _engine.TensorAdd(c, a);
-                var e = _engine.TensorMultiply(d, b);
-                var f = _engine.TensorAdd(e, c);
-                var loss = _engine.ReduceSum(f, null);
-                var outp = new System.Collections.Generic.Dictionary<string, double[]>();
-                tape.ComputeGradientsStreaming(loss, new[] { a, b }, (src, grad) =>
-                {
-                    outp[ReferenceEquals(src, a) ? "a" : "b"] = grad.ToArray();
-                });
-                return outp;
-            }
-
-            var on = Run(release: true);
-            var off = Run(release: false);
-
-            Assert.Equal(off["a"], on["a"]);
-            Assert.Equal(off["b"], on["b"]);
-            Assert.Contains(on["a"], g => g != 0.0);
+                Persistent = true,
+                StreamingGraphRetention = retention,
+            });
+            // Deeper chain so multiple intermediates are released mid-walk.
+            var c = _engine.TensorMultiply(a, b);
+            var d = _engine.TensorAdd(c, a);
+            var e = _engine.TensorMultiply(d, b);
+            var f = _engine.TensorAdd(e, c);
+            var loss = _engine.ReduceSum(f, null);
+            var outp = new System.Collections.Generic.Dictionary<string, double[]>();
+            tape.ComputeGradientsStreaming(loss, new[] { a, b }, (src, grad) =>
+            {
+                outp[ReferenceEquals(src, a) ? "a" : "b"] = grad.ToArray();
+            });
+            return outp;
         }
-        finally
-        {
-            GradientTape<double>.ReleaseStreamingActivations = saved;
-        }
+
+        var released = Run(StreamingGraphRetentionMode.ReleaseAfterBackward);
+        var retained = Run(StreamingGraphRetentionMode.RetainUntilTapeDisposal);
+
+        Assert.Equal(retained["a"], released["a"]);
+        Assert.Equal(retained["b"], released["b"]);
+        Assert.Contains(released["a"], g => g != 0.0);
     }
 
     /// <summary>
@@ -191,6 +184,145 @@ public class GradientTapeStreamingTests
         Assert.DoesNotContain(unused, emitted);
     }
 
+    [Fact]
+    public void Streaming_RejectsIntermediateSourcesBeforeMutatingTheTape()
+    {
+        var source = new Tensor<double>(new[] { 2 }, new Vector<double>(new[] { 2.0, 3.0 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
+        Tensor<double> intermediate = _engine.TensorMultiply(source, source);
+        Tensor<double> loss = _engine.ReduceSum(intermediate, null);
+        int entryCount = tape.EntryCount;
+
+        Assert.Throws<ArgumentException>(() =>
+            tape.ComputeGradientsStreaming(
+                loss,
+                new[] { intermediate, source },
+                (_, _) => throw new InvalidOperationException("Callback must not run.")));
+
+        Assert.Equal(entryCount, tape.EntryCount);
+        Dictionary<Tensor<double>, Tensor<double>> gradients =
+            tape.ComputeGradients(loss, new[] { source });
+        Assert.Equal(new[] { 4.0, 6.0 }, gradients[source].ToArray());
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Streaming_CallbackFailureClearsEverySourceGradientAndRetainedGraphReplays(
+        int failingCallback)
+    {
+        var a = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 1, 2, 3 }));
+        var b = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 4, 5, 6 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        });
+        Tensor<double> loss = _engine.ReduceSum(_engine.TensorMultiply(a, b), null);
+        var expected = new InvalidOperationException("injected streaming callback failure");
+        int callbacks = 0;
+
+        InvalidOperationException actual = Assert.Throws<InvalidOperationException>(() =>
+            tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, _) =>
+            {
+                callbacks++;
+                if (callbacks == failingCallback) throw expected;
+            }));
+
+        Assert.Same(expected, actual);
+        Assert.Null(a.Grad);
+        Assert.Null(b.Grad);
+
+        var replayed = new HashSet<Tensor<double>>(ReferenceEqualityComparer<Tensor<double>>.Instance);
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (source, _) => replayed.Add(source));
+        Assert.Contains(a, replayed);
+        Assert.Contains(b, replayed);
+        Assert.Null(a.Grad);
+        Assert.Null(b.Grad);
+    }
+
+    [Fact]
+    public void Streaming_CallbackFailureInReleaseMode_ClearsTheConsumedGraph()
+    {
+        var a = new Tensor<double>(new[] { 3 }, new Vector<double>(new[] { 1.0, 2.0, 3.0 }));
+        var b = new Tensor<double>(new[] { 3 }, new Vector<double>(new[] { 4.0, 5.0, 6.0 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = StreamingGraphRetentionMode.ReleaseAfterBackward,
+        });
+        Tensor<double> loss = _engine.ReduceSum(_engine.TensorMultiply(a, b), null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            tape.ComputeGradientsStreaming(
+                loss,
+                new[] { a, b },
+                (_, _) => throw new InvalidOperationException("injected failure")));
+
+        Assert.Equal(0, tape.EntryCount);
+        Assert.Null(loss.GradFn?.Backward);
+        Assert.Null(a.Grad);
+        Assert.Null(b.Grad);
+        Assert.Throws<InvalidOperationException>(() => tape.ComputeGradients(loss, new[] { a, b }));
+    }
+
+    [Fact]
+    public void StreamingTyped_EmbeddingGradientStaysSparseAndPreservesRepeatedRows()
+    {
+        const int vocabulary = 1_000_000;
+        const int embeddingDimension = 2;
+        var embeddings = new Tensor<float>(new[] { vocabulary, embeddingDimension });
+        var indices = new Tensor<int>(new[] { 4 });
+        indices[0] = 7;
+        indices[1] = 7;
+        indices[2] = 42;
+        indices[3] = 999_999;
+
+        using var tape = new GradientTape<float>();
+        Tensor<float> output = _engine.TensorEmbeddingLookup<float, int>(embeddings, indices);
+        Tensor<float> loss = _engine.ReduceSum(output, null);
+        StreamingSourceGradientKind? observedKind = null;
+        int observedValueCount = 0;
+        long[]? observedIndices = null;
+
+        tape.ComputeGradientsStreamingTyped(loss, new[] { embeddings }, (_, gradient) =>
+        {
+            observedKind = gradient.Kind;
+            Assert.False(gradient.HasDense);
+            IReadOnlyList<SparseEmbeddingGradient<float>> sparse = gradient.SparseEmbedding;
+            SparseEmbeddingGradient<float> contribution = Assert.Single(sparse);
+            observedValueCount = contribution.Values.Length;
+            observedIndices = contribution.Indices.ToArray();
+        });
+
+        Assert.Equal(StreamingSourceGradientKind.SparseEmbedding, observedKind);
+        Assert.Equal(indices.Length * embeddingDimension, observedValueCount);
+        Assert.Equal(new long[] { 7, 7, 42, 999_999 }, observedIndices);
+        Assert.Null(embeddings.Grad);
+    }
+
+    [Fact]
+    public void Float32AccumulationOverridesOnlyTheNestedAdditionAutocastScope()
+    {
+        using var backwardScope = new AutocastScope(PrecisionMode.Float16);
+        Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+
+        using (var accumulation = new GradientAccumulationPrecisionScope(
+            GradientAccumulationPrecision.Float32))
+        {
+            using (IDisposable? additionScope =
+                GradientAccumulationPrecisionScope.EnterFloat32AutocastForAddition())
+            {
+                Assert.NotNull(additionScope);
+                Assert.Equal(PrecisionMode.Float32, AutocastScope.ActivePrecision);
+            }
+
+            Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+        }
+
+        Assert.Equal(PrecisionMode.Float16, AutocastScope.ActivePrecision);
+    }
+
     /// <summary>
     /// Determinism: streaming twice over the same graph yields identical
     /// gradients (the accumulation order is the fixed reverse-topological order).
@@ -239,7 +371,6 @@ public class GradientTapeStreamingTests
     [Fact]
     public void StreamingActivationRelease_FreesIntermediateActivationChain()
     {
-        var saved = GradientTape<double>.ReleaseStreamingActivations;
         GradientTape<double>? tapeOff = null;
         GradientTape<double>? tapeOn = null;
         try
@@ -264,11 +395,10 @@ public class GradientTapeStreamingTests
         }
         finally
         {
-            GradientTape<double>.ReleaseStreamingActivations = saved;
             // The persistent tapes were intentionally kept alive across the GC checks above; dispose
             // them now so their graph/arena resources don't leak into later tests.
-            tapeOff?.Dispose();
             tapeOn?.Dispose();
+            tapeOff?.Dispose();
         }
     }
 
@@ -281,35 +411,129 @@ public class GradientTapeStreamingTests
     [Fact]
     public void PersistentTape_AfterStreamingRelease_RejectsReuse()
     {
-        var saved = GradientTape<double>.ReleaseStreamingActivations;
-        GradientTape<double>.ReleaseStreamingActivations = true;
+        var a = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 1, 2, 3, 4 }));
+        var b = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 5, 6, 7, 8 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
+        var c = _engine.TensorMultiply(a, b);
+        var loss = _engine.ReduceSum(c, null);
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+
+        // The streaming release destroyed the persistent graph: any reuse must throw, not corrupt.
+        Assert.Throws<System.InvalidOperationException>(
+            () => tape.ComputeGradients(loss, new[] { a, b }));
+        Assert.Throws<System.InvalidOperationException>(
+            () => tape.Record(default));
+    }
+
+    [Fact]
+    public void RetainedPersistentTape_ReplaysStreamingBackwardBitIdentically()
+    {
+        var a = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 1, 2, 3, 4 }));
+        var b = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 5, 6, 7, 8 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        });
+        var loss = _engine.ReduceSum(_engine.TensorMultiply(a, b), null);
+
+        var first = new Dictionary<Tensor<double>, double[]>(ReferenceEqualityComparer<Tensor<double>>.Instance);
+        var second = new Dictionary<Tensor<double>, double[]>(ReferenceEqualityComparer<Tensor<double>>.Instance);
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (source, gradient) => first[source] = gradient.ToArray());
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (source, gradient) => second[source] = gradient.ToArray());
+
+        Assert.Equal(first[a], second[a]);
+        Assert.Equal(first[b], second[b]);
+    }
+
+    [Fact]
+    public void RetainedPersistentTape_KeepsStatefulOperationSavedTensorPinnedAcrossReplay()
+    {
+        TensorPool<float>.Clear();
+        var engine = new CpuEngine();
+        var input = new Tensor<float>(
+            new float[] { 0.25f, -0.5f, 0.75f, 1.5f, -1.25f, 0.1f, 0.2f, 0.3f },
+            new[] { 2, 4 });
+        var gamma = new Tensor<float>(new float[] { 1.0f, 0.9f, 1.1f, 0.8f }, new[] { 4 });
+        var tape = new GradientTape<float>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        });
+        Tensor<float>? savedRms = null;
         try
         {
-            var a = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 1, 2, 3, 4 }));
-            var b = new Tensor<double>(new[] { 4 }, new Vector<double>(new double[] { 5, 6, 7, 8 }));
-            using var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
-            var c = _engine.TensorMultiply(a, b);
-            var loss = _engine.ReduceSum(c, null);
-            tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+            var output = engine.RMSNorm(input, gamma, 1e-5, out var rms);
+            savedRms = rms;
+            var loss = engine.ReduceSum(output, null);
+            float[]? first = null;
+            float[]? second = null;
 
-            // The streaming release destroyed the persistent graph: any reuse must throw, not corrupt.
-            Assert.Throws<System.InvalidOperationException>(
-                () => tape.ComputeGradients(loss, new[] { a, b }));
-            Assert.Throws<System.InvalidOperationException>(
-                () => tape.Record(default));
+            tape.ComputeGradientsStreaming(loss, new[] { input }, (_, gradient) => first = gradient.ToArray());
+            Assert.True(rms._pinnedByTape);
+
+            // A retained pin must keep the saved RMS out of the reusable tensor pool. If streaming
+            // cleanup drops only the pin while leaving the graph, this rent can overwrite the state
+            // that RMSNormBackward needs on the second pass.
+            TensorPool<float>.Return(rms);
+            Tensor<float> churn = TensorPool<float>.Rent((int[])rms._shape.Clone());
+            Assert.NotSame(rms, churn);
+            for (int i = 0; i < churn.Length; i++) churn[i] = 12345.0f + i;
+
+            tape.ComputeGradientsStreaming(loss, new[] { input }, (_, gradient) => second = gradient.ToArray());
+            Assert.Equal(first, second);
+            Assert.True(rms._pinnedByTape);
+            TensorPool<float>.Return(churn);
         }
-        finally { GradientTape<double>.ReleaseStreamingActivations = saved; }
+        finally
+        {
+            tape.Dispose();
+        }
+
+        Tensor<float> releasedRms = Assert.IsType<Tensor<float>>(savedRms);
+        Assert.False(releasedRms._pinnedByTape);
+        TensorPool<float>.Return(releasedRms);
+        Tensor<float> reused = TensorPool<float>.Rent((int[])releasedRms._shape.Clone());
+        Assert.Same(releasedRms, reused);
+        TensorPool<float>.Return(reused);
+    }
+
+    [Fact]
+    public void OppositeRetentionPolicies_RunConcurrentlyWithoutInterference()
+    {
+        using var ready = new CountdownEvent(2);
+        using var start = new ManualResetEventSlim(false);
+
+        Task retained = Task.Run(() => RunConcurrentTape(
+            StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+            expectReplay: true,
+            ready,
+            start));
+        Task released = Task.Run(() => RunConcurrentTape(
+            StreamingGraphRetentionMode.ReleaseAfterBackward,
+            expectReplay: false,
+            ready,
+            start));
+
+        ready.Wait();
+        start.Set();
+        Task.WaitAll(retained, released);
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private (System.WeakReference weak, GradientTape<double> tape, Tensor<double> src) BuildPersistentChainAndStream(bool release)
     {
-        GradientTape<double>.ReleaseStreamingActivations = release;
         var aData = new double[32]; var bData = new double[32];
         for (int i = 0; i < 32; i++) { aData[i] = 1.3; bData[i] = 0.7; }
         var a = new Tensor<double>(new[] { 32 }, new Vector<double>(aData));
         var b = new Tensor<double>(new[] { 32 }, new Vector<double>(bData));
-        var tape = new GradientTape<double>(new GradientTapeOptions { Persistent = true });
+        var tape = new GradientTape<double>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = release
+                ? StreamingGraphRetentionMode.ReleaseAfterBackward
+                : StreamingGraphRetentionMode.RetainUntilTapeDisposal,
+        });
         var t1 = _engine.TensorMultiply(a, b);
         var t2 = _engine.TensorMultiply(t1, b);   // mid-chain activation we weak-ref
         var t3 = _engine.TensorMultiply(t2, b);
@@ -320,5 +544,35 @@ public class GradientTapeStreamingTests
         // t1..t4 and loss are locals — not rooted after return; only the persistent tape's node graph
         // could keep t2 alive (via a consumer node's Input field), which the release drops.
         return (weak, tape, a);
+    }
+
+    private static void RunConcurrentTape(
+        StreamingGraphRetentionMode retention,
+        bool expectReplay,
+        CountdownEvent ready,
+        ManualResetEventSlim start)
+    {
+        var engine = new CpuEngine();
+        var a = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 2, 3, 4 }));
+        var b = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 5, 6, 7 }));
+        using var tape = new GradientTape<double>(new GradientTapeOptions
+        {
+            Persistent = true,
+            StreamingGraphRetention = retention,
+        });
+        var loss = engine.ReduceSum(engine.TensorMultiply(a, b), null);
+        ready.Signal();
+        start.Wait();
+        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+
+        if (expectReplay)
+        {
+            tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+        }
+        else
+        {
+            Assert.Throws<System.InvalidOperationException>(
+                () => tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { }));
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/GradientTapeStreamingTests.cs
@@ -499,7 +499,7 @@ public class GradientTapeStreamingTests
     }
 
     [Fact]
-    public void OppositeRetentionPolicies_RunConcurrentlyWithoutInterference()
+    public async Task OppositeRetentionPolicies_RunConcurrentlyWithoutInterference()
     {
         using var ready = new CountdownEvent(2);
         using var start = new ManualResetEventSlim(false);
@@ -515,9 +515,15 @@ public class GradientTapeStreamingTests
             ready,
             start));
 
-        ready.Wait();
-        start.Set();
-        Task.WaitAll(retained, released);
+        try
+        {
+            Assert.True(ready.Wait(TimeSpan.FromSeconds(30)),
+                "A concurrent tape worker did not reach the start barrier.");
+        }
+        finally { start.Set(); }
+        Task completion = Task.WhenAll(retained, released);
+        Assert.Same(completion, await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(60))));
+        await completion;
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -552,27 +558,36 @@ public class GradientTapeStreamingTests
         CountdownEvent ready,
         ManualResetEventSlim start)
     {
-        var engine = new CpuEngine();
-        var a = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 2, 3, 4 }));
-        var b = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 5, 6, 7 }));
-        using var tape = new GradientTape<double>(new GradientTapeOptions
+        bool signaled = false;
+        try
         {
-            Persistent = true,
-            StreamingGraphRetention = retention,
-        });
-        var loss = engine.ReduceSum(engine.TensorMultiply(a, b), null);
-        ready.Signal();
-        start.Wait();
-        tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
-
-        if (expectReplay)
-        {
+            var engine = new CpuEngine();
+            var a = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 2, 3, 4 }));
+            var b = new Tensor<double>(new[] { 3 }, new Vector<double>(new double[] { 5, 6, 7 }));
+            using var tape = new GradientTape<double>(new GradientTapeOptions
+            {
+                Persistent = true,
+                StreamingGraphRetention = retention,
+            });
+            var loss = engine.ReduceSum(engine.TensorMultiply(a, b), null);
+            ready.Signal();
+            signaled = true;
+            Assert.True(start.Wait(TimeSpan.FromSeconds(30)), "The concurrent tape start barrier was not released.");
             tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+
+            if (expectReplay)
+            {
+                tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { });
+            }
+            else
+            {
+                Assert.Throws<System.InvalidOperationException>(
+                    () => tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { }));
+            }
         }
-        else
+        finally
         {
-            Assert.Throws<System.InvalidOperationException>(
-                () => tape.ComputeGradientsStreaming(loss, new[] { a, b }, (_, __) => { }));
+            if (!signaled) ready.Signal();
         }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
@@ -509,7 +509,11 @@ public class SavedStatePinningReproTests
     {
         TensorPool<float>.Clear();
         var engine = new CpuEngine();
-        using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
+        using var tape = new GradientTape<float>(new GradientTapeOptions
+        {
+            Persistent = false,
+            StreamingGraphRetention = StreamingGraphRetentionMode.ReleaseAfterBackward,
+        });
             var deadInput = Fixed(new[] { 2, 8 }, 0.2f, 0.03f);
             var deadGamma = Fixed(new[] { 8 }, 1f, 0.01f);
             _ = engine.RMSNorm(deadInput, deadGamma, 1e-5, out var deadRms);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/SavedStatePinningReproTests.cs
@@ -508,12 +508,8 @@ public class SavedStatePinningReproTests
     public void StreamingBackward_ReleasesSavedStateForExecutedAndDeadEntries()
     {
         TensorPool<float>.Clear();
-        bool previousReleaseSetting = GradientTape<float>.ReleaseStreamingActivations;
-        GradientTape<float>.ReleaseStreamingActivations = true;
-        try
-        {
-            var engine = new CpuEngine();
-            using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
+        var engine = new CpuEngine();
+        using var tape = new GradientTape<float>(new GradientTapeOptions { Persistent = false });
             var deadInput = Fixed(new[] { 2, 8 }, 0.2f, 0.03f);
             var deadGamma = Fixed(new[] { 8 }, 1f, 0.01f);
             _ = engine.RMSNorm(deadInput, deadGamma, 1e-5, out var deadRms);
@@ -532,11 +528,6 @@ public class SavedStatePinningReproTests
 
             Assert.True(emitted);
             Assert.False(liveRms._pinnedByTape);
-            AssertReleasedAndPoolable(deadRms, "streaming dead-entry cleanup");
-        }
-        finally
-        {
-            GradientTape<float>.ReleaseStreamingActivations = previousReleaseSetting;
-        }
+        AssertReleasedAndPoolable(deadRms, "streaming dead-entry cleanup");
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Compilation/FusedOptimizerNonFiniteGradientTests.cs
@@ -113,7 +113,7 @@ public class FusedOptimizerNonFiniteGradientTests
         for (int i = 0; i < data.Length; i++) data[i] = value;
         tensor._gpuBuffer = new MockGpuBuffer(data);
         tensor._gpuBackend = backend;
-        tensor._gpuBufferVersion = tensor.Version;
+        tensor._gpuBufferVersion = tensor.GpuCacheVersion;
     }
 
     private static Tensor<float>[] GetPlanGradients(ICompiledTrainingPlan<float> plan)

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/EvictActivationsCreatedAfterLifetimeTests.cs
@@ -194,7 +194,7 @@ public class EvictActivationsCreatedAfterLifetimeTests
             new[]
             {
                 typeof(object), typeof(IGpuBuffer), typeof(int[]), typeof(IDirectGpuBackend),
-                typeof(bool), typeof(int)
+                typeof(bool), typeof(int), typeof(int)
             },
             null) ?? throw new InvalidOperationException("DirectGpuTensorEngine CacheActivation method was not found.");
         object activationCache = activationCacheField.GetValue(engine)
@@ -215,7 +215,7 @@ public class EvictActivationsCreatedAfterLifetimeTests
         });
         cacheActivation.Invoke(engine, new object[]
         {
-            vectorKey, buffer, new[] { 1, 4 }, backend, false, 0
+            vectorKey, buffer, new[] { 1, 4 }, backend, false, 0, 0
         });
 
         Assert.Equal(new[] { 3f, 5f, 7f, 11f }, tensor.ToArray());
@@ -274,7 +274,7 @@ public class EvictActivationsCreatedAfterLifetimeTests
             new[]
             {
                 typeof(object), typeof(IGpuBuffer), typeof(int[]), typeof(IDirectGpuBackend),
-                typeof(bool), typeof(int)
+                typeof(bool), typeof(int), typeof(int)
             },
             null) ?? throw new InvalidOperationException("DirectGpuTensorEngine CacheActivation method was not found.");
         object activationCache = activationCacheField.GetValue(engine)
@@ -296,7 +296,7 @@ public class EvictActivationsCreatedAfterLifetimeTests
         });
         cacheActivation.Invoke(engine, new object[]
         {
-            vectorKey, residentBuffer, new[] { 1, 4 }, backend, false, 0
+            vectorKey, residentBuffer, new[] { 1, 4 }, backend, false, 0, 0
         });
         Assert.Equal(new[] { 2f, 3f, 5f, 7f }, tensor.ToArray());
         object arrayKey = tensor.GetBackingArrayForCacheLookupUnsafe()
@@ -306,7 +306,7 @@ public class EvictActivationsCreatedAfterLifetimeTests
 
         cacheActivation.Invoke(engine, new object[]
         {
-            arrayKey, displacedBuffer, new[] { 1, 4 }, backend, false, 0
+            arrayKey, displacedBuffer, new[] { 1, 4 }, backend, false, 0, 0
         });
         bool staleMaterializerRan = false;
         AiDotNet.Tensors.Helpers.DeferredArrayMaterializer.Register(

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClFp16NativeOpTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClFp16NativeOpTests.cs
@@ -56,7 +56,8 @@ public sealed class OpenClFp16NativeOpTests : IClassFixture<OpenClBackendTestFix
     private IGpuBuffer ToFp16(float[] x)
     {
         using var f32 = Backend.AllocateBuffer(x);
-        var f16 = Backend.AllocateBuffer(x.Length); // over-allocated as floats; harmless
+        var f16 = Backend.AllocateByteBuffer(checked(x.Length * sizeof(ushort)));
+        Assert.Equal((long)x.Length * sizeof(ushort), f16.SizeInBytes);
         Backend.ConvertToFp16(f32, f16, x.Length);
         return f16;
     }
@@ -97,7 +98,7 @@ public sealed class OpenClFp16NativeOpTests : IClassFixture<OpenClBackendTestFix
         }
 
         using var inB = ToFp16(x);
-        using var outB = Backend.AllocateBuffer(n);
+        using var outB = Backend.AllocateByteBuffer(checked(n * sizeof(ushort)));
         Backend.Fp16Gelu(inB, outB, n);
         AssertClose(expected, FromFp16(outB, n), absTol: 3e-2, relTol: 4e-2);
     }
@@ -114,7 +115,7 @@ public sealed class OpenClFp16NativeOpTests : IClassFixture<OpenClBackendTestFix
         for (int i = 0; i < n; i++) { float xi = ToFp16AndBack(x[i]); expected[i] = xi > 0 ? xi : 0; }
 
         using var inB = ToFp16(x);
-        using var outB = Backend.AllocateBuffer(n);
+        using var outB = Backend.AllocateByteBuffer(checked(n * sizeof(ushort)));
         Backend.Fp16Relu(inB, outB, n);
         AssertClose(expected, FromFp16(outB, n), absTol: 1e-3, relTol: 1e-3);
     }
@@ -132,7 +133,7 @@ public sealed class OpenClFp16NativeOpTests : IClassFixture<OpenClBackendTestFix
 
         using var aB = ToFp16(a);
         using var bB = ToFp16(b);
-        using var outB = Backend.AllocateBuffer(n);
+        using var outB = Backend.AllocateByteBuffer(checked(n * sizeof(ushort)));
         Backend.Fp16Add(aB, bB, outB, n);
         AssertClose(expected, FromFp16(outB, n), absTol: 2e-2, relTol: 2e-2);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClHalfPrecisionGemmTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClHalfPrecisionGemmTests.cs
@@ -97,11 +97,11 @@ public sealed class OpenClHalfPrecisionGemmTests : IClassFixture<OpenClBackendTe
         var aFp32 = Backend.AllocateBuffer(a);
         var bFp32 = Backend.AllocateBuffer(b);
 
-        // FP16 buffers hold M*K / K*N halfs (2 bytes each). Allocating that many
-        // floats over-allocates (4 bytes each) which is harmless and mirrors the
-        // CUDA engine path's AllocateOutputBuffer(M*K) sizing.
-        var aFp16 = Backend.AllocateBuffer(m * k);
-        var bFp16 = Backend.AllocateBuffer(k * n);
+        // Use the actual half-width allocation made by the precision planner.
+        var aFp16 = Backend.AllocateByteBuffer(checked(m * k * sizeof(ushort)));
+        var bFp16 = Backend.AllocateByteBuffer(checked(k * n * sizeof(ushort)));
+        Assert.Equal((long)m * k * sizeof(ushort), aFp16.SizeInBytes);
+        Assert.Equal((long)k * n * sizeof(ushort), bFp16.SizeInBytes);
         Backend.ConvertToFp16(aFp32, aFp16, m * k);
         Backend.ConvertToFp16(bFp32, bFp16, k * n);
 
@@ -166,8 +166,7 @@ public sealed class OpenClHalfPrecisionGemmTests : IClassFixture<OpenClBackendTe
         var expected = CpuReferenceFromFp16(a, b, m, n, k);
 
         var (aFp16, bFp16) = UploadFp16Inputs(a, b, m, n, k);
-        // FP16 output buffer (M*N halfs); over-allocate as floats.
-        using var cFp16 = Backend.AllocateBuffer(m * n);
+        using var cFp16 = Backend.AllocateByteBuffer(checked(m * n * sizeof(ushort)));
         // Convert the FP16 result back to FP32 for comparison.
         using var cFp32 = Backend.AllocateBuffer(m * n);
         try

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClPrecisionBufferOwnershipTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/OpenClPrecisionBufferOwnershipTests.cs
@@ -1,0 +1,82 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.DirectGpu.OpenCL;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("DirectGpuSerial")]
+public sealed class OpenClPrecisionBufferOwnershipTests : IClassFixture<OpenClBackendTestFixture>
+{
+    public enum BufferWrapper { Float, Byte }
+    public enum Operand { Left, Right, Output }
+    private readonly OpenClBackendTestFixture _fixture;
+
+    public OpenClPrecisionBufferOwnershipTests(OpenClBackendTestFixture fixture) => _fixture = fixture;
+
+    [SkippableTheory]
+    [InlineData(BufferWrapper.Float, Operand.Left)]
+    [InlineData(BufferWrapper.Float, Operand.Right)]
+    [InlineData(BufferWrapper.Float, Operand.Output)]
+    [InlineData(BufferWrapper.Byte, Operand.Left)]
+    [InlineData(BufferWrapper.Byte, Operand.Right)]
+    [InlineData(BufferWrapper.Byte, Operand.Output)]
+    public void HalfGemm_RejectsForeignContextBeforeDispatch(BufferWrapper wrapper, Operand operand)
+    {
+        OpenClBackend backend = RequireBackend();
+        using var foreign = new OpenClBackend();
+        Assert.True(foreign.IsAvailable, "The second OpenCL context failed to initialize.");
+        using IGpuBuffer left = Allocate(operand == Operand.Left ? foreign : backend, wrapper);
+        using IGpuBuffer right = Allocate(operand == Operand.Right ? foreign : backend, wrapper);
+        using IGpuBuffer output = Allocate(operand == Operand.Output ? foreign : backend, wrapper);
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => backend.GemmFp16In32fOut(left, right, output, 1, 1, 1));
+
+        Assert.Contains("context", error.Message);
+        Assert.NotEqual(IntPtr.Zero, left.Handle);
+        Assert.NotEqual(IntPtr.Zero, right.Handle);
+        Assert.NotEqual(IntPtr.Zero, output.Handle);
+    }
+
+    [SkippableTheory]
+    [InlineData(BufferWrapper.Float)]
+    [InlineData(BufferWrapper.Byte)]
+    public void HalfGemm_AcceptsBothWrappersFromItsOwnContext(BufferWrapper wrapper)
+    {
+        OpenClBackend backend = RequireBackend();
+        using IGpuBuffer left = Allocate(backend, wrapper);
+        using IGpuBuffer right = Allocate(backend, wrapper);
+        using IGpuBuffer output = backend.AllocateBuffer(new[] { -1f });
+
+        backend.GemmFp16In32fOut(left, right, output, 1, 1, 1);
+        backend.Synchronize();
+
+        Assert.Equal(new[] { 0f }, backend.DownloadBuffer(output));
+    }
+
+    private OpenClBackend RequireBackend()
+    {
+        bool ready = _fixture.IsAvailable && _fixture.Backend?.SupportsHgemm == true;
+        if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1")
+            Assert.True(ready, "OpenCL FP16 GEMM was required but is unavailable.");
+        Skip.IfNot(ready, "OpenCL FP16 GEMM is unavailable.");
+        return _fixture.Backend ?? throw new InvalidOperationException("The OpenCL backend is unavailable.");
+    }
+
+    private static IGpuBuffer Allocate(OpenClBackend backend, BufferWrapper wrapper)
+    {
+        if (wrapper == BufferWrapper.Float) return backend.AllocateBuffer(new[] { 0f });
+        IGpuBuffer buffer = backend.AllocateByteBuffer(sizeof(float));
+        try
+        {
+            backend.UploadByteBuffer(buffer, new byte[sizeof(float)]);
+            return buffer;
+        }
+        catch { buffer.Dispose(); throw; }
+    }
+}
+
+#endif

--- a/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentCacheOwnershipTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/DirectGpu/PersistentCacheOwnershipTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.DirectGpu;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class PersistentCacheOwnershipTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Invalidation_RetiresThePriorOwnerAndRecoversFromFailedUpload(bool failUpload)
+    {
+        var backend = new TrackingBackend();
+        using var direct = new DirectGpuEngine(backend);
+        using var engine = new DirectGpuTensorEngine(direct);
+        float[] values = { 1, 2, 3 };
+        using var tensor = new Tensor<float>(values, new[] { 3 });
+        engine.RegisterResidentParamBuffer(tensor);
+        MockGpuBuffer original = Assert.IsType<MockGpuBuffer>(tensor.TryGetGpuBuffer());
+        values[0] = 10;
+        backend.FailAllocation = failUpload;
+
+        engine.InvalidatePersistentTensor(tensor);
+
+        Assert.Equal(0, original.DisposeCount);
+        Assert.Equal(failUpload ? 0 : 1, engine.CachedTensorCount);
+        backend.FailAllocation = false;
+        engine.RegisterResidentParamBuffer(tensor);
+        MockGpuBuffer current = Assert.IsType<MockGpuBuffer>(tensor.TryGetGpuBuffer());
+        Assert.NotSame(original, current);
+        Assert.Equal(new float[] { 10, 2, 3 }, current.Data);
+        Assert.Equal(1, original.DisposeCount);
+        Assert.Equal(0, current.DisposeCount);
+
+        engine.Dispose();
+        Assert.All(backend.Allocations, buffer => Assert.Equal(1, buffer.DisposeCount));
+    }
+
+    [Fact]
+    public async Task ConcurrentInvalidations_RetireEveryReplacedAllocationExactlyOnce()
+    {
+        var backend = new TrackingBackend();
+        using var direct = new DirectGpuEngine(backend);
+        using var engine = new DirectGpuTensorEngine(direct);
+        using var tensor = new Tensor<float>(new float[] { 1, 2, 3 }, new[] { 3 });
+        engine.RegisterResidentParamBuffer(tensor);
+
+        Task completion = Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(_ => Task.Run(() => engine.InvalidatePersistentTensor(tensor))));
+        Assert.Same(completion, await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(30))));
+        await completion;
+        Assert.Equal(9, backend.Allocations.Count);
+        Assert.Equal(1, engine.CachedTensorCount);
+        engine.RegisterResidentParamBuffer(tensor);
+        MockGpuBuffer current = Assert.IsType<MockGpuBuffer>(tensor.TryGetGpuBuffer());
+        Assert.Equal(new float[] { 1, 2, 3 }, current.Data);
+        Assert.Single(backend.Allocations, buffer => buffer.DisposeCount == 0);
+        Assert.Equal(0, current.DisposeCount);
+
+        engine.Dispose();
+        Assert.All(backend.Allocations, buffer => Assert.Equal(1, buffer.DisposeCount));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Invalidation_RemovesStaleCacheWhenUploadSynchronizationAndCleanupFail(bool failDisposal)
+    {
+        var backend = new TrackingBackend();
+        using var direct = new DirectGpuEngine(backend);
+        using var engine = new DirectGpuTensorEngine(direct);
+        float[] values = { 1, 2, 3 };
+        using var tensor = new Tensor<float>(values, new[] { 3 });
+        engine.RegisterResidentParamBuffer(tensor);
+        MockGpuBuffer original = Assert.IsType<MockGpuBuffer>(tensor.TryGetGpuBuffer());
+        values[0] = 10;
+        backend.FailSynchronization = true;
+        backend.FailBufferDisposal = failDisposal;
+
+        if (failDisposal)
+            Assert.Throws<IOException>(() => engine.InvalidatePersistentTensor(tensor));
+        else
+            engine.InvalidatePersistentTensor(tensor);
+
+        Assert.Equal(0, engine.CachedTensorCount);
+        Assert.Equal(0, original.DisposeCount);
+        backend.FailSynchronization = false;
+        backend.FailBufferDisposal = false;
+        engine.RegisterResidentParamBuffer(tensor);
+        MockGpuBuffer current = Assert.IsType<MockGpuBuffer>(tensor.TryGetGpuBuffer());
+        Assert.NotSame(original, current);
+        Assert.Equal(new float[] { 10, 2, 3 }, current.Data);
+        engine.Dispose();
+        Assert.All(backend.Allocations, buffer => Assert.Equal(1, buffer.DisposeCount));
+    }
+
+    private sealed class ThrowingDisposalBuffer : IGpuBuffer
+    {
+        private readonly MockGpuBuffer _inner;
+        internal ThrowingDisposalBuffer(MockGpuBuffer inner) => _inner = inner;
+        public int Size => _inner.Size;
+        public long SizeInBytes => _inner.SizeInBytes;
+        public IntPtr Handle => _inner.Handle;
+        public void Dispose()
+        {
+            _inner.Dispose();
+            throw new IOException("Injected device cleanup failure.");
+        }
+    }
+
+    private sealed class TrackingBackend : DelegatingGpuBackend
+    {
+        internal ConcurrentBag<MockGpuBuffer> Allocations { get; } = new();
+        internal bool FailAllocation { get; set; }
+        internal bool FailSynchronization { get; set; }
+        internal bool FailBufferDisposal { get; set; }
+
+        internal TrackingBackend() : base(MockDirectGpuBackend.Create(new MockBackendState())) { }
+
+        public override IGpuBuffer AllocateBuffer(float[] values)
+        {
+            if (FailAllocation) throw new OutOfMemoryException("Injected device allocation failure.");
+            var buffer = new MockGpuBuffer((float[])values.Clone());
+            Allocations.Add(buffer);
+            return FailBufferDisposal ? new ThrowingDisposalBuffer(buffer) : buffer;
+        }
+
+        public override void Synchronize()
+        {
+            if (FailSynchronization) throw new InvalidOperationException("Injected device synchronization failure.");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionPolicyTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Gpu/GpuPrecisionPolicyTests.cs
@@ -9,6 +9,22 @@ namespace AiDotNet.Tensors.Tests.Engines.Gpu;
 
 public sealed class GpuPrecisionPolicyTests
 {
+    [Theory]
+    [InlineData(GpuPrecisionOperation.MatMul)]
+    [InlineData(GpuPrecisionOperation.MatMulTransposed)]
+    [InlineData(GpuPrecisionOperation.BatchMatMul)]
+    public void CpuFallback_PreservesTheRequestedOperation(GpuPrecisionOperation operation)
+    {
+        var backend = CreateBackend(Fp32());
+        GpuComputePlan plan = GpuPrecisionPlanner.CpuFallback<float>(backend,
+            nameof(CpuFallback_PreservesTheRequestedOperation), GpuComputePreference.Float16,
+            "Injected GPU failure", operation);
+        Assert.Equal(operation, plan.OperationKind);
+        Assert.Equal(GpuExecutionRoute.Cpu, plan.Route);
+        Assert.Equal(GpuComputePreference.Float16, plan.RequestedPreference);
+        Assert.Equal("Injected GPU failure", plan.FallbackReason);
+    }
+
     [Fact]
     public void CublasDefaultAlgorithmMatchesTheNativeHeaderValue()
         => Assert.Equal(-1, CuBlasNative.CUBLAS_GEMM_DEFAULT);

--- a/tests/AiDotNet.Tensors.Tests/Engines/Simd/AdamMomentKernelsParityTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Simd/AdamMomentKernelsParityTests.cs
@@ -137,4 +137,144 @@ public class AdamMomentKernelsParityTests
             if (ams) Assert.Equal(BitConverter.DoubleToInt64Bits(vmR[i]), BitConverter.DoubleToInt64Bits(vmK[i]));
         }
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Float_SparseAdamMatchesGpuSparseContract_BitForBitAcrossRotatingSteps(bool useAmsgrad)
+    {
+        const int n = 32;
+        const float beta1 = 0.9f;
+        const float beta2 = 0.999f;
+        const float learningRate = 1e-3f;
+        const float epsilon = 1e-8f;
+        var random = new Random(2088);
+        float[] referenceParameters = RandF(random, n);
+        float[] sparseParameters = (float[])referenceParameters.Clone();
+        var referenceFirstMoment = new float[n];
+        var sparseFirstMoment = new float[n];
+        var referenceSecondMoment = new float[n];
+        var sparseSecondMoment = new float[n];
+        var referenceMaximumMoment = new float[n];
+        var sparseMaximumMoment = new float[n];
+        int[][] indicesByStep =
+        {
+            new[] { 1, 7, 18, 31 },
+            new[] { 0, 7, 19, 30 },
+            new[] { 2, 8, 19, 29 },
+            new[] { 3, 8, 20, 28 },
+            new[] { 4, 9, 20, 27 },
+        };
+
+        for (int step = 1; step <= 5; step++)
+        {
+            int[] indices = indicesByStep[step - 1];
+            float[] sparseValues = RandF(random, indices.Length);
+            float biasCorrection1 = 1.0f - (float)Math.Pow(beta1, step);
+            float biasCorrection2 = 1.0f - (float)Math.Pow(beta2, step);
+            for (int sparsePosition = 0; sparsePosition < indices.Length; sparsePosition++)
+            {
+                int index = indices[sparsePosition];
+                float gradient = sparseValues[sparsePosition];
+                float first = FastMath
+                    ? FmaF(1.0f - beta1, gradient, beta1 * referenceFirstMoment[index])
+                    : beta1 * referenceFirstMoment[index] + (1.0f - beta1) * gradient;
+                float second = FastMath
+                    ? FmaF((1.0f - beta2) * gradient, gradient, beta2 * referenceSecondMoment[index])
+                    : beta2 * referenceSecondMoment[index] + (1.0f - beta2) * gradient * gradient;
+                referenceFirstMoment[index] = first;
+                referenceSecondMoment[index] = second;
+                float effectiveSecond = second / biasCorrection2;
+                if (useAmsgrad)
+                {
+                    referenceMaximumMoment[index] = Math.Max(referenceMaximumMoment[index], second);
+                    effectiveSecond = referenceMaximumMoment[index] / biasCorrection2;
+                }
+                referenceParameters[index] -= learningRate * (first / biasCorrection1)
+                    / (SqrtF(effectiveSecond) + epsilon);
+            }
+            AdamMomentKernels.AdamStepSparse(
+                sparseParameters, indices, sparseValues, sparseFirstMoment, sparseSecondMoment, sparseMaximumMoment,
+                beta1, beta2, 1.0f - beta1, 1.0f - beta2,
+                biasCorrection1, biasCorrection2, learningRate, epsilon, useAmsgrad);
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(FloatBits(referenceParameters[i]), FloatBits(sparseParameters[i]));
+            Assert.Equal(FloatBits(referenceFirstMoment[i]), FloatBits(sparseFirstMoment[i]));
+            Assert.Equal(FloatBits(referenceSecondMoment[i]), FloatBits(sparseSecondMoment[i]));
+            Assert.Equal(FloatBits(referenceMaximumMoment[i]), FloatBits(sparseMaximumMoment[i]));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Double_SparseAdamUpdatesOnlyIndexedCoordinatesAcrossRotatingSteps(bool useAmsgrad)
+    {
+        const int n = 32;
+        const double beta1 = 0.9;
+        const double beta2 = 0.999;
+        const double learningRate = 1e-3;
+        const double epsilon = 1e-8;
+        var random = new Random(2089);
+        double[] referenceParameters = RandD(random, n);
+        double[] sparseParameters = (double[])referenceParameters.Clone();
+        var referenceFirstMoment = new double[n];
+        var sparseFirstMoment = new double[n];
+        var referenceSecondMoment = new double[n];
+        var sparseSecondMoment = new double[n];
+        var referenceMaximumMoment = new double[n];
+        var sparseMaximumMoment = new double[n];
+        int[][] indicesByStep =
+        {
+            new[] { 0, 9, 17, 30 },
+            new[] { 1, 9, 18, 29 },
+            new[] { 2, 10, 18, 28 },
+            new[] { 3, 10, 19, 27 },
+            new[] { 4, 11, 19, 26 },
+        };
+
+        for (int step = 1; step <= 5; step++)
+        {
+            int[] indices = indicesByStep[step - 1];
+            double[] sparseValues = RandD(random, indices.Length);
+            double biasCorrection1 = 1.0 - Math.Pow(beta1, step);
+            double biasCorrection2 = 1.0 - Math.Pow(beta2, step);
+            for (int sparsePosition = 0; sparsePosition < indices.Length; sparsePosition++)
+            {
+                int index = indices[sparsePosition];
+                double gradient = sparseValues[sparsePosition];
+                double first = FastMath
+                    ? FmaD(1.0 - beta1, gradient, beta1 * referenceFirstMoment[index])
+                    : beta1 * referenceFirstMoment[index] + (1.0 - beta1) * gradient;
+                double second = FastMath
+                    ? FmaD((1.0 - beta2) * gradient, gradient, beta2 * referenceSecondMoment[index])
+                    : beta2 * referenceSecondMoment[index] + (1.0 - beta2) * gradient * gradient;
+                referenceFirstMoment[index] = first;
+                referenceSecondMoment[index] = second;
+                double effectiveSecond = second / biasCorrection2;
+                if (useAmsgrad)
+                {
+                    referenceMaximumMoment[index] = Math.Max(referenceMaximumMoment[index], second);
+                    effectiveSecond = referenceMaximumMoment[index] / biasCorrection2;
+                }
+                referenceParameters[index] -= learningRate * (first / biasCorrection1)
+                    / (Math.Sqrt(effectiveSecond) + epsilon);
+            }
+            AdamMomentKernels.AdamStepSparse(
+                sparseParameters, indices, sparseValues, sparseFirstMoment, sparseSecondMoment, sparseMaximumMoment,
+                beta1, beta2, 1.0 - beta1, 1.0 - beta2,
+                biasCorrection1, biasCorrection2, learningRate, epsilon, useAmsgrad);
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.Equal(BitConverter.DoubleToInt64Bits(referenceParameters[i]), BitConverter.DoubleToInt64Bits(sparseParameters[i]));
+            Assert.Equal(BitConverter.DoubleToInt64Bits(referenceFirstMoment[i]), BitConverter.DoubleToInt64Bits(sparseFirstMoment[i]));
+            Assert.Equal(BitConverter.DoubleToInt64Bits(referenceSecondMoment[i]), BitConverter.DoubleToInt64Bits(sparseSecondMoment[i]));
+            Assert.Equal(BitConverter.DoubleToInt64Bits(referenceMaximumMoment[i]), BitConverter.DoubleToInt64Bits(sparseMaximumMoment[i]));
+        }
+    }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorJournalTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorJournalTests.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class StreamingTensorJournalTests
+{
+    [Fact]
+    public void FloatJournal_RoundTripsBitIdenticallyAfterSpill()
+    {
+        using var journal = new StreamingTensorJournal<float>(maxResidentBytes: 16);
+        int[] firstBits =
+        {
+            0, unchecked((int)0x80000000), 1, unchecked((int)0x80000001),
+            0x7f800000, unchecked((int)0xff800000), 0x7fc01234, unchecked((int)0xffc05678),
+        };
+        int[] secondBits =
+        {
+            0x3f000000, unchecked((int)0xbf000000), 0x7f7fffff, unchecked((int)0xff7fffff),
+            0x00800000, unchecked((int)0x80800000), 0x00012345, unchecked((int)0x80012345),
+        };
+        var first = new Tensor<float>(firstBits.Select(SingleFromBits).ToArray(), new[] { 8 });
+        var second = new Tensor<float>(secondBits.Select(SingleFromBits).ToArray(), new[] { 8 });
+
+        var firstRecord = journal.Append(first);
+        var secondRecord = journal.Append(second);
+        Tensor<float> firstReplay = journal.Read(firstRecord);
+        Tensor<float> secondReplay = journal.Read(secondRecord);
+
+        Assert.Equal(firstBits, firstReplay.ToArray().Select(SingleBits));
+        Assert.Equal(secondBits, secondReplay.ToArray().Select(SingleBits));
+        StreamingTensorJournalReport report = journal.GetReport();
+        Assert.True(report.DiskWriteBytes > 0);
+        Assert.InRange(report.ResidentBytes, 0, report.MaxResidentBytes);
+        Assert.InRange(report.ResidentBytesPeak, 0, report.MaxResidentBytes);
+    }
+
+    [Fact]
+    public void DoubleJournal_RestoresExistingTensorBitIdentically()
+    {
+        using var journal = new StreamingTensorJournal<double>(maxResidentBytes: 64);
+        long[] sourceBits =
+        {
+            0L, unchecked((long)0x8000000000000000), 1L,
+            0x7ff0000000000000, unchecked((long)0xfff0000000000000),
+            0x7ff8000000001234,
+        };
+        var source = new Tensor<double>(
+            sourceBits.Select(BitConverter.Int64BitsToDouble).ToArray(), new[] { 2, 3 });
+        var record = journal.Append(source);
+        var destination = new Tensor<double>(new[] { 2, 3 });
+        int versionBeforeRestore = destination.Version;
+
+        journal.Restore(record, destination);
+
+        Assert.Equal(sourceBits, destination.ToArray().Select(BitConverter.DoubleToInt64Bits));
+        Assert.Equal(new[] { 2, 3 }, record.Shape);
+        Assert.Equal(versionBeforeRestore + 1, destination.Version);
+    }
+
+    [Fact]
+    public void Int64Journal_RoundTripsSparseIndicesWithoutNumericConversion()
+    {
+        using var journal = new StreamingTensorJournal<long>(maxResidentBytes: 16);
+        long[] expected = { 0, -1, int.MaxValue, (long)int.MaxValue + 1, long.MaxValue };
+        var source = new Tensor<long>(expected, new[] { expected.Length });
+
+        Tensor<long> replay = journal.Read(journal.Append(source));
+
+        Assert.Equal(expected, replay.ToArray());
+    }
+
+    [Fact]
+    public void Replay_UsesOneBoundedReusableBufferForOversizedRecord()
+    {
+        using var journal = new StreamingTensorJournal<float>(maxResidentBytes: 32);
+        int[] expectedBits = Enumerable.Range(0, 37)
+            .Select(i => SingleBits(i + 0.25f))
+            .ToArray();
+        var source = new Tensor<float>(
+            expectedBits.Select(SingleFromBits).ToArray(), new[] { 37 });
+        var actualBits = new int[source.Length];
+        Tensor<float>? firstBuffer = null;
+        int callbackCount = 0;
+
+        var record = journal.Append(source);
+        journal.Replay(record, (offset, buffer, count) =>
+        {
+            firstBuffer ??= buffer;
+            Assert.Same(firstBuffer, buffer);
+            Assert.InRange(count, 1, 4);
+            for (int i = 0; i < count; i++)
+                actualBits[offset + i] = SingleBits(buffer[i]);
+            callbackCount++;
+        });
+
+        Assert.True(callbackCount > 1);
+        Assert.Equal(expectedBits, actualBits);
+        Assert.InRange(journal.GetReport().ResidentBytesPeak, 0, 32);
+    }
+
+    [Fact]
+    public void Dispose_ReleasesResidentPayloadRootedByCallerHeldRecord()
+    {
+        var journal = new StreamingTensorJournal<float>(maxResidentBytes: 256);
+        var record = journal.Append(new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 }));
+        Assert.NotNull(record.Segments[0].ResidentData);
+
+        journal.Dispose();
+
+        Assert.Null(record.Segments[0].ResidentData);
+    }
+
+    [Fact]
+    public void ContiguousOffsetViewRoundTripsAndNonContiguousViewIsRejected()
+    {
+        using var journal = new StreamingTensorJournal<float>(64);
+        var source = new Tensor<float>(new float[] { 10, 20, 30, 40, 50, 60 }, new[] { 2, 3 });
+        Tensor<float> contiguousOffsetView = source.Slice(1);
+        Assert.True(contiguousOffsetView.IsContiguous);
+        Assert.Equal(new float[] { 40, 50, 60 }, journal.Read(journal.Append(contiguousOffsetView)).ToArray());
+
+        Tensor<float> nonContiguous = source.Transpose(new[] { 1, 0 });
+        Assert.False(nonContiguous.IsContiguous);
+        Assert.Throws<NotSupportedException>(() => journal.Append(nonContiguous));
+    }
+
+    [Fact]
+    public void Restore_RejectsWrongShapeAndNonContiguousDestinationBeforeMutation()
+    {
+        using var journal = new StreamingTensorJournal<float>(64);
+        var record = journal.Append(new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 2, 2 }));
+        var wrongShape = new Tensor<float>(new[] { 4 });
+        var nonContiguous = new Tensor<float>(new[] { 2, 2 }).Transpose(new[] { 1, 0 });
+
+        Assert.Throws<ArgumentException>(() => journal.Restore(record, wrongShape));
+        Assert.Throws<NotSupportedException>(() => journal.Restore(record, nonContiguous));
+        Assert.Equal(new float[4], wrongShape.ToArray());
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Restore_InvalidatesPrimedPhysicalGpuValueCache(bool activation, bool inference)
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        if (!RequireGpuIfRequested(gpu)) return;
+        bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+        try
+        {
+            var seed = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+            var destination = activation ? gpu.TensorMultiplyScalar(seed, 1.0f) : seed;
+            if (!activation) gpu.RegisterResidentParamBuffer(destination);
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, destination.ToArray());
+            Assert.True(gpu.IsDeviceResidentArray(destination.GetReadOnlyDataArray()));
+            int autogradVersion = destination.Version;
+
+            using var journal = new StreamingTensorJournal<float>(16);
+            var record = journal.Append(new Tensor<float>(new float[] { 10, 20, 30, 40 }, new[] { 4 }));
+            if (inference)
+            {
+                using (new InferenceModeScope<float>()) journal.Restore(record, destination);
+                Assert.Equal(autogradVersion, destination.Version);
+            }
+            else journal.Restore(record, destination);
+
+            Assert.Equal(new float[] { 20, 40, 60, 80 }, gpu.TensorMultiplyScalar(destination, 2.0f).ToArray());
+        }
+        finally { DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict; }
+    }
+
+    [Fact]
+    public void ResidentCache_MutationThroughSharedViewInvalidatesSourceSnapshot()
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        if (!RequireGpuIfRequested(gpu)) return;
+        bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+        try
+        {
+            var source = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(source);
+            Tensor<float> view = source.Reshape(new[] { 2, 2 });
+            view[0] = 10f;
+            Assert.Equal(new float[] { 20, 4, 6, 8 }, gpu.TensorMultiplyScalar(source, 2f).ToArray());
+        }
+        finally { DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict; }
+    }
+
+    private static bool RequireGpuIfRequested(DirectGpuTensorEngine gpu)
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1")
+            Assert.True(gpu.IsGpuAvailable, "A physical GPU was required, but no GPU backend initialized.");
+        return gpu.IsGpuAvailable;
+    }
+
+    [Fact]
+    public void RecordOwnershipAndRemoval_AreEnforced()
+    {
+        using var first = new StreamingTensorJournal<float>(maxResidentBytes: 64);
+        using var second = new StreamingTensorJournal<float>(maxResidentBytes: 64);
+        var record = first.Append(new Tensor<float>(new[] { 2 }));
+
+        Assert.Throws<ArgumentException>(() => second.Read(record));
+        first.Remove(record);
+        Assert.Equal(0, first.Count);
+        Assert.Throws<InvalidOperationException>(() => first.Read(record));
+    }
+
+    [Fact]
+    public void UnsupportedElementTypeAndInvalidBudget_AreRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new StreamingTensorJournal<float>(0));
+        Assert.Throws<NotSupportedException>(() => new StreamingTensorJournal<decimal>(64));
+    }
+
+    [Fact]
+    public void Append_IsReadOnlyForCopyOnWriteTensor()
+    {
+        var source = new Tensor<float>(new[] { 4 });
+        var clone = (Tensor<float>)source.CloneShared();
+        Assert.True(source.IsCowShared);
+        Assert.True(clone.IsCowShared);
+
+        using var journal = new StreamingTensorJournal<float>(32);
+        var record = journal.Append(clone);
+
+        Assert.True(source.IsCowShared);
+        Assert.True(clone.IsCowShared);
+        Assert.Equal(clone.ToArray(), journal.Read(record).ToArray());
+    }
+
+    [Fact]
+    public void Remove_ReclaimsAndReusesBackingFileRanges()
+    {
+        using var journal = new StreamingTensorJournal<float>(4);
+        var tensor = new Tensor<float>(Enumerable.Range(0, 64).Select(i => (float)i).ToArray(), new[] { 64 });
+
+        for (int iteration = 0; iteration < 8; iteration++)
+        {
+            var record = journal.Append(tensor);
+            Assert.Equal(tensor.Length * sizeof(float), journal.GetReport().BackingStoreBytes);
+            journal.Remove(record);
+            Assert.Equal(0, journal.GetReport().BackingStoreBytes);
+        }
+    }
+
+    [Fact]
+    public void Remove_ReusesInteriorFileRangeWithoutCorruptingNeighborRecords()
+    {
+        using var journal = new StreamingTensorJournal<float>(4);
+        var first = new Tensor<float>(Enumerable.Range(0, 8).Select(i => i + 0.25f).ToArray(), new[] { 8 });
+        var middle = new Tensor<float>(Enumerable.Range(0, 8).Select(i => i + 100.5f).ToArray(), new[] { 8 });
+        var last = new Tensor<float>(Enumerable.Range(0, 8).Select(i => i + 200.75f).ToArray(), new[] { 8 });
+        var replacement = new Tensor<float>(Enumerable.Range(0, 8).Select(i => i - 50.125f).ToArray(), new[] { 8 });
+
+        var firstRecord = journal.Append(first);
+        var middleRecord = journal.Append(middle);
+        var lastRecord = journal.Append(last);
+        long fullLength = journal.GetReport().BackingStoreBytes;
+        journal.Remove(middleRecord);
+
+        var replacementRecord = journal.Append(replacement);
+
+        Assert.Equal(fullLength, journal.GetReport().BackingStoreBytes);
+        Assert.Equal(first.ToArray(), journal.Read(firstRecord).ToArray());
+        Assert.Equal(replacement.ToArray(), journal.Read(replacementRecord).ToArray());
+        Assert.Equal(last.ToArray(), journal.Read(lastRecord).ToArray());
+
+        journal.Remove(lastRecord);
+        journal.Remove(replacementRecord);
+        Assert.Equal(first.Length * sizeof(float), journal.GetReport().BackingStoreBytes);
+    }
+
+    [Fact]
+    public void Replay_RejectsReentrantAndConcurrentLifecycleOperationsWithoutDeadlock()
+    {
+        using var journal = new StreamingTensorJournal<float>(16);
+        var source = new Tensor<float>(Enumerable.Range(0, 20).Select(i => (float)i).ToArray(), new[] { 20 });
+        var record = journal.Append(source);
+        int callbacks = 0;
+
+        journal.Replay(record, (_, _, _) =>
+        {
+            callbacks++;
+            Assert.Throws<InvalidOperationException>(() => journal.Remove(record));
+            Assert.Throws<InvalidOperationException>(() => journal.Dispose());
+            Assert.Throws<InvalidOperationException>(() => journal.Replay(record, (_, _, _) => { }));
+
+            Task<Exception?> concurrentRead = Task.Run(() => Record.Exception(() => journal.Read(record)));
+            Assert.True(concurrentRead.Wait(TimeSpan.FromSeconds(5)),
+                "A concurrent journal operation blocked behind the replay callback.");
+            Assert.IsType<InvalidOperationException>(concurrentRead.Result);
+        });
+
+        Assert.True(callbacks > 1);
+        Assert.Equal(source.ToArray(), journal.Read(record).ToArray());
+    }
+
+    [Fact]
+    public void Dispose_RemovesPrivateBackingDirectory()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "aidotnet-journal-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var journal = new StreamingTensorJournal<float>(4, root);
+            journal.Append(new Tensor<float>(Enumerable.Range(0, 64).Select(i => (float)i).ToArray(), new[] { 64 }));
+            Assert.Single(Directory.GetDirectories(root));
+
+            journal.Dispose();
+
+            Assert.Empty(Directory.GetDirectories(root));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ConcurrentRecordLifecycles_AreSerializedWithoutCorruption()
+    {
+        using var journal = new StreamingTensorJournal<double>(64);
+        var failures = new ConcurrentQueue<Exception>();
+
+        Parallel.For(0, 32, i =>
+        {
+            try
+            {
+                var source = new Tensor<double>(new[] { 16 });
+                for (int j = 0; j < source.Length; j++) source[j] = i * 1000.0 + j;
+                var record = journal.Append(source);
+                Assert.Equal(source.ToArray(), journal.Read(record).ToArray());
+                journal.Remove(record);
+            }
+            catch (Exception exception)
+            {
+                failures.Enqueue(exception);
+            }
+        });
+
+        Assert.Empty(failures);
+        Assert.Equal(0, journal.Count);
+        Assert.InRange(journal.GetReport().ResidentBytesPeak, 0, 64);
+    }
+
+    [Fact]
+    public void ScalarAndZeroLengthShapes_RoundTripWithoutSpecialCases()
+    {
+        using var journal = new StreamingTensorJournal<float>(8);
+        var scalar = new Tensor<float>(Array.Empty<int>());
+        scalar[0] = SingleFromBits(unchecked((int)0x80000000));
+        var empty = new Tensor<float>(new[] { 0, 3 });
+
+        var scalarReplay = journal.Read(journal.Append(scalar));
+        var emptyReplay = journal.Read(journal.Append(empty));
+
+        Assert.Equal(SingleBits(scalar[0]), SingleBits(scalarReplay[0]));
+        Assert.Empty(emptyReplay.ToArray());
+        Assert.Equal(new[] { 0, 3 }, emptyReplay._shape);
+    }
+
+    private static float SingleFromBits(int bits) => BitConverter.ToSingle(BitConverter.GetBytes(bits), 0);
+
+    private static int SingleBits(float value) => BitConverter.ToInt32(BitConverter.GetBytes(value), 0);
+
+    [Fact]
+    public void PropertiesAndRecordsRejectUseAfterDisposal()
+    {
+        var journal = new StreamingTensorJournal<float>(16);
+        var record = journal.Append(new Tensor<float>(new[] { 2 }));
+        journal.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => journal.Read(record));
+        Assert.Throws<ObjectDisposedException>(() => journal.Remove(record));
+        Assert.Throws<ObjectDisposedException>(() => journal.GetReport());
+        Assert.Throws<ObjectDisposedException>(() => _ = journal.Count);
+        Assert.Throws<ObjectDisposedException>(() => _ = journal.ResidentBytes);
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorJournalTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorJournalTests.cs
@@ -14,6 +14,59 @@ namespace AiDotNet.Tensors.Tests.LinearAlgebra;
 public sealed class StreamingTensorJournalTests
 {
     [Fact]
+    public void OversizedDeferredPayload_IsRejectedBeforeMaterialization()
+    {
+        using var tensor = Tensor<double>.CreateDeferred(new[] { int.MaxValue / sizeof(double) + 1 });
+        using var journal = new StreamingTensorJournal<double>(32);
+        Assert.Null(tensor.GetLiveBackingArrayOrNull());
+
+        Assert.Throws<NotSupportedException>(() => journal.Append(tensor));
+
+        Assert.Null(tensor.GetLiveBackingArrayOrNull());
+        Assert.Equal(0, journal.Count);
+        Assert.Equal(0, journal.GetReport().DiskWriteBytes);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FailedAppend_PoisonsOnlyWhenRangeCleanupAlsoFails(bool failCleanup)
+    {
+        bool failWrite = true;
+        var observed = new System.Collections.Generic.List<StreamingTensorJournalFileOperation>();
+        using var journal = new StreamingTensorJournal<float>(32, null, operation =>
+        {
+            observed.Add(operation);
+            if (operation == StreamingTensorJournalFileOperation.Write && failWrite)
+                throw new IOException("Injected backing-store write failure.");
+            if (operation == StreamingTensorJournalFileOperation.ReleaseRange && failCleanup)
+                throw new IOException("Injected backing-range cleanup failure.");
+        });
+        var retained = journal.Append(new Tensor<float>(new float[] { 7 }, new[] { 1 }));
+        var oversized = new Tensor<float>(Enumerable.Range(0, 16).Select(i => (float)i).ToArray(), new[] { 16 });
+
+        IOException original = Assert.Throws<IOException>(() => journal.Append(oversized));
+        Assert.Contains("write failure", original.Message);
+        Assert.Equal(new[] { StreamingTensorJournalFileOperation.Write, StreamingTensorJournalFileOperation.ReleaseRange }, observed);
+        if (failCleanup)
+        {
+            Assert.Null(retained.Segments[0].ResidentData);
+            Assert.Throws<InvalidOperationException>(() => journal.Read(retained));
+            Assert.Throws<InvalidOperationException>(() => journal.Remove(retained));
+            Assert.Throws<InvalidOperationException>(() => journal.Append(oversized));
+            Assert.Throws<InvalidOperationException>(() => journal.GetReport());
+        }
+        else
+        {
+            Assert.Equal(new[] { 7f }, journal.Read(retained).ToArray());
+            failWrite = false;
+            var recovered = journal.Append(oversized);
+            Assert.Equal(oversized.ToArray(), journal.Read(recovered).ToArray());
+            Assert.Equal(2, journal.Count);
+        }
+    }
+
+    [Fact]
     public void FloatJournal_RoundTripsBitIdenticallyAfterSpill()
     {
         using var journal = new StreamingTensorJournal<float>(maxResidentBytes: 16);
@@ -146,7 +199,7 @@ public sealed class StreamingTensorJournalTests
         Assert.Equal(new float[4], wrongShape.ToArray());
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(false, false)]
     [InlineData(false, true)]
     [InlineData(true, false)]
@@ -154,7 +207,7 @@ public sealed class StreamingTensorJournalTests
     public void Restore_InvalidatesPrimedPhysicalGpuValueCache(bool activation, bool inference)
     {
         using var gpu = new DirectGpuTensorEngine();
-        if (!RequireGpuIfRequested(gpu)) return;
+        RequireGpuIfRequested(gpu);
         bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
         DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
         try
@@ -180,11 +233,11 @@ public sealed class StreamingTensorJournalTests
         finally { DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict; }
     }
 
-    [Fact]
+    [SkippableFact]
     public void ResidentCache_MutationThroughSharedViewInvalidatesSourceSnapshot()
     {
         using var gpu = new DirectGpuTensorEngine();
-        if (!RequireGpuIfRequested(gpu)) return;
+        RequireGpuIfRequested(gpu);
         bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
         DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
         try
@@ -198,11 +251,11 @@ public sealed class StreamingTensorJournalTests
         finally { DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict; }
     }
 
-    private static bool RequireGpuIfRequested(DirectGpuTensorEngine gpu)
+    private static void RequireGpuIfRequested(DirectGpuTensorEngine gpu)
     {
         if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1")
             Assert.True(gpu.IsGpuAvailable, "A physical GPU was required, but no GPU backend initialized.");
-        return gpu.IsGpuAvailable;
+        Skip.IfNot(gpu.IsGpuAvailable, "No physical GPU backend initialized.");
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorPoolTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/StreamingTensorPoolTests.cs
@@ -14,6 +14,32 @@ namespace AiDotNet.Tensors.Tests.LinearAlgebra;
 public class StreamingTensorPoolTests
 {
     [Fact]
+    public void Register_EvictionFailureRollsBackEntryAndRestoresReservation()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "aidotnet-register-rollback-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            using var pool = new StreamingTensorPool(new GpuOffloadOptions
+            {
+                StreamingPoolMaxResidentBytes = 96,
+                StreamingBackingStorePath = directory,
+            });
+            var original = new byte[64];
+            original[0] = 42;
+            long existing = pool.Register(original);
+            pool.ReserveBytes(32);
+            string backing = Assert.Single(Directory.GetDirectories(directory));
+            Directory.Delete(backing); // Empty, test-owned directory; force the first disk write to fail.
+            Assert.ThrowsAny<IOException>(() => pool.RegisterReserved(new byte[64], 32));
+            Assert.Equal(1, pool.RegisteredEntryCount);
+            Assert.Equal(64, pool.ResidentBytes);
+            Assert.Equal(32, pool.ReservedBytes);
+            Assert.Equal(42, pool.Rehydrate(existing)[0]);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
     public void Register_StaysResident_BelowBudget()
     {
         var dir = Path.Combine(Path.GetTempPath(), "aidotnet-stream-test-" + Guid.NewGuid().ToString("N"));

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorArrayAccessContractTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorArrayAccessContractTests.cs
@@ -1,0 +1,131 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class TensorArrayAccessContractTests
+{
+    [Fact]
+    public void FullContiguousView_ReadOnlyAccessIsZeroCopy()
+    {
+        float[] values = { 1, 2, 3, 4, 5, 6 };
+        using var source = new Tensor<float>(values, new[] { 2, 3 });
+        using var view = source.Reshape(new[] { 3, 2 });
+        Assert.True(view.IsView && view.IsContiguous);
+
+        Assert.Same(values, view.GetLiveBackingArrayOrNull());
+        for (int i = 0; i < 10; i++)
+            Assert.Same(values, view.GetReadOnlyDataArray());
+        Assert.Equal(values, view.ToArray());
+    }
+
+    [Fact]
+    public void FullContiguousView_WritableAccessStillWritesThrough()
+    {
+        float[] values = { 1, 2, 3, 4, 5, 6 };
+        using var source = new Tensor<float>(values, new[] { 2, 3 });
+        using var view = source.Reshape(new[] { 3, 2 });
+
+        float[] writable = view.GetDataArray();
+        Assert.Same(values, writable);
+        writable[2] = 30f;
+        view.IncrementVersion();
+
+        Assert.Equal(30f, source[2]);
+        Assert.Equal(30f, view[2]);
+    }
+
+    [Fact]
+    public void CowView_ReadOnlyAccessDoesNotDetach_ThenWriteDetachesRequestedFamily()
+    {
+        float[] values = { 1, 2, 3, 4, 5, 6 };
+        using var source = new Tensor<float>(values, new[] { 2, 3 });
+        using var clone = (Tensor<float>)source.CloneShared();
+        using var view = clone.Reshape(new[] { 3, 2 });
+
+        Assert.Same(values, view.GetReadOnlyDataArray());
+        Assert.Same(source._storage, clone._storage);
+        Assert.True(source.IsCowShared && clone.IsCowShared && view.IsCowShared);
+
+        float[] writable = view.GetDataArray();
+        Assert.NotSame(values, writable);
+        Assert.Same(writable, clone.GetReadOnlyDataArray());
+        writable[0] = 99f;
+        view.IncrementVersion();
+
+        Assert.Equal(1f, source[0]);
+        Assert.Equal(99f, clone[0]);
+        Assert.Equal(99f, view[0]);
+        Assert.Same(values, source.GetReadOnlyDataArray());
+        Assert.NotSame(source._storage, clone._storage);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void PartialContiguousView_ReturnsExactLogicalSnapshot(int row)
+    {
+        float[] values = { 1, 2, 3, 4, 5, 6 };
+        using var source = new Tensor<float>(values, new[] { 2, 3 });
+        using var view = source.Slice(row);
+        Assert.True(view.IsContiguous);
+        Assert.Null(view.GetLiveBackingArrayOrNull());
+
+        float[] snapshot = view.GetReadOnlyDataArray();
+        Assert.NotSame(values, snapshot);
+        Assert.Equal(row == 0 ? new float[] { 1, 2, 3 } : new float[] { 4, 5, 6 }, snapshot);
+        source[row * 3] = 99f;
+        Assert.Equal(row == 0 ? 1f : 4f, snapshot[0]);
+        Assert.Equal(99f, view.GetReadOnlyDataArray()[0]);
+    }
+
+    [Fact]
+    public void NonContiguousView_ReadOnlySnapshotFollowsLogicalOrder()
+    {
+        float[] values = { 1, 2, 3, 4, 5, 6 };
+        using var source = new Tensor<float>(values, new[] { 2, 3 });
+        using var view = source.Transpose(new[] { 1, 0 });
+        Assert.False(view.IsContiguous);
+        Assert.Null(view.GetLiveBackingArrayOrNull());
+
+        float[] snapshot = view.GetReadOnlyDataArray();
+        Assert.NotSame(values, snapshot);
+        Assert.Equal(new float[] { 1, 4, 2, 5, 3, 6 }, snapshot);
+        source[0] = 99f;
+        Assert.Equal(1f, snapshot[0]);
+        Assert.Equal(new float[] { 99, 4, 2, 5, 3, 6 }, view.GetReadOnlyDataArray());
+    }
+
+    [Fact]
+    public void DeferredStorage_ReadOnlyAccessMaterializesValuesOnce()
+    {
+        int initializations = 0;
+        using var deferred = Tensor<float>.CreateDeferred(new[] { 3 }, tensor =>
+        {
+            initializations++;
+            tensor.CopyFromArray(new float[] { 10, 20, 30 });
+        });
+        Assert.True(deferred.IsStorageDeferred);
+
+        Assert.Equal(new float[] { 10, 20, 30 }, deferred.GetReadOnlyDataArray());
+        Assert.Equal(new float[] { 10, 20, 30 }, deferred.GetReadOnlyDataArray());
+        Assert.Equal(1, initializations);
+        Assert.False(deferred.IsStorageDeferred);
+    }
+
+    [Fact]
+    public void LazyGraph_ReadOnlyAccessRealizesValueInsteadOfReturningPlaceholder()
+    {
+        var engine = new CpuEngine();
+        using var input = new Tensor<float>(new float[] { 1, 2, 3 }, new[] { 3 });
+        using var graph = GraphMode.Enable();
+        using var deferred = engine.TensorMultiplyScalar(input, 2f);
+        Assert.NotNull(deferred.LazySource);
+
+        Assert.Equal(new float[] { 2, 4, 6 }, deferred.GetReadOnlyDataArray());
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCachePhysicalTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCachePhysicalTests.cs
@@ -1,0 +1,238 @@
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class TensorGpuCachePhysicalTests
+{
+    public enum InPlaceOperation
+    {
+        MultiplyScalar,
+        AddCachedOperand,
+        AddUncachedOperand,
+    }
+
+    public enum ExternalWrapperKind
+    {
+        Array,
+        Vector,
+        OffsetVector,
+    }
+
+    [Theory]
+    [InlineData(ExternalWrapperKind.Array, false)]
+    [InlineData(ExternalWrapperKind.Array, true)]
+    [InlineData(ExternalWrapperKind.Vector, false)]
+    [InlineData(ExternalWrapperKind.Vector, true)]
+    [InlineData(ExternalWrapperKind.OffsetVector, false)]
+    [InlineData(ExternalWrapperKind.OffsetVector, true)]
+    public void IndependentExternalWrapperMutation_InvalidatesSharedArrayGpuSnapshot(
+        ExternalWrapperKind kind, bool inference)
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            float[] values = { 1, 2, 3, 4 };
+            using var source = new Tensor<float>(values, new[] { 4 });
+            using Tensor<float> wrapper = kind switch
+            {
+                ExternalWrapperKind.Array => new Tensor<float>(values, new[] { 4 }),
+                ExternalWrapperKind.Vector => new Tensor<float>(new[] { 4 }, Vector<float>.WrapMemory(values)),
+                ExternalWrapperKind.OffsetVector => new Tensor<float>(new[] { 2 }, Vector<float>.WrapMemory(values.AsMemory(1, 2))),
+                _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+            };
+            Assert.NotSame(source._storage, wrapper._storage);
+            gpu.RegisterResidentParamBuffer(source);
+            Assert.NotNull(source.TryGetGpuBuffer());
+            int sourceVersion = source.Version;
+            int wrapperVersion = wrapper.Version;
+            int epoch = source.GpuCacheVersion;
+
+            WithInference(inference, () => wrapper.CopyFromArray(kind == ExternalWrapperKind.OffsetVector
+                ? new float[] { 20, 30 }
+                : new float[] { 10, 20, 30, 40 }));
+
+            Assert.Equal(sourceVersion, source.Version);
+            if (inference) Assert.Equal(wrapperVersion, wrapper.Version);
+            Assert.Equal(epoch + 1, source.GpuCacheVersion);
+            Assert.Equal(source.GpuCacheVersion, wrapper.GpuCacheVersion);
+            Assert.Equal(kind == ExternalWrapperKind.OffsetVector
+                ? new float[] { 2, 40, 60, 8 }
+                : new float[] { 20, 40, 60, 80 }, gpu.TensorMultiplyScalar(source, 2f).ToArray());
+        });
+    }
+
+    [Fact]
+    public void ExternalWrapperCreatedAfterGpuRefresh_InheritsCurrentArrayEpoch()
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            float[] values = { 1, 2, 3, 4 };
+            using var source = new Tensor<float>(values, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(source);
+            source.CopyFromArray(new float[] { 10, 20, 30, 40 });
+            gpu.RegisterResidentParamBuffer(source);
+            Assert.True(source.GpuCacheVersion > 0);
+
+            using var wrapper = new Tensor<float>(values, new[] { 4 });
+            Assert.Equal(source.GpuCacheVersion, wrapper.GpuCacheVersion);
+            gpu.RegisterResidentParamBuffer(wrapper);
+            Assert.Same(source.TryGetGpuBuffer(), wrapper.TryGetGpuBuffer());
+
+            wrapper.CopyFromArray(new float[] { 100, 200, 300, 400 });
+            Assert.Equal(new float[] { 200, 400, 600, 800 }, gpu.TensorMultiplyScalar(source, 2f).ToArray());
+        });
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CopyOnWriteDetach_CopiesButDoesNotShareExternalArrayEpoch(bool inference)
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            float[] values = { 1, 2, 3, 4 };
+            using var source = new Tensor<float>(values, new[] { 4 });
+            using var external = new Tensor<float>(values, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(source);
+            int sourceEpoch = source.GpuCacheVersion;
+            using var clone = (Tensor<float>)source.CloneShared();
+            Assert.Same(source._storage, clone._storage);
+
+            WithInference(inference, () => clone.CopyFromArray(new float[] { 10, 20, 30, 40 }));
+            Assert.NotSame(source._storage, clone._storage);
+            Assert.Equal(sourceEpoch, source.GpuCacheVersion);
+            gpu.RegisterResidentParamBuffer(clone);
+            int cloneEpoch = clone.GpuCacheVersion;
+
+            WithInference(inference, () => external.CopyFromArray(new float[] { 5, 6, 7, 8 }));
+            Assert.Equal(sourceEpoch + 1, source.GpuCacheVersion);
+            Assert.Equal(cloneEpoch, clone.GpuCacheVersion);
+            Assert.Equal(new float[] { 10, 12, 14, 16 }, gpu.TensorMultiplyScalar(source, 2f).ToArray());
+            Assert.Equal(new float[] { 20, 40, 60, 80 }, gpu.TensorMultiplyScalar(clone, 2f).ToArray());
+        });
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ViewCreatedAfterHostMutation_PreservesStaleParentSnapshot(bool inference)
+    {
+        WithPhysicalGpu((gpu, backend) =>
+        {
+            using var source = Tensor<float>.FromGpuBuffer(
+                backend, backend.AllocateBuffer(new float[] { 1, 2, 3, 4 }), new[] { 4 });
+            Assert.True(source.IsGpuResident);
+            Assert.Equal(new float[] { 1, 2, 3, 4 }, source.ToArray());
+            int version = source.Version;
+
+            WithInference(inference, () => source.CopyFromArray(new float[] { 10, 20, 30, 40 }));
+            if (inference) Assert.Equal(version, source.Version);
+
+            using Tensor<float> view = source.Reshape(new[] { 2, 2 });
+            Assert.Equal(source._gpuBufferVersion, view._gpuBufferVersion);
+            Assert.NotEqual(view.GpuCacheVersion, view._gpuBufferVersion);
+            Assert.Equal(new float[] { 20, 40, 60, 80 }, gpu.TensorMultiplyScalar(view, 2f).ToArray());
+        });
+    }
+
+    [Theory]
+    [InlineData(InPlaceOperation.MultiplyScalar, false)]
+    [InlineData(InPlaceOperation.MultiplyScalar, true)]
+    [InlineData(InPlaceOperation.AddCachedOperand, false)]
+    [InlineData(InPlaceOperation.AddCachedOperand, true)]
+    [InlineData(InPlaceOperation.AddUncachedOperand, false)]
+    [InlineData(InPlaceOperation.AddUncachedOperand, true)]
+    public void InPlaceOperation_AfterHostMutationUsesCurrentValues(InPlaceOperation operation, bool inference)
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            using var target = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+            using var other = new Tensor<float>(new float[] { 5, 6, 7, 8 }, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(target);
+            Assert.NotNull(target.TryGetGpuBuffer());
+            if (operation == InPlaceOperation.AddCachedOperand)
+            {
+                gpu.RegisterResidentParamBuffer(other);
+                Assert.NotNull(other.TryGetGpuBuffer());
+            }
+
+            int version = target.Version;
+            WithInference(inference, () =>
+            {
+                target.CopyFromArray(new float[] { 10, 20, 30, 40 });
+                other.CopyFromArray(new float[] { 50, 60, 70, 80 });
+            });
+            if (inference) Assert.Equal(version, target.Version);
+
+            if (operation == InPlaceOperation.MultiplyScalar)
+            {
+                ((IEngine)gpu).TensorMultiplyScalarInPlace(target, 2f);
+                Assert.Equal(new float[] { 20, 40, 60, 80 }, target.ToArray());
+            }
+            else
+            {
+                gpu.TensorAddInPlace(target, other);
+                Assert.Equal(new float[] { 60, 80, 100, 120 }, target.ToArray());
+            }
+        });
+    }
+
+    [Theory]
+    [InlineData(InPlaceOperation.MultiplyScalar)]
+    [InlineData(InPlaceOperation.AddCachedOperand)]
+    [InlineData(InPlaceOperation.AddUncachedOperand)]
+    public void InPlaceOperation_PreservesCurrentPersistentAllocation(InPlaceOperation operation)
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            using var target = new Tensor<float>(new float[] { 1, 2, 3, 4 }, new[] { 4 });
+            using var other = new Tensor<float>(new float[] { 5, 6, 7, 8 }, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(target);
+            var originalBuffer = target.TryGetGpuBuffer()
+                ?? throw new InvalidOperationException("The physical GPU parameter cache was not populated.");
+            if (operation == InPlaceOperation.AddCachedOperand)
+                gpu.RegisterResidentParamBuffer(other);
+
+            for (int iteration = 0; iteration < 2; iteration++)
+            {
+                if (operation == InPlaceOperation.MultiplyScalar)
+                    ((IEngine)gpu).TensorMultiplyScalarInPlace(target, 2f);
+                else
+                    gpu.TensorAddInPlace(target, other);
+
+                gpu.RegisterResidentParamBuffer(target);
+                Assert.Same(originalBuffer, target.TryGetGpuBuffer());
+                Assert.NotEqual(IntPtr.Zero, originalBuffer.Handle);
+            }
+
+            Assert.Equal(operation == InPlaceOperation.MultiplyScalar
+                ? new float[] { 4, 8, 12, 16 }
+                : new float[] { 11, 14, 17, 20 }, target.ToArray());
+        });
+    }
+
+    private static void WithInference(bool enabled, Action action)
+    {
+        if (!enabled) { action(); return; }
+        using (new InferenceModeScope<float>()) action();
+    }
+
+    private static void WithPhysicalGpu(Action<DirectGpuTensorEngine, IDirectGpuBackend> action)
+    {
+        using var gpu = new DirectGpuTensorEngine();
+        if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1")
+            Assert.True(gpu.IsGpuAvailable, "A physical GPU was required, but no GPU backend initialized.");
+        if (!gpu.IsGpuAvailable) return;
+        var backend = gpu.TestBackend
+            ?? throw new InvalidOperationException("GPU availability did not produce an initialized backend.");
+        bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;
+        DirectGpuTensorEngine.ThrowOnGpuKernelFallback = true;
+        try { action(gpu, backend); }
+        finally { DirectGpuTensorEngine.ThrowOnGpuKernelFallback = previousStrict; }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCachePhysicalTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCachePhysicalTests.cs
@@ -24,7 +24,7 @@ public sealed class TensorGpuCachePhysicalTests
         OffsetVector,
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ExternalWrapperKind.Array, false)]
     [InlineData(ExternalWrapperKind.Array, true)]
     [InlineData(ExternalWrapperKind.Vector, false)]
@@ -66,7 +66,7 @@ public sealed class TensorGpuCachePhysicalTests
         });
     }
 
-    [Fact]
+    [SkippableFact]
     public void ExternalWrapperCreatedAfterGpuRefresh_InheritsCurrentArrayEpoch()
     {
         WithPhysicalGpu((gpu, _) =>
@@ -88,7 +88,7 @@ public sealed class TensorGpuCachePhysicalTests
         });
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void CopyOnWriteDetach_CopiesButDoesNotShareExternalArrayEpoch(bool inference)
@@ -117,7 +117,7 @@ public sealed class TensorGpuCachePhysicalTests
         });
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]
     public void ViewCreatedAfterHostMutation_PreservesStaleParentSnapshot(bool inference)
@@ -140,7 +140,7 @@ public sealed class TensorGpuCachePhysicalTests
         });
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(InPlaceOperation.MultiplyScalar, false)]
     [InlineData(InPlaceOperation.MultiplyScalar, true)]
     [InlineData(InPlaceOperation.AddCachedOperand, false)]
@@ -182,7 +182,7 @@ public sealed class TensorGpuCachePhysicalTests
         });
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(InPlaceOperation.MultiplyScalar)]
     [InlineData(InPlaceOperation.AddCachedOperand)]
     [InlineData(InPlaceOperation.AddUncachedOperand)]
@@ -222,12 +222,47 @@ public sealed class TensorGpuCachePhysicalTests
         using (new InferenceModeScope<float>()) action();
     }
 
+    [SkippableFact]
+    public void ExplicitInvalidation_PublishesRawHostMutationAcrossRepeatedReplacement()
+    {
+        WithPhysicalGpu((gpu, _) =>
+        {
+            float[] values = { 1, 2, 3, 4 };
+            using var tensor = new Tensor<float>(values, new[] { 4 });
+            gpu.RegisterResidentParamBuffer(tensor);
+            int epoch = tensor.GpuCacheVersion;
+            IGpuBuffer original = tensor.TryGetGpuBuffer()
+                ?? throw new InvalidOperationException("The persistent buffer was not populated.");
+
+            for (int iteration = 0; iteration < 2; iteration++)
+            {
+                values[0] = 10 + iteration;
+                gpu.InvalidatePersistentTensor(tensor);
+
+                Assert.Equal(epoch, tensor.GpuCacheVersion);
+                Assert.NotEqual(IntPtr.Zero, original.Handle);
+                gpu.RegisterResidentParamBuffer(tensor);
+                IGpuBuffer current = tensor.TryGetGpuBuffer()
+                    ?? throw new InvalidOperationException("The replacement buffer was not published.");
+                Assert.NotSame(original, current);
+                // OpenCL returns retired allocations to its pool without zeroing their
+                // native handles. Exact disposal ownership is covered by the tracking
+                // backend tests; this test verifies replacement and real device values.
+                Assert.Equal(new float[] { 2 * values[0], 4, 6, 8 },
+                    gpu.TensorMultiplyScalar(tensor, 2f).ToArray());
+                // Eager reads may clear the tensor-local shortcut while keeping the
+                // persistent cache entry; retain the last published borrowed buffer.
+                original = current;
+            }
+        });
+    }
+
     private static void WithPhysicalGpu(Action<DirectGpuTensorEngine, IDirectGpuBackend> action)
     {
         using var gpu = new DirectGpuTensorEngine();
         if (Environment.GetEnvironmentVariable("AIDOTNET_REQUIRE_GPU_TESTS") == "1")
             Assert.True(gpu.IsGpuAvailable, "A physical GPU was required, but no GPU backend initialized.");
-        if (!gpu.IsGpuAvailable) return;
+        Skip.IfNot(gpu.IsGpuAvailable, "No physical GPU backend initialized.");
         var backend = gpu.TestBackend
             ?? throw new InvalidOperationException("GPU availability did not produce an initialized backend.");
         bool previousStrict = DirectGpuTensorEngine.ThrowOnGpuKernelFallback;

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCacheVersionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/TensorGpuCacheVersionTests.cs
@@ -1,0 +1,81 @@
+using System;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.LinearAlgebra;
+
+public sealed class TensorGpuCacheVersionTests
+{
+    [Fact]
+    public void SharedViews_AdvanceOneCacheEpochWithoutChangingOtherAutogradVersions()
+    {
+        var source = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        int epoch = source.GpuCacheVersion;
+        int version = source.Version;
+        var view = source.Reshape(new[] { 1, 2 });
+        view[0] = 9f;
+        Assert.True(source.GpuCacheVersion > epoch);
+        Assert.Equal(source.GpuCacheVersion, view.GpuCacheVersion);
+        Assert.Equal(version, source.Version);
+    }
+
+    [Fact]
+    public void InferenceMutation_AdvancesCacheEpochButNotAutogradVersion()
+    {
+        var tensor = new Tensor<double>(new[] { 1.0 }, new[] { 1 });
+        int epoch = tensor.GpuCacheVersion;
+        int version = tensor.Version;
+        using (new InferenceModeScope<double>()) tensor[0] = 2.0;
+        Assert.True(tensor.GpuCacheVersion > epoch);
+        Assert.Equal(version, tensor.Version);
+    }
+
+    [Fact]
+    public void CopyOnWrite_DetachmentPreservesTrackingWithoutInvalidatingUntouchedSibling()
+    {
+        var source = new Tensor<float>(new[] { 1f, 2f }, new[] { 2 });
+        int epoch = source.GpuCacheVersion;
+        var clone = (Tensor<float>)source.CloneShared();
+        using (new InferenceModeScope<float>()) clone[0] = 9f;
+        Assert.Equal(epoch, source.GpuCacheVersion);
+        Assert.True(clone.GpuCacheVersion > epoch);
+        Assert.Equal(new[] { 1f, 2f }, source.ToArray());
+        Assert.Equal(new[] { 9f, 2f }, clone.ToArray());
+    }
+
+    [Fact]
+    public void CpuOnlyWrites_DoNotPayForGpuEpochUntilStorageParticipatesInCaching()
+    {
+        var tensor = new Tensor<float>(new[] { 1 });
+        using (new InferenceModeScope<float>())
+            for (int i = 0; i < 100; i++) tensor[0] = i;
+        Assert.Equal(0, tensor.GpuCacheVersion);
+        using (new InferenceModeScope<float>()) tensor[0] = 101;
+        Assert.Equal(1, tensor.GpuCacheVersion);
+    }
+
+    [Fact]
+    public void ExclusiveClaim_DoesNotInvokeFallibleResourceDisposalBeforeStorageSwap()
+    {
+        var storage = new TensorStorage<float>(new Vector<float>(2));
+        var resource = new ThrowingOwner();
+        storage.AttachGpuBufferOwner(resource);
+        Assert.True(storage.TryClaimExclusive());
+        Assert.Equal(0, resource.Attempts);
+        Assert.Throws<InvalidOperationException>(() => storage.DisposeClaimedOwners());
+        Assert.Equal(1, resource.Attempts);
+        storage.DisposeClaimedOwners();
+        Assert.Equal(1, resource.Attempts);
+    }
+
+    private sealed class ThrowingOwner : IDisposable
+    {
+        internal int Attempts { get; private set; }
+        public void Dispose()
+        {
+            Attempts++;
+            throw new InvalidOperationException("Injected resource cleanup failure.");
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightLifetimeIntegrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightLifetimeIntegrationTests.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -21,6 +23,42 @@ namespace AiDotNet.Tensors.Tests.LinearAlgebra;
 [Collection("WeightRegistry")]
 public class WeightLifetimeIntegrationTests
 {
+    private sealed class TrackingOffloadAllocator : IGpuOffloadAllocator
+    {
+        private readonly System.Collections.Generic.HashSet<IntPtr> _live = new();
+        private int _allocationCount;
+        public int FailOnAllocation { get; set; } = int.MaxValue;
+        public int LiveCount => _live.Count;
+
+        public bool IsAvailable => true;
+        public int FreeCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public GpuOffloadHandle Allocate(long bytes, OffloadScheme scheme)
+        {
+            if (++_allocationCount == FailOnAllocation) throw new OutOfMemoryException("Injected allocation failure.");
+            IntPtr pointer = Marshal.AllocHGlobal(checked((int)bytes));
+            _live.Add(pointer);
+            return new GpuOffloadHandle(pointer, pointer, bytes, scheme);
+        }
+
+        public void Free(GpuOffloadHandle handle)
+        {
+            if (!_live.Remove(handle.HostPointer))
+                throw new InvalidOperationException("Allocation was freed through the wrong allocator.");
+            Marshal.FreeHGlobal(handle.HostPointer);
+            FreeCount++;
+        }
+
+        public void Dispose()
+        {
+            foreach (IntPtr pointer in _live)
+                Marshal.FreeHGlobal(pointer);
+            _live.Clear();
+            DisposeCount++;
+        }
+    }
+
     [Fact]
     public void Tensor_DefaultLifetime_IsDefault()
     {
@@ -28,6 +66,89 @@ public class WeightLifetimeIntegrationTests
         Assert.Equal(WeightLifetime.Default, t.Lifetime);
         Assert.Equal(-1L, t.StreamingPoolHandle);
         Assert.Equal(IntPtr.Zero, t.OffloadDevicePointer);
+    }
+
+    [Fact]
+    public void ConfigureBatch_FailedSecondAllocationPreservesPriorConfigurationAndWeights()
+    {
+        WeightRegistry.Reset();
+        var priorAllocator = new TrackingOffloadAllocator();
+        var candidateAllocator = new TrackingOffloadAllocator { FailOnAllocation = 2 };
+        try
+        {
+            var priorOptions = new GpuOffloadOptions();
+            WeightRegistry.Configure(priorOptions, priorAllocator);
+            var first = new Tensor<float>(new float[] { 1, 2 }, new[] { 2 });
+            var second = new Tensor<float>(new float[] { 3, 4 }, new[] { 2 });
+            Assert.Throws<OutOfMemoryException>(() => WeightRegistry.ConfigureAndRegisterBatch(
+                new GpuOffloadOptions(), new[] { first, second }, candidateAllocator));
+            Assert.Same(priorOptions, WeightRegistry.CurrentOptions);
+            Assert.Same(priorAllocator, WeightRegistry.OffloadAllocator);
+            Assert.Equal(0, priorAllocator.DisposeCount);
+            Assert.Equal(0, candidateAllocator.LiveCount);
+            Assert.Equal(1, candidateAllocator.FreeCount);
+            foreach (var weight in new[] { first, second })
+            {
+                Assert.Equal(WeightLifetime.Default, weight.Lifetime);
+                Assert.Equal(-1, weight.OffloadRegistryHandle);
+                Assert.Equal(IntPtr.Zero, weight.OffloadHostPointer);
+            }
+            Assert.Equal(new float[] { 1, 2 }, first.ToArray());
+            Assert.Equal(new float[] { 3, 4 }, second.ToArray());
+            candidateAllocator.FailOnAllocation = int.MaxValue;
+            WeightRegistry.ConfigureAndRegisterBatch(new GpuOffloadOptions(), new[] { first, first, second }, candidateAllocator);
+            Assert.Equal(2, candidateAllocator.LiveCount);
+            WeightRegistry.RegisterBatch(new[] { first, second }, WeightLifetime.GpuOffload);
+            Assert.Equal(2, candidateAllocator.LiveCount);
+        }
+        finally { WeightRegistry.Reset(); candidateAllocator.Dispose(); }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ConfigureBatch_InvalidBackingPathLeavesPreviousGlobalsAndDataUnchanged(bool lazy)
+    {
+        WeightRegistry.Reset();
+        string invalidDirectory = Path.GetTempFileName();
+        try
+        {
+            var previous = new GpuOffloadOptions();
+            WeightRegistry.Configure(previous);
+            var weight = new Tensor<float>(new float[] { 1, 2 }, new[] { 2 });
+            Assert.ThrowsAny<IOException>(() => WeightRegistry.ConfigureAndRegisterBatch(
+                new GpuOffloadOptions { StreamingBackingStorePath = invalidDirectory }, lazy ? Array.Empty<Tensor<float>>() : new[] { weight }));
+            Assert.Same(previous, WeightRegistry.CurrentOptions);
+            Assert.Equal(WeightLifetime.Default, weight.Lifetime);
+            Assert.Equal(-1, weight.StreamingPoolHandle);
+            Assert.Equal(new float[] { 1, 2 }, weight.ToArray());
+        }
+        finally { WeightRegistry.Reset(); File.Delete(invalidDirectory); }
+    }
+
+    [Fact]
+    public void RegisterBatch_FailedDeltaPreservesExistingOffloadAndUnregisteredWeights()
+    {
+        WeightRegistry.Reset();
+        var allocator = new TrackingOffloadAllocator { FailOnAllocation = 3 };
+        try
+        {
+            var existing = new Tensor<float>(new float[] { 7 }, new[] { 1 });
+            WeightRegistry.ConfigureAndRegisterBatch(new GpuOffloadOptions(), new[] { existing }, allocator);
+            long originalHandle = existing.OffloadRegistryHandle;
+            var first = new Tensor<float>(new float[] { 1 }, new[] { 1 });
+            var second = new Tensor<float>(new float[] { 2 }, new[] { 1 });
+            Assert.Throws<OutOfMemoryException>(() => WeightRegistry.RegisterBatch(
+                new[] { existing, first, second }, WeightLifetime.GpuOffload));
+            Assert.Equal(1, allocator.LiveCount);
+            Assert.Equal(originalHandle, existing.OffloadRegistryHandle);
+            Assert.Equal(7, Marshal.PtrToStructure<float>(existing.OffloadHostPointer));
+            Assert.Equal(WeightLifetime.Default, first.Lifetime);
+            Assert.Equal(WeightLifetime.Default, second.Lifetime);
+            Assert.Equal(-1, first.OffloadRegistryHandle);
+            Assert.Equal(-1, second.OffloadRegistryHandle);
+        }
+        finally { WeightRegistry.Reset(); }
     }
 
     [Fact]
@@ -72,5 +193,39 @@ public class WeightLifetimeIntegrationTests
         WeightRegistry.RegisterWeight(t);
         Assert.Equal(WeightLifetime.Default, t.Lifetime);
         Assert.Equal(IntPtr.Zero, t.OffloadDevicePointer);
+    }
+
+    [Fact]
+    public void Configure_CannotReplaceAllocatorThatOwnsLiveOffloadHandles()
+    {
+        WeightRegistry.Reset();
+        var allocatorA = new TrackingOffloadAllocator();
+        var allocatorB = new TrackingOffloadAllocator();
+        try
+        {
+            var options = new GpuOffloadOptions();
+            WeightRegistry.Configure(options, allocatorA);
+            var tensor = new Tensor<float>(new[] { 8 })
+            {
+                Lifetime = WeightLifetime.GpuOffload,
+            };
+            WeightRegistry.RegisterWeight(tensor);
+
+            Assert.Throws<InvalidOperationException>(
+                () => WeightRegistry.Configure(options, allocatorB));
+            Assert.Equal(0, allocatorA.DisposeCount);
+            Assert.Equal(0, allocatorB.DisposeCount);
+
+            WeightRegistry.UnregisterWeight(tensor);
+            Assert.Equal(1, allocatorA.FreeCount);
+
+            WeightRegistry.Configure(options, allocatorB);
+            Assert.Equal(1, allocatorA.DisposeCount);
+            Assert.Same(allocatorB, WeightRegistry.OffloadAllocator);
+        }
+        finally
+        {
+            WeightRegistry.Reset();
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightLifetimeIntegrationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightLifetimeIntegrationTests.cs
@@ -28,6 +28,8 @@ public class WeightLifetimeIntegrationTests
         private readonly System.Collections.Generic.HashSet<IntPtr> _live = new();
         private int _allocationCount;
         public int FailOnAllocation { get; set; } = int.MaxValue;
+        public int FailAfterFreeAttempt { get; set; } = int.MaxValue;
+        public int FreeAttempts { get; private set; }
         public int LiveCount => _live.Count;
 
         public bool IsAvailable => true;
@@ -44,10 +46,13 @@ public class WeightLifetimeIntegrationTests
 
         public void Free(GpuOffloadHandle handle)
         {
+            FreeAttempts++;
             if (!_live.Remove(handle.HostPointer))
                 throw new InvalidOperationException("Allocation was freed through the wrong allocator.");
             Marshal.FreeHGlobal(handle.HostPointer);
             FreeCount++;
+            if (FreeAttempts == FailAfterFreeAttempt)
+                throw new IOException("Injected failure after the allocator released its handle.");
         }
 
         public void Dispose()
@@ -57,6 +62,91 @@ public class WeightLifetimeIntegrationTests
             _live.Clear();
             DisposeCount++;
         }
+    }
+
+    private sealed class ThrowingTraceListener : System.Diagnostics.TraceListener
+    {
+        public override void Write(string? message) => throw new IOException("Injected diagnostic failure.");
+        public override void WriteLine(string? message) => throw new IOException("Injected diagnostic failure.");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Reset_AttemptsEveryFreeAndClearsHandlesWhenOneFreeThrows(bool failLogging)
+    {
+        WeightRegistry.Reset();
+        var allocator = new TrackingOffloadAllocator { FailAfterFreeAttempt = 1 };
+        using var listener = new ThrowingTraceListener();
+        try
+        {
+            var weights = new[] { new Tensor<float>(new[] { 2 }), new Tensor<float>(new[] { 3 }) };
+            WeightRegistry.ConfigureAndRegisterBatch(new GpuOffloadOptions(), weights, allocator);
+            if (failLogging) System.Diagnostics.Trace.Listeners.Add(listener);
+
+            WeightRegistry.Reset();
+
+            Assert.Equal(2, allocator.FreeAttempts);
+            Assert.Equal(2, allocator.FreeCount);
+            Assert.Equal(0, allocator.LiveCount);
+            Assert.Equal(1, allocator.DisposeCount);
+            WeightRegistry.Reset();
+            Assert.Equal(2, allocator.FreeAttempts);
+            GC.KeepAlive(weights);
+        }
+        finally
+        {
+            System.Diagnostics.Trace.Listeners.Remove(listener);
+            WeightRegistry.Reset();
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Configure_PrunesEveryDeadOwnerEvenWhenOneFreeThrows(bool failLogging)
+    {
+        WeightRegistry.Reset();
+        var allocator = new TrackingOffloadAllocator { FailAfterFreeAttempt = 1 };
+        var replacement = new TrackingOffloadAllocator();
+        using var listener = new ThrowingTraceListener();
+        try
+        {
+            WeightRegistry.Configure(new GpuOffloadOptions(), allocator);
+            WeakReference[] abandoned = RegisterAndAbandonOffloadWeights();
+            for (int attempt = 0; attempt < 5 && Array.Exists(abandoned, weak => weak.IsAlive); attempt++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+            Assert.All(abandoned, weak => Assert.False(weak.IsAlive));
+            if (failLogging) System.Diagnostics.Trace.Listeners.Add(listener);
+
+            WeightRegistry.Configure(new GpuOffloadOptions(), replacement);
+
+            Assert.Equal(2, allocator.FreeAttempts);
+            Assert.Equal(2, allocator.FreeCount);
+            Assert.Equal(0, allocator.LiveCount);
+            Assert.Equal(1, allocator.DisposeCount);
+            Assert.Same(replacement, WeightRegistry.OffloadAllocator);
+            WeightRegistry.Configure(new GpuOffloadOptions(), replacement);
+            Assert.Equal(2, allocator.FreeAttempts);
+        }
+        finally
+        {
+            System.Diagnostics.Trace.Listeners.Remove(listener);
+            WeightRegistry.Reset();
+        }
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference[] RegisterAndAbandonOffloadWeights()
+    {
+        var first = new Tensor<float>(new[] { 2 });
+        var second = new Tensor<float>(new[] { 3 });
+        WeightRegistry.RegisterBatch(new[] { first, second }, WeightLifetime.GpuOffload);
+        return new[] { new WeakReference(first), new WeakReference(second) };
     }
 
     [Fact]

--- a/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/LinearAlgebra/WeightStreamingTransparentAccessTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -68,6 +69,23 @@ public class WeightStreamingTransparentAccessTests : IDisposable
 
         // Side effect: the tensor is now resident again.
         Assert.Equal(expected.Length, t.DataVector.Length);
+    }
+
+    [Fact]
+    public void ParameterBufferCopyFrom_OnDroppedStreamingWeight_UsesLogicalTensorCopy()
+    {
+        float[] expected = { 1.5f, -2.25f, 3.125f, 4.0f, 5.5f, -6.75f };
+        var parameter = new Tensor<float>(expected, new[] { 2, 3 })
+        {
+            Lifetime = WeightLifetime.Streaming,
+        };
+        WeightRegistry.RegisterWeight(parameter);
+        Assert.Equal(0, parameter.DataVector.Length);
+
+        var buffer = new ParameterBuffer<float>(new[] { new[] { 2, 3 } });
+        buffer.CopyFrom(new[] { parameter });
+
+        Assert.Equal(expected, buffer.AsVector().ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
## Scope

Companion dependency for ooples/AiDotNet#2088. Fixes transactional weight registration/rollback and offload ownership, bounded streaming gradient delivery/journaling, sparse Adam semantics, shared-storage GPU cache invalidation (including inference and COW), and real OpenCL half-buffer handling. Keeps full contiguous views and SIMD/GPU cache reuse; uses typed precision policies.

## Executed proof

Validated after merging main at 5d22aa7f4:

- All library target frameworks build; all test target frameworks build.
- Expanded autodiff/storage/streaming family: 1,508 passed, 30 documented skips, zero failures.
- AMD Radeon RX 5500 XT/OpenCL set: 208 passed, zero skips. Includes 39 strict physical numerical/data-path cases and two hardware-backed argument guards; not 208 physical kernel tests.
- Five original stale-cache repros fail before and pass after. Causal-attention and MaxPool1D numerical-gradient regressions also pass unchanged.
- Actual AMD accumulation error: inherited half 0.0004765625 versus FP32 0.00000003624.
- AiDotNet integration against this dependency: 536 focused tests passed, zero skips; full model-family validation is still running separately.

Exact commands, tested commit/binary/TRX hashes, before/after values, skip details, hardware limits, and local-versus-CI evidence boundaries are in [the validation record](docs/development/streaming-tape-transaction-validation.md). Independent adversarial review covered storage ownership, transaction failures, optimizer semantics, and real-device cache freshness. No new null-forgiving operators or reduced numerical tolerances.

## Release dependency

This must be reviewed, merged, and published before AiDotNet#2088 can consume these new APIs through NuGet. Local integration used the source dependency; it is not proof of a published-package CI run. CUDA/Metal physical execution and end-to-end throughput improvements are not claimed.

### Stable-package blocker found by release-path validation

Actual stable-version packing (Version=0.130.4, candidate only) fails NU5104 on all three TFMs because main already depends on prerelease-only AiDotNet.Evolution 0.1.0-preview.1. Normal source builds and the tests above are green, but the stable release gate is not. A validated stable Evolution release and dependency-pin update are required before publishing Tensors; no NU5104 suppression is proposed. AiDotNet also needs its existing package-ownership migration (#2092) before default NuGet integration. This PR is open for review, not being presented as merge/publish-ready.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable streaming graph retention and typed sparse embedding gradients.
  * Added FP32 gradient accumulation control for improved numerical accuracy.
  * Added bounded tensor journaling with append, replay, restore, and disk-backed storage.
  * Added batch weight registration and configuration with failure-safe rollback.
  * Added sparse Adam and AMSGrad updates for indexed parameters.
* **Bug Fixes**
  * Improved tensor and GPU cache consistency after mutations, transfers, and in-place operations.
  * Improved OpenCL half-precision buffer compatibility and validation.
  * Fixed streaming tensor copies and MaxPool1D gradient updates.
* **Documentation**
  * Clarified sparse embedding gradient storage and optimizer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->