### PR TITLE
fix(blas): ignore the timed autotune cache in deterministic mode

### DIFF
--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/AutotuneDispatcher.cs
@@ -88,7 +88,25 @@ internal static class AutotuneDispatcher
         // large enough that the block choice actually matters), benchmark a set
         // of candidate (Mc, Nc, Kc) tuples and cache the measured winner. Off by
         // default — falls through to the heuristic below.
-        if ((MeasurementEnabled || ForceMeasureOnMiss) && ShouldMeasure(m, n, k))
+        // DETERMINISM GATE (narrow, and deliberately only here). This is the ONLY
+        // timing-derived branch in Decide: BlockSizeSweep.Measure clocks candidate
+        // (Mc, Nc, Kc) tuples and persists the winner. Kc sets the K-panel width and the
+        // strategies accumulate C across K-panels, so a wall-clock-chosen Kc changes the
+        // accumulation order and therefore the result bits — the same defect as the
+        // strategy cache (see Dispatcher.SelectStrategy).
+        //
+        // The rest of this method is NOT gated: with measurement off (the default — it is
+        // behind AIDOTNET_BLAS_AUTOTUNE_MEASURE=1) the cache merely memoizes
+        // FallbackToHeuristic, a pure function of the shape, so hitting or missing it yields
+        // identical bits. Bypassing that memo under determinism would be strictly worse:
+        // FallbackToHeuristic's mc depends on `procs`, so recomputing per call would make
+        // blocking vary with NumThreads — exactly what DeterministicParallelGemmContractTests
+        // pins as bit-identical.
+        //
+        // Honours the caller's explicit isDeterministic argument as well as the ambient
+        // switch; falling through to the heuristic is the safe direction for both.
+        bool skipTimedMeasurement = isDeterministic || Helpers.BlasProvider.IsDeterministicMode;
+        if ((MeasurementEnabled || ForceMeasureOnMiss) && ShouldMeasure(m, n, k) && !skipTimedMeasurement)
         {
             try
             {

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BackgroundAutotuner.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BackgroundAutotuner.cs
@@ -103,6 +103,12 @@ internal static class BackgroundAutotuner
     public static void Observe(int m, int n, int k, bool fp64, bool transA, bool transB)
     {
         if (!Enabled || !ShouldMeasureSize(m, n, k)) return;
+        // Deterministic mode never consults the learned cache (see the determinism gate in
+        // Dispatcher.SelectStrategy), so measuring for it would burn wall-clock producing an
+        // entry nothing reads. Gated HERE, in the dispatch-path entry point, rather than
+        // inside Measure() — so MeasureNowForTest and the offline pre-warm pipeline keep
+        // working regardless of the ambient mode.
+        if (BlasProvider.IsDeterministicMode) return;
         var id = new SightingTracker.ShapeId(m, n, k, fp64, transA, transB);
         if (!_tracker.RecordAndShouldMeasure(id)) return;
         EnsureStarted();

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BlasManagedEvolutionAutotuner.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Autotune/BlasManagedEvolutionAutotuner.cs
@@ -96,7 +96,12 @@ public static class BlasManagedEvolutionAutotuner
             CpuParallelSettings.MaxDegreeOfParallelism));
         ParallelismAxis heuristicAxis = AxisSelector.Select(
             m, n, k, mr: 4, nr: 8, processorCount, deterministic);
-        PackingMode heuristicMode = StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k);
+        // Transpose flags threaded through so the heuristic SEED matches the strategy
+        // production would actually route this shape to. Without them a transposed shape is
+        // seeded from the untransposed route, which on a >64T avx2 box is a strategy measured
+        // up to 3.2x slower -- the search would start from a config production never uses.
+        PackingMode heuristicMode = StrategyDefaultTable.Route(
+            HardwareFingerprint.Key, m, n, k, transA, transB);
         var seeds = new List<BlasManagedGemmConfiguration>();
         var seen = new HashSet<BlasManagedGemmConfiguration>();
         ShapeProfile shape = BlasManagedAutotune.EncodeShape<T>(

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/BlasManaged.cs
@@ -1048,7 +1048,7 @@ public static partial class BlasManaged
         if (s_forwardPackBothBlocking && strategy == PackingMode.DisableAutotune)
         {
             var packBothProbe = new BlasOptions<T> { PackingMode = PackingMode.Auto };
-            PackingMode effStrategy = Dispatcher.SelectStrategy(m, n, k, packBothProbe);
+            PackingMode effStrategy = Dispatcher.SelectStrategy(m, n, k, transA, transB, packBothProbe);
             if (effStrategy == PackingMode.ForcePackAOnly && transB) effStrategy = PackingMode.ForcePackBoth;
             effectivePackBoth = effStrategy == PackingMode.ForcePackBoth;
         }
@@ -1210,7 +1210,7 @@ public static partial class BlasManaged
                 // are already populated from the heuristic above.
                 {
                     var defaultedOptions = new BlasOptions<T> { PackingMode = PackingMode.Auto };
-                    PackingMode fallback = Dispatcher.SelectStrategy(m, n, k, defaultedOptions);
+                    PackingMode fallback = Dispatcher.SelectStrategy(m, n, k, transA, transB, defaultedOptions);
                     if (fallback == PackingMode.ForcePackAOnly && transB)
                         fallback = PackingMode.ForcePackBoth;
                     switch (fallback)

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/Dispatcher.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/Dispatcher.cs
@@ -53,6 +53,34 @@ internal static class Dispatcher
         // path — Streaming/PackAOnly ignore a packed B, which would silently drop it.
         if (hasPrePack) return PackingMode.ForcePackBoth;
 
+        // DETERMINISM GATE. The learned cache is populated by BackgroundAutotuner.Measure,
+        // which TIMES ForceStreaming / ForcePackAOnly / ForcePackBoth and persists whichever
+        // was fastest. Those three strategies are NOT reduction-order equivalent (Streaming
+        // reduces a transposed-B column with a vectorized-K horizontal sum; the packed paths
+        // accumulate sequentially over k), so consulting a timing-derived entry makes the
+        // RESULT BITS of a GEMM depend on what the autotuner happened to clock — on this box
+        // a persisted entry flips 10036/12288 elements of a 48x256x64 transB GEMM. That
+        // contradicts the documented contract: AiDotNetEngine.DeterministicMode promises
+        // "bit-identical results across runs on the same hardware", and AiModelBuilder turns
+        // determinism ON for every model it builds unless AllowNondeterminism() is called.
+        //
+        // A wall-clock measurement is not reproducible input, so under determinism we ignore
+        // the learned cache entirely and route via StrategyDefaultTable — a pure function of
+        // (hardware key, shape). Observe() is skipped too: determinism must not spend
+        // wall-clock measuring, nor persist an entry that nothing will ever read.
+        //
+        // Fast mode is untouched and keeps the full learned-routing benefit.
+        // Gated on BlasProvider.IsDeterministicMode ONLY — deliberately NOT on
+        // options.Mode. BlasMode.Deterministic is the enum's ZERO value, so every
+        // default-constructed BlasOptions reports Mode == Deterministic; keying off it would
+        // fire this gate at essentially every call site and make the learned cache dead code
+        // for fast-mode callers too. The two flags also mean different things: BlasMode is a
+        // per-call "bit-exact across THREAD COUNTS" knob (see BlasMode.cs), which the strategy
+        // cache does not violate in-process, whereas IsDeterministicMode is the across-RUNS
+        // switch driven by SetDeterministicMode/AiModelBuilder whose contract it does violate.
+        if (Helpers.BlasProvider.IsDeterministicMode)
+            return StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k);
+
         // #375 hybrid layer 1 (highest precedence): learned / shipped-prewarm entry for
         // THIS shape on THIS fingerprint. KernelVersion-gated inside TryLookupStrategy.
         // Strategy routing is tile-independent → encode with mr=nr=0; the background

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/Dispatcher.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/Dispatcher.cs
@@ -79,7 +79,7 @@ internal static class Dispatcher
         // cache does not violate in-process, whereas IsDeterministicMode is the across-RUNS
         // switch driven by SetDeterministicMode/AiModelBuilder whose contract it does violate.
         if (Helpers.BlasProvider.IsDeterministicMode)
-            return StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k);
+            return StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k, transA, transB);
 
         // #375 hybrid layer 1 (highest precedence): learned / shipped-prewarm entry for
         // THIS shape on THIS fingerprint. KernelVersion-gated inside TryLookupStrategy.
