### PR TITLE
fix(attention): support rectangular noncausal queries safely

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/FlashAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FlashAttention.cs
@@ -74,7 +74,7 @@ public static class FlashAttention<T> where T : unmanaged
         double? scale = null, bool isCausal = false, int queryOffset = 0,
         Tensor<T>? attentionBias = null)
     {
-        ValidateInputs(query, key, value, attentionBias, queryOffset,
+        ValidateInputs(query, key, value, attentionBias, queryOffset, isCausal,
             out int batchProduct, out int Sq, out int Sk, out int headDim, out int Dv,
             out int[] prefixShape, out int[] biasPrefixShape, out int[] biasPrefixStrides);
 
@@ -168,7 +168,7 @@ public static class FlashAttention<T> where T : unmanaged
         if (output is null) throw new ArgumentNullException(nameof(output));
         if (logsumexp is null) throw new ArgumentNullException(nameof(logsumexp));
 
-        ValidateInputs(query, key, value, attentionBias, queryOffset,
+        ValidateInputs(query, key, value, attentionBias, queryOffset, isCausal,
             out int batchProduct, out int Sq, out int Sk, out int headDim, out int Dv,
             out int[] prefixShape, out int[] biasPrefixShape, out int[] biasPrefixStrides);
 
@@ -363,7 +363,7 @@ public static class FlashAttention<T> where T : unmanaged
     /// </summary>
     private static void ValidateInputs(
         Tensor<T> query, Tensor<T> key, Tensor<T> value, Tensor<T>? attentionBias,
-        int queryOffset,
+        int queryOffset, bool isCausal,
         out int batchProduct, out int Sq, out int Sk, out int headDim, out int Dv,
         out int[] prefixShape, out int[] biasPrefixShape, out int[] biasPrefixStrides)
     {
@@ -389,8 +389,10 @@ public static class FlashAttention<T> where T : unmanaged
             throw new ArgumentException($"query/key headDim mismatch: {headDim} vs {key._shape[kRank - 1]}.", nameof(key));
         if (value._shape[vRank - 2] != Sk)
             throw new ArgumentException($"key/value seq len mismatch: {Sk} vs {value._shape[vRank - 2]}.", nameof(value));
-        if (queryOffset < 0 || queryOffset + Sq > Sk)
-            throw new ArgumentException($"queryOffset={queryOffset} + Sq={Sq} must be <= Sk={Sk}.", nameof(queryOffset));
+        // Ordinary noncausal attention has independent query/memory lengths. Causal
+        // or explicitly offset calls retain cached-window bounds, without overflow.
+        if (queryOffset < 0 || ((isCausal || queryOffset != 0) && queryOffset > Sk - Sq))
+            throw new ArgumentException($"queryOffset={queryOffset} must be nonnegative and, for causal attention or a nonzero offset, queryOffset + Sq={Sq} must be <= Sk={Sk}.", nameof(queryOffset));
 
         // Build the shared prefix shape and verify q/k/v share it.
         prefixShape = new int[qRank - 2];

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FlashAttention2.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FlashAttention2.cs
@@ -55,9 +55,11 @@ public static class FlashAttention2
         int Dv = value._shape[3];
         if (key._shape[3] != headDim) throw new ArgumentException("query/key headDim mismatch.");
         if (value._shape[2] != Sk) throw new ArgumentException("key/value seq len mismatch.");
-        if (queryOffset < 0 || queryOffset + Sq > Sk)
+        // Noncausal cross-attention has independent query/memory lengths. Keep
+        // cached-window bounds for causal or explicitly offset calls, without overflow.
+        if (queryOffset < 0 || ((isCausal || queryOffset != 0) && queryOffset > Sk - Sq))
             throw new ArgumentException(
-                $"queryOffset={queryOffset} + Sq={Sq} must be <= Sk={Sk}.", nameof(queryOffset));
+                $"queryOffset={queryOffset} must be nonnegative and, for causal attention or a nonzero offset, queryOffset + Sq={Sq} must be <= Sk={Sk}.", nameof(queryOffset));
 
         double scaleVal = scale ?? 1.0 / Math.Sqrt(headDim);
         float scaleF = (float)scaleVal;

--- a/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/FusedAttention.cs
@@ -229,12 +229,13 @@ public static class FusedAttention<T>
 
         // KV-cache / query-offset support (issue #198 gap D): when the
         // caller supplies a queryOffset, q_i must attend to keys
-        // k_j where j <= queryOffset + i. We validate queryOffset fits
-        // within the KV history here; the mask itself is built below.
+        // k_j where j <= queryOffset + i. Causal attention or an explicit
+        // nonzero offset denotes a window into KV history. Ordinary noncausal
+        // queries may outnumber memory tokens. Subtraction avoids overflow.
         int queryOffset = config.QueryOffset;
-        if (queryOffset < 0 || queryOffset + query._shape[2] > key._shape[2])
+        if (queryOffset < 0 || ((config.IsCausal || queryOffset != 0) && queryOffset > key._shape[2] - query._shape[2]))
             throw new ArgumentException(
-                $"queryOffset={queryOffset} + seqQ={query._shape[2]} must be <= seqKV={key._shape[2]}.",
+                $"queryOffset={queryOffset} must be nonnegative and, for causal attention or a nonzero offset, queryOffset + seqQ={query._shape[2]} must be <= seqKV={key._shape[2]}.",
                 nameof(config));
 
         // FlashAttention-2 block-tiled dispatch: O(seqLen) memory, uses

--- a/tests/AiDotNet.Tensors.RectangularAttentionReview/AiDotNet.Tensors.RectangularAttentionReview.csproj
+++ b/tests/AiDotNet.Tensors.RectangularAttentionReview/AiDotNet.Tensors.RectangularAttentionReview.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
+    <AssemblyName>AiDotNet.Tensors.Tests</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <_GetChildProjectCopyToOutputDirectoryItems>false</_GetChildProjectCopyToOutputDirectoryItems>
+    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/AiDotNet.Tensors/AiDotNet.Tensors.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionRectangularTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionAuditTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionFp32PrecisionTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionTiledBackwardTests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FlashAttention2Tests.cs" />
+    <Compile Include="../AiDotNet.Tensors.Tests/Engines/Autodiff/FlashAttentionGenericTests.cs" />
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <Target Name="CopyLegacyManagedRuntime" AfterTargets="Build" Condition="'$(TargetFramework)' == 'net471'">
+    <Copy SourceFiles="@(RuntimeCopyLocalItems)"
+          DestinationFiles="@(RuntimeCopyLocalItems->'$(TargetDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/tests/AiDotNet.Tensors.RectangularAttentionReview/README.md
+++ b/tests/AiDotNet.Tensors.RectangularAttentionReview/README.md
@@ -1,0 +1,116 @@
+# Rectangular attention validation
+
+This runner compiles the actual Tensors library and links 34 new regression cases plus
+58 existing standard, tiled, generic, precision and backward attention cases. It does
+not replace the attention implementation with a stub or disable fused dispatch.
+
+## Defect and preserved contract
+
+Ordinary noncausal cross-attention with query offset zero permits more queries than
+keys. The old unconditional `queryOffset + queryLength > keyLength` check incorrectly
+rejected that geometry and could overflow for a large positive offset. The same check
+existed in the standard fused facade, direct tiled implementation and generic
+forward/backward validator. All three now use a subtraction-safe bound only for
+causal attention or an explicitly nonzero query offset. Negative offsets remain invalid.
+
+The existing explicit-offset fitting-window contract is preserved even for noncausal
+attention. Existing positive dimension, rank, batch/head, bias and key/value checks
+remain in place. Kernel arithmetic, dispatch thresholds and fused implementations are
+unchanged; no timing or GPU-throughput improvement is claimed.
+
+## Actual before and after
+
+Baseline: fresh `origin/main` commit
+`5d22aa7f4aec3f0a2d0b14953d3d398333f376dd`.
+Baseline net10 core SHA-256:
+`EC526D0060E5C65E4A14B7F7619339A58F8C86922BD86E70DF83169DA5DDA3AB`.
+
+The final 34 regression cases were run against that unchanged original core, not just
+an early test draft: **17 passed, 17 failed** in
+`artifacts/rectangular-attention-review/rectangular-final34-original-head-before.trx`.
+The unchanged final test DLL SHA-256 was
+`2D0B90F5A8F0AAE897E4AA010C6FFAF4E6F554005E640462632D4E43506F6326`.
+Its failures expose rectangular-query rejection and positive-offset integer overflow
+across the three actual implementations. The original core was copied only into this
+owned runner output for that control, and the corrected core was restored afterward;
+the global NuGet cache was never altered.
+
+| Target framework | Core build errors/warnings | Passed | Failed | Skipped | After TRX |
+| --- | --- | --- | --- | --- | --- |
+| net10.0 | 0 / 0 | 92 | 0 | 0 | `rectangular-complete-net10.0.trx` |
+| net8.0 | 0 / 0 | 92 | 0 | 0 | `rectangular-complete-net8.0.trx` |
+| net471 | 0 / 0 | 92 | 0 | 0 | `rectangular-complete-net471.trx` |
+
+All TRXs are under `artifacts/rectangular-attention-review`. The focused runner has
+one existing unused-variable warning in the unchanged `FlashAttention2Tests`; this is
+not presented as a warning-free test build. Tests explicitly select the CPU engine
+and run without collection parallelism. These are real CPU value/gradient tests, not
+physical GPU execution evidence.
+
+After core SHA-256 values:
+
+- net10.0: `CF366B1B208EA6342AF377406CAF67DA4768F54EDD17C6C3BA18B908C59D771F`
+- net8.0: `F0124656CD4869A224315545FA7BEACFA280A71FE342E9ECF934A7F774C4BEAC`
+- net471: `3D53048B9C8EA70A6FEF5218675CB9560D1FF604EEB6180855DB1FA0E81542B8`
+
+After test DLL SHA-256 values:
+
+- net10.0: `2D0B90F5A8F0AAE897E4AA010C6FFAF4E6F554005E640462632D4E43506F6326`
+- net8.0: `9791BC7448C0766A1BBD24680B15F6AF21F61F135538891489FF5BACBB3FEA60`
+- net471: `B32A575C783F5158EB2E92658F96FC1E7D7B344E4249BB7DF7CF52CBDB8A8FC7`
+
+An independent reviewer read all three production changes and the complete new test
+matrix, then replayed the same net10 core/test binaries: **92 passed, zero failed or
+skipped**, in `results/rectangular-root-independent.trx` under the artifact directory.
+
+The consuming AiDotNet PR2136 runner also passed all ten direct framework/dependency
+attention controls against this exact local net10 Tensors DLL. Its TRX records the
+actually loaded path and `CF366B1B...` hash. The larger MGIE run was **44 passed / one
+failed**: the remaining failure is a separate injected-component clone-configuration
+defect, not claimed fixed here. Consumer core SHA-256:
+`9A33FF8B6AD3D9DA392C98EA9FAAEE94D0BAA835494946F8C346A1E2E85D05E9`;
+consumer evidence: `artifacts/pr2136-mgie-review/pr2136-mgie-local-tensors-net10.trx`
+in the AiDotNet PR2136 worktree.
+
+The new cases exercise rank-three and rank-four inputs, multiple batches/heads,
+query lengths 3, 77 and 129 versus two keys, independently calculated stable-softmax
+values and analytic dQ/dK/dV, unchanged input values, explicit weights, tiled and
+generic paths, exact-end causal windows, negative offsets and `int.MaxValue` offsets.
+Earlier partial runs are retained as diagnostics; the complete results above supersede
+them and include the existing offset-contract controls that caught an overbroad first
+predicate draft.
+
+## Reproduce after validation
+
+Run in this repository with the .NET SDK and Windows .NET Framework 4.7.1 runtime
+available. Package restore is explicit; every build is checked before any no-build test.
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$env:AIDOTNET_FORCE_CPU = '1'
+$env:DOTNET_gcServer = '0'
+$env:COMPlus_gcServer = '0'
+$runner = 'tests/AiDotNet.Tensors.RectangularAttentionReview/AiDotNet.Tensors.RectangularAttentionReview.csproj'
+dotnet restore $runner
+if ($LASTEXITCODE -ne 0) { throw 'Restore failed; do not test stale binaries.' }
+
+foreach ($tfm in @('net10.0', 'net8.0', 'net471')) {
+    dotnet build src/AiDotNet.Tensors/AiDotNet.Tensors.csproj -c Release -f $tfm --no-restore `
+        -p:GeneratePackageOnBuild=false -p:CopyLocalRuntimeTargetAssets=false `
+        -p:CopyLocalLockFileAssemblies=false -m:1 -v:q
+    if ($LASTEXITCODE -ne 0) { throw "Core build failed: $tfm" }
+
+    dotnet build $runner -c Release -f $tfm --no-restore -p:BuildProjectReferences=false `
+        -p:GeneratePackageOnBuild=false -p:CopyLocalRuntimeTargetAssets=false -m:1 -v:q
+    if ($LASTEXITCODE -ne 0) { throw "Runner build failed: $tfm" }
+
+    dotnet test $runner -c Release -f $tfm --no-build --no-restore `
+        --logger "trx;LogFileName=rectangular-reproduction-$tfm.trx" `
+        --results-directory artifacts/rectangular-attention-review
+    if ($LASTEXITCODE -ne 0) { throw "Tests failed: $tfm" }
+}
+```
+
+AiDotNet's corresponding MGIE replay uses this local corrected assembly as an explicit
+unpublished dependency. A successful local replay does not mean a stable NuGet package
+has been released or that the consuming PR can merge before that dependency is available.

--- a/tests/AiDotNet.Tensors.RectangularAttentionReview/xunit.runner.json
+++ b/tests/AiDotNet.Tensors.RectangularAttentionReview/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "parallelizeTestCollections": false
+}

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionRectangularTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/FusedAttentionRectangularTests.cs
@@ -1,0 +1,233 @@
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+public sealed class FusedAttentionRectangularTests
+{
+    public enum ForwardRoute { Engine, Tiled, ExplicitWeights, Generic }
+
+    [Theory]
+    [InlineData(3, false, ForwardRoute.Engine)]
+    [InlineData(3, true, ForwardRoute.Engine)]
+    [InlineData(77, true, ForwardRoute.Engine)]
+    [InlineData(129, true, ForwardRoute.Engine)]
+    [InlineData(3, false, ForwardRoute.Tiled)]
+    [InlineData(77, true, ForwardRoute.Tiled)]
+    [InlineData(77, true, ForwardRoute.ExplicitWeights)]
+    [InlineData(3, false, ForwardRoute.Generic)]
+    [InlineData(77, true, ForwardRoute.Generic)]
+    public void MoreQueriesThanMemory_UsesActualKernelAndMatchesManualSoftmax(int queryCount, bool rank4, ForwardRoute route)
+    {
+        const int batch = 2, dimension = 4, memoryCount = 2;
+        int heads = rank4 ? 2 : 1;
+        var query = Data(rank4 ? new[] { batch, heads, queryCount, dimension } : new[] { batch, queryCount, dimension }, 0.7);
+        var key = Data(rank4 ? new[] { batch, heads, memoryCount, dimension } : new[] { batch, memoryCount, dimension }, 1.1);
+        var value = Data(key.Shape.ToArray(), 1.9);
+        var beforeQuery = query.ToArray();
+        var beforeKey = key.ToArray();
+        var beforeValue = value.ToArray();
+        var config = new FlashAttentionConfig
+        {
+            IsCausal = false,
+            UseFlashAttention2 = route == ForwardRoute.Tiled,
+            ReturnAttentionWeights = route == ForwardRoute.ExplicitWeights
+        };
+        Tensor<float> actual;
+        Tensor<float>? weights;
+        if (route == ForwardRoute.Generic)
+        {
+            actual = FlashAttention<float>.Forward(query, key, value).Output;
+            weights = null;
+        }
+        else (actual, weights) = FusedAttention<float>.Forward(query, key, value, config, engine: new CpuEngine());
+        var expected = Reference(beforeQuery, beforeKey, beforeValue, batch * heads, queryCount, memoryCount, dimension);
+        Assert.Equal(query.Shape.ToArray(), actual.Shape.ToArray());
+        Close(expected, actual.ToArray());
+        Assert.Equal(beforeQuery, query.ToArray());
+        Assert.Equal(beforeKey, key.ToArray());
+        Assert.Equal(beforeValue, value.ToArray());
+        if (route == ForwardRoute.ExplicitWeights)
+        {
+            Assert.NotNull(weights);
+            Assert.Equal(new[] { batch, heads, queryCount, memoryCount }, weights.Shape.ToArray());
+        }
+        else Assert.Null(weights);
+    }
+
+    [Theory]
+    [InlineData(3, false, false)]
+    [InlineData(77, true, false)]
+    [InlineData(129, true, false)]
+    [InlineData(3, false, true)]
+    [InlineData(77, true, true)]
+    public void RectangularGradients_MatchIndependentAnalyticReference(int queryCount, bool rank4, bool generic)
+    {
+        const int dimension = 4, memoryCount = 2;
+        var query = Data(rank4 ? new[] { 1, 1, queryCount, dimension } : new[] { 1, queryCount, dimension }, 0.7);
+        var key = Data(rank4 ? new[] { 1, 1, memoryCount, dimension } : new[] { 1, memoryCount, dimension }, 1.1);
+        var value = Data(key.Shape.ToArray(), 1.9);
+        var upstream = Data(query.Shape.ToArray(), 2.3);
+        var expectedQuery = new double[query.Length];
+        var expectedKey = new double[key.Length];
+        var expectedValue = new double[value.Length];
+        double scale = 1.0 / Math.Sqrt(dimension);
+        for (int row = 0; row < queryCount; row++)
+        {
+            var probabilities = Probabilities(query.ToArray(), key.ToArray(), row * dimension, 0, memoryCount, dimension);
+            var probabilityGradient = new double[memoryCount];
+            double average = 0;
+            for (int memory = 0; memory < memoryCount; memory++)
+            {
+                for (int column = 0; column < dimension; column++)
+                {
+                    probabilityGradient[memory] += upstream[row * dimension + column] * value[memory * dimension + column];
+                    expectedValue[memory * dimension + column] += probabilities[memory] * upstream[row * dimension + column];
+                }
+                average += probabilities[memory] * probabilityGradient[memory];
+            }
+            for (int memory = 0; memory < memoryCount; memory++)
+            {
+                double scoreGradient = probabilities[memory] * (probabilityGradient[memory] - average) * scale;
+                for (int column = 0; column < dimension; column++)
+                {
+                    expectedQuery[row * dimension + column] += scoreGradient * key[memory * dimension + column];
+                    expectedKey[memory * dimension + column] += scoreGradient * query[row * dimension + column];
+                }
+            }
+        }
+        (Tensor<float> actualQuery, Tensor<float> actualKey, Tensor<float> actualValue) =
+            generic ? GenericBackward(upstream, query, key, value)
+                : FusedAttention<float>.Backward(upstream, query, key, value, engine: new CpuEngine());
+        Close(expectedQuery, actualQuery.ToArray());
+        Close(expectedKey, actualKey.ToArray());
+        Close(expectedValue, actualValue.ToArray());
+        Assert.Contains(expectedQuery, gradient => Math.Abs(gradient) > 1e-5);
+        Assert.Contains(expectedKey, gradient => Math.Abs(gradient) > 1e-5);
+        Assert.Contains(expectedValue, gradient => Math.Abs(gradient) > 1e-5);
+    }
+
+    [Theory]
+    [InlineData(-1, false)]
+    [InlineData(-1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    [InlineData(int.MaxValue, false)]
+    [InlineData(int.MaxValue, true)]
+    public void InvalidQueryOffsets_StillRejectIncludingOverflow(int offset, bool causal)
+    {
+        var query = new Tensor<float>(new[] { 1, 2, 2 });
+        var key = new Tensor<float>(new[] { 1, 3, 2 });
+        Assert.Throws<ArgumentException>(() => FusedAttention<float>.Forward(query, key, key,
+            new FlashAttentionConfig { IsCausal = causal, QueryOffset = offset }, engine: new CpuEngine()));
+    }
+
+    [Fact]
+    public void CausalWindow_AtExactEndPreservesMaskedValues()
+    {
+        var query = new Tensor<float>(new[] { 1, 2, 2 });
+        var key = new Tensor<float>(new[] { 1, 3, 2 });
+        var value = new Tensor<float>(new[] { 1, 3, 2 }, new Vector<float>(new[] { 1f, 2f, 3f, 4f, 5f, 6f }));
+        var actual = FusedAttention<float>.Forward(query, key, value,
+            new FlashAttentionConfig { IsCausal = true, QueryOffset = 1 }, engine: new CpuEngine()).Output;
+        Close(new[] { 2.0, 3.0, 3.0, 4.0 }, actual.ToArray());
+    }
+
+    [Theory]
+    [InlineData(-1, false)]
+    [InlineData(-1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    [InlineData(int.MaxValue, false)]
+    [InlineData(int.MaxValue, true)]
+    public void DirectTiledEntry_RejectsInvalidExplicitWindows(int offset, bool causal)
+    {
+        var query = new Tensor<float>(new[] { 1, 1, 2, 2 });
+        var key = new Tensor<float>(new[] { 1, 1, 3, 2 });
+        Assert.Throws<ArgumentException>(() => FlashAttention2.Forward(query, key, key, isCausal: causal, queryOffset: offset));
+    }
+
+    [Fact]
+    public void CausalQueries_CannotExtendBeyondMemory()
+    {
+        var query = new Tensor<float>(new[] { 1, 1, 3, 2 });
+        var key = new Tensor<float>(new[] { 1, 1, 2, 2 });
+        Assert.Throws<ArgumentException>(() => FusedAttention<float>.Forward(query, key, key,
+            new FlashAttentionConfig { IsCausal = true }, engine: new CpuEngine()));
+        Assert.Throws<ArgumentException>(() => FlashAttention2.Forward(query, key, key, isCausal: true));
+        Assert.Throws<ArgumentException>(() => FlashAttention<float>.Forward(query, key, key, isCausal: true));
+    }
+
+    [Theory]
+    [InlineData(-1, false)]
+    [InlineData(-1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    [InlineData(int.MaxValue, false)]
+    [InlineData(int.MaxValue, true)]
+    public void GenericEntry_RejectsInvalidExplicitWindows(int offset, bool causal)
+    {
+        var query = new Tensor<float>(new[] { 1, 1, 2, 2 });
+        var key = new Tensor<float>(new[] { 1, 1, 3, 2 });
+        Assert.Throws<ArgumentException>(() => FlashAttention<float>.Forward(query, key, key, isCausal: causal, queryOffset: offset));
+    }
+
+    private static (Tensor<float>, Tensor<float>, Tensor<float>) GenericBackward(
+        Tensor<float> upstream, Tensor<float> query, Tensor<float> key, Tensor<float> value)
+    {
+        var (output, logSumExp) = FlashAttention<float>.Forward(query, key, value);
+        return FlashAttention<float>.Backward(upstream, query, key, value, output, logSumExp);
+    }
+
+    private static Tensor<float> Data(int[] shape, double phase)
+    {
+        var tensor = new Tensor<float>(shape);
+        for (int i = 0; i < tensor.Length; i++) tensor[i] = (float)Math.Sin(i * 0.37 + phase);
+        return tensor;
+    }
+
+    private static double[] Reference(float[] query, float[] key, float[] value, int groups, int queries, int memory, int dimension)
+    {
+        var output = new double[query.Length];
+        for (int group = 0; group < groups; group++)
+        for (int row = 0; row < queries; row++)
+        {
+            int queryOffset = (group * queries + row) * dimension;
+            int memoryOffset = group * memory * dimension;
+            var probabilities = Probabilities(query, key, queryOffset, memoryOffset, memory, dimension);
+            for (int column = 0; column < dimension; column++)
+            for (int keyRow = 0; keyRow < memory; keyRow++)
+                output[queryOffset + column] += probabilities[keyRow] * value[memoryOffset + keyRow * dimension + column];
+        }
+        return output;
+    }
+
+    private static double[] Probabilities(float[] query, float[] key, int queryOffset, int memoryOffset, int memory, int dimension)
+    {
+        var probabilities = new double[memory];
+        double maximum = double.NegativeInfinity;
+        for (int row = 0; row < memory; row++)
+        {
+            for (int column = 0; column < dimension; column++)
+                probabilities[row] += (double)query[queryOffset + column] * key[memoryOffset + row * dimension + column];
+            probabilities[row] /= Math.Sqrt(dimension);
+            maximum = Math.Max(maximum, probabilities[row]);
+        }
+        double total = 0;
+        for (int row = 0; row < memory; row++) total += probabilities[row] = Math.Exp(probabilities[row] - maximum);
+        for (int row = 0; row < memory; row++) probabilities[row] /= total;
+        return probabilities;
+    }
+
+    private static void Close(double[] expected, float[] actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.False(float.IsNaN(actual[i]) || float.IsInfinity(actual[i]));
+            Assert.InRange(Math.Abs(expected[i] - actual[i]), 0, 2e-5 * (1 + Math.Abs(expected[i])));
+        }
+    }
+}


### PR DESCRIPTION
## Root cause and fix

Noncausal cross-attention must allow independent query/key lengths. Three shared validators rejected Q > K even when causal masking was disabled, and `queryOffset + queryLength` could overflow. This blocked actual MGIE learned-query cross-attention in AiDotNet PR2136.

- Apply the same subtraction-safe fitting-window predicate in FusedAttention, FlashAttention2, and generic FlashAttention forward/backward validation.
- Keep negative offsets invalid. Keep the existing nonzero-offset fitting-window contract, including noncausal explicit offsets.
- Preserve all numerical kernels and fused dispatch; no fallback or reduced model geometry.

## Actual before/after proof

Baseline is fresh main `5d22aa7f4aec3f0a2d0b14953d3d398333f376dd`.

| Execution | Passed | Failed | Skipped |
| --- | --- | --- | --- |
| Final 34 new tests against unchanged original net10 core | 17 | 17 | 0 |
| Corrected net10: 34 new + 58 existing tests | 92 | 0 | 0 |
| Corrected net8: same complete set | 92 | 0 | 0 |
| Corrected net471: same complete set | 92 | 0 | 0 |
| Independent reviewer replay, exact frozen net10 binaries | 92 | 0 | 0 |

All three actual library builds had zero errors/warnings. The focused test project retains one preexisting unused-variable warning in unchanged FlashAttention2Tests. New tests cover manual stable-softmax values and analytic dQ/dK/dV; rank3/rank4, batched/multihead, Q3/Q77/Q129 versus K2; standard/tiled/generic/explicit-weights routes; input nonmutation; causal and explicit-offset boundaries including int.MaxValue.

Original core SHA-256: `EC526D0060E5C65E4A14B7F7619339A58F8C86922BD86E70DF83169DA5DDA3AB`.
Corrected core SHA-256: `CF366B1B208EA6342AF377406CAF67DA4768F54EDD17C6C3BA18B908C59D771F`.
Same final net10 test SHA-256: `2D0B90F5A8F0AAE897E4AA010C6FFAF4E6F554005E640462632D4E43506F6326`.

Commands, all target hashes, original and final TRX names, and reviewer results are recorded in [the reproducible validation README](tests/AiDotNet.Tensors.RectangularAttentionReview/README.md). Preserved original-head replay is `rectangular-final34-original-head-before.trx`; complete after results are `rectangular-complete-<tfm>.trx`.

## Consumer and limits

AiDotNet PR2136's ten direct framework/dependency attention controls passed against this exact local corrected assembly, with loaded path/hash recorded in TRX. Its larger integrated MGIE run is 44/45: the remaining injected-component clone-configuration defect is separate and is not claimed fixed here.

Independent adversarial review of all three production changes and all 34 new cases is complete. This is local CPU correctness evidence, not physical-GPU performance evidence. The package is not released and the global NuGet cache was not modified. Draft companion for review; do not merge/release as part of this action.
