### PR TITLE
fix(autodiff): reduce the rank-3 weight gradient to its rank-2 leaf

### DIFF
--- a/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
+++ b/src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs
@@ -869,6 +869,26 @@ internal static class BackwardFunctions<T>
         var aT = TransposeLastTwoDims(inputs[0], engine);
         var gradBFallback = engine.TensorMatMul(aT, gradOutput);
 
+        // Reduce each gradient back to its operand's shape before accumulating.
+        //
+        // When one operand is rank-3 and the other rank-2 — e.g. a non-contiguous
+        // [1, S, K] narrow times a [K, N] weight — the batched matmul above emits a
+        // PER-BATCH [1, K, N] gradient for a [K, N] leaf. Non-contiguity is precisely what
+        // lands a caller here: TrySelectiveLinearBackward, the rank-3 fast path and the
+        // collapsed-2D path all require IsContiguous, so a Tensor.Slice narrow skips every
+        // one of them. AccumulateGrad then adds the unreduced gradient to any correctly
+        // shaped contribution to the same leaf and throws
+        // "Tensor shapes must match. Got [80, 80] and [1, 80, 80]".
+        //
+        // This sums away only the leading axes the target does not have — PyTorch's
+        // sum_to_size semantics for a shared parameter, matching what
+        // FusedLinearBackwardCore's equivalent fallback has done since #234. The gradient
+        // VALUES were already correct ([1, K, N] flattens to the same elements as [K, N]),
+        // so this is a pure rank reduction, not a numerical change. SumToShape early-returns
+        // when the shapes already match, so the common case costs one shape comparison.
+        gradAFallback = SumToShape(gradAFallback, inputs[0]._shape, engine);
+        gradBFallback = SumToShape(gradBFallback, inputs[1]._shape, engine);
+
         DifferentiableOps.AccumulateGrad(grads, inputs[0], gradAFallback, engine);
         DifferentiableOps.AccumulateGrad(grads, inputs[1], gradBFallback, engine);
     }

