### PR TITLE
fix(broadcast): follow NumPy's rule for zero-size extents across engine, autodiff and ONNX

### DIFF
--- a/src/AiDotNet.Tensors.Onnx/Operators/ArithOperators.cs
+++ b/src/AiDotNet.Tensors.Onnx/Operators/ArithOperators.cs
@@ -74,7 +74,9 @@ internal static class ArithOperators
                         throw new InvalidDataException(
                             $"MatMul batch shapes aren't broadcast-compatible: " +
                             $"a.shape=[{string.Join(",", a._shape)}] b.shape=[{string.Join(",", b._shape)}].");
-                    batchShape[i] = Math.Max(aDim, bDim);
+                    // 1 stretches to the other extent, including 0 — Math.Max would turn (0, 1) into 1
+                    // and size an empty batch as one matrix.
+                    batchShape[i] = aDim == 1 ? bDim : aDim;
                 }
                 int totalBatch = 1;
                 for (int i = 0; i < maxBatchRank; i++) totalBatch *= batchShape[i];

--- a/src/AiDotNet.Tensors.Onnx/Operators/MathOperators.cs
+++ b/src/AiDotNet.Tensors.Onnx/Operators/MathOperators.cs
@@ -608,11 +608,24 @@ internal static class MathOperators
                 ctx.PutTensor(node.Output[0], input);
                 return;
             }
+            // Reject an incompatible target at import time with an ONNX-level error naming both
+            // shapes, rather than surfacing whatever the engine's add throws (or, under a lenient
+            // shape policy, not throwing at all).
+            _ = ComputeBroadcastShape(input._shape, targetShape);
             var zero = new Tensor<T>(targetShape);
             ctx.PutTensor(node.Output[0], ctx.Engine.TensorAdd(input, zero));
         }
     }
 
+    /// <summary>
+    /// NumPy / ONNX multidirectional broadcast shape of <paramref name="a"/> and <paramref name="b"/>.
+    /// </summary>
+    /// <remarks>
+    /// An extent of 1 stretches to the other extent — including 0 — so each output axis is
+    /// <c>ai == 1 ? bi : ai</c>, not <c>Math.Max(ai, bi)</c> (which turns (0, 1) into 1). Any other
+    /// mismatch is rejected here, at import time, with both shapes named; without the check a
+    /// mismatch such as [2,3] vs [3,3] was silently sized [3,3] and failed later inside the engine.
+    /// </remarks>
     private static int[] ComputeBroadcastShape(int[] a, int[] b)
     {
         int rank = Math.Max(a.Length, b.Length);
@@ -621,7 +634,11 @@ internal static class MathOperators
         {
             int ai = i < a.Length ? a[a.Length - 1 - i] : 1;
             int bi = i < b.Length ? b[b.Length - 1 - i] : 1;
-            result[rank - 1 - i] = Math.Max(ai, bi);
+            if (ai != bi && ai != 1 && bi != 1)
+                throw new InvalidDataException(
+                    $"Shapes [{string.Join(",", a)}] and [{string.Join(",", b)}] are not broadcast-compatible: " +
+                    $"axis {rank - 1 - i} has sizes {ai} and {bi} (must be equal or one must be 1).");
+            result[rank - 1 - i] = ai == 1 ? bi : ai;
         }
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -2260,11 +2260,13 @@ internal static class BackwardFunctions<T>
         // Pad target shape with leading 1s to match rank
         var paddedTarget = PadShapeToRank(targetShape, gradShape.Length);
 
-        // Find axes where target has size 1 but grad has size > 1 (broadcast dims)
+        // Find axes where target has size 1 but grad does not (broadcast dims). "Does not" rather
+        // than "> 1": an axis stretched from 1 to 0 must be summed too — a sum over no positions,
+        // i.e. zero — or the zero-length gradient is later reshaped to the operand's non-empty shape.
         var reduceAxes = new List<int>();
         for (int i = 0; i < gradShape.Length; i++)
         {
-            if (paddedTarget[i] == 1 && gradShape[i] > 1)
+            if (paddedTarget[i] == 1 && gradShape[i] != 1)
                 reduceAxes.Add(i);
         }
 

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -4184,9 +4184,19 @@ public partial class CpuEngine : ITensorLevelEngine
             }
         }
 
-        var aOrig = a;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
-        if (!a.IsContiguous) a = a.Contiguous();
-        var bOrig = b;  // #257: preserve user-facing ref before .Contiguous() discards GradFn.
+        // A non-contiguous target (a transpose, a strided slice) used to be swapped for a contiguous
+        // COPY here, so every kernel below added into the copy and the caller's tensor came back
+        // unchanged — an in-place op that silently did nothing. Compute into a contiguous working
+        // copy, then scatter the result back through the view's own strides. Contiguous targets —
+        // the only kind every existing caller passes — never reach this branch.
+        if (!a.IsContiguous)
+        {
+            ThrowIfInPlaceTargetAliasesItself(a);
+            var work = a.Contiguous();
+            TensorBroadcastAddInPlace(work, b);
+            a.CopyFromArray(work.ToArray());
+            return;
+        }
         if (!b.IsContiguous) b = b.Contiguous();
 
         var numOps = MathHelper.GetNumericOperations<T>();
@@ -4263,6 +4273,25 @@ public partial class CpuEngine : ITensorLevelEngine
                 $"In-place broadcast add cannot resize its target: {FormatShape(a._shape)} " +
                 $"+= {FormatShape(b._shape)} broadcasts to {FormatShape(result._shape)}.", nameof(b));
         result.Data.Span.CopyTo(aSpan);