@@ -102,7 +102,10 @@ internal static class Dispatcher
         // for unmeasured shapes and encodes the measured per-hardware wins (e.g. cpu16
         // routes 512×512×64 / 128³ to Streaming, cpu32 to blocking). The learned cache
         // (Phase 2) and background autotuner (Phase 3) refine this per fingerprint.
-        return StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k);
+        // Transpose flags are threaded through so the cold-start route matches the
+        // deterministic route above: the >64T avx2 transposed-B entry is measured, and a
+        // fast-mode cold start should not begin on a strategy we know is up to 3.2x slower.
+        return StrategyDefaultTable.Route(HardwareFingerprint.Key, m, n, k, transA, transB);
     }
 
     /// <summary>

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/StrategyDefaultTable.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/StrategyDefaultTable.cs
@@ -47,9 +47,31 @@ internal static class StrategyDefaultTable
     /// Route a shape to a packing strategy via the seed table for the given hardware key.
     /// Falls back to a conservative default for unmapped keys; never throws.
     /// </summary>
-    internal static PackingMode Route(HardwareFingerprint.HwKey key, int m, int n, int k)
+    internal static PackingMode Route(
+        HardwareFingerprint.HwKey key, int m, int n, int k,
+        bool transA = false, bool transB = false)
     {
         var bucket = Bucket(m, n, k);
+
+        // Very-wide avx2 (>64T, band 3) + TRANSPOSED-B: Streaming.
+        //
+        // Measured on x64-amd-avx2-cpu128 (PR #1034), interleaved and rotated, median of 7 x
+        // min-of-N: Streaming won EVERY transposed shape in a 17-shape sweep spanning 786K to
+        // 1.07G work and all eight shape buckets, by 1.12x-3.22x over whichever packed strategy
+        // this table previously selected. Worst offenders were 128x768x768 (3.22x),
+        // 48x512x128 (3.09x), 96x1024x512 (2.66x) and 128^3 (2.68x).
+        //
+        // Scoped deliberately narrowly:
+        //   * transB only -- the sweep varied transB, and the UNTRANSPOSED optimum is different
+        //     and sometimes opposite (512x2048x512 untransposed wants PackBoth, with Streaming
+        //     ~3.0x slower). Untransposed shapes fall through to the band-2 routing below,
+        //     unchanged. transA-only shapes were not measured and are left alone.
+        //   * band 3 only -- band 2's entries were calibrated on a 32-thread Ryzen (#464) which
+        //     is not this hardware. Thread-budget sweeps at 128/32/16 all favoured Streaming,
+        //     but throttling a 128-core part is not the same machine as a real 16- or 32-core
+        //     part (same L3, memory bandwidth and CCX topology), so bands 0-2 are untouched.
+        if (key.Simd == "avx2" && key.CpuBucket >= 3 && transB)
+            return PackingMode.ForceStreaming;
 
         // #653: the MediumMWide bucket (m∈[128,256], wide-N, k≥256) is mis-routed to PackAOnly
         // for NON-transposed shapes (they reach this transposed-calibrated table via

--- a/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/StrategyDefaultTable.cs
+++ b/src/AiDotNet.Tensors/Engines/BlasManaged/Dispatcher/StrategyDefaultTable.cs
@@ -70,7 +70,7 @@ internal static class StrategyDefaultTable
         //     is not this hardware. Thread-budget sweeps at 128/32/16 all favoured Streaming,
         //     but throttling a 128-core part is not the same machine as a real 16- or 32-core
         //     part (same L3, memory bandwidth and CCX topology), so bands 0-2 are untouched.
-        if (key.Simd == "avx2" && key.CpuBucket >= 3 && transB)
+        if (key.Simd == "avx2" && key.CpuBucket >= HardwareFingerprint.VeryWideCpuBucket && transB)
             return PackingMode.ForceStreaming;
 
         // #653: the MediumMWide bucket (m∈[128,256], wide-N, k≥256) is mis-routed to PackAOnly

--- a/src/AiDotNet.Tensors/Helpers/Autotune/HardwareFingerprint.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/HardwareFingerprint.cs
@@ -24,6 +24,14 @@ namespace AiDotNet.Tensors.Helpers.Autotune;
 /// </summary>
 public static class HardwareFingerprint
 {
+    internal const int SmallCpuBucket = 0;
+    internal const int MidCpuBucket = 1;
+    internal const int LargeCpuBucket = 2;
+    internal const int VeryWideCpuBucket = 3;
+    internal const int SmallProcessorCountMaximum = 4;
+    internal const int MidProcessorCountMaximum = 16;
+    internal const int LargeProcessorCountMaximum = 64;
+
     // Lazy-computed, never changes during process lifetime.
     private static string? _cachedFingerprint;
     private static readonly object _lock = new();
@@ -99,7 +107,10 @@ public static class HardwareFingerprint
     /// </para>
     /// </summary>
     public static int BucketFor(int processorCount)
-        => processorCount <= 4 ? 0 : processorCount <= 16 ? 1 : processorCount <= 64 ? 2 : 3;
+        => processorCount <= SmallProcessorCountMaximum ? SmallCpuBucket
+         : processorCount <= MidProcessorCountMaximum ? MidCpuBucket
+         : processorCount <= LargeProcessorCountMaximum ? LargeCpuBucket
+         : VeryWideCpuBucket;
 
     private static string Compute()
     {

--- a/src/AiDotNet.Tensors/Helpers/Autotune/HardwareFingerprint.cs
+++ b/src/AiDotNet.Tensors/Helpers/Autotune/HardwareFingerprint.cs
@@ -87,11 +87,19 @@ public static class HardwareFingerprint
     }
 
     /// <summary>
-    /// Core-count band for routing: 0 = ≤4 (small), 1 = 5–16 (mid), 2 = &gt;16 (large).
-    /// Separates the amd-avx2-cpu16 vs amd-avx2-cpu32 collision (#375 G1).
+    /// Core-count band for routing: 0 = ≤4 (small), 1 = 5–16 (mid), 2 = 17–64 (large),
+    /// 3 = &gt;64 (very large).
+    /// <para>
+    /// Band 2 separates the amd-avx2-cpu16 vs amd-avx2-cpu32 collision (#375 G1). Band 3 was
+    /// split out of it because band 2 previously meant "everything above 16", lumping the
+    /// 32-thread Ryzen that <see cref="Engines.BlasManaged.StrategyDefaultTable"/>'s band-2
+    /// entries were calibrated on together with 128-thread parts whose measured optimum
+    /// differs. Splitting the band lets a very-wide machine carry its own routing instead of
+    /// overwriting a calibration taken on a much narrower one.
+    /// </para>
     /// </summary>
     public static int BucketFor(int processorCount)
-        => processorCount <= 4 ? 0 : processorCount <= 16 ? 1 : 2;
+        => processorCount <= 4 ? 0 : processorCount <= 16 ? 1 : processorCount <= 64 ? 2 : 3;
 
     private static string Compute()
     {

--- a/tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj
+++ b/tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
+    <AssemblyName>AiDotNet.Tensors.Tests</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <CopyLocalRuntimeTargetAssets>false</CopyLocalRuntimeTargetAssets>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/AiDotNet.Tensors/AiDotNet.Tensors.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs" Link="DeterministicStrategySelectionTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategyFixtureIsolationTests.cs" Link="DeterministicStrategyFixtureIsolationTests.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj
+++ b/tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj
@@ -11,6 +11,7 @@
     <CopyLocalRuntimeTargetAssets>false</CopyLocalRuntimeTargetAssets>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/BlasManaged/StrategyDefaultTableTests.cs" Link="StrategyDefaultTableTests.cs" />
     <ProjectReference Include="../../src/AiDotNet.Tensors/AiDotNet.Tensors.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AiDotNet.Tensors.DeterministicReview/AssemblyInfo.cs
+++ b/tests/AiDotNet.Tensors.DeterministicReview/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/tests/AiDotNet.Tensors.DeterministicReview/README.md
+++ b/tests/AiDotNet.Tensors.DeterministicReview/README.md
@@ -1,0 +1,45 @@
+# Deterministic fixture isolation review proof
+
+The fixture now saves the thread-local override, clears it, and only then reads
+the unmasked process-global deterministic setting. Teardown restores the two
+independent values. This change does not modify production GEMM or GPU code.
+
+## Actual before and after
+
+The same six regression cases construct and dispose the real
+`DeterministicStrategySelectionTests` fixture, covering both global values and
+all three nullable thread-local values. Against the original fixture at
+`fb7d68228110c5e24130b5888bc0a5be89500306`, four passed and two failed: the
+disagreeing overrides were incorrectly written back to the global setting.
+
+After the fixture correction, all six passed. The focused project also runs
+the existing thirteen deterministic-cache/GEMM tests against an actual project
+reference to AiDotNet.Tensors, not a replacement implementation.
+
+| Runtime | Passed | Failed | Skipped |
+| --- | ---: | ---: | ---: |
+| .NET 10 | 19 | 0 | 0 |
+| .NET 8 | 19 | 0 | 0 |
+| .NET Framework 4.7.1 | 19 | 0 | 0 |
+
+All three builds completed with zero errors and zero warnings. This is a
+focused CPU correctness/isolation check, not full CI or a GPU performance claim.
+
+## Reproduce
+
+Run from the repository root, substituting `net8.0` or `net471` for the other
+frameworks (the .NET Framework run requires Windows):
+
+```powershell
+dotnet build tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj -c Release -f net10.0 -m:1 -p:UseSharedCompilation=false -p:CopyLocalRuntimeTargetAssets=false -p:GeneratePackageOnBuild=false -v:quiet
+dotnet test tests/AiDotNet.Tensors.DeterministicReview/AiDotNet.Tensors.DeterministicReview.csproj -c Release -f net10.0 --no-build --no-restore --logger 'trx;LogFileName=scope-and-gemm-after-net10.trx' --results-directory artifacts/pr1034-review -v:quiet
+```
+
+Local evidence is retained under `artifacts/pr1034-review`: `scope-before.trx`
+and `scope-and-gemm-after-net10.trx`, `scope-and-gemm-after-net8.0.trx`, and
+`scope-and-gemm-after-net471.trx`. The frozen before runner is under `before/`.
+
+The .NET 10 production DLL was identical before and after:
+`D0358327AA1CF076956A14423CE6371268DA4493B0EA685C45184D7200F53121`.
+Before test DLL: `61B4D478ACDB2B7B984A45A5D7A131266FBA294D1461C33F07C07CE5618CD549`.
+After test DLL: `422072CA9E2B23FCBCDCD93158243A9131716D742D473CFD05884D31AE422664`.

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategyFixtureIsolationTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategyFixtureIsolationTests.cs
@@ -1,0 +1,44 @@
+using System;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+/// <summary>Checks the real fixture's setup/teardown under disagreeing global and thread-local modes.</summary>
+[Collection("BlasManaged-Stats-Serial")]
+public sealed class DeterministicStrategyFixtureIsolationTests
+{
+    [Theory]
+    [InlineData(false, null)]
+    [InlineData(true, null)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void FixtureRestoresGlobalAndThreadLocalModesIndependently(bool globalMode, bool? localMode)
+    {
+        bool? priorLocal = BlasProvider.GetThreadLocalDeterministicMode();
+        BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool priorGlobal = BlasProvider.IsDeterministicMode;
+        try
+        {
+            BlasProvider.SetDeterministicMode(globalMode);
+            BlasProvider.SetThreadLocalDeterministicMode(localMode);
+            using (var fixture = new DeterministicStrategySelectionTests())
+            {
+                Assert.True(BlasProvider.IsDeterministicMode);
+                Assert.Null(BlasProvider.GetThreadLocalDeterministicMode());
+            }
+
+            Assert.Equal(localMode, BlasProvider.GetThreadLocalDeterministicMode());
+            BlasProvider.SetThreadLocalDeterministicMode(null);
+            Assert.Equal(globalMode, BlasProvider.IsDeterministicMode);
+        }
+        finally
+        {
+            BlasProvider.SetThreadLocalDeterministicMode(null);
+            BlasProvider.SetDeterministicMode(priorGlobal);
+            BlasProvider.SetThreadLocalDeterministicMode(priorLocal);
+        }
+    }
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
@@ -42,8 +42,11 @@ public sealed class DeterministicStrategySelectionTests : IDisposable
     public DeterministicStrategySelectionTests()
     {
         _priorCachePath = Environment.GetEnvironmentVariable(EnvVarCachePath);
-        _priorDeterministic = BlasProvider.IsDeterministicMode;
         _priorThreadLocal = BlasProvider.GetThreadLocalDeterministicMode();
+        // IsDeterministicMode includes the thread override. Save the unmasked global
+        // value so teardown restores both independent settings without contaminating later tests.
+        BlasProvider.SetThreadLocalDeterministicMode(null);
+        _priorDeterministic = BlasProvider.IsDeterministicMode;
         _priorBackgroundAutotuner = BackgroundAutotuner.Enabled;
 
         _cacheRoot = Path.Combine(Path.GetTempPath(), "aidotnet-determinism-" + Guid.NewGuid().ToString("N"));
@@ -53,7 +56,6 @@ public sealed class DeterministicStrategySelectionTests : IDisposable
         // The background autotuner would race these cases by persisting a timed winner
         // mid-test; the point here is what a PRESENT entry does, written deterministically.
         BackgroundAutotuner.Enabled = false;
-        BlasProvider.SetThreadLocalDeterministicMode(null);
         BlasProvider.SetDeterministicMode(true);
         ClearCache();
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
@@ -84,6 +84,40 @@ public sealed class DeterministicStrategySelectionTests : IDisposable
         { 384, 1024, 128, true },
     };
 
+    [Fact]
+    public void DisableAutotune_TransposedFloat_MatchesStreamingBits() => VerifyTransposeFallback<float>();
+
+    [Fact]
+    public void DisableAutotune_TransposedDouble_MatchesStreamingBits() => VerifyTransposeFallback<double>();
+
+    private static void VerifyTransposeFallback<T>() where T : unmanaged
+    {
+        var keyField = typeof(AiDotNet.Tensors.Helpers.Autotune.HardwareFingerprint).GetField(
+            "_cachedKeyBox", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Hardware routing key field not found.");
+        object? priorKey = keyField.GetValue(null);
+        try
+        {
+            keyField.SetValue(null, new AiDotNet.Tensors.Helpers.Autotune.HardwareFingerprint.HwKey(
+                "avx2", "amd", AiDotNet.Tensors.Helpers.Autotune.HardwareFingerprint.VeryWideCpuBucket));
+            const int m = 48, n = 512, k = 128;
+            var random = new Random(812);
+            var a = new T[m * k];
+            var b = new T[n * k];
+            for (int i = 0; i < a.Length; i++) a[i] = (T)Convert.ChangeType(random.NextDouble() - 0.5, typeof(T));
+            for (int i = 0; i < b.Length; i++) b[i] = (T)Convert.ChangeType(random.NextDouble() - 0.5, typeof(T));
+            var expected = new T[m * n];
+            var actual = new T[m * n];
+            BlasManagedLib.Gemm<T>(a, k, false, b, k, true, expected, n, m, n, k,
+                new BlasOptions<T> { PackingMode = PackingMode.ForceStreaming });
+            BlasManagedLib.Gemm<T>(a, k, false, b, k, true, actual, n, m, n, k,
+                new BlasOptions<T> { PackingMode = PackingMode.DisableAutotune });
+            Assert.Equal(System.Runtime.InteropServices.MemoryMarshal.AsBytes(expected.AsSpan()).ToArray(),
+                System.Runtime.InteropServices.MemoryMarshal.AsBytes(actual.AsSpan()).ToArray());
+        }
+        finally { keyField.SetValue(null, priorKey); }
+    }
+
     [Theory]
     [MemberData(nameof(AffectedShapes))]
     public void DeterministicMode_PersistedStrategy_DoesNotChangeResultBits(int m, int n, int k, bool transB)

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/DeterministicStrategySelectionTests.cs
@@ -1,0 +1,231 @@
+// Regression test for the deterministic-mode autotune-strategy bug.
+//
+// BlasManaged.Gemm picks its packing strategy from a TIMING-MEASURED, disk-persisted
+// autotune cache (Dispatcher.SelectStrategy -> BlasManagedAutotune.TryLookupStrategy,
+// populated by BackgroundAutotuner.Measure, which times ForceStreaming / ForcePackAOnly /
+// ForcePackBoth and persists the fastest). Those strategies are NOT reduction-order
+// equivalent, so whichever one the autotuner happened to clock fastest changed the
+// RESULT BITS of the very same GEMM -- including while deterministic mode was on, which
+// AiModelBuilder documents as producing "bitwise-identical results across runs on the
+// same hardware".
+//
+// Each test redirects AIDOTNET_AUTOTUNE_CACHE_PATH at a private temp directory. That is
+// load-bearing, not hygiene: against the real ~/.aidotnet/autotune cache these assertions
+// would pass or fail purely according to what the background autotuner had already
+// measured on the host -- the warm-cache dependence that hid this bug in the first place.
+// A private root makes every case start from a guaranteed-empty cache.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.BlasManaged;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+using BlasManagedLib = AiDotNet.Tensors.Engines.BlasManaged.BlasManaged;
+
+namespace AiDotNet.Tensors.Tests.Engines.BlasManaged;
+
+// Toggles process-global deterministic mode and the on-disk autotune cache; serialize
+// against the other BlasManaged bit-exactness tests.
+[Collection("BlasManaged-Stats-Serial")]
+public sealed class DeterministicStrategySelectionTests : IDisposable
+{
+    private const string EnvVarCachePath = "AIDOTNET_AUTOTUNE_CACHE_PATH";
+
+    private readonly string _cacheRoot;
+    private readonly string? _priorCachePath;
+    private readonly bool _priorDeterministic;
+    private readonly bool? _priorThreadLocal;
+    private readonly bool _priorBackgroundAutotuner;
+
+    public DeterministicStrategySelectionTests()
+    {
+        _priorCachePath = Environment.GetEnvironmentVariable(EnvVarCachePath);
+        _priorDeterministic = BlasProvider.IsDeterministicMode;
+        _priorThreadLocal = BlasProvider.GetThreadLocalDeterministicMode();
+        _priorBackgroundAutotuner = BackgroundAutotuner.Enabled;
+
+        _cacheRoot = Path.Combine(Path.GetTempPath(), "aidotnet-determinism-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_cacheRoot);
+        Environment.SetEnvironmentVariable(EnvVarCachePath, _cacheRoot);
+
+        // The background autotuner would race these cases by persisting a timed winner
+        // mid-test; the point here is what a PRESENT entry does, written deterministically.
+        BackgroundAutotuner.Enabled = false;
+        BlasProvider.SetThreadLocalDeterministicMode(null);
+        BlasProvider.SetDeterministicMode(true);
+        ClearCache();
+    }
+
+    public void Dispose()
+    {
+        ClearCache();
+        Environment.SetEnvironmentVariable(EnvVarCachePath, _priorCachePath);
+        BackgroundAutotuner.Enabled = _priorBackgroundAutotuner;
+        BlasProvider.SetDeterministicMode(_priorDeterministic);
+        BlasProvider.SetThreadLocalDeterministicMode(_priorThreadLocal);
+        BlasManagedAutotune.ClearStrategyMemo();
+        try { if (Directory.Exists(_cacheRoot)) Directory.Delete(_cacheRoot, recursive: true); } catch { }
+    }
+
+    public static TheoryData<int, int, int, bool> AffectedShapes => new()
+    {
+        // Transposed-B shapes reach Dispatcher.SelectStrategy: the non-transposed
+        // machine-code and GotoGemm fast paths decline transB, so strategy selection
+        // (and therefore the learned cache) actually decides the kernel for these.
+        { 48, 256, 64, true },
+        { 48, 512, 128, true },
+        { 48, 1024, 256, true },
+        { 96, 1024, 512, true },
+        { 192, 1024, 256, true },
+        { 384, 1024, 128, true },
+    };
+
+    [Theory]
+    [MemberData(nameof(AffectedShapes))]
+    public void DeterministicMode_PersistedStrategy_DoesNotChangeResultBits(int m, int n, int k, bool transB)
+    {
+        var (a, b) = MakeOperands(m, n, k, transA: false, transB, seed: 12345);
+
+        ClearCache();
+        float[] coldCache = Gemm(a, b, m, n, k, transB, PackingMode.Auto);
+
+        foreach (var candidate in new[]
+                 {
+                     PackingMode.ForceStreaming,
+                     PackingMode.ForcePackAOnly,
+                     PackingMode.ForcePackBoth,
+                 })
+        {
+            ClearCache();
+            StoreStrategy(m, n, k, transB, candidate);
+
+            float[] warmCache = Gemm(a, b, m, n, k, transB, PackingMode.Auto);
+
+            int differing = CountDifferingBits(coldCache, warmCache);
+            Assert.True(
+                differing == 0,
+                $"Deterministic mode must not let a persisted autotune entry change result bits, but a "
+                + $"'{candidate}' entry changed {differing}/{coldCache.Length} elements of the "
+                + $"{m}x{n}x{k} (transB={transB}) GEMM. Deterministic mode is documented as producing "
+                + "bitwise-identical results across runs on the same hardware, and the autotune cache "
+                + "is populated from wall-clock timings, so it is not reproducible input.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AffectedShapes))]
+    public void DeterministicMode_StrategySelection_IgnoresPersistedEntry(int m, int n, int k, bool transB)
+    {
+        ClearCache();
+        PackingMode cold = SelectStrategy(m, n, k, transB);
+
+        foreach (var candidate in new[]
+                 {
+                     PackingMode.ForceStreaming,
+                     PackingMode.ForcePackAOnly,
+                     PackingMode.ForcePackBoth,
+                 })
+        {
+            ClearCache();
+            StoreStrategy(m, n, k, transB, candidate);
+
+            PackingMode warm = SelectStrategy(m, n, k, transB);
+            Assert.True(
+                cold == warm,
+                $"Deterministic strategy selection must be a pure function of shape and hardware, but a "
+                + $"persisted '{candidate}' entry changed the choice from {cold} to {warm} for "
+                + $"{m}x{n}x{k} (transB={transB}).");
+        }
+    }
+
+    [Fact]
+    public void FastMode_StillConsultsThePersistedStrategyCache()
+    {
+        // The fix must not disable learned routing for callers who did NOT ask for
+        // determinism -- fast mode keeps the autotuner's benefit.
+        BlasProvider.SetDeterministicMode(false);
+
+        const int m = 48, n = 1024, k = 256;
+        ClearCache();
+        PackingMode cold = SelectStrategy(m, n, k, transB: true);
+
+        PackingMode other = cold == PackingMode.ForceStreaming
+            ? PackingMode.ForcePackBoth
+            : PackingMode.ForceStreaming;
+
+        ClearCache();
+        StoreStrategy(m, n, k, transB: true, other);
+        Assert.Equal(other, SelectStrategy(m, n, k, transB: true));
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static PackingMode SelectStrategy(int m, int n, int k, bool transB) =>
+        Dispatcher.SelectStrategy<float>(
+            m, n, k, transA: false, transB, new BlasOptions<float> { PackingMode = PackingMode.Auto });
+
+    private static void StoreStrategy(int m, int n, int k, bool transB, PackingMode mode)
+    {
+        var shape = BlasManagedAutotune.EncodeShape<float>(
+            m, n, k, transA: false, transB, mr: 0, nr: 0, hasEpilogue: false,
+            isDeterministic: BlasProvider.IsDeterministicMode);
+        BlasManagedAutotune.StoreStrategy(
+            shape, mode, ParallelismAxis.M,
+            mc: 64, nc: 64, kc: 64,
+            threadCount: Environment.ProcessorCount, BlasKernelVersion.Current);
+    }
+
+    private void ClearCache()
+    {
+        BlasManagedAutotune.ClearStrategyMemo();
+        try
+        {
+            foreach (string dir in Directory.GetDirectories(_cacheRoot)) Directory.Delete(dir, recursive: true);
+            foreach (string file in Directory.GetFiles(_cacheRoot)) File.Delete(file);
+        }
+        catch
+        {
+            // Best effort: a stale handle must not fail the test outright.
+        }
+        BlasManagedAutotune.ClearStrategyMemo();
+    }
+
+    private static float[] Gemm(float[] a, float[] b, int m, int n, int k, bool transB, PackingMode mode)
+    {
+        var c = new float[m * n];
+        BlasManagedLib.Gemm<float>(
+            a, k, false,
+            b, transB ? k : n, transB,
+            c, n, m, n, k,
+            new BlasOptions<float> { PackingMode = mode });
+        return c;
+    }
+
+    private static (float[] a, float[] b) MakeOperands(int m, int n, int k, bool transA, bool transB, int seed)
+    {
+        var rng = new Random(seed);
+        var a = new float[transA ? k * m : m * k];
+        var b = new float[transB ? n * k : k * n];
+        for (int i = 0; i < a.Length; i++) a[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < b.Length; i++) b[i] = (float)(rng.NextDouble() * 2 - 1);
+        return (a, b);
+    }
+
+    private static int CountDifferingBits(float[] x, float[] y)
+    {
+        int differing = 0;
+        for (int i = 0; i < x.Length; i++)
+        {
+            // Bitwise, not value-equality: the contract is bit-identical, and .Equals
+            // would treat +0.0 == -0.0 and mishandle NaN payloads, masking a drift.
+            if (FloatBits(x[i]) != FloatBits(y[i])) differing++;
+        }
+        return differing;
+    }
+
+    // BitConverter.SingleToInt32Bits is net5+; this test project also targets net471,
+    // where GetBytes -> ToInt32 is the equivalent (matches DeterministicParallelGemmContractTests).
+    private static int FloatBits(float f) => BitConverter.ToInt32(BitConverter.GetBytes(f), 0);
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/HybridStrategyEndToEndTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/HybridStrategyEndToEndTests.cs
@@ -46,13 +46,34 @@ public class HybridStrategyEndToEndTests
     {
         // Store a learned entry differing from the table's default, then assert
         // SelectStrategy returns the learned strategy (precedence learned > table).
-        const int M = 200, N = 200, K = 64;  // table → Streaming on this box; learned → PackBoth
-        var shape = BlasManagedAutotune.EncodeShape<float>(M, N, K, false, false, 0, 0, false,
-            AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode);
-        BlasManagedAutotune.StoreStrategy(shape, PackingMode.ForcePackBoth, ParallelismAxis.M,
-            64, 64, 64, 8, BlasKernelVersion.Current);
-        var opts = default(BlasOptions<float>);
-        Assert.Equal(PackingMode.ForcePackBoth, Dispatcher.SelectStrategy<float>(M, N, K, in opts));
+        //
+        // Pinned to FAST mode: learned-cache routing is a fast-mode feature. Deterministic
+        // mode deliberately ignores the timing-derived cache and routes via
+        // StrategyDefaultTable, because a wall-clock-measured strategy would otherwise change
+        // result bits (see the determinism gate in Dispatcher.SelectStrategy and
+        // DeterministicStrategySelectionTests). This test used to inherit the ambient mode,
+        // which defaults to deterministic, so it was asserting fast-mode behaviour under
+        // determinism by accident.
+        bool? beforeThreadDet = AiDotNet.Tensors.Helpers.BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) AiDotNet.Tensors.Helpers.BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode;
+        try
+        {
+            AiDotNet.Tensors.Helpers.BlasProvider.SetDeterministicMode(false);
+
+            const int M = 200, N = 200, K = 64;  // table → Streaming on this box; learned → PackBoth
+            var shape = BlasManagedAutotune.EncodeShape<float>(M, N, K, false, false, 0, 0, false,
+                AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode);
+            BlasManagedAutotune.StoreStrategy(shape, PackingMode.ForcePackBoth, ParallelismAxis.M,
+                64, 64, 64, 8, BlasKernelVersion.Current);
+            var opts = default(BlasOptions<float>);
+            Assert.Equal(PackingMode.ForcePackBoth, Dispatcher.SelectStrategy<float>(M, N, K, in opts));
+        }
+        finally
+        {
+            AiDotNet.Tensors.Helpers.BlasProvider.SetDeterministicMode(beforeDet);
+            AiDotNet.Tensors.Helpers.BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+        }
     }
 
     [Fact]
@@ -60,20 +81,33 @@ public class HybridStrategyEndToEndTests
     {
         // Two transB calls of the same small shape → 2nd sighting enqueues a background
         // measurement; after a short wait the learned cache should hold a strategy.
-        const int M = 72, N = 72, K = 48;
-        var a = new double[M * K];
-        var b = new double[N * K]; // [N,K] for transB
-        var c = new double[M * N];
-        var shape = BlasManagedAutotune.EncodeShape<double>(M, N, K, false, true, 0, 0, false,
-            AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode);
+        // Pinned to FAST mode: background measurement is a fast-mode-only activity.
+        // Deterministic mode skips BackgroundAutotuner.Observe entirely — a timing-derived
+        // strategy would change result bits (see the determinism gate in
+        // Dispatcher.SelectStrategy) — so no learned entry would ever appear and this would
+        // fail after burning its 10s poll. The mode is pinned BEFORE the shape key is encoded,
+        // because EncodeShape mixes IsDeterministicMode into the key. This test previously
+        // inherited the ambient mode, which defaults to deterministic.
+        bool? beforeThreadDet = AiDotNet.Tensors.Helpers.BlasProvider.GetThreadLocalDeterministicMode();
+        if (beforeThreadDet is not null) AiDotNet.Tensors.Helpers.BlasProvider.SetThreadLocalDeterministicMode(null);
+        bool beforeDet = AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode;
         // Background autotuner is disabled assembly-wide for tests; enable locally and
         // restore the PRIOR value (not unconditionally false) so global state never leaks.
         // This class is in the DisableParallelization serial collection, so the worker never
         // overlaps other tests during this window.
         bool prevEnabled = BackgroundAutotuner.Enabled;
-        BackgroundAutotuner.Enabled = true;
         try
         {
+            AiDotNet.Tensors.Helpers.BlasProvider.SetDeterministicMode(false);
+
+            const int M = 72, N = 72, K = 48;
+            var a = new double[M * K];
+            var b = new double[N * K]; // [N,K] for transB
+            var c = new double[M * N];
+            var shape = BlasManagedAutotune.EncodeShape<double>(M, N, K, false, true, 0, 0, false,
+                AiDotNet.Tensors.Helpers.BlasProvider.IsDeterministicMode);
+
+            BackgroundAutotuner.Enabled = true;
             for (int i = 0; i < 2; i++)
                 BlasManagedLib.Gemm<double>(a, K, false, b, K, true, c, N, M, N, K);
             // Poll with timeout instead of a fixed sleep — the below-normal worker may take
@@ -83,6 +117,11 @@ public class HybridStrategyEndToEndTests
                 System.Threading.Thread.Sleep(50);
             Assert.NotNull(BlasManagedAutotune.TryLookupStrategy(shape));
         }
-        finally { BackgroundAutotuner.Enabled = prevEnabled; }
+        finally
+        {
+            BackgroundAutotuner.Enabled = prevEnabled;
+            AiDotNet.Tensors.Helpers.BlasProvider.SetDeterministicMode(beforeDet);
+            AiDotNet.Tensors.Helpers.BlasProvider.SetThreadLocalDeterministicMode(beforeThreadDet);
+        }
     }
 }

--- a/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/StrategyDefaultTableTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/BlasManaged/StrategyDefaultTableTests.cs
@@ -12,7 +12,55 @@ public class StrategyDefaultTableTests
         var key = HardwareFingerprint.Key;
         Assert.False(string.IsNullOrEmpty(key.Simd));
         Assert.False(string.IsNullOrEmpty(key.Vendor));
-        Assert.True(key.CpuBucket >= 0 && key.CpuBucket <= 2);
+        // Upper bound raised 2 -> 3 in PR #1034: band 2 used to mean "everything above 16
+        // threads", which lumped the 32-thread Ryzen its routing was calibrated on together
+        // with 64+-thread parts that measure differently. See BucketFor.
+        Assert.True(key.CpuBucket >= 0 && key.CpuBucket <= 3);
+    }
+
+    [Fact]
+    public void CpuBucket_SeparatesVeryWideMachinesFromTheRyzenBand()
+    {
+        Assert.Equal(0, HardwareFingerprint.BucketFor(4));
+        Assert.Equal(1, HardwareFingerprint.BucketFor(16));
+        Assert.Equal(2, HardwareFingerprint.BucketFor(32));
+        Assert.Equal(2, HardwareFingerprint.BucketFor(64));
+        Assert.Equal(3, HardwareFingerprint.BucketFor(65));
+        Assert.Equal(3, HardwareFingerprint.BucketFor(128));
+    }
+
+    [Theory]
+    // Band 3 (>64T) avx2 with a TRANSPOSED B routes to Streaming. Measured on
+    // x64-amd-avx2-cpu128: Streaming won all 17 transposed shapes swept, by 1.12x-3.22x.
+    [InlineData(512, 512, 64)]
+    [InlineData(128, 128, 128)]
+    [InlineData(48, 1024, 256)]
+    [InlineData(96, 1024, 512)]
+    [InlineData(128, 768, 768)]
+    [InlineData(49, 512, 512)]
+    public void Route_VeryWideAvx2_TransposedB_PrefersStreaming(int m, int n, int k)
+    {
+        var key = new HardwareFingerprint.HwKey("avx2", "amd", 3);
+        Assert.Equal(
+            PackingMode.ForceStreaming,
+            StrategyDefaultTable.Route(key, m, n, k, transA: false, transB: true));
+    }
+
+    [Theory]
+    // The UNTRANSPOSED routing for band 3 is deliberately identical to band 2. The sweep
+    // showed untransposed optima differ and sometimes oppose the transposed ones
+    // (512x2048x512 untransposed wants PackBoth; Streaming is ~3.0x slower there).
+    [InlineData(512, 2048, 512)]
+    [InlineData(256, 256, 256)]
+    [InlineData(128, 128, 128)]
+    [InlineData(512, 512, 64)]
+    public void Route_VeryWideAvx2_Untransposed_IsUnchangedFromLargeBand(int m, int n, int k)
+    {
+        var band2 = new HardwareFingerprint.HwKey("avx2", "amd", 2);
+        var band3 = new HardwareFingerprint.HwKey("avx2", "amd", 3);
+        Assert.Equal(
+            StrategyDefaultTable.Route(band2, m, n, k),
+            StrategyDefaultTable.Route(band3, m, n, k));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`BlasManaged` picked its GEMM packing strategy from a **timing-measured, disk-persisted** autotune cache even while deterministic mode was on. The candidate strategies are **not reduction-order equivalent**, so the same GEMM returned different bits depending on what the autotuner happened to clock — on this box, a persisted entry flipped **10,036 of 12,288** output elements of a `48x256x64` transB GEMM.

That contradicts the library's own documented contract, and it sits on the **default** path, not an opt-in one.

Under determinism, strategy selection now routes through `StrategyDefaultTable.Route` — a pure function of `(hardware key, shape)` — and the background autotuner no longer measures. **Fast mode is completely unchanged** and keeps the full learned-routing benefit.

Making determinism always take the table then exposed that the table itself was **miscalibrated for transposed shapes on very wide machines** — routing there was up to **2.55x slower** than the strategy the autotuner had learned. Shipping the gate alone would have moved that regression onto the default path of every AiDotNet model, so this PR also retunes the table (second commit) rather than landing the fix and repairing it later.

## Root cause

| Where | What |
|---|---|
| `Engines/BlasManaged/Dispatcher/Dispatcher.cs:57-68` (pre-fix) | Strategy comes from `BlasManagedAutotune.TryLookupStrategy(shapeKey)`; on a miss it calls `BackgroundAutotuner.Observe(...)`. |
| `Engines/BlasManaged/Autotune/BackgroundAutotuner.cs:138-161` | `Measure()` **times** `ForceStreaming` / `ForcePackAOnly` / `ForcePackBoth` (min-of-12) and persists the fastest via `StoreStrategy`. |
| `Helpers/Autotune/AutotuneCache.cs:14-15,72-84` | Persisted under `~/.aidotnet/autotune/{fingerprint}/`, shared across processes and surviving restarts. |

**Why the strategies disagree numerically.** `StreamingStrategy.GetColumnTileWidth` (`Strategies/StreamingStrategy.cs:355-380`) returns a tile width of `1` for `transB`, so a transposed-B column is reduced with a **vectorized-K horizontal sum**, while `PackBothStrategy` / `PackAOnlyStrategy` accumulate **sequentially over k**. Both are valid; they are simply different summation orders, and float addition is not associative.

A wall-clock measurement is not reproducible input, so feeding it into strategy selection makes results depend on machine load, core count and cache warmth.

**The contract this violates:**

- `Engines/AiDotNetEngine.cs:497-502` — *"When true, floating-point reductions (matmul, softmax, sums) produce **bit-identical results across runs on the same hardware**."*
- AiDotNet `src/AiModelBuilder.Configure.cs:743-765` — `AllowNondeterminism()` documents a *deterministic-by-default policy*: *"By default, `BuildAsync` calls `AiDotNetEngine.SetDeterministicMode(true)` so **every model built by this library produces bitwise-identical results across runs on the same hardware**"*, and *"Do NOT call this in production serving."*

Determinism is therefore the **default**: `BlasProvider.cs:1015` initialises `_deterministicMode = true`; AiDotNet sets it at `AiModelBuilder.Configure.cs:1174` and `AiModelResult.cs:2425`; and `NeuralNetworkBase.cs:483`, `MobileNetV2Network.cs:159`, `MobileNetV3Network.cs:128` force it unconditionally.

## Evidence — before / after

All measurements on `x64-amd-avx2-cpu128`, deterministic mode ON, using a **private autotune cache root** (`AIDOTNET_AUTOTUNE_CACHE_PATH`) so nothing depends on this machine's warm cache.

### 1. Does a persisted cache entry change an `Auto` GEMM's bits?

For each shape: run with an empty cache, then persist each candidate strategy and re-run, counting differing elements (bitwise).

| | Before | After |
|---|---|---|
| Shapes scanned | 192 | 192 |
| **Shapes whose bits changed with cache content** | **24** | **0** |

Representative before-rows (differing elements vs the empty-cache result):

| shape (M,N,K,tA,tB) | elems | cold route | vs Streaming | vs PackAOnly | vs PackBoth |
|---|---|---|---|---|---|
| 48,256,64,0,1 | 12288 | ForceStreaming | 0 | 10036 | 10036 |
| 48,512,128,0,1 | 24576 | ForcePackAOnly | 21353 | 0 | 0 |
| 96,1024,512,0,1 | 98304 | ForcePackBoth | 91613 | 0 | 0 |
| 384,1024,128,0,1 | 393216 | ForcePackAOnly | 342168 | 0 | 0 |

All 24 affected shapes were `transB=true` — the non-transposed machine-code and GotoGemm fast paths decline `transB`, so those are the shapes where strategy selection actually decides the kernel.

Independently, the three shapes from the original report show the raw strategy disagreement (forced strategy vs `PackingMode.DisableAutotune`):

| shape | elems | Streaming | PackAOnly | PackBoth |
|---|---|---|---|---|
| 80,513,80,0,1 | 41040 | 33611 | 0 | 0 |
| 32,513,80,1,0 | 16416 | 12603 | 12603 | 12603 |
| 80,513,80,0,0 | 41040 | 32506 | 32506 | 32506 |

### 2. Regression test

`DeterministicStrategySelectionTests` (new). It redirects the autotune cache to a private temp directory — load-bearing, not hygiene: against the real `~/.aidotnet/autotune` these assertions would pass or fail according to whatever the background autotuner had already measured on the host, which is the warm-cache dependence that hid this bug.

| | Before fix | After fix |
|---|---|---|
| `DeterministicStrategySelectionTests` | **12 failed / 1 passed** | **13 passed / 0 failed** |

The one case that passed before and still passes is `FastMode_StillConsultsThePersistedStrategyCache`, which guards against over-fixing by asserting fast mode *does* still honour the learned cache.

`35cb76b7` (by @ooples, on this branch) then fixed a real defect in that fixture: it captured `_priorDeterministic = BlasProvider.IsDeterministicMode` **before** clearing the thread-local override, so when the global and thread-local values disagreed it captured the *merged* value and wrote it back into the process-global on dispose, contaminating later tests. The fixture now clears the override first and reads the unmasked global. `DeterministicStrategyFixtureIsolationTests` pins this with 6 cases over global x thread-local combinations (4 passed / 2 failed against the original fixture; 6/6 after).

### 3. Table retune (commit 2)

Interleaved and rotated arms, median of 7 x min-of-N, strategies forced via `BlasOptions.PackingMode` so the dispatcher and cache are bypassed and only kernel cost is measured. Arm-by-arm measurement was rejected: it made whichever arm ran last look ~1.9x slower than the same strategy measured first, an allocator/ordering artifact.

**Noise floor: ~1.2x.** Established empirically — `192,1024,256` had the table route and the autotuner choosing the *same* strategy, and the two arms still measured 529.6 vs 451.3 us apart. Ratios below ~1.2x are treated as no difference.

**What the table said before, and why it was wrong here.** `Route` keys on `HwKey(Simd, Vendor, CpuBucket)` where `CpuBucket` was `0 = <=4`, `1 = 5-16`, `2 = >16`. The note that transposed `512x512x64` wants PackBoth with "Streaming 2.5x slower" lives in the **`CpuBucket <= 1`** arm, whose own comment reads *"amd-avx2 mid-core (<=16T, this box)"* — a different machine. This 128-thread box lands in band 2, whose entries were calibrated on a **32-thread Ryzen (#464)**. Band 2 meant "everything above 16 threads", so it lumped that Ryzen together with this box.

**Was core count the deciding dimension? No.** Sweeping thread budgets 128/32/16/4, Streaming won transposed shapes at 128, 32 **and** 16; the winner only flipped at 4. **Transpose is the deciding dimension**, which the table's own comments already half-admit ("calibrated for the TRANSPOSED case") while `Route` had no transpose parameter to act on it.

Two dimensions were therefore *added*, and no existing entry was overwritten:

1. **Band 3 (`>64T`) split out of band 2**, so a measurement taken here cannot silently retune the 32-thread Ryzen. Bands 0-2 are untouched.
2. **`Route` is transpose-aware**, and the new entry applies to **`transB` only**.

Scoping to `transB` is load-bearing, not caution: untransposed `512x2048x512` measures Streaming at **113,276 us vs PackBoth 5,250 us — 21x slower**. A blanket tier-wide Streaming route would have been a far worse regression than the one being fixed.

**Before -> after distribution, transposed shapes at the machine's real core count (128T):**

| shape | bucket | route before | route/best before | route after | route/best after |
|---|---|---|---|---|---|
| 48,256,64 | SmallLowK | Streaming | 1.000x | Streaming | 1.000x |
| 96,128,64 | SmallLowK | Streaming | 1.000x | Streaming | 1.000x |
| 3136,64,64 | TallThin | Streaming | 1.000x | Streaming | 1.000x |
| 192,1024,256 | MediumMWide | Streaming | 1.000x | Streaming | 1.000x |
| 48,512,128 | ThinK | PackAOnly | 3.089x | Streaming | 1.000x |
| 512,512,64 | ThinK | PackAOnly | 1.222x | Streaming | 1.000x |
| 384,1024,128 | ThinK | PackAOnly | 1.124x | Streaming | 1.133x (tie, see below) |
| 128,128,128 | MediumSquare | PackBoth | 2.678x | Streaming | 1.000x |
| 48,1024,256 | Large | PackBoth | 1.962x | Streaming | 1.000x |
| 256,256,256 | Large | PackBoth | 2.232x | Streaming | 1.000x |
| 49,512,512 | Large | PackBoth | 2.007x | Streaming | 1.000x |
| 96,1024,512 | WideCompute | PackBoth | 2.657x | Streaming | 1.000x |
| 512,512,512 | WideCompute | PackBoth | 1.414x | Streaming | 1.000x |
| 512,2048,512 | WideCompute | PackBoth | 1.179x | Streaming | 1.000x |
| 512,512,2048 | WideCompute | PackBoth | 1.361x | Streaming | 1.000x |
| 128,768,768 | MediumMWide | PackBoth | 3.216x | Streaming | 1.000x |
| 197,768,768 | MediumMWide | PackBoth | 2.027x | Streaming | 1.000x |

**16 of 17 transposed shapes are now optimal (1.000x).** The exception, `384,1024,128`, flipped ordering between runs (before: Streaming won by 1.124x; after: PackAOnly won by 1.133x) with the arms ~13% apart — at/below the noise floor, so it is a tie rather than a regression.

Untransposed shapes are unchanged by construction and show no regressions. They do retain **pre-existing** opportunities this PR deliberately does not touch: `nt/thin-k-512` (route PackAOnly, Streaming 3.05x faster) and `nt/square-1024` (route PackBoth, Streaming 1.39x faster).

### 4. Residual regression — stated, not rounded away

`Route` keys on machine `ProcessorCount`, so a caller that pins a **small `NumThreads` on a very wide box** now gets Streaming regardless:

| shape | NumThreads | route/best after |
|---|---|---|
| 384,1024,128 | 4 | **2.533x** |
| 192,1024,256 | 4 | 1.708x |
| ffn-up 512,2048,512 | 4 | 1.649x |
| ffn-down 512,512,2048 | 4 | 1.543x |
| square-512 | 4 | 1.502x |
| 384,1024,128 | 16 | 1.522x |
| resnet/layer4 49,512,512 | 4 | 1.368x |
| vit 197,768,768 | 4 | 1.355x |
| ffn-down 512,512,2048 | 16 | 1.242x |

**This is not fixable by making routing thread-aware.** Doing so would make the same GEMM choose different strategies at different thread counts, breaking the bit-identity across thread counts that `DeterministicParallelGemmContractTests` pins — the very contract this PR exists to protect. Optimising for the default all-core path is the deliberate trade.

### 5. Full test suite

Run in 11 namespace shards (a single whole-suite run crashes the test host on this box).

| | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| Before (`origin/main` @ `5d22aa7f`) | 14,283 | 13,850 | 9 | 424 |
| After (all three commits) | 14,313 | 13,880 | 9 | 424 |

**+30 total / +30 passed, no new failures.** The 30 break down as 13 (`DeterministicStrategySelectionTests`) + 11 (new `StrategyDefaultTableTests` cases) + 6 (`DeterministicStrategyFixtureIsolationTests`, from `35cb76b7`). The BlasManaged shard alone goes 846 -> 876.

The 9 failures are identical before and after, all pre-existing on this GPU box:

- `QuantGemmVulkanTests.DequantGemmInt_MatchesCpuOracle` (4 cases)
- `QuantGemmVulkanTests.DequantGemmFp8E4M3_MatchesCpuOracle` (2 cases)
- `MesaRoutedScanGpuParityTests.RoutedNativeForward_MatchesCpuEngine(Vulkan)`
- `HyperbolicOctonionGpuCorrectnessTests.OctonionLinearForward_NumericalGradientCheck`
- `DirectPtxDenseLinearBackendTests.PrewarmedExperimentalFamilies_AreZeroAllocationAndGraphCapturable`

The test project multi-targets `net10.0;net471`; the shards above run net10.0, and **net471 was separately confirmed to build clean** (0 errors) against this tree, since the new `StrategyDefaultTableTests` cases and `DeterministicStrategyFixtureIsolationTests` had otherwise only ever been compiled for net10.0.

## Blast radius / file map

| File | Change |
|---|---|
| `src/.../BlasManaged/Dispatcher/Dispatcher.cs` | Determinism gate before the learned-cache lookup; routes via `StrategyDefaultTable.Route`, now passing transpose flags. Placed **after** the pre-pack branch so a supplied pre-pack handle is still consumed. |
| `src/.../BlasManaged/Autotune/BackgroundAutotuner.cs` | `Observe` returns early under determinism. Gated here, **not** in `Measure`, so `MeasureNowForTest` and the offline pre-warm pipeline keep working. |
| `src/.../BlasManaged/Autotune/AutotuneDispatcher.cs` | Only the **timed** `BlockSizeSweep.Measure` branch is gated. |
| `src/.../BlasManaged/Dispatcher/StrategyDefaultTable.cs` | `Route` gains optional transpose parameters + the band-3 transposed-B entry. |
| `src/.../Helpers/Autotune/HardwareFingerprint.cs` | `BucketFor` splits band 3 (`>64T`) out of band 2. |
| `src/.../BlasManaged/Autotune/BlasManagedEvolutionAutotuner.cs` | Passes transpose flags into `Route` so the evolution seed matches production routing. |
| `tests/.../BlasManaged/HybridStrategyEndToEndTests.cs` | Two cases pinned to fast mode explicitly. |
| `tests/.../BlasManaged/StrategyDefaultTableTests.cs` | Bucket range 2 -> 3; 11 new cases pinning band-3 transposed routing and band-3-equals-band-2 untransposed. |
| `tests/.../BlasManaged/DeterministicStrategySelectionTests.cs` | **New** regression test (fixture corrected by `35cb76b7`). |
| `tests/.../BlasManaged/DeterministicStrategyFixtureIsolationTests.cs` | **New** (`35cb76b7`) — pins fixture setup/teardown isolation. |
| `tests/AiDotNet.Tensors.DeterministicReview/` | **New** (`35cb76b7`) — focused multi-TFM review project. Intentionally **not** added to `AiDotNet.Tensors.slnx`: it sets `AssemblyName=AiDotNet.Tensors.Tests` to inherit `InternalsVisibleTo`, which would collide with the main test project in a solution-wide build. |

Three subtleties worth review attention:

1. **The gate keys on `BlasProvider.IsDeterministicMode` only, never on `BlasOptions.Mode`.** `BlasMode.Deterministic` is the enum's **zero** value (`BlasMode.cs:34`), so every default-constructed `BlasOptions` reports `Mode == Deterministic`. Keying off it — as I first did — fires the gate at essentially every call site and makes the learned cache dead code for fast-mode callers too. The two flags also mean different things: `BlasMode` is a per-call *across-thread-counts* knob, which the strategy cache does not violate in-process; `IsDeterministicMode` is the *across-runs* switch whose contract it does violate.

2. **`AutotuneDispatcher`'s blocking cache is deliberately left intact.** With measurement off (the default — it is behind `AIDOTNET_BLAS_AUTOTUNE_MEASURE=1`) that cache merely memoizes `FallbackToHeuristic`, a pure function of the shape, so hitting or missing it yields identical bits. Bypassing it would be strictly worse: `FallbackToHeuristic`'s `mc` depends on `procs`, so recomputing per call would make blocking vary with `NumThreads` — exactly what `DeterministicParallelGemmContractTests` pins as bit-identical.

3. **`Route` gained defaulted parameters**, so a missed call site would silently keep untransposed behaviour rather than failing the build. All four call sites were enumerated and updated: `Dispatcher.cs` x2 (deterministic gate + fast-mode cold start) and `BlasManagedEvolutionAutotuner.cs:99`; test call sites intentionally keep the untransposed default.

`HybridStrategyEndToEndTests.LearnedCache_Overrides_Table` and `Repeated_SmallShape_Eventually_GetsLearnedEntry` assert learned-routing behaviour, which this PR confines to fast mode. They previously inherited the ambient mode — which defaults to deterministic — so they were asserting fast-mode behaviour under determinism by accident. They now pin the mode explicitly and restore it, including the thread-local override.

## What this does NOT do

- **It does not make the strategies reduction-order equivalent.** Approach (i) — fixing K-blocking so Streaming and the packed paths accumulate identically — would require changing the transposed-B streaming kernel's vectorized-K reduction, which is where its speed comes from. That is a deep kernel change with its own perf cost and was not attempted here.
- **It does not make fast mode deterministic across processes.** Fast mode still consults the timed cache by design, so two fast-mode processes with different cache states can still differ in the last bits.
- **It does not retune bands 0-2, or any untransposed route.** Thread-budget sweeps at 16 and 32 also favoured Streaming for transposed shapes, but throttling a 128-core part is **not** the same machine as a real 16- or 32-core part — same L3, memory bandwidth and CCX topology — so those regimes remain unmeasured and untouched. `transA`-only shapes were likewise not measured. Non-avx2 hardware (avx512, sse2, neon) falls to the unchanged conservative default arm.
- **It does not close the pre-poisoned-cache hole.** If a process previously ran with `AIDOTNET_BLAS_AUTOTUNE_MEASURE=1`, measured blocking entries (`MeasuredTimeMs > 0`) remain on disk and are still replayed by the non-timed blocking path. Rejecting measured entries under determinism needs `MeasuredTimeMs` plumbed through `TryLookup`.
- **It does not change the opt-in evolution replay path.** `BlasManaged.GemmCore` -> `TryLookupEvolutionStrategy` is still honoured under determinism because an operator activates it explicitly.
- **It bypasses the shipped pre-warm seed under determinism**, as a consequence of not consulting the strategy cache at all.
- **It does not touch `BackwardFunctions`.** The reported selective-vs-full gradient divergence **did not reproduce**: 0/20 seeds showed any bit difference across all 13 shapes scanned (including the reported `[1,513,80] x [80,64]`), versus the reported 99/100. `TrySelectiveLinearBackward` and the two-sided route already issue the same GEMM call form for these shapes, so no change was made.

## Separately reproduced (not fixed here)

`MatMulBackward` gives a rank-2 weight leaf a **rank-3** gradient when a non-contiguous narrow feeds a rank-3 matmul. With a rank-2 activation also feeding the same weight, `AccumulateGrad` then throws:

```
ArgumentException: Tensor shapes must match. Got [80, 80] and [1, 80, 80].
```

The rank-3 route does not reduce its weight gradient back to rank 2 (`SumToShape` is applied on the slow fallback at `BackwardFunctions.cs:6218` but not on this path). This will be opened as its own PR with the repro and a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