--- a/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MatMulBackwardRankReductionTests.cs
+++ b/tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MatMulBackwardRankReductionTests.cs
@@ -1,0 +1,173 @@
+// Regression tests for MatMulBackward's generic fallback failing to reduce a rank-3
+// weight gradient back to the rank-2 weight leaf.
+//
+// A non-contiguous narrow (Tensor.Slice on the last axis) fails the IsContiguous gate on
+// every fast path in MatMulBackward -- the selective-linear route, the rank-3 collapsed
+// route, and the 2D fast path all require contiguity -- so it lands in the generic
+// fallback. That fallback computes `TransposeLastTwoDims(inputs[0]) x gradOutput`, which
+// for a rank-3 input and a rank-2 weight produces a rank-3 [1, K, N] gradient for a
+// [K, N] leaf and accumulates it unreduced. FusedLinearBackwardCore's equivalent fallback
+// already applies SumToShape for exactly this reason (issue #234); MatMulBackward did not.
+//
+// Symptom when the same weight also receives a correctly-shaped rank-2 contribution:
+//   ArgumentException: Tensor shapes must match. Got [80, 80] and [1, 80, 80].
+
+using System;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tensors.Tests.Engines.Autodiff;
+
+[Collection("EngineCurrentGlobalState")]
+public sealed class MatMulBackwardRankReductionTests : IDisposable
+{
+    private const int Rows = 513;
+    private const int K = 80;
+    private const int N = 80;
+
+    private readonly IEngine _priorEngine;
+    private readonly CpuEngine _engine;
+
+    public MatMulBackwardRankReductionTests()
+    {
+        _priorEngine = AiDotNetEngine.Current;
+        _engine = new CpuEngine();
+        AiDotNetEngine.Current = _engine;
+    }
+
+    public void Dispose() => AiDotNetEngine.Current = _priorEngine;
+
+    /// <summary>
+    /// The reported repro. Two rank-3 non-contiguous narrows and one rank-2 activation all
+    /// feed the SAME rank-2 weight. Backward runs in reverse-topological order, so the
+    /// last-recorded (rank-2) contribution accumulates first and the unreduced rank-3
+    /// gradient is added to it second -- which is why the thrown message reads
+    /// "Got [80, 80] and [1, 80, 80]" in that operand order.
+    /// </summary>
+    [Fact]
+    public void NonContiguousNarrow_SharedRank2Weight_AccumulatesWithoutShapeMismatch()
+    {
+        var (wide, flat, weight) = MakeInputs(seed: 7);
+
+        using var tape = new GradientTape<float>();
+
+        var head = wide.Slice(2, 0, K);          // non-contiguous [1, Rows, K]
+        var tail = wide.Slice(2, K, K * 2);      // non-contiguous [1, Rows, K]
+        Assert.False(head.IsContiguous);          // the defect requires the non-contiguous route
+        Assert.False(tail.IsContiguous);
+
+        var y1 = _engine.TensorMatMul(head, weight);
+        var y2 = _engine.TensorMatMul(tail, weight);
+        var y3 = _engine.TensorMatMul(flat, weight);   // recorded LAST => accumulates FIRST
+
+        var loss = _engine.TensorAdd(
+            _engine.TensorAdd(_engine.ReduceSum(y1), _engine.ReduceSum(y2)),
+            _engine.ReduceSum(y3));
+
+        // Before the fix this throws:
+        //   ArgumentException: Tensor shapes must match. Got [80, 80] and [1, 80, 80].
+        var grads = tape.ComputeGradients(loss, new[] { weight });
+
+        Assert.True(grads.ContainsKey(weight));
+        Assert.Equal(2, grads[weight].Rank);
+        Assert.Equal(K, grads[weight]._shape[0]);
+        Assert.Equal(N, grads[weight]._shape[1]);
+    }
+
+    /// <summary>
+    /// The invariant on its own, with no second contribution to collide with: a rank-2
+    /// weight leaf must never receive a higher-rank gradient. Before the fix this returns
+    /// [1, 80, 80].
+    /// </summary>
+    [Fact]
+    public void NonContiguousNarrow_RankThreeMatMul_ProducesRank2WeightGradient()
+    {
+        var (wide, _, weight) = MakeInputs(seed: 11);
+
+        using var tape = new GradientTape<float>();
+        var tail = wide.Slice(2, K, K * 2);
+        Assert.False(tail.IsContiguous);
+
+        var y = _engine.TensorMatMul(tail, weight);
+        var loss = _engine.ReduceSum(y);
+        var grads = tape.ComputeGradients(loss, new[] { weight });
+
+        Assert.Equal(2, grads[weight].Rank);
+        Assert.Equal(K, grads[weight]._shape[0]);
+        Assert.Equal(N, grads[weight]._shape[1]);
+    }
+
+    /// <summary>
+    /// Shape alone is not enough: the reduced gradient must also hold the right VALUES.
+    /// Compares the non-contiguous-narrow route against a materialised contiguous copy of
+    /// the same sub-tensor, which takes a different (already-correct) route through
+    /// MatMulBackward.
+    /// </summary>
+    [Fact]
+    public void NonContiguousNarrow_WeightGradient_MatchesContiguousEquivalent()
+    {
+        var (wide, _, weight) = MakeInputs(seed: 23);
+
+        float[] narrowGrad;
+        using (var tape = new GradientTape<float>())
+        {
+            var tail = wide.Slice(2, K, K * 2);
+            var loss = _engine.ReduceSum(_engine.TensorMatMul(tail, weight));
+            narrowGrad = ToArray(tape.ComputeGradients(loss, new[] { weight })[weight]);
+        }
+
+        // Materialise the same [1, Rows, K] block contiguously: wide is [1, Rows, 2K]
+        // row-major, so element (0, r, K + j) lives at r * 2K + K + j.
+        var wideData = ToArray(wide);
+        var contiguousData = new float[Rows * K];
+        for (int r = 0; r < Rows; r++)
+            for (int j = 0; j < K; j++)
+                contiguousData[r * K + j] = wideData[r * (K * 2) + K + j];
+        var contiguous = new Tensor<float>(contiguousData, new[] { 1, Rows, K });
+
+        float[] referenceGrad;
+        using (var tape = new GradientTape<float>())
+        {
+            var loss = _engine.ReduceSum(_engine.TensorMatMul(contiguous, weight));
+            referenceGrad = ToArray(tape.ComputeGradients(loss, new[] { weight })[weight]);
+        }
+
+        Assert.Equal(referenceGrad.Length, narrowGrad.Length);
+        for (int i = 0; i < referenceGrad.Length; i++)
+        {
+            double expected = referenceGrad[i];
+            double actual = narrowGrad[i];
+            double tolerance = 1e-3 * Math.Max(1.0, Math.Abs(expected));
+            Assert.True(
+                Math.Abs(expected - actual) <= tolerance,
+                $"weight gradient mismatch at {i}: contiguous={expected:G9} narrow={actual:G9}");
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (Tensor<float> wide, Tensor<float> flat, Tensor<float> weight) MakeInputs(int seed)
+    {
+        var rng = new Random(seed);
+        var wideData = new float[Rows * K * 2];
+        for (int i = 0; i < wideData.Length; i++) wideData[i] = (float)(rng.NextDouble() * 2 - 1);
+        var flatData = new float[Rows * K];
+        for (int i = 0; i < flatData.Length; i++) flatData[i] = (float)(rng.NextDouble() * 2 - 1);
+        var weightData = new float[K * N];
+        for (int i = 0; i < weightData.Length; i++) weightData[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        return (
+            new Tensor<float>(wideData, new[] { 1, Rows, K * 2 }),
+            new Tensor<float>(flatData, new[] { Rows, K }),
+            new Tensor<float>(weightData, new[] { K, N }));
+    }
+
+    private static float[] ToArray(Tensor<float> tensor)
+    {
+        var copy = new float[tensor.Length];
+        tensor.AsSpan().CopyTo(copy);
+        return copy;
+    }
+}


### PR DESCRIPTION
## Summary

`MatMulBackward`'s generic fallback gave a **rank-2 weight leaf a rank-3 gradient**. Accumulating that against any correctly shaped contribution to the same leaf threw:

```
ArgumentException: Tensor shapes must match. Got [80, 80] and [1, 80, 80].
```

Both fallback gradients are now reduced to their operand's shape before accumulation.

This is a **pure rank defect, not a numerical one** — `[1, K, N]` flattens to the same elements as `[K, N]`, so the gradient *values* were always correct and only the leading singleton axis was wrong. A regression test pins that explicitly.

## Root cause

| Where | What |
|---|---|
| `Engines/Autodiff/BackwardFunctions.cs:863-873` (pre-fix) | Generic fallback computes `TransposeLastTwoDims(inputs[0]) x gradOutput` and accumulates it **unreduced**. |
| `Engines/Autodiff/BackwardFunctions.cs:6217-6218` | `FusedLinearBackwardCore`'s *equivalent* fallback does the same matmul and immediately applies `SumToShape(weightGradFb, inputs[1]._shape, engine)` — the #234 fix. `MatMulBackward` never got it. |

**Why a narrow reaches that fallback.** Every faster route in `MatMulBackward` is gated on contiguity:

- `TrySelectiveLinearBackward` (`:6243`) requires `inputs[0].IsContiguous`
- `rank3FastPathEligible` (`:678-685`) requires `inputs[0].IsContiguous`
- the collapsed-2D route (`:814-816`) requires all three operands contiguous

`Tensor.Slice(axis, start, end)` returns an O(1) **non-contiguous view** (`Tensor.cs:4472` → `CreateNarrowView`, which adjusts `_storageOffset` and narrows the shape without copying). So a narrowed `[1, S, K]` view skips all three and lands in the fallback, where a rank-3 input against a rank-2 weight makes the batched matmul emit a per-batch `[1, K, N]` gradient for a `[K, N]` parameter.

## Evidence — before / after

### Regression test

`MatMulBackwardRankReductionTests` (new), three cases:

| Test | Before | After |
|---|---|---|
| `NonContiguousNarrow_SharedRank2Weight_AccumulatesWithoutShapeMismatch` | **FAIL** — `System.ArgumentException : Tensor shapes must match. Got [80, 80] and [1, 80, 80].` | PASS |
| `NonContiguousNarrow_RankThreeMatMul_ProducesRank2WeightGradient` | **FAIL** — `Assert.Equal() Failure: Values differ` (rank 3, expected 2) | PASS |
| `NonContiguousNarrow_WeightGradient_MatchesContiguousEquivalent` | PASS | PASS |

Totals: **2 failed / 1 passed → 3 passed / 0 failed.**

Two deliberate details:

1. **Operand order in the message is not incidental.** Backward runs in reverse-topological order, so the *last-recorded* contribution accumulates *first*. The test records the two rank-3 narrows first and the rank-2 activation last, which is what makes the thrown message read `Got [80, 80] and [1, 80, 80]` rather than the reverse. Reproducing the message verbatim requires that ordering.
2. **The third case passing before the fix is the point, not a gap.** It compares the narrowed route against a materialised contiguous copy of the same block and passes either way, because both flatten to the same 6,400 elements. It exists to prove the fix reduces the *shape* without changing the *values*, and it must keep passing.

### Full test suite

Run in 11 namespace shards (a single whole-suite run crashes the test host on this box).

| | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| Before (`origin/main` @ `5d22aa7f`) | 14,283 | 13,850 | 9 | 424 |
| After (this branch) | 14,286 | 13,853 | 9 | 424 |

**+3 total / +3 passed, no new failures.** The three new cases land in the Autodiff shard (976 → 979). The "before" row was measured on `5d22aa7f`, which is byte-identical to this branch's base — verified by SHA, not re-run on an equivalent commit.

Worth noting as a cross-check on branch independence: the BlasManaged shard here is **846**, the pristine baseline figure, rather than the 876 seen on #1034. This branch carries none of that PR's changes.

The 9 failures are identical before and after, all pre-existing on this GPU box:

- `QuantGemmVulkanTests.DequantGemmInt_MatchesCpuOracle` (4 cases)
- `QuantGemmVulkanTests.DequantGemmFp8E4M3_MatchesCpuOracle` (2 cases)
- `MesaRoutedScanGpuParityTests.RoutedNativeForward_MatchesCpuEngine(Vulkan)`
- `HyperbolicOctonionGpuCorrectnessTests.OctonionLinearForward_NumericalGradientCheck`
- `DirectPtxDenseLinearBackendTests.PrewarmedExperimentalFamilies_AreZeroAllocationAndGraphCapturable`

Both target frameworks build clean. `net471` was built explicitly as well as `net10.0` — the test project multi-targets `net10.0;net471` and CI builds both, and the new test deliberately avoids `Math.Clamp` / `MathF`, which do not exist there.

## Blast radius / file map

| File | Change |
|---|---|
| `src/AiDotNet.Tensors/Engines/Autodiff/BackwardFunctions.cs` | Two `SumToShape` calls in `MatMulBackward`'s generic fallback (+ comment). No other path touched. |
| `tests/AiDotNet.Tensors.Tests/Engines/Autodiff/MatMulBackwardRankReductionTests.cs` | **New** — 3 regression cases. |

Scope notes:

- **Only the generic fallback changed.** The selective, rank-3 and collapsed-2D fast paths already produce correctly shaped gradients and are untouched, so the hot training paths are bit-identical.
- **`SumToShape` is a no-op when shapes already match** (it early-returns on `ShapeEquals`), so callers that were already correct pay one shape comparison and nothing else. No allocation, no reduction.
- **Applied to both operands, not just the weight.** The mirror case — a rank-2 `inputs[0]` against a higher-rank `inputs[1]` — has the same defect shape. Only the weight side is covered by a reproduced test; the `gradA` side is defensive symmetry and is a no-op today for every shape exercised by the suite.

## What this does NOT do

- **It does not touch `BatchMatMulBackward` or the other `TransposeLastTwoDims` fallbacks.** `BackwardFunctions.cs:2494/2496`, `:4301/4303` and `:4399/4401` perform the same transpose-and-matmul without a nearby `SumToShape` and are *candidates* for the same defect class — but I did not reproduce a failure in any of them, and `BatchMatMulBackward` operates on genuinely batched operands where a per-batch rank-3 gradient can be **correct**. Blanket-reducing there could introduce a bug rather than fix one, so it needs its own repro first.
- **It does not make narrowed inputs take a fast path.** A non-contiguous narrow still falls to the slow generic fallback (full ND transpose + per-batch matmul). This fixes correctness, not the performance of that route.
- **It does not change gradient values anywhere.** The reduction only removes leading axes the target does not have; where shapes already matched, nothing happens at all.
- **It does not address `transA`-style or higher-rank-than-3 combinations beyond what `SumToShape` already handles.** `SumToShape` collapses leading extra axes and size-1 broadcast axes; anything requiring a different reduction is out of scope.

## Relationship to #1034

Based on `main`, **not** stacked on #1034. There is no file overlap (#1034 touches `Engines/BlasManaged/*` and `Helpers/Autotune/HardwareFingerprint.cs`) and no semantic dependency — this repro is pure autodiff shape handling and never reaches GEMM strategy selection. The two can review and merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed automatic differentiation for matrix multiplication involving sliced or non-contiguous tensors.
  - Corrected gradient shape handling when batched operations produce gradients for lower-rank weights.
  - Prevented shape-mismatch errors during gradient accumulation.

- **Tests**
  - Added regression coverage for gradient shapes, accumulation, and values in non-contiguous matrix multiplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->