+    }
+
+    /// <summary>
+    /// Rejects an in-place target whose logical elements share storage — a stride-0 (expanded)
+    /// axis of extent &gt; 1 — because there is no well-defined result to write back: every
+    /// position along that axis would have to hold a different sum in the same memory slot.
+    /// PyTorch rejects the same case. Materialize with <c>Contiguous()</c> first.
+    /// </summary>
+    private static void ThrowIfInPlaceTargetAliasesItself<T>(Tensor<T> target)
+    {
+        for (int axis = 0; axis < target.Rank; axis++)
+        {
+            if (target._shape[axis] > 1 && target._strides[axis] == 0)
+                throw new ArgumentException(
+                    $"Cannot write in place into a tensor of shape [{string.Join(", ", target._shape)}] whose " +
+                    $"axis {axis} has stride 0: several of its elements share one storage location (an " +
+                    "expanded/broadcast view). Call Contiguous() to materialize it before the in-place op.",
+                    "a");
+        }
     }
 
     protected static void ValidateGroupNormArguments<T>(

--- a/src/AiDotNet.Tensors/Engines/CpuEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/CpuEngine.cs
@@ -4238,6 +4238,8 @@ public partial class CpuEngine : ITensorLevelEngine
         if (b.Rank == 1 && a._shape[^1] == b._shape[0])
         {
             int lastDim = b._shape[0];
+            // A zero-extent last axis means `a` is empty: nothing to add, and a.Length / 0 throws.
+            if (lastDim == 0) return;
             int outerSize = a.Length / lastDim;
             for (int outer = 0; outer < outerSize; outer++)
             {
@@ -4251,6 +4253,15 @@ public partial class CpuEngine : ITensorLevelEngine
         // General fallback: compute broadcast result and copy back.
         // This allocates a temporary — acceptable for rare arbitrary broadcast shapes.
         var result = TensorBroadcastAdd(a, b);
+        // In place cannot grow or shrink the target. Stretching one of a's size-1 axes to a larger
+        // extent already failed in CopyTo (destination too short), but stretching it to 0 produced an
+        // empty result that "copied" nothing and returned a non-empty target silently unmodified.
+        // Compared by length, not shape, so the long-standing tolerance for a result that differs
+        // from `a` only by padded leading 1s ([C] += [1,C]) is left exactly as it was.
+        if (result.Length != a.Length)
+            throw new ArgumentException(
+                $"In-place broadcast add cannot resize its target: {FormatShape(a._shape)} " +
+                $"+= {FormatShape(b._shape)} broadcasts to {FormatShape(result._shape)}.", nameof(b));
         result.Data.Span.CopyTo(aSpan);
     }
 
@@ -13073,7 +13084,8 @@ public partial class CpuEngine : ITensorLevelEngine
             int dim2 = i < shape2.Length ? shape2[shape2.Length - 1 - i] : 1;
             if (dim1 != dim2 && dim1 != 1 && dim2 != 1)
                 throw new ArgumentException($"Shapes are not broadcast-compatible at dimension {maxRank - 1 - i}: {dim1} vs {dim2}");
-            result[maxRank - 1 - i] = Math.Max(dim1, dim2);
+            // 1 stretches to the other extent, including 0 — Math.Max would turn (0, 1) into 1.
+            result[maxRank - 1 - i] = dim1 == 1 ? dim2 : dim1;
         }
         return result;
     }

--- a/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
+++ b/src/AiDotNet.Tensors/Engines/DirectGpuTensorEngine.cs
@@ -16846,6 +16846,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
             return base.TensorBroadcastMultiply(a, b);
         }
 
+        // An empty operand belongs to the CPU base, which returns the (empty) broadcast-shaped result
+        // or rejects an incompatible pair. There is no kernel to launch for an empty result, and the
+        // last-axis fast paths below divide a.Length by a zero inner extent.
+        if (a.Length == 0 || b.Length == 0)
+            return base.TensorBroadcastMultiply(a, b);
+
         Tensor<T> RecordGpuResult(Tensor<T> output)
         {
             Autodiff.DifferentiableOps.RecordBinary(
@@ -22418,6 +22424,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.TensorBroadcastAdd(a, b);
 
+        // An empty operand belongs to the CPU base, which returns the (empty) broadcast-shaped result
+        // or rejects an incompatible pair. There is no kernel to launch for an empty result, and the
+        // last-axis fast path's a.Length % b.Length divides by zero on an empty right operand.
+        if (a.Length == 0 || b.Length == 0)
+            return base.TensorBroadcastAdd(a, b);
+
         Tensor<T> RecordGpuResult(Tensor<T> output)
         {
             Autodiff.DifferentiableOps.RecordBinary(
@@ -22521,6 +22533,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
         if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
             return base.TensorBroadcastSubtract(a, b);
 
+        // An empty operand belongs to the CPU base, which returns the (empty) broadcast-shaped result
+        // or rejects an incompatible pair. There is no kernel to launch for an empty result, and the
+        // last-axis fast path's a.Length % b.Length divides by zero on an empty right operand.
+        if (a.Length == 0 || b.Length == 0)
+            return base.TensorBroadcastSubtract(a, b);
+
         Tensor<T> RecordGpuResult(Tensor<T> output)
         {
             Autodiff.DifferentiableOps.RecordBinary(
@@ -22583,6 +22601,12 @@ public partial class DirectGpuTensorEngine : CpuEngine, ITensorLevelEngine, IDis
     public override Tensor<T> TensorBroadcastDivide<T>(Tensor<T> a, Tensor<T> b)
     {
         if (DirectGpuEngine.ShouldFallbackForPrecision<T>())
+            return base.TensorBroadcastDivide(a, b);
+
+        // An empty operand belongs to the CPU base, which returns the (empty) broadcast-shaped result
+        // or rejects an incompatible pair. There is no kernel to launch for an empty result, and the
+        // last-axis fast path's a.Length % b.Length divides by zero on an empty right operand.
+        if (a.Length == 0 || b.Length == 0)
             return base.TensorBroadcastDivide(a, b);
 
         Tensor<T> RecordGpuResult(Tensor<T> output)

--- a/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
+++ b/src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs
@@ -2507,7 +2507,10 @@ public partial class Tensor<T> : TensorBase<T>, IEnumerable<T>
 
             if (dim1 == dim2 || dim1 == 1 || dim2 == 1)
             {
-                broadcastShape[maxRank - 1 - i] = Math.Max(dim1, dim2);
+                // An extent of 1 stretches to the OTHER extent — including 0. Math.Max(dim1, dim2)
+                // agrees with that for every pair of positive extents but turns (0, 1) into 1, which
+                // sized [0,2,2,2] + [1,2,1,1] as eight elements drawn from an operand with none.
+                broadcastShape[maxRank - 1 - i] = dim1 == 1 ? dim2 : dim1;
             }
             else
             {

--- a/tests/AiDotNet.Tensors.Onnx.Tests/Operators/EmptyBroadcastOnnxTests.cs
+++ b/tests/AiDotNet.Tensors.Onnx.Tests/Operators/EmptyBroadcastOnnxTests.cs
@@ -1,0 +1,166 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Onnx.Operators;
+using AiDotNet.Tensors.Onnx.Protos;
+using Xunit;
+
+namespace AiDotNet.Tensors.Onnx.Tests.Operators;
+
+/// <summary>
+/// ONNX translators that compute a broadcast shape themselves must follow the NumPy rule: an
+/// extent of 1 stretches to the other extent, including 0.
+/// </summary>
+/// <remarks>
+/// <c>MathOperators.ComputeBroadcastShape</c> (used by Min, Max and Equal) and MatMul's batch-shape
+/// loop both computed each axis as <c>Math.Max(a, b)</c>, which is right for positive extents but
+/// turns (0, 1) into 1. ComputeBroadcastShape also had no compatibility check, so [2,3] vs [3,3]
+/// was silently sized [3,3]. The translators are driven directly here so the tests do not depend
+/// on how the importer treats a zero <c>dim_value</c> in a graph-input declaration.
+/// </remarks>
+public class EmptyBroadcastOnnxTests
+{
+    private static Tensor<float> Run(IOnnxOpTranslator<float> translator, string opType,
+        params (string Name, Tensor<float> Value)[] inputs)
+    {
+        var tensors = new Dictionary<string, Tensor<float>>(StringComparer.Ordinal);
+        var node = new NodeProto { OpType = opType };
+        foreach (var (name, value) in inputs)
+        {
+            tensors[name] = value;
+            node.Input.Add(name);
+        }
+        node.Output.Add("Y");
+        var ctx = new OnnxTranslationContext<float>(new CpuEngine(), tensors, new OnnxImportOptions());
+        translator.Translate(ctx, node);
+        return ctx.GetTensor("Y");
+    }
+
+    private static Tensor<float> Filled(int[] shape, float start = 1f)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = start + i;
+        return t;
+    }
+
+    public static TheoryData<int[], int[], int[]> EmptyPairs => new()
+    {
+        { new[] { 0, 3 }, new[] { 1, 3 }, new[] { 0, 3 } },
+        { new[] { 1, 3 }, new[] { 0, 3 }, new[] { 0, 3 } },
+        { new[] { 2, 0, 3 }, new[] { 2, 1, 1 }, new[] { 2, 0, 3 } },
+        { new[] { 0, 2, 3 }, new[] { 2, 1 }, new[] { 0, 2, 3 } },
+    };
+
+    [Theory]
+    [MemberData(nameof(EmptyPairs))]
+    public void MinMax_ZeroSizeBroadcast_ReturnsEmptyBroadcastShape(int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var min = Run(new MathOperators.Min<float>(), "Min", ("A", Filled(shapeA)), ("B", Filled(shapeB)));
+        var max = Run(new MathOperators.Max<float>(), "Max", ("A", Filled(shapeA)), ("B", Filled(shapeB)));
+
+        Assert.Equal(expected, min.Shape.ToArray());
+        Assert.Equal(expected, max.Shape.ToArray());
+        Assert.Equal(0, min.Length);
+        Assert.Equal(0, max.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyPairs))]
+    public void Equal_ZeroSizeBroadcast_ReturnsEmptyBroadcastShape(int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var eq = Run(new MathOperators.Equal<float>(), "Equal", ("A", Filled(shapeA)), ("B", Filled(shapeB)));
+
+        Assert.Equal(expected, eq.Shape.ToArray());
+        Assert.Equal(0, eq.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyPairs))]
+    public void Expand_ToZeroSizeShape_ReturnsEmptyBroadcastShape(int[] shapeA, int[] shapeB, int[] expected)
+    {
+        // Expand(input, shape) is the multidirectional broadcast of input.shape and `shape`.
+        var shape = new Tensor<float>(new[] { shapeB.Length });
+        for (int i = 0; i < shapeB.Length; i++) shape[i] = shapeB[i];
+
+        var y = Run(new MathOperators.Expand<float>(), "Expand", ("X", Filled(shapeA)), ("S", shape));
+
+        Assert.Equal(expected, y.Shape.ToArray());
+        Assert.Equal(0, y.Length);
+    }
+
+    /// <summary>Incompatible shapes are rejected at import time with an ONNX-level error.</summary>
+    [Theory]
+    [InlineData(new[] { 2, 3 }, new[] { 3, 3 })]
+    [InlineData(new[] { 0, 3 }, new[] { 2, 3 })]   // 0 is not a wildcard: it only stretches from 1
+    public void MinMaxEqual_IncompatibleShapes_ThrowOnnxError(int[] shapeA, int[] shapeB)
+    {
+        foreach (var (translator, op) in new (IOnnxOpTranslator<float>, string)[]
+                 {
+                     (new MathOperators.Min<float>(), "Min"),
+                     (new MathOperators.Max<float>(), "Max"),
+                     (new MathOperators.Equal<float>(), "Equal"),
+                 })
+        {
+            var ex = Assert.Throws<InvalidDataException>(
+                () => Run(translator, op, ("A", Filled(shapeA)), ("B", Filled(shapeB))));
+            Assert.Contains("not broadcast-compatible", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Expand_IncompatibleTarget_ThrowsOnnxError()
+    {
+        var input = Filled(new[] { 2, 3 });
+        var shape = new Tensor<float>(new[] { 2 });
+        shape[0] = 3; shape[1] = 3;
+
+        var ex = Assert.Throws<InvalidDataException>(
+            () => Run(new MathOperators.Expand<float>(), "Expand", ("X", input), ("S", shape)));
+        Assert.Contains("not broadcast-compatible", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Non-empty broadcasting keeps producing the NumPy result.</summary>
+    [Fact]
+    public void Max_NonEmptyBroadcast_ValuesUnchanged()
+    {
+        var a = Filled(new[] { 2, 3 });          // 1..6
+        var b = new Tensor<float>(new[] { 2, 1 });
+        b[0] = 2.5f; b[1] = 10f;
+
+        var y = Run(new MathOperators.Max<float>(), "Max", ("A", a), ("B", b));
+
+        Assert.Equal(new[] { 2, 3 }, y.Shape.ToArray());
+        Assert.Equal(new[] { 2.5f, 2.5f, 3f, 10f, 10f, 10f }, y.ToArray());
+    }
+
+    [Theory]
+    [InlineData(new[] { 0, 2, 3 }, new[] { 1, 3, 4 }, new[] { 0, 2, 4 })]
+    [InlineData(new[] { 1, 2, 3 }, new[] { 0, 3, 4 }, new[] { 0, 2, 4 })]
+    [InlineData(new[] { 2, 1, 2, 3 }, new[] { 1, 0, 3, 4 }, new[] { 2, 0, 2, 4 })]
+    [InlineData(new[] { 0, 2, 3 }, new[] { 3, 4 }, new[] { 0, 2, 4 })]
+    public void MatMul_ZeroSizeBatchBroadcast_ReturnsEmptyBatch(int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var y = Run(new ArithOperators.MatMul<float>(), "MatMul", ("A", Filled(shapeA)), ("B", Filled(shapeB)));
+
+        Assert.Equal(expected, y.Shape.ToArray());
+        Assert.Equal(0, y.Length);
+    }
+
+    [Fact]
+    public void MatMul_NonEmptyBatchBroadcast_ValuesUnchanged()
+    {
+        var a = Filled(new[] { 2, 2, 3 });
+        var b = Filled(new[] { 1, 3, 2 }, start: -2f);
+
+        var y = Run(new ArithOperators.MatMul<float>(), "MatMul", ("A", a), ("B", b));
+
+        Assert.Equal(new[] { 2, 2, 2 }, y.Shape.ToArray());
+        for (int n = 0; n < 2; n++)
+        for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+        {
+            float expected = 0f;
+            for (int k = 0; k < 3; k++) expected += a[n, i, k] * b[0, k, j];
+            Assert.Equal(expected, y[n, i, j], 4);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/BroadcastAddInPlaceStridedTargetTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/BroadcastAddInPlaceStridedTargetTests.cs
@@ -1,0 +1,93 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Broadcasting;
+
+/// <summary>
+/// <c>TensorBroadcastAddInPlace</c> must mutate the tensor the caller passed, including when that
+/// tensor is a non-contiguous view.
+/// </summary>
+/// <remarks>
+/// The defect: the method rebound a non-contiguous target to <c>a.Contiguous()</c> — a fresh copy —
+/// and every kernel after that added into the copy. The call returned normally and the caller's
+/// tensor was unchanged. Each shape below reaches a different branch of the method (same shape,
+/// channel bias, scalar, last-axis bias, general fallback), and every branch had the defect.
+/// </remarks>
+public class BroadcastAddInPlaceStridedTargetTests
+{
+    private readonly CpuEngine _engine = new();
+
+    private static Tensor<double> Filled(int[] shape, double start)
+    {
+        var t = new Tensor<double>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = start + i;
+        return t;
+    }
+
+    /// <summary>
+    /// (target's contiguous source shape, permutation that makes the view, operand shape).
+    /// </summary>
+    public static TheoryData<int[], int[], int[]> Cases => new()
+    {
+        { new[] { 3, 2 }, new[] { 1, 0 }, new[] { 2, 3 } },             // same shape
+        { new[] { 3, 2 }, new[] { 1, 0 }, new[] { 1 } },                // scalar
+        { new[] { 3, 2 }, new[] { 1, 0 }, new[] { 3 } },                // last-axis bias
+        { new[] { 3, 2 }, new[] { 1, 0 }, new[] { 2, 1 } },             // general fallback
+        { new[] { 2, 2, 3, 3 }, new[] { 0, 1, 3, 2 }, new[] { 1, 2, 1, 1 } }, // conv-bias pattern
+        { new[] { 2, 4, 3 }, new[] { 0, 2, 1 }, new[] { 1, 3, 1 } },    // rank-3 general
+    };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void NonContiguousTarget_IsMutated(int[] sourceShape, int[] permutation, int[] operandShape)
+    {
+        var source = Filled(sourceShape, 1.0);
+        var view = source.Transpose(permutation);
+        Assert.False(view.IsContiguous, "test precondition: the target must be a strided view");
+        var before = view.ToArray();                  // logical (row-major) order of the view
+        var operand = Filled(operandShape, 100.0);
+
+        // Reference: the out-of-place broadcast add of the same logical values.
+        var expected = _engine.TensorAdd(new Tensor<double>(before, view.Shape.ToArray()), operand).ToArray();
+
+        _engine.TensorBroadcastAddInPlace(view, operand);
+
+        Assert.Equal(expected, view.ToArray());
+    }
+
+    /// <summary>
+    /// An in-place op on a view writes through to the storage the view shares with its source —
+    /// that aliasing is what distinguishes it from returning a new tensor.
+    /// </summary>
+    [Fact]
+    public void NonContiguousTarget_WritesThroughToItsSource()
+    {
+        var source = Filled(new[] { 3, 2 }, 1.0);        // [[1,2],[3,4],[5,6]]
+        var view = source.Transpose(new[] { 1, 0 });     // [[1,3,5],[2,4,6]]
+        var row = new Tensor<double>(new[] { 10.0, 20.0, 30.0 }, new[] { 1, 3 });
+
+        _engine.TensorBroadcastAddInPlace(view, row);
+
+        Assert.Equal(new[] { 11.0, 23.0, 35.0, 12.0, 24.0, 36.0 }, view.ToArray());
+        Assert.Equal(new[] { 11.0, 12.0, 23.0, 24.0, 35.0, 36.0 }, source.ToArray());
+    }
+
+    /// <summary>
+    /// A stride-0 (expanded) target has several elements in one memory slot, so there is no
+    /// well-defined in-place result. It must be rejected clearly, not written last-wins.
+    /// </summary>
+    [Fact]
+    public void ExpandedTarget_ThrowsClearly()
+    {
+        var column = Filled(new[] { 3, 1 }, 1.0);
+        var expanded = column.ExpandTo(new[] { 3, 4 });
+        Assert.False(expanded.IsContiguous, "test precondition: ExpandTo returns a stride-0 view");
+        var operand = Filled(new[] { 1, 4 }, 10.0);
+
+        var ex = Assert.Throws<ArgumentException>(() => _engine.TensorBroadcastAddInPlace(expanded, operand));
+
+        Assert.Contains("stride 0", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(new[] { 1.0, 2.0, 3.0 }, column.ToArray());
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/EmptyBroadcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/EmptyBroadcastTests.cs
@@ -1,0 +1,323 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Broadcasting;
+
+/// <summary>
+/// Broadcasting against a zero-size axis yields a zero-size result, exactly as NumPy, PyTorch and
+/// JAX define it: an extent of 1 stretches to whatever the other operand has, and that includes 0.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The defect: the broadcast-shape helpers computed each output extent as
+/// <c>Math.Max(dim1, dim2)</c>. That equals the broadcast rule for every pair of POSITIVE extents,
+/// but for the pair (0, 1) it returns 1 where the rule gives 0. So
+/// <c>[0,2,2,2] + [1,2,1,1]</c> was sized as <c>[1,2,2,2]</c> — eight output elements drawn from a
+/// left operand that has none — and the SIMD walk's bounds guard threw
+/// <c>"Inner left-operand block exceeds its span."</c>. Rank 2 looked fine only because the
+/// <c>[N,M] + [1,M]</c> bias fast path never asks for a broadcast shape.
+/// </para>
+/// <para>
+/// The same (0, 1) blind spot sat in the backward reduction: an axis the operand had stretched from
+/// 1 to 0 was not summed ("grad dim &gt; 1" is false for 0), so the gradient was reshaped from a
+/// zero-length tensor to the operand's non-empty shape and threw. The gradient of an operand that
+/// only ever met an empty partner is zeros of the operand's shape — a sum over nothing.
+/// </para>
+/// </remarks>
+public class EmptyBroadcastTests
+{
+    private readonly CpuEngine _engine = new();
+
+    /// <summary>(left shape, right shape, expected broadcast shape).</summary>
+    private static readonly (int[] A, int[] B, int[] Expected)[] s_cases =
+    {
+        // rank 2 — the bias fast path already handled the first; the others reach the general walk
+        (new[] { 0, 2 }, new[] { 1, 2 }, new[] { 0, 2 }),
+        (new[] { 0, 2 }, new[] { 1, 1 }, new[] { 0, 2 }),
+        (new[] { 2, 0 }, new[] { 2, 1 }, new[] { 2, 0 }),
+        (new[] { 1, 2 }, new[] { 0, 2 }, new[] { 0, 2 }),
+        // rank 3 — zero in the leading dim, a middle dim, and on the broadcast-from side
+        (new[] { 0, 2, 3 }, new[] { 1, 2, 1 }, new[] { 0, 2, 3 }),
+        (new[] { 2, 0, 3 }, new[] { 2, 1, 1 }, new[] { 2, 0, 3 }),
+        (new[] { 1, 2, 1 }, new[] { 0, 2, 3 }, new[] { 0, 2, 3 }),
+        (new[] { 2, 1, 3 }, new[] { 1, 0, 1 }, new[] { 2, 0, 3 }),
+        (new[] { 0, 2, 1 }, new[] { 0, 1, 3 }, new[] { 0, 2, 3 }),
+        // rank 4 — the reported repro and its mirror, plus a middle zero
+        (new[] { 0, 2, 2, 2 }, new[] { 1, 2, 1, 1 }, new[] { 0, 2, 2, 2 }),
+        (new[] { 1, 2, 1, 1 }, new[] { 0, 2, 2, 2 }, new[] { 0, 2, 2, 2 }),
+        (new[] { 2, 2, 0, 2 }, new[] { 2, 1, 1, 1 }, new[] { 2, 2, 0, 2 }),
+        (new[] { 2, 2, 0, 2 }, new[] { 1, 2, 1, 1 }, new[] { 2, 2, 0, 2 }),
+        // rank 5
+        (new[] { 0, 2, 2, 2, 2 }, new[] { 1, 2, 1, 1, 1 }, new[] { 0, 2, 2, 2, 2 }),
+        (new[] { 2, 2, 2, 0, 2 }, new[] { 1, 2, 1, 1, 1 }, new[] { 2, 2, 2, 0, 2 }),
+        (new[] { 1, 2, 1, 1, 1 }, new[] { 0, 2, 2, 2, 2 }, new[] { 0, 2, 2, 2, 2 }),
+        // rank padding: the padded-in leading 1 must stretch to 0 as well
+        (new[] { 0, 2, 3 }, new[] { 2, 1 }, new[] { 0, 2, 3 }),
+        (new[] { 2, 1 }, new[] { 0, 2, 3 }, new[] { 0, 2, 3 }),
+    };
+
+    private static readonly string[] s_operations = { "add", "subtract", "multiply", "divide" };
+
+    public static TheoryData<string, int[], int[], int[]> Cases
+    {
+        get
+        {
+            var data = new TheoryData<string, int[], int[], int[]>();
+            foreach (string op in s_operations)
+            foreach (var (a, b, expected) in s_cases)
+                data.Add(op, a, b, expected);
+            return data;
+        }
+    }
+
+    public static TheoryData<int[], int[], int[]> Shapes
+    {
+        get
+        {
+            var data = new TheoryData<int[], int[], int[]>();
+            foreach (var (a, b, expected) in s_cases)
+                data.Add(a, b, expected);
+            return data;
+        }
+    }
+
+    internal static Tensor<T> Filled<T>(int[] shape, Func<int, T> value)
+    {
+        var t = new Tensor<T>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = value(i);
+        return t;
+    }
+
+    internal static Tensor<T> Apply<T>(IEngine engine, string op, Tensor<T> a, Tensor<T> b) => op switch
+    {
+        "add" => engine.TensorAdd(a, b),
+        "subtract" => engine.TensorSubtract(a, b),
+        "multiply" => engine.TensorMultiply(a, b),
+        "divide" => engine.TensorDivide(a, b),
+        _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Unknown element-wise operation."),
+    };
+
+    internal static void AssertEmptyWithShape<T>(Tensor<T> result, int[] expected, string context)
+    {
+        Assert.True(expected.SequenceEqual(result.Shape.ToArray()),
+            $"{context} produced [{string.Join(",", result.Shape.ToArray())}], " +
+            $"expected [{string.Join(",", expected)}]");
+        Assert.Equal(0, result.Length);
+    }
+
+    internal static string Describe(string op, int[] a, int[] b)
+        => $"{op}([{string.Join(",", a)}], [{string.Join(",", b)}])";
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void EngineOp_Double_ZeroSizeBroadcast_ReturnsEmptyResultOfBroadcastShape(
+        string op, int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var a = Filled<double>(shapeA, i => 1.0 + i);
+        var b = Filled<double>(shapeB, i => 2.0 + i);
+
+        AssertEmptyWithShape(Apply(_engine, op, a, b), expected, Describe(op, shapeA, shapeB));
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void EngineOp_Float_ZeroSizeBroadcast_ReturnsEmptyResultOfBroadcastShape(
+        string op, int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var a = Filled<float>(shapeA, i => 1f + i);
+        var b = Filled<float>(shapeB, i => 2f + i);
+
+        AssertEmptyWithShape(Apply(_engine, op, a, b), expected, Describe(op, shapeA, shapeB));
+    }
+
+    [Fact]
+    public void ReportedRepro_TensorAddRank4_DoesNotThrow()
+    {
+        var result = _engine.TensorAdd(new Tensor<double>(new[] { 0, 2, 2, 2 }), new Tensor<double>(new[] { 1, 2, 1, 1 }));
+
+        AssertEmptyWithShape(result, new[] { 0, 2, 2, 2 }, "TensorAdd([0,2,2,2], [1,2,1,1])");
+    }
+
+    /// <summary>The public <c>Tensor.Broadcast*</c> methods share the same shape helper.</summary>
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void TensorBroadcastMethods_ZeroSizeBroadcast_ReturnEmptyResultOfBroadcastShape(
+        int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var a = Filled<double>(shapeA, i => 1.0 + i);
+        var b = Filled<double>(shapeB, i => 2.0 + i);
+
+        AssertEmptyWithShape(a.BroadcastAdd(b), expected, Describe("BroadcastAdd", shapeA, shapeB));
+        AssertEmptyWithShape(a.BroadcastSubtract(b), expected, Describe("BroadcastSubtract", shapeA, shapeB));
+        AssertEmptyWithShape(a.BroadcastMultiply(b), expected, Describe("BroadcastMultiply", shapeA, shapeB));
+        AssertEmptyWithShape(a.BroadcastDivide(b), expected, Describe("BroadcastDivide", shapeA, shapeB));
+    }
+
+    /// <summary>
+    /// A zero extent only stretches FROM 1. Pairing it with any other extent is still a mismatch,
+    /// exactly as it is in NumPy — the fix must not turn 0 into a wildcard.
+    /// </summary>
+    [Theory]
+    [InlineData(new[] { 0, 2 }, new[] { 2, 2 })]
+    [InlineData(new[] { 2, 0, 3 }, new[] { 2, 2, 3 })]
+    [InlineData(new[] { 0, 2, 2, 2 }, new[] { 3, 2, 1, 1 })]
+    public void ZeroAgainstNonUnitExtent_StillThrows(int[] shapeA, int[] shapeB)
+    {
+        var a = new Tensor<double>(shapeA);
+        var b = new Tensor<double>(shapeB);
+
+        foreach (string op in s_operations)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => Apply(_engine, op, a, b));
+            Assert.ThrowsAny<ArgumentException>(() => Apply(_engine, op, b, a));
+        }
+    }
+
+    /// <summary>Non-empty broadcasts keep producing the values they always did.</summary>
+    [Fact]
+    public void NonEmptyBroadcast_ValuesUnchanged()
+    {
+        var a = Filled<double>(new[] { 2, 3, 2, 2 }, i => 1.0 + i);
+        var b = Filled<double>(new[] { 1, 3, 1, 2 }, i => 10.0 * (i + 1));
+
+        var sum = _engine.TensorAdd(a, b);
+
+        Assert.Equal(new[] { 2, 3, 2, 2 }, sum.Shape.ToArray());
+        for (int n = 0; n < 2; n++)
+        for (int c = 0; c < 3; c++)
+        for (int h = 0; h < 2; h++)
+        for (int w = 0; w < 2; w++)
+            Assert.Equal(a[n, c, h, w] + b[0, c, 0, w], sum[n, c, h, w], 12);
+    }
+
+    [Theory]
+    [InlineData(new[] { 0, 2, 3 }, new[] { 1, 2, 1 })]
+    [InlineData(new[] { 0, 2, 2, 2 }, new[] { 1, 2, 1, 1 })]
+    [InlineData(new[] { 2, 0, 2, 2 }, new[] { 1, 1, 2, 1 })]
+    [InlineData(new[] { 2, 0 }, new[] { 0 })]
+    [InlineData(new[] { 3, 0 }, new[] { 1 })]
+    public void BroadcastAddInPlace_EmptyTarget_IsANoOp(int[] shapeA, int[] shapeB)
+    {
+        var a = new Tensor<double>(shapeA);
+        var b = Filled<double>(shapeB, i => 1.0 + i);
+
+        _engine.TensorBroadcastAddInPlace(a, b);
+
+        Assert.Equal(shapeA, a.Shape.ToArray());
+        Assert.Equal(0, a.Length);
+    }
+
+    /// <summary>
+    /// An in-place op cannot change its target's shape. Stretching a size-1 target axis to 0 is a
+    /// shape change, so it must be rejected rather than silently copying zero elements into a
+    /// non-empty target and returning it unmodified.
+    /// </summary>
+    [Fact]
+    public void BroadcastAddInPlace_TargetWouldHaveToShrinkToEmpty_Throws()
+    {
+        var a = Filled<double>(new[] { 1, 2, 1 }, i => 1.0 + i);
+        var b = new Tensor<double>(new[] { 0, 2, 3 });
+
+        // Pin the dedicated rejection, not just "some ArgumentException": before the shape fix this
+        // threw an unrelated out-of-range error from the SIMD walk, and after it — without the guard —
+        // it threw nothing at all.
+        var ex = Assert.ThrowsAny<ArgumentException>(() => _engine.TensorBroadcastAddInPlace(a, b));
+        Assert.Contains("cannot resize its target", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(new[] { 1.0, 2.0 }, a.ToArray());
+    }
+
+    /// <summary>
+    /// The resize guard compares lengths, so the pre-existing tolerance for a broadcast result that
+    /// differs from the target only by padded leading 1s is unchanged.
+    /// </summary>
+    [Fact]
+    public void BroadcastAddInPlace_LeadingOnePaddedOperand_StillAccumulates()
+    {
+        var a = Filled<double>(new[] { 3 }, i => 1.0 + i);
+        var b = Filled<double>(new[] { 1, 3 }, i => 10.0 * (i + 1));
+
+        _engine.TensorBroadcastAddInPlace(a, b);
+
+        Assert.Equal(new[] { 3 }, a.Shape.ToArray());
+        Assert.Equal(new[] { 11.0, 22.0, 33.0 }, a.ToArray());
+    }
+
+    /// <summary>
+    /// The gradient of each operand must come back in the operand's own shape. For the operand that
+    /// was stretched against an empty axis that is zeros — a sum over no positions.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void Backward_ZeroSizeBroadcast_GradientsHaveOperandShapesAndAreZero(
+        string op, int[] shapeA, int[] shapeB, int[] expected)
+    {
+        _ = expected;
+        var a = Filled<double>(shapeA, i => 1.0 + i);
+        var b = Filled<double>(shapeB, i => 2.0 + i);
+
+        using var tape = new GradientTape<double>();
+        var loss = _engine.ReduceSum(Apply(_engine, op, a, b), null, keepDims: false);
+        var grads = tape.ComputeGradients(loss, new[] { a, b });
+
+        foreach (var (operand, name) in new[] { (a, "a"), (b, "b") })
+        {
+            Assert.True(grads.ContainsKey(operand), $"no gradient for {name} of {Describe(op, shapeA, shapeB)}");
+            var g = grads[operand];
+            Assert.True(operand.Shape.ToArray().SequenceEqual(g.Shape.ToArray()),
+                $"gradient of {name} for {Describe(op, shapeA, shapeB)} has shape " +
+                $"[{string.Join(",", g.Shape.ToArray())}], expected [{string.Join(",", operand.Shape.ToArray())}]");
+            Assert.All(g.ToArray(), v => Assert.Equal(0.0, v));
+        }
+    }
+
+    /// <summary>The lazy-graph recorder sizes its placeholder with the engine's own shape helper.</summary>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void GraphMode_ZeroSizeBroadcast_RecordsTheBroadcastShape(
+        string op, int[] shapeA, int[] shapeB, int[] expected)
+    {
+        var a = Filled<float>(shapeA, i => 1f + i);
+        var b = Filled<float>(shapeB, i => 2f + i);
+
+        using var scope = GraphMode.Enable();
+        // Replay on THIS engine, not the process-global one, so the result does not depend on
+        // whether the host happens to auto-detect a GPU. The GPU overrides are pinned separately.
+        scope.BindEngineIfUnset(_engine);
+        var placeholder = Apply(_engine, op, a, b);
+
+        Assert.True(expected.SequenceEqual(placeholder.Shape.ToArray()),
+            $"{Describe(op, shapeA, shapeB)} recorded [{string.Join(",", placeholder.Shape.ToArray())}], " +
+            $"expected [{string.Join(",", expected)}]");
+    }
+}
+
+/// <summary>GPU-engine counterpart of <see cref="EmptyBroadcastTests"/>.</summary>
+[Collection("DirectGpuSerial")]
+public class EmptyBroadcastGpuTests
+{
+    /// <summary>
+    /// <see cref="DirectGpuTensorEngine"/> overrides the four broadcast operators with last-axis fast
+    /// paths guarded by <c>a.Length % b.Length == 0</c>, which divides by zero — outside any
+    /// try/catch — as soon as the right operand is empty. Skips without a GPU.
+    /// </summary>
+    [SkippableTheory]
+    [MemberData(nameof(EmptyBroadcastTests.Cases), MemberType = typeof(EmptyBroadcastTests))]
+    public void GpuEngine_Float_ZeroSizeBroadcast_ReturnsEmptyResultOfBroadcastShape(
+        string op, int[] shapeA, int[] shapeB, int[] expected)
+    {
+        DirectGpuTensorEngine gpu;
+        try { gpu = new DirectGpuTensorEngine(); }
+        catch { Skip.If(true, "No GPU backend"); return; }
+        using (gpu)
+        {
+            Skip.IfNot(gpu.IsGpuAvailable, "No GPU available");
+            var a = EmptyBroadcastTests.Filled<float>(shapeA, i => 1f + i);
+            var b = EmptyBroadcastTests.Filled<float>(shapeB, i => 2f + i);
+
+            EmptyBroadcastTests.AssertEmptyWithShape(EmptyBroadcastTests.Apply(gpu, op, a, b), expected, "GPU " + EmptyBroadcastTests.Describe(op, shapeA, shapeB));
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/EmptyBroadcastTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Broadcasting/EmptyBroadcastTests.cs
@@ -2,6 +2,7 @@ using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Engines.Compilation;
 using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tensors.Tests.Engines.DirectGpu;
 using Xunit;
 
 namespace AiDotNet.Tensors.Tests.Engines.Broadcasting;
@@ -296,8 +297,15 @@ public class EmptyBroadcastTests
 
 /// <summary>GPU-engine counterpart of <see cref="EmptyBroadcastTests"/>.</summary>
 [Collection("DirectGpuSerial")]
-public class EmptyBroadcastGpuTests
+public class EmptyBroadcastGpuTests : IClassFixture<DirectGpuTensorEngineTestFixture>
 {
+    private readonly DirectGpuTensorEngineTestFixture _fixture;
+
+    public EmptyBroadcastGpuTests(DirectGpuTensorEngineTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
     /// <summary>
     /// <see cref="DirectGpuTensorEngine"/> overrides the four broadcast operators with last-axis fast
     /// paths guarded by <c>a.Length % b.Length == 0</c>, which divides by zero — outside any
@@ -308,16 +316,12 @@ public class EmptyBroadcastGpuTests
     public void GpuEngine_Float_ZeroSizeBroadcast_ReturnsEmptyResultOfBroadcastShape(
         string op, int[] shapeA, int[] shapeB, int[] expected)
     {
-        DirectGpuTensorEngine gpu;
-        try { gpu = new DirectGpuTensorEngine(); }
-        catch { Skip.If(true, "No GPU backend"); return; }
-        using (gpu)
-        {
-            Skip.IfNot(gpu.IsGpuAvailable, "No GPU available");
-            var a = EmptyBroadcastTests.Filled<float>(shapeA, i => 1f + i);
-            var b = EmptyBroadcastTests.Filled<float>(shapeB, i => 2f + i);
+        Skip.IfNot(_fixture.IsAvailable, "No GPU available");
+        var gpu = _fixture.Engine ?? throw new InvalidOperationException(
+            "Direct GPU engine was not initialized.", _fixture.InitializationException);
+        var a = EmptyBroadcastTests.Filled<float>(shapeA, i => 1f + i);
+        var b = EmptyBroadcastTests.Filled<float>(shapeB, i => 2f + i);
 
-            EmptyBroadcastTests.AssertEmptyWithShape(EmptyBroadcastTests.Apply(gpu, op, a, b), expected, "GPU " + EmptyBroadcastTests.Describe(op, shapeA, shapeB));
-        }
+        EmptyBroadcastTests.AssertEmptyWithShape(EmptyBroadcastTests.Apply(gpu, op, a, b), expected, "GPU " + EmptyBroadcastTests.Describe(op, shapeA, shapeB));
     }
 }


### PR DESCRIPTION
## GPU fixture review follow-up (2026-09-11)

[Commit f4161b24e](https://github.com/ooples/AiDotNet.Tensors/commit/f4161b24e5147f0b114caa4a156e9a0a0d8ba841) replaces the broad constructor catch with the existing shared DirectGpuTensorEngineTestFixture. Only PlatformNotSupportedException and DllNotFoundException are treated as unavailable backends; unexpected initialization failures now fail fixture construction. Availability still produces an explicit skip, and xUnit owns disposal once all theory rows finish. No production code changed.

Independent source review accepted the exception boundary and lifetime. Actual local results on the final change:

- Full test-project build: net10.0 zero errors (110 existing warnings); net471 zero errors (81 existing warnings).
- Targeted empty/implicit/strided broadcast tests: **475 passed, zero failed, zero skipped on each framework**, including all **72 GPU-engine cases on each**.
- The zero-size GPU cases exercise the GPU engine's empty-operand handling, not nonempty GPU kernel throughput. No full-suite-green or simulated missing-backend claim is made.

Reproduce from the repository root in PowerShell:

```powershell
$ErrorActionPreference = 'Stop'
$env:DOTNET_gcServer = '0'
$env:COMPlus_gcServer = '0'
foreach ($framework in @('net10.0', 'net471')) {
    dotnet build tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f $framework -p:GeneratePackageOnBuild=false --nologo -v:q
    if ($LASTEXITCODE -ne 0) { throw "Build failed for $framework" }
    dotnet test tests/AiDotNet.Tensors.Tests/AiDotNet.Tensors.Tests.csproj -c Release -f $framework --no-build --no-restore --filter 'FullyQualifiedName~EmptyBroadcast|FullyQualifiedName~ImplicitBroadcast|FullyQualifiedName~BroadcastAddInPlaceStridedTarget' --logger "trx;LogFileName=pr1033-review-$framework.trx"
    if ($LASTEXITCODE -ne 0) { throw "Tests failed for $framework" }
}
```

## Summary

Broadcasting with a zero-size extent threw instead of returning an empty result. `CpuEngine.TensorAdd([0,2,2,2], [1,2,1,1])` failed with *"Inner left-operand block exceeds its span (Parameter 'aBase')"*. Found by AiDotNet's VideoMAE investigation: a one-frame clip produced zero tubelets, and the empty batch reached a convolution's bias add. NumPy and PyTorch return an empty tensor of the broadcast shape here, and this PR does the same. It also fixes the same rule wherever it was copied: autodiff, in-place add, the GPU engine and the ONNX importer. And it fixes one silent-no-op bug found on the way.

## Root cause

`Tensor.GetBroadcastShape` (`src/AiDotNet.Tensors/LinearAlgebra/Tensor.cs:2510`) sized each output axis as `Math.Max(dim1, dim2)`. That equals NumPy's rule ("a 1 stretches to the other extent") for every pair of positive extents, **except `(0, 1)`**, where it gives 1 instead of 0. So `[0,2,2,2] + [1,2,1,1]` was sized `[1,2,2,2]`: eight output elements read from an operand with none. `ValidateInnerBounds` then threw correctly. `BroadcastElementwise` already returns early for an empty result, so fixing the shape was sufficient there.

The rank-2 case `[0,2] + [1,2]` only worked because the bias fast path never computes a broadcast shape; `[0,2] + [1,1]` failed the same way.

## Changes (3 commits)

| Commit | File | Before | After |
|---|---|---|---|
| `0df91c50` | `Tensor.GetBroadcastShape`, `CpuEngine.ComputeBroadcastShape` (graph mode) | `Math.Max` | `dim1 == 1 ? dim2 : dim1` (the GPU engine's general path already used this) |
| | `BackwardFunctions.ReduceGradToShape` | summed only where grad extent `> 1`, so an axis stretched 1→0 was skipped and the later reshape threw | sums where the extent `!= 1`; the non-empty operand gets a zero gradient of its own shape |
| | `CpuEngine.TensorBroadcastAddInPlace` | divide-by-zero on `[2,0] += [0]`; silently did nothing on `[1,2,1] += [0,2,3]` | empty works; a target that would have to shrink throws `ArgumentException` (compared by length, so the existing `[C] += [1,C]` tolerance still works) |
| | `DirectGpuTensorEngine` add/subtract/divide/multiply | computed `a.Length % b.Length` outside any guard, dividing by zero on an empty right operand | empty operands go to the CPU implementation |
| `373f2d72` | ONNX `MathOperators.ComputeBroadcastShape` (used by Min/Max/Equal) | same `Math.Max`, and no compatibility check: `[2,3]` vs `[3,3]` was silently sized `[3,3]` and failed later in the engine | NumPy rule; throws `InvalidDataException` naming both shapes at import time |
| | ONNX `Expand` | no shape check | validated through the same helper before the add |
| | ONNX `ArithOperators` MatMul batch dims | `Math.Max` | NumPy rule: `[0,2,3] × [1,3,4]` → `[0,2,4]` |
| `b67f2846` | `CpuEngine.TensorBroadcastAddInPlace` on a **non-contiguous** target | replaced the target with a contiguous copy and added into the copy: the caller's tensor never changed, and every branch returned normally | adds on a contiguous working copy, then writes back through the view's own strides, so the view and the storage it shares are both updated; a stride-0 (expanded) target, where several elements share one slot, throws instead of writing last-one-wins |

**Hot path:** no per-element cost. `BroadcastElementwise`, the `ApplyInner*` SIMD kernels and the channel/trailing-repeat fast paths are unchanged; every change is per-dimension shape arithmetic or one constant-time check per call. (Verified by reading the diff; no timing benchmark was run.)

## Tests: fail before, pass after

| Suite | Unfixed | Fixed |
|---|---|---|
| New `EmptyBroadcastTests` (add/sub/mul/div, float+double, ranks 2-5, zero in leading/middle/stretched axis, public `Tensor.Broadcast*`, graph mode, gradients, in-place, GPU engine, and 0-vs-non-1 still throws) | **302 of 389 fail** | 390/390 (net10.0); 467/467 on net471 with `ImplicitBroadcastTests` |
| New `EmptyBroadcastOnnxTests` (21, driving the translators directly) | 15 fail (with commit 1 applied) | 21/21 |
| New `BroadcastAddInPlaceStridedTargetTests` (all five branches, write-through to the source, expanded-target rejection) | 8/8 fail | 8/8 |

**Full `AiDotNet.Tensors.Tests`, branch vs `main`, net10.0** (run in 11 namespace shards on both sides: a single run crashes this GPU box's test host in unrelated DirectPtx/CUDA-linker tests):

| | Total | Passed | Failed | Not run |
|---|---|---|---|---|
| main | 14,907 | 14,452 | 11 | 444 |
| branch | 15,305 | 14,847 | 14 | 444 |

The branch has exactly 398 extra tests, all new; no main test is missing. Every branch failure accounted for:
- **9 fail on main too:**
  - 6× `QuantGemmVulkanTests.DequantGemm*`
  - `MesaRoutedScanGpuParityTests…(Vulkan)`
  - `HyperbolicOctonionGpuCorrectnessTests.OctonionLinearForward_NumericalGradientCheck`
  - `DirectPtxDenseLinearBackendTests.PrewarmedExperimentalFamilies…`
- **5 fail only on the branch run, but pass on rerun on both sides (20/20 each):**
  - 3 DirectPtx cast/MSE driver tests
  - 2 TensorCodec benchmarks (CUDA error 900)

  None touches broadcast code.
- **2 fail only on main** and pass on the branch and in isolation: DirectPtx convolution; flaky the same way.

ONNX operator tests: 4 fail on both main and branch, unchanged (`MatMul_2D`, `Gemm_WithBias`, `LayerNormalization_LastAxis`, `TransformerBlockTests.LayerNorm_FanOut_ThreeMatMuls`).

## Not in this PR

The pre-existing `main` failures above are listed so they aren't mistaken for regressions; they're separate issues. `TensorMax`/`TensorMin` require identical shapes and don't broadcast at all, so they weren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broadcasting with zero-sized dimensions to produce correctly shaped empty results.
  * Improved validation for incompatible broadcast shapes, including clearer errors.
  * Corrected automatic differentiation for zero-length broadcast axes.
  * Fixed in-place broadcast addition for non-contiguous tensor views.
  * Prevented errors and incorrect results in empty-tensor operations on CPU and GPU engines.
  * Added safeguards for unsupported expanded targets and invalid in-place broadcast results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